### PR TITLE
`azurerm_storage_account` - exposing a formatted Connection String for Blob access

### DIFF
--- a/azurerm/import_arm_storage_account_test.go
+++ b/azurerm/import_arm_storage_account_test.go
@@ -2,9 +2,7 @@ package azurerm
 
 import (
 	"testing"
-
-	"fmt"
-
+	
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -14,18 +12,18 @@ func TestAccAzureRMStorageAccount_importBasic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
+	config := testAccAzureRMStorageAccount_basic(ri, rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_storage_account_test.go
+++ b/azurerm/import_arm_storage_account_test.go
@@ -2,7 +2,7 @@ package azurerm
 
 import (
 	"testing"
-	
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -137,6 +137,16 @@ func resourceArmStorageAccount() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_blob_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secondary_blob_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -366,13 +376,21 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("primary_queue_endpoint", resp.AccountProperties.PrimaryEndpoints.Queue)
 		d.Set("primary_table_endpoint", resp.AccountProperties.PrimaryEndpoints.Table)
 		d.Set("primary_file_endpoint", resp.AccountProperties.PrimaryEndpoints.File)
+
+		pscs := fmt.Sprintf("DefaultEndpointsProtocol=https;BlobEndpoint=%s;AccountName=%s;AccountKey=%s",
+			*resp.AccountProperties.PrimaryEndpoints.Blob, *resp.Name, *accessKeys[0].Value)
+		d.Set("primary_blob_connection_string", pscs)
 	}
 
 	if resp.AccountProperties.SecondaryEndpoints != nil {
 		if resp.AccountProperties.SecondaryEndpoints.Blob != nil {
 			d.Set("secondary_blob_endpoint", resp.AccountProperties.SecondaryEndpoints.Blob)
+			sscs := fmt.Sprintf("DefaultEndpointsProtocol=https;BlobEndpoint=%s;AccountName=%s;AccountKey=%s",
+				*resp.AccountProperties.SecondaryEndpoints.Blob, *resp.Name, *accessKeys[1].Value)
+			d.Set("secondary_blob_connection_string", sscs)
 		} else {
 			d.Set("secondary_blob_endpoint", "")
+			d.Set("secondary_blob_connection_string", "")
 		}
 		if resp.AccountProperties.SecondaryEndpoints.Queue != nil {
 			d.Set("secondary_queue_endpoint", resp.AccountProperties.SecondaryEndpoints.Queue)

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -53,15 +53,15 @@ func TestValidateArmStorageAccountName(t *testing.T) {
 func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
-	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_update, ri, rs)
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
+	postConfig := testAccAzureRMStorageAccount_update(ri, rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -71,7 +71,7 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -87,14 +87,14 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -112,15 +112,15 @@ func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobEncryption, ri, rs)
-	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobEncryptionDisabled, ri, rs)
+	preConfig := testAccAzureRMStorageAccount_blobEncryption(ri, rs)
+	postConfig := testAccAzureRMStorageAccount_blobEncryptionDisabled(ri, rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -128,7 +128,7 @@ func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -142,15 +142,15 @@ func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobStorage, ri, rs)
-	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobStorageUpdate, ri, rs)
+	preConfig := testAccAzureRMStorageAccount_blobStorage(ri, rs)
+	postConfig := testAccAzureRMStorageAccount_blobStorageUpdate(ri, rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -159,7 +159,7 @@ func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
@@ -180,14 +180,14 @@ func TestAccAzureRMStorageAccount_NonStandardCasing(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config:             preConfig,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
@@ -270,7 +270,8 @@ func testCheckAzureRMStorageAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMStorageAccount_basic = `
+func testAccAzureRMStorageAccount_basic(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "westus"
@@ -286,9 +287,11 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "production"
     }
-}`
+}`, rInt, rString)
+}
 
-var testAccAzureRMStorageAccount_update = `
+func testAccAzureRMStorageAccount_update(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "westus"
@@ -304,9 +307,11 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "staging"
     }
-}`
+}`, rInt, rString)
+}
 
-var testAccAzureRMStorageAccount_blobEncryption = `
+func testAccAzureRMStorageAccount_blobEncryption(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "westus"
@@ -323,9 +328,11 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "production"
     }
-}`
+}`, rInt, rString)
+}
 
-var testAccAzureRMStorageAccount_blobEncryptionDisabled = `
+func testAccAzureRMStorageAccount_blobEncryptionDisabled(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "westus"
@@ -342,10 +349,12 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "production"
     }
-}`
+}`, rInt, rString)
+}
 
 // BlobStorage accounts are not available in WestUS
-var testAccAzureRMStorageAccount_blobStorage = `
+func testAccAzureRMStorageAccount_blobStorage(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "northeurope"
@@ -362,9 +371,12 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "production"
     }
-}`
+}
+`, rInt, rString)
+}
 
-var testAccAzureRMStorageAccount_blobStorageUpdate = `
+func testAccAzureRMStorageAccount_blobStorageUpdate(rInt int, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
     location = "northeurope"
@@ -382,7 +394,9 @@ resource "azurerm_storage_account" "testsa" {
     tags {
         environment = "production"
     }
-}`
+}
+`, rInt, rString)
+}
 
 func testAccAzureRMStorageAccountNonStandardCasing(ri int, rs string) string {
 	return fmt.Sprintf(`

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -109,6 +109,27 @@ func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageAccount_blobConnectionString(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
+					resource.TestCheckResourceAttrSet("azurerm_storage_account.testsa", "primary_blob_connection_string"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -84,6 +84,8 @@ The following attributes are exported in addition to the arguments listed above:
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
 * `primary_access_key` - The primary access key for the storage account
 * `secondary_access_key` - The secondary access key for the storage account
+* `primary_blob_connection_string` - The connection string associated with the primary blob location
+* `secondary_blob_connection_string` - The connection string associated with the secondary blob location
 
 ## Import
 
@@ -92,4 +94,3 @@ Storage Accounts can be imported using the `resource id`, e.g.
 ```
 terraform import azurerm_storage_account.storageAcc1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount
 ```
-


### PR DESCRIPTION
Chatting with @radeksimko during #130 - I realised we were having to manually construct the Connection Strings for accessing Storage Accounts. This PR exposes a couple of fields with the Primary + Secondary (where appropriate) Connection Strings for Blob access to Storage Accounts.

Relevant test:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 300m -parallel 5 -run TestAccAzureRMStorageAccount_blobConnectionString
=== RUN   TestAccAzureRMStorageAccount_blobConnectionString
--- PASS: TestAccAzureRMStorageAccount_blobConnectionString (116.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	116.397s
```

Running the rest of the suite now