### PR TITLE
Fix azure table storage name length requirement.

### DIFF
--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -43,9 +43,9 @@ func validateArmStorageTableName(v interface{}, k string) (ws []string, errors [
 			"Table Storage %q cannot use the word `table`: %q",
 			k, value))
 	}
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{6,63}$`).MatchString(value) {
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{2,62}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"Table Storage %q cannot begin with a numeric character, only alphanumeric characters are allowed and must be between 6 and 63 characters long: %q",
+			"Table Storage %q cannot begin with a numeric character, only alphanumeric characters are allowed and must be between 3 and 63 characters long: %q",
 			k, value))
 	}
 

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -192,6 +192,8 @@ func TestValidateArmStorageTableName(t *testing.T) {
 		"mytable",
 		"myTable",
 		"MYTABLE",
+		"tbl",
+		strings.Repeat("w", 63),
 	}
 	for _, v := range validNames {
 		_, errors := validateArmStorageTableName(v, "name")
@@ -206,7 +208,7 @@ func TestValidateArmStorageTableName(t *testing.T) {
 		"invalid_name",
 		"invalid!",
 		"ww",
-		strings.Repeat("w", 65),
+		strings.Repeat("w", 64),
 	}
 	for _, v := range invalidNames {
 		_, errors := validateArmStorageTableName(v, "name")


### PR DESCRIPTION
https://docs.microsoft.com/en-us/rest/api/storageservices/Understanding-the-Table-Service-Data-Model?redirectedfrom=MSDN#table-names.

I'm not sure if this requirement changed since this was created, but it's currently breaking my infrastructure because I have a 5-character-name table.

I'm having difficulty getting my go dev environment set up so this will likely break tests. I'll fix them once the red build comes back.