### PR TITLE
Allowing `azurerm_cdn_endpoint`'s to be updated

### DIFF
--- a/azurerm/import_arm_cdn_endpoint_test.go
+++ b/azurerm/import_arm_cdn_endpoint_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,7 +11,7 @@ func TestAccAzureRMCdnEndpoint_importWithTags(t *testing.T) {
 	resourceName := "azurerm_cdn_endpoint.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
+	config := testAccAzureRMCdnEndpoint_withTags(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_cdn_profile_test.go
+++ b/azurerm/import_arm_cdn_profile_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,7 +11,7 @@ func TestAccAzureRMCdnProfile_importWithTags(t *testing.T) {
 	resourceName := "azurerm_cdn_profile.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMCdnProfile_withTags, ri, ri)
+	config := testAccAzureRMCdnProfile_withTags(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -260,10 +260,6 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	cdnEndpointsClient := meta.(*ArmClient).cdnEndpointsClient
 
-	if !d.HasChange("tags") {
-		return nil
-	}
-
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	profileName := d.Get("profile_name").(string)

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
+	config := testAccAzureRMCdnEndpoint_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -31,7 +31,7 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 
 func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
+	config := testAccAzureRMCdnEndpoint_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,8 +52,8 @@ func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
 
 func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTagsUpdate, ri, ri, ri)
+	preConfig := testAccAzureRMCdnEndpoint_withTags(ri)
+	postConfig := testAccAzureRMCdnEndpoint_withTagsUpdate(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -169,7 +169,8 @@ func testCheckAzureRMCdnEndpointDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMCdnEndpoint_basic = `
+func testAccAzureRMCdnEndpoint_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -194,9 +195,11 @@ resource "azurerm_cdn_endpoint" "test" {
 	http_port = 80
     }
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMCdnEndpoint_withTags = `
+func testAccAzureRMCdnEndpoint_withTags(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -226,9 +229,11 @@ resource "azurerm_cdn_endpoint" "test" {
 	cost_center = "MSFT"
     }
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMCdnEndpoint_withTagsUpdate = `
+func testAccAzureRMCdnEndpoint_withTagsUpdate(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -257,4 +262,5 @@ resource "azurerm_cdn_endpoint" "test" {
 	environment = "staging"
     }
 }
-`
+`, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMCdnEndpoint_basic(ri)
 
@@ -22,7 +23,7 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
+					testCheckAzureRMCdnEndpointExists(resourceName),
 				),
 			},
 		},
@@ -30,6 +31,7 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 }
 
 func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMCdnEndpoint_basic(ri)
 
@@ -41,8 +43,8 @@ func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
-					testCheckAzureRMCdnEndpointDisappears("azurerm_cdn_endpoint.test"),
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					testCheckAzureRMCdnEndpointDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -50,7 +52,37 @@ func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCdnEndpoint_updateHostHeader(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMCdnEndpoint_hostHeader(ri, "www.example.com")
+	updatedConfig := testAccAzureRMCdnEndpoint_hostHeader(ri, "www.example2.com")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "origin_host_header", "www.example.com"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "origin_host_header", "www.example2.com"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
 	ri := acctest.RandInt()
 	preConfig := testAccAzureRMCdnEndpoint_withTags(ri)
 	postConfig := testAccAzureRMCdnEndpoint_withTagsUpdate(ri)
@@ -63,24 +95,19 @@ func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_endpoint.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_endpoint.test", "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_endpoint.test", "tags.cost_center", "MSFT"),
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
 
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnEndpointExists("azurerm_cdn_endpoint.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_endpoint.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_endpoint.test", "tags.environment", "staging"),
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -196,6 +223,41 @@ resource "azurerm_cdn_endpoint" "test" {
     }
 }
 `, rInt, rInt, rInt)
+}
+
+func testAccAzureRMCdnEndpoint_hostHeader(rInt int, domain string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+resource "azurerm_cdn_profile" "test" {
+    name = "acctestcdnprof%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "Standard_Verizon"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+    name = "acctestcdnend%d"
+    profile_name = "${azurerm_cdn_profile.test.name}"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    origin_host_header = "%s"
+
+    origin {
+	name = "acceptanceTestCdnOrigin2"
+	host_name = "www.example.com"
+	https_port = 443
+	http_port = 80
+    }
+
+    tags {
+	environment = "Production"
+	cost_center = "MSFT"
+    }
+}
+`, rInt, rInt, rInt, domain)
 }
 
 func testAccAzureRMCdnEndpoint_withTags(rInt int) string {

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -51,9 +51,8 @@ func TestResourceAzureRMCdnProfileSKU_validation(t *testing.T) {
 }
 
 func TestAccAzureRMCdnProfile_basic(t *testing.T) {
-
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMCdnProfile_basic, ri, ri)
+	config := testAccAzureRMCdnProfile_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -73,8 +72,8 @@ func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMCdnProfile_withTags, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMCdnProfile_withTagsUpdate, ri, ri)
+	preConfig := testAccAzureRMCdnProfile_withTags(ri)
+	postConfig := testAccAzureRMCdnProfile_withTagsUpdate(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -109,7 +108,6 @@ func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 }
 
 func TestAccAzureRMCdnProfile_NonStandardCasing(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMCdnProfileNonStandardCasing(ri)
 
@@ -118,14 +116,13 @@ func TestAccAzureRMCdnProfile_NonStandardCasing(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
@@ -188,7 +185,8 @@ func testCheckAzureRMCdnProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMCdnProfile_basic = `
+func testAccAzureRMCdnProfile_basic(ri int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -199,13 +197,16 @@ resource "azurerm_cdn_profile" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Standard_Verizon"
 }
-`
+`, ri, ri)
+}
 
-var testAccAzureRMCdnProfile_withTags = `
+func testAccAzureRMCdnProfile_withTags(ri int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_cdn_profile" "test" {
     name = "acctestcdnprof%d"
     location = "West US"
@@ -217,9 +218,10 @@ resource "azurerm_cdn_profile" "test" {
 	cost_center = "MSFT"
     }
 }
-`
-
-var testAccAzureRMCdnProfile_withTagsUpdate = `
+`, ri, ri)
+}
+func testAccAzureRMCdnProfile_withTagsUpdate(ri int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -234,7 +236,8 @@ resource "azurerm_cdn_profile" "test" {
 	environment = "staging"
     }
 }
-`
+`, ri, ri)
+}
 
 func testAccAzureRMCdnProfileNonStandardCasing(ri int) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Fixes a bug which meant CDN Endpoints couldn't be updated - also updated the CDN tests to match the new function format

Fixes #97