### PR TITLE
Fix import of public ip of a network interface

### DIFF
--- a/azurerm/import_arm_network_interface_card_test.go
+++ b/azurerm/import_arm_network_interface_card_test.go
@@ -94,3 +94,25 @@ func TestAccAzureRMNetworkInterface_importMultipleLoadBalancers(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMNetworkInterface_importPublicIP(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMNetworkInterface_publicIP(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_network_interface_card.go
+++ b/azurerm/resource_arm_network_interface_card.go
@@ -442,7 +442,7 @@ func flattenNetworkInterfaceIPConfigurations(ipConfigs *[]network.InterfaceIPCon
 		}
 
 		if ipConfig.InterfaceIPConfigurationPropertiesFormat.PublicIPAddress != nil {
-			niIPConfig["public_ip_address_id"] = ipConfig.InterfaceIPConfigurationPropertiesFormat.PublicIPAddress.ID
+			niIPConfig["public_ip_address_id"] = *ipConfig.InterfaceIPConfigurationPropertiesFormat.PublicIPAddress.ID
 		}
 
 		var pools []interface{}

--- a/azurerm/resource_arm_network_interface_card_test.go
+++ b/azurerm/resource_arm_network_interface_card_test.go
@@ -597,3 +597,46 @@ resource "azurerm_network_interface" "test2" {
 }
 `, rInt, rInt, rInt, rInt, rInt, rInt)
 }
+
+func testAccAzureRMNetworkInterface_publicIP(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctest-rg-%d"
+  location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name = "acceptanceTestVirtualNetwork1"
+  address_space = ["10.0.0.0/16"]
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name = "testsubnet"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "testext" {
+  name                         = "testpublicipext"
+  location                     = "West US"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "test" {
+  name = "acceptanceTestNetworkInterface1"
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name = "testconfiguration1"
+    subnet_id = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id = "${azurerm_public_ip.testext.id}"
+  }
+}
+`, rInt)
+}


### PR DESCRIPTION
Fix runtime error on conversion of `*string` to `string` when presence of public ip 

Before:

```
$ make testacc TEST=./azurerm TESTARGS="-run
TestAccAzureRMNetworkInterface_importPublicIP"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run
TestAccAzureRMNetworkInterface_importPublicIP -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_importPublicIP
panic: interface conversion: interface {} is *string, not string

goroutine 393 [running]:
github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmNetworkInterfaceIpConfigurationHash(0x183ad00, 0xc4201aa4b0, 0xc4202a9478)
        /Users/thiagocaiubi/Development/go/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_network_interface_card.go:401 +0xa75
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).hash(0xc4202a9460, 0x183ad00, 0xc4201aa4b0, 0x10, 0x20)
        /Users/thiagocaiubi/Development/go/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:180 +0x3d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).add(0xc4202a9460, 0x183ad00, 0xc4201aa4b0, 0x1884d00, 0x1, 0xc4202a9460)
        /Users/thiagocaiubi/Development/go/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:167 +0x81
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).Add(0xc4202a9460, 0x183ad00, 0xc4201aa4b0)
        /Users/thiagocaiubi/Development/go/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:69 +0x44
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.NewSet(0x198c5e8, 0xc4202fac30, 0x1, 0x1, 0xc4202fac00)
        /Users/thiagocaiubi/Development/go/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:56 +0xa2
github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmNetworkInterfaceRead(0xc4201cda40, 0x1875c20, 0xc4202ee000, 0xc4203690e0, 0x0)
```

After:

```
$ make testacc TEST=./azurerm TESTARGS="-run
TestAccAzureRMNetworkInterface_importPublicIP"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run
TestAccAzureRMNetworkInterface_importPublicIP -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_importPublicIP
--- PASS: TestAccAzureRMNetworkInterface_importPublicIP (120.69s)
PASS
ok github.com/terraform-providers/terraform-provider-azurerm/azurerm 120.801s
```