### PR TITLE
Fix #105 detect missing subnet properties

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -169,10 +169,14 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	if resp.SubnetPropertiesFormat.NetworkSecurityGroup != nil {
 		d.Set("network_security_group_id", resp.SubnetPropertiesFormat.NetworkSecurityGroup.ID)
+	} else {
+		d.Set("network_security_group_id", "")
 	}
 
 	if resp.SubnetPropertiesFormat.RouteTable != nil {
 		d.Set("route_table_id", resp.SubnetPropertiesFormat.RouteTable.ID)
+	} else {
+		d.Set("route_table_id", "")
 	}
 
 	if resp.SubnetPropertiesFormat.IPConfigurations != nil {


### PR DESCRIPTION
[#105](https://github.com/terraform-providers/terraform-provider-azurerm/issues/105)

We should catch missing security group and route table entries for subnets if they're missing from the Azure API response. This sets both to an empty string in the read function if no result was returned from the Azure API.