### PR TITLE
Networking Updates

### DIFF
--- a/azurerm/resource_arm_network_security_rule.go
+++ b/azurerm/resource_arm_network_security_rule.go
@@ -34,6 +34,7 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 			"network_security_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"description": {

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -194,11 +194,11 @@
               <a href="#">Network Resources</a>
               <ul class="nav nav-visible">
 
-                <li<%= sidebar_current("docs-azurerm-resource-express-route-circuit") %>>
+                <li<%= sidebar_current("docs-azurerm-resource-network-express-route-circuit") %>>
                   <a href="/docs/providers/azurerm/r/express_route_circuit.html">azurerm_express_route_circuit</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-local-network-gateway") %>>
+                <li<%= sidebar_current("docs-azurerm-resource-network-local-network-gateway") %>>
                   <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
                 </li>
 
@@ -345,8 +345,6 @@
                 </li>
               </ul>
             </li>
-
-
 
             <li<%= sidebar_current("docs-azurerm-resource-virtual") %>>
               <a href="#">Virtual Machine Resources</a>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -29,7 +29,7 @@
                 <li<%= sidebar_current("docs-azurerm-datasource-resource-group") %>>
                     <a href="/docs/providers/azurerm/d/resource_group.html">azurerm_resource_group</a>
                 </li>
-                
+
               </ul>
             </li>
 
@@ -194,12 +194,16 @@
               <a href="#">Network Resources</a>
               <ul class="nav nav-visible">
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network") %>>
-                  <a href="/docs/providers/azurerm/r/virtual_network.html">azurerm_virtual_network</a>
+                <li<%= sidebar_current("docs-azurerm-resource-express-route-circuit") %>>
+                  <a href="/docs/providers/azurerm/r/express_route_circuit.html">azurerm_express_route_circuit</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-peering") %>>
-                  <a href="/docs/providers/azurerm/r/virtual_network_peering.html">azurerm_virtual_network_peering</a>
+                <li<%= sidebar_current("docs-azurerm-resource-local-network-gateway") %>>
+                  <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-network-interface") %>>
+                  <a href="/docs/providers/azurerm/r/network_interface.html">azurerm_network_interface</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-security-group") %>>
@@ -214,36 +218,32 @@
                   <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-subnet") %>>
-                  <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
-                </li>
-
-                <li<%= sidebar_current("docs-azurerm-resource-local-network-gateway") %>>
-                  <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
-                </li>
-
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface") %>>
-                  <a href="/docs/providers/azurerm/r/network_interface.html">azurerm_network_interface</a>
+                <li<%= sidebar_current("docs-azurerm-resource-network-route") %>>
+                  <a href="/docs/providers/azurerm/r/route.html">azurerm_route</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-route-table") %>>
                   <a href="/docs/providers/azurerm/r/route_table.html">azurerm_route_table</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-route") %>>
-                  <a href="/docs/providers/azurerm/r/route.html">azurerm_route</a>
-                </li>
-
-                <li<%= sidebar_current("docs-azurerm-resource-network-traffic-manager-profile") %>>
-                  <a href="/docs/providers/azurerm/r/traffic_manager_profile.html">azurerm_traffic_manager_profile</a>
+                <li<%= sidebar_current("docs-azurerm-resource-network-subnet") %>>
+                  <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-traffic-manager-endpoint") %>>
                   <a href="/docs/providers/azurerm/r/traffic_manager_endpoint.html">azurerm_traffic_manager_endpoint</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-express-route-circuit") %>>
-                  <a href="/docs/providers/azurerm/r/express_route_circuit.html">azurerm_express_route_circuit</a>
+                <li<%= sidebar_current("docs-azurerm-resource-network-traffic-manager-profile") %>>
+                  <a href="/docs/providers/azurerm/r/traffic_manager_profile.html">azurerm_traffic_manager_profile</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network") %>>
+                  <a href="/docs/providers/azurerm/r/virtual_network.html">azurerm_virtual_network</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-peering") %>>
+                  <a href="/docs/providers/azurerm/r/virtual_network_peering.html">azurerm_virtual_network_peering</a>
                 </li>
               </ul>
             </li>

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit"
-sidebar_current: "docs-azurerm-resource-express-route-circuit"
+sidebar_current: "docs-azurerm-resource-network-express-route-circuit"
 description: |-
   Creates an ExpressRoute circuit.
 ---
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `peering_location` - (Required) The name of the peering location and not the ARM resource location.
 
-* `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created. Once you increase your bandwidth, 
+* `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created. Once you increase your bandwidth,
     you will not be able to decrease it to its previous value.
 
 * `sku` - (Required) Chosen SKU of ExpressRoute circuit as documented below.
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `tier` - (Required) The service tier. Value must be either "Premium" or "Standard".
 
-* `family` - (Required) The billing mode. Value must be either "MeteredData" or "UnlimitedData". 
+* `family` - (Required) The billing mode. Value must be either "MeteredData" or "UnlimitedData".
    Once you set the billing model to "UnlimitedData", you will not be able to switch to "MeteredData".
 
 ## Attributes Reference
@@ -76,7 +76,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Resource ID of the ExpressRoute circuit.
-* `service_provider_provisioning_state` - The ExpressRoute circuit provisioning state from your chosen service provider. 
+* `service_provider_provisioning_state` - The ExpressRoute circuit provisioning state from your chosen service provider.
     Possible values are "NotProvisioned", "Provisioning", "Provisioned", and "Deprovisioning".
 * `service_key` - The string needed by the service provider to provision the ExpressRoute circuit.
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_local_network_gateway"
-sidebar_current: "docs-azurerm-resource-local-network-gateway"
+sidebar_current: "docs-azurerm-resource-network-local-network-gateway"
 description: |-
   Creates a new local network gateway connection over which specific connections can be configured.
 ---

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Create a network security group that contains a list of network security rules.
 
+~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+provides both a standalone [Network Security Rule resource](network_security_rule.html), and allows for Network Security Rules to be defined in-line within the [Network Security Group resource](network_security_group.html).
+At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Create a Network Security Rule.
 
+~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+provides both a standalone [Network Security Rule resource](network_security_rule.html), and allows for Network Security Rules to be defined in-line within the [Network Security Group resource](network_security_group.html).
+At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_network_security_rule" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the security rule.
+* `name` - (Required) The name of the security rule. This needs to be unique across all Rules in the Network Security Group. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to
     create the Network Security Rule.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Creates a new subnet. Subnets represent network segments within the IP space defined by the virtual network.
 
+~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+provides both a standalone [Subnet resource](subnet.html), and allows for Subnets to be defined in-line within the [Virtual Network resource](virtual_network.html).
+At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Create a template deployment of resources
 
+~> **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
+This means that when deleting the `azurerm_template_deployment` resource, Terraform will only remove the reference to the deployment, whilst leaving any resources created by that ARM Template Deployment.
+One workaround for this is to use a unique Resource Group for each ARM Template Deployment, which means deleting the Resource Group would contain any resources created within it - however this isn't ideal. [More information](https://docs.microsoft.com/en-us/rest/api/resources/deployments#Deployments_Delete).
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -11,6 +11,10 @@ description: |-
 Creates a new virtual network including any configured subnets. Each subnet can
 optionally be configured with a security group to be associated with the subnet.
 
+~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+provides both a standalone [Subnet resource](subnet.html), and allows for Subnets to be defined in-line within the [Virtual Network resource](virtual_network.html).
+At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Made `network_security_group_name` a `ForceNew` in Network Security Rule's

Otherwise documentation updates:
- Adding disclaimers to match the AWS resources:
  - Virtual Networks/Subnets - about inline/separate resources conflicting
  - Network Security Groups / Network Security Rules - about inline/separate resources conflicting
  - ARM Template Deployments about what an ARM Template Deployment _actually_ is
- Re-organising the Network sidebar to be alphabetical like the other groupings
- Fixing the highlighting for Express Route's / Local Network Gateway's

Fixes #115 #65