### PR TITLE
Support import for network interface

### DIFF
--- a/azurerm/import_arm_network_interface_card_test.go
+++ b/azurerm/import_arm_network_interface_card_test.go
@@ -1,0 +1,96 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMNetworkInterface_importBasic(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_basic(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterface_importIPForwarding(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_ipForwarding(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterface_importWithTags(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_withTags(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterface_importMultipleLoadBalancers(t *testing.T) {
+	resourceName := "azurerm_network_interface.test1"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_multipleLoadBalancers(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Addresses #25

```
make testacc TEST=./azurerm TESTARGS="-run TestAccAzureRMNetworkInterface_import"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run TestAccAzureRMNetworkInterface_import -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_importBasic
--- PASS: TestAccAzureRMNetworkInterface_importBasic (117.50s)
=== RUN   TestAccAzureRMNetworkInterface_importIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_importIPForwarding (116.48s)
=== RUN   TestAccAzureRMNetworkInterface_importWithTags
--- PASS: TestAccAzureRMNetworkInterface_importWithTags (126.00s)
=== RUN   TestAccAzureRMNetworkInterface_importMultipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_importMultipleLoadBalancers (156.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       516.124s
```