### PR TITLE
Fixing the Deadlock issue

### DIFF
--- a/azurerm/locks.go
+++ b/azurerm/locks.go
@@ -1,12 +1,24 @@
 package azurerm
 
-func azureRMUnlockMultiple(names *[]string) {
+// handle the case of using the same name for different kinds of resources
+func azureRMLockByName(name string, resourceType string) {
+	updatedName := resourceType + "." + name
+	armMutexKV.Lock(updatedName)
+}
+
+func azureRMLockMultipleByName(names *[]string, resourceType string) {
 	for _, name := range *names {
-		armMutexKV.Unlock(name)
+		azureRMLockByName(name, resourceType)
 	}
 }
-func azureRMLockMultiple(names *[]string) {
+
+func azureRMUnlockByName(name string, resourceType string) {
+	updatedName := resourceType + "." + name
+	armMutexKV.Unlock(updatedName)
+}
+
+func azureRMUnlockMultipleByName(names *[]string, resourceType string) {
 	for _, name := range *names {
-		armMutexKV.Lock(name)
+		azureRMUnlockByName(name, resourceType)
 	}
 }

--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+var networkSecurityGroupResourceName = "azurerm_network_security_group"
+
 func resourceArmNetworkSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmNetworkSecurityGroupCreate,

--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -139,6 +139,9 @@ func resourceArmNetworkSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error Building list of Network Security Group Rules: %s", sgErr)
 	}
 
+	azureRMLockByName(name, networkSecurityGroupResourceName)
+	defer azureRMUnlockByName(name, networkSecurityGroupResourceName)
+
 	sg := network.SecurityGroup{
 		Name:     &name,
 		Location: &location,

--- a/azurerm/resource_arm_network_security_rule.go
+++ b/azurerm/resource_arm_network_security_rule.go
@@ -120,8 +120,8 @@ func resourceArmNetworkSecurityRuleCreate(d *schema.ResourceData, meta interface
 	direction := d.Get("direction").(string)
 	protocol := d.Get("protocol").(string)
 
-	armMutexKV.Lock(nsgName)
-	defer armMutexKV.Unlock(nsgName)
+	azureRMLockByName(nsgName, networkSecurityGroupResourceName)
+	defer azureRMUnlockByName(nsgName, networkSecurityGroupResourceName)
 
 	properties := network.SecurityRulePropertiesFormat{
 		SourcePortRange:          &source_port_range,
@@ -155,8 +155,7 @@ func resourceArmNetworkSecurityRuleCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Security Group Rule %s/%s (resource group %s) ID",
-			nsgName, name, resGroup)
+		return fmt.Errorf("Cannot read Security Group Rule %s/%s (resource group %s) ID", nsgName, name, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -211,8 +210,8 @@ func resourceArmNetworkSecurityRuleDelete(d *schema.ResourceData, meta interface
 	nsgName := id.Path["networkSecurityGroups"]
 	sgRuleName := id.Path["securityRules"]
 
-	armMutexKV.Lock(nsgName)
-	defer armMutexKV.Unlock(nsgName)
+	azureRMLockByName(nsgName, networkSecurityGroupResourceName)
+	defer azureRMUnlockByName(nsgName, networkSecurityGroupResourceName)
 
 	_, error := secRuleClient.Delete(resGroup, nsgName, sgRuleName, make(chan struct{}))
 	err = <-error

--- a/azurerm/resource_arm_route.go
+++ b/azurerm/resource_arm_route.go
@@ -72,8 +72,8 @@ func resourceArmRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	addressPrefix := d.Get("address_prefix").(string)
 	nextHopType := d.Get("next_hop_type").(string)
 
-	armMutexKV.Lock(rtName)
-	defer armMutexKV.Unlock(rtName)
+	azureRMLockByName(rtName, routeTableResourceName)
+	defer azureRMUnlockByName(rtName, routeTableResourceName)
 
 	properties := network.RoutePropertiesFormat{
 		AddressPrefix: &addressPrefix,
@@ -153,8 +153,8 @@ func resourceArmRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	rtName := id.Path["routeTables"]
 	routeName := id.Path["routes"]
 
-	armMutexKV.Lock(rtName)
-	defer armMutexKV.Unlock(rtName)
+	azureRMLockByName(rtName, routeTableResourceName)
+	defer azureRMUnlockByName(rtName, routeTableResourceName)
 
 	_, error := routesClient.Delete(resGroup, rtName, routeName, make(chan struct{}))
 	err = <-error

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+var routeTableResourceName = "azurerm_route_table"
+
 func resourceArmRouteTable() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmRouteTableCreate,

--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+var virtualNetworkResourceName = "azurerm_virtual_network"
+
 func resourceArmVirtualNetwork() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmVirtualNetworkCreate,
@@ -114,8 +116,8 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	azureRMLockMultiple(&networkSecurityGroupNames)
-	defer azureRMUnlockMultiple(&networkSecurityGroupNames)
+	azureRMLockMultipleByName(&networkSecurityGroupNames, virtualNetworkResourceName)
+	defer azureRMUnlockMultipleByName(&networkSecurityGroupNames, virtualNetworkResourceName)
 
 	_, error := vnetClient.CreateOrUpdate(resGroup, name, vnet, make(chan struct{}))
 	err := <-error
@@ -208,8 +210,8 @@ func resourceArmVirtualNetworkDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("[ERROR] Error parsing Network Security Group ID's: %+v", err)
 	}
 
-	azureRMLockMultiple(&nsgNames)
-	defer azureRMUnlockMultiple(&nsgNames)
+	azureRMLockMultipleByName(&nsgNames, virtualNetworkResourceName)
+	defer azureRMUnlockMultipleByName(&nsgNames, virtualNetworkResourceName)
 
 	_, error := vnetClient.Delete(resGroup, name, make(chan struct{}))
 	err = <-error

--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -116,8 +116,8 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	azureRMLockMultipleByName(&networkSecurityGroupNames, virtualNetworkResourceName)
-	defer azureRMUnlockMultipleByName(&networkSecurityGroupNames, virtualNetworkResourceName)
+	azureRMLockMultipleByName(&networkSecurityGroupNames, networkSecurityGroupResourceName)
+	defer azureRMUnlockMultipleByName(&networkSecurityGroupNames, networkSecurityGroupResourceName)
 
 	_, error := vnetClient.CreateOrUpdate(resGroup, name, vnet, make(chan struct{}))
 	err := <-error


### PR DESCRIPTION
A deadlock issue was identified in https://github.com/hashicorp/terraform/issues/15204 and https://github.com/hashicorp/terraform/issues/7986.

Investigating further - some Terraform configs have matching Subnet and Virtual Network names - which we lock on due to a requirement in Azure. After discussion with @grubernaut / @mbfrahry I've updated _all_ locks in Azure by Name to prefix the resource name - which _isn't ideal_ but ensures that all locks are unique.

I've used [these test cases](https://gist.github.com/tombuildsstuff/109f6794f85cd289e2003dc9390f2df1) to validate this - built up from the bugs reported below. The acceptance tests are running at the moment, but this looks like it _should_ be good.

Fixes:
 - hashicorp/terraform#7986
 - #100
 - #104