### PR TITLE
Fixing the NIC/Subnet tests

### DIFF
--- a/azurerm/resource_arm_network_interface_card.go
+++ b/azurerm/resource_arm_network_interface_card.go
@@ -324,12 +324,12 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("network_security_group_id", resp.NetworkSecurityGroup.ID)
 	}
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("applied_dns_servers", appliedDNSServers)
 	d.Set("dns_servers", dnsServers)
 	d.Set("enable_ip_forwarding", resp.EnableIPForwarding)
-	d.Set("location", resp.Location)
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resGroup)
 
 	flattenAndSetTags(d, resp.Tags)
 

--- a/azurerm/resource_arm_network_interface_card_test.go
+++ b/azurerm/resource_arm_network_interface_card_test.go
@@ -126,7 +126,7 @@ func TestAccAzureRMNetworkInterface_bug7986(t *testing.T) {
 			{
 				Config: testAccAzureRMNetworkInterface_bug7986(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test"),
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test1"),
 				),
 			},
 		},
@@ -505,26 +505,28 @@ resource "azurerm_network_security_group" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
-  security_rule {
-    name                       = "test123"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
   tags {
     environment = "Production"
   }
 }
 
-resource "azurerm_network_security_rule" "test" {
-  name                        = "test"
-  priority                    = 100
+resource "azurerm_network_security_rule" "test1" {
+  name                        = "test1"
+  priority                    = 101
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.test.name}"
+  network_security_group_name = "${azurerm_network_security_group.test.name}"
+}
+
+resource "azurerm_network_security_rule" "test2" {
+  name                        = "test2"
+  priority                    = 102
   direction                   = "Outbound"
   access                      = "Allow"
   protocol                    = "Tcp"
@@ -552,12 +554,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-
-  subnet {
-    name           = "second"
-    address_prefix = "10.0.3.0/24"
-    security_group = "${azurerm_network_security_group.test.id}"
-  }
 }
 
 resource "azurerm_subnet" "test" {

--- a/azurerm/resource_arm_network_interface_card_test.go
+++ b/azurerm/resource_arm_network_interface_card_test.go
@@ -127,6 +127,7 @@ func TestAccAzureRMNetworkInterface_bug7986(t *testing.T) {
 				Config: testAccAzureRMNetworkInterface_bug7986(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test1"),
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test2"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -72,7 +72,7 @@ func TestAccAzureRMSubnet_bug7986(t *testing.T) {
 			{
 				Config: initConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+					testCheckAzureRMSubnetExists("azurerm_subnet.first"),
 				),
 			},
 		},
@@ -445,7 +445,7 @@ resource "azurerm_subnet" "first" {
 }
 
 resource "azurerm_route_table" "second" {
-  name                = "$acctest%d-private-2"
+  name                = "acctest%d-private-2"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
@@ -459,7 +459,7 @@ resource "azurerm_route" "second" {
 }
 
 resource "azurerm_subnet" "second" {
-  name                 = "acctest%d-private-1"
+  name                 = "acctest%d-private-2"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.1.0/24"

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -73,6 +73,7 @@ func TestAccAzureRMSubnet_bug7986(t *testing.T) {
 				Config: initConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSubnetExists("azurerm_subnet.first"),
+					testCheckAzureRMSubnetExists("azurerm_subnet.second"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes some broken tests identified in the nightly run. Tests pass:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -run TestAccAzureRMSubnet_bug7986 -timeout 300m -parallel 5
=== RUN   TestAccAzureRMSubnet_bug7986
--- PASS: TestAccAzureRMSubnet_bug7986 (103.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	103.248s

$ TF_ACC=1 envchain azurerm go test ./azurerm -v -run TestAccAzureRMNetworkInterface -timeout 300m -parallel 5
=== RUN   TestAccAzureRMNetworkInterface_importBasic
--- PASS: TestAccAzureRMNetworkInterface_importBasic (117.97s)
=== RUN   TestAccAzureRMNetworkInterface_importIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_importIPForwarding (118.17s)
=== RUN   TestAccAzureRMNetworkInterface_importWithTags
--- PASS: TestAccAzureRMNetworkInterface_importWithTags (102.32s)
=== RUN   TestAccAzureRMNetworkInterface_importMultipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_importMultipleLoadBalancers (156.95s)
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (117.07s)
=== RUN   TestAccAzureRMNetworkInterface_disappears
--- PASS: TestAccAzureRMNetworkInterface_disappears (115.30s)
=== RUN   TestAccAzureRMNetworkInterface_enableIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_enableIPForwarding (101.36s)
=== RUN   TestAccAzureRMNetworkInterface_multipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_multipleLoadBalancers (136.90s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (157.60s)
=== RUN   TestAccAzureRMNetworkInterface_bug7986
--- PASS: TestAccAzureRMNetworkInterface_bug7986 (118.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1241.927s
```