### PR TITLE
`azurerm_servicebus_topic` - added a `status` field to allow disabling the topic

### DIFF
--- a/azurerm/import_arm_servicebus_namespace_test.go
+++ b/azurerm/import_arm_servicebus_namespace_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,18 @@ func TestAccAzureRMServiceBusNamespace_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_namespace.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_servicebus_topic_test.go
+++ b/azurerm/import_arm_servicebus_topic_test.go
@@ -29,3 +29,26 @@ func TestAccAzureRMServiceBusTopic_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMServiceBusTopic_importBasicDisabled(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMServiceBusTopic_basicDisabled(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/import_arm_servicebus_topic_test.go
+++ b/azurerm/import_arm_servicebus_topic_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMServiceBusTopic_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+	config := testAccAzureRMServiceBusTopic_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -43,52 +43,20 @@ func TestAccAzureRMServiceBusNamespaceCapacity_validation(t *testing.T) {
 	}
 }
 
-func TestAccAzureRMServiceBusNamespaceSku_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Basic",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Standard",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Premium",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Random",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateServiceBusNamespaceSku(tc.Value, "azurerm_servicebus_namespace")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM ServiceBus Namespace Sku to trigger a validation error")
-		}
-	}
-}
-
 func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
-
+	resourceName := "azurerm_servicebus_namespace.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusNamespaceExists("azurerm_servicebus_namespace.test"),
+					testCheckAzureRMServiceBusNamespaceExists(resourceName),
 				),
 			},
 		},
@@ -96,26 +64,27 @@ func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusNamespace_readDefaultKeys(t *testing.T) {
+	resourceName := "azurerm_servicebus_namespace.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusNamespaceExists("azurerm_servicebus_namespace.test"),
+					testCheckAzureRMServiceBusNamespaceExists(resourceName),
 					resource.TestMatchResourceAttr(
-						"azurerm_servicebus_namespace.test", "default_primary_connection_string", regexp.MustCompile("Endpoint=.+")),
+						resourceName, "default_primary_connection_string", regexp.MustCompile("Endpoint=.+")),
 					resource.TestMatchResourceAttr(
-						"azurerm_servicebus_namespace.test", "default_secondary_connection_string", regexp.MustCompile("Endpoint=.+")),
+						resourceName, "default_secondary_connection_string", regexp.MustCompile("Endpoint=.+")),
 					resource.TestMatchResourceAttr(
-						"azurerm_servicebus_namespace.test", "default_primary_key", regexp.MustCompile(".+")),
+						resourceName, "default_primary_key", regexp.MustCompile(".+")),
 					resource.TestMatchResourceAttr(
-						"azurerm_servicebus_namespace.test", "default_secondary_key", regexp.MustCompile(".+")),
+						resourceName, "default_secondary_key", regexp.MustCompile(".+")),
 				),
 			},
 		},
@@ -123,6 +92,7 @@ func TestAccAzureRMServiceBusNamespace_readDefaultKeys(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusNamespace_NonStandardCasing(t *testing.T) {
+	resourceName := "azurerm_servicebus_namespace.test"
 
 	ri := acctest.RandInt()
 	config := testAccAzureRMServiceBusNamespaceNonStandardCasing(ri)
@@ -132,13 +102,13 @@ func TestAccAzureRMServiceBusNamespace_NonStandardCasing(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusNamespaceExists("azurerm_servicebus_namespace.test"),
+					testCheckAzureRMServiceBusNamespaceExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
@@ -201,18 +171,20 @@ func testCheckAzureRMServiceBusNamespaceExists(name string) resource.TestCheckFu
 	}
 }
 
-var testAccAzureRMServiceBusNamespace_basic = `
+func testAccAzureRMServiceBusNamespace_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "basic"
 }
-`
+`, rInt, rInt)
+}
 
 func testAccAzureRMServiceBusNamespaceNonStandardCasing(ri int) string {
 	return fmt.Sprintf(`
@@ -222,7 +194,7 @@ resource "azurerm_resource_group" "test" {
 }
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Basic"
 }

--- a/azurerm/resource_arm_servicebus_topic.go
+++ b/azurerm/resource_arm_servicebus_topic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/servicebus"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/jen20/riviera/azure"
 )
 
 func resourceArmServiceBusTopic() *schema.Resource {
@@ -134,26 +135,26 @@ func resourceArmServiceBusTopicCreate(d *schema.ResourceData, meta interface{}) 
 		Location: &location,
 		TopicProperties: &servicebus.TopicProperties{
 			Status:                            servicebus.EntityStatus(status),
-			EnableBatchedOperations:           &enableBatchedOps,
-			EnableExpress:                     &enableExpress,
-			FilteringMessagesBeforePublishing: &enableFiltering,
-			EnablePartitioning:                &enablePartitioning,
-			MaxSizeInMegabytes:                &maxSize,
-			RequiresDuplicateDetection:        &requiresDuplicateDetection,
-			SupportOrdering:                   &supportOrdering,
+			EnableBatchedOperations:           azure.Bool(enableBatchedOps),
+			EnableExpress:                     azure.Bool(enableExpress),
+			FilteringMessagesBeforePublishing: azure.Bool(enableFiltering),
+			EnablePartitioning:                azure.Bool(enablePartitioning),
+			MaxSizeInMegabytes:                azure.Int64(maxSize),
+			RequiresDuplicateDetection:        azure.Bool(requiresDuplicateDetection),
+			SupportOrdering:                   azure.Bool(supportOrdering),
 		},
 	}
 
 	if autoDeleteOnIdle := d.Get("auto_delete_on_idle").(string); autoDeleteOnIdle != "" {
-		parameters.TopicProperties.AutoDeleteOnIdle = &autoDeleteOnIdle
+		parameters.TopicProperties.AutoDeleteOnIdle = azure.String(autoDeleteOnIdle)
 	}
 
 	if defaultTTL := d.Get("default_message_ttl").(string); defaultTTL != "" {
-		parameters.TopicProperties.DefaultMessageTimeToLive = &defaultTTL
+		parameters.TopicProperties.DefaultMessageTimeToLive = azure.String(defaultTTL)
 	}
 
 	if duplicateWindow := d.Get("duplicate_detection_history_time_window").(string); duplicateWindow != "" {
-		parameters.TopicProperties.DuplicateDetectionHistoryTimeWindow = &duplicateWindow
+		parameters.TopicProperties.DuplicateDetectionHistoryTimeWindow = azure.String(duplicateWindow)
 	}
 
 	_, err := client.CreateOrUpdate(resGroup, namespaceName, name, parameters)

--- a/azurerm/resource_arm_servicebus_topic.go
+++ b/azurerm/resource_arm_servicebus_topic.go
@@ -49,6 +49,7 @@ func resourceArmServiceBusTopic() *schema.Resource {
 					string(servicebus.EntityStatusActive),
 					string(servicebus.EntityStatusDisabled),
 				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"auto_delete_on_idle": {

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -11,18 +11,19 @@ import (
 )
 
 func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+	config := testAccAzureRMServiceBusTopic_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+					testCheckAzureRMServiceBusTopicExists(resourceName),
 				),
 			},
 		},
@@ -32,7 +33,7 @@ func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_basicDisabled(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basicDisabled, ri, ri, ri)
+	config := testAccAzureRMServiceBusTopic_basicDisabled(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,8 +53,8 @@ func TestAccAzureRMServiceBusTopic_basicDisabled(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_basicDisableEnable(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	enabledConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	disabledConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basicDisabled, ri, ri, ri)
+	enabledConfig := testAccAzureRMServiceBusTopic_basic(ri)
+	disabledConfig := testAccAzureRMServiceBusTopic_basicDisabled(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -84,21 +85,21 @@ func TestAccAzureRMServiceBusTopic_basicDisableEnable(t *testing.T) {
 
 func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_update, ri, ri, ri)
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
+	postConfig := testAccAzureRMServiceBusTopic_update(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -112,29 +113,28 @@ func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningStandard, ri, ri, ri)
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
+	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningStandard(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+					testCheckAzureRMServiceBusTopicExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "enable_partitioning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "true"),
 					// Ensure size is read back in it's original value and not the x16 value returned by Azure
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "5120"),
+					resource.TestCheckResourceAttr(resourceName, "max_size_in_megabytes", "5120"),
 				),
 			},
 		},
@@ -142,28 +142,27 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningPremium, ri, ri, ri)
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
+	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningPremium(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+					testCheckAzureRMServiceBusTopicExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "enable_partitioning", "true"),
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "81920"),
+					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "max_size_in_megabytes", "81920"),
 				),
 			},
 		},
@@ -171,26 +170,26 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusTopic_enableDuplicateDetection(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enableDuplicateDetection, ri, ri, ri)
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
+	postConfig := testAccAzureRMServiceBusTopic_enableDuplicateDetection(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+					testCheckAzureRMServiceBusTopicExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "requires_duplicate_detection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requires_duplicate_detection", "true"),
 				),
 			},
 		},
@@ -255,7 +254,8 @@ func testCheckAzureRMServiceBusTopicExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var testAccAzureRMServiceBusTopic_basic = `
+func testAccAzureRMServiceBusTopic_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -274,9 +274,11 @@ resource "azurerm_servicebus_topic" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusTopic_basicDisabled = `
+func testAccAzureRMServiceBusTopic_basicDisabled(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -295,9 +297,11 @@ resource "azurerm_servicebus_topic" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusTopic_update = `
+func testAccAzureRMServiceBusTopic_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -318,9 +322,11 @@ resource "azurerm_servicebus_topic" "test" {
     enable_batched_operations = true
     enable_express = true
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusTopic_enablePartitioningStandard = `
+func testAccAzureRMServiceBusTopic_enablePartitioningStandard(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -339,11 +345,13 @@ resource "azurerm_servicebus_topic" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
-	max_size_in_megabytes = 5120
+    max_size_in_megabytes = 5120
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusTopic_enablePartitioningPremium = `
+func testAccAzureRMServiceBusTopic_enablePartitioningPremium(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -362,11 +370,13 @@ resource "azurerm_servicebus_topic" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
-	max_size_in_megabytes = 81920
+    max_size_in_megabytes = 81920
 }
-`
+`, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusTopic_enableDuplicateDetection = `
+func testAccAzureRMServiceBusTopic_enableDuplicateDetection(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -386,4 +396,5 @@ resource "azurerm_servicebus_topic" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     requires_duplicate_detection = true
 }
-`
+`, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -29,6 +29,59 @@ func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusTopic_basicDisabled(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basicDisabled, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceBusTopic_basicDisableEnable(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
+	ri := acctest.RandInt()
+	enabledConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+	disabledConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basicDisabled, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: enabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists(resourceName),
+				),
+			},
+			{
+				Config: disabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists(resourceName),
+				),
+			},
+			{
+				Config: enabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
@@ -223,7 +276,7 @@ resource "azurerm_servicebus_topic" "test" {
 }
 `
 
-var testAccAzureRMServiceBusTopic_basicPremium = `
+var testAccAzureRMServiceBusTopic_basicDisabled = `
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -233,7 +286,7 @@ resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "premium"
+    sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -296,6 +296,7 @@ resource "azurerm_servicebus_topic" "test" {
     location = "West US"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
+    status = "disabled"
 }
 `, rInt, rInt, rInt)
 }

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 Create a ServiceBus Topic.
 
-**Note** Topics can only be created in Namespaces with an SKU of `standard` or
-higher.
+**Note** Topics can only be created in Namespaces with an SKU of `standard` or higher.
 
 ## Example Usage
 
@@ -57,6 +56,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to
     create the namespace. Changing this forces a new resource to be created.
+
+* `status` - (Optional) The Status of the Service Bus Topic. Acceptable values are `Active` or `Disabled`. Defaults to `Active`.
 
 * `auto_delete_on_idle` - (Optional) The idle interval after which the
     Topic is automatically deleted, minimum of 5 minutes. Provided in the [TimeSpan](#timespan-format)


### PR DESCRIPTION
Allows Service Bus Topic's to be set to a Disabled state.

Fixes #146 

Tests pass:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMServiceBusTopic
=== RUN   TestAccAzureRMServiceBusTopic_importBasic
--- PASS: TestAccAzureRMServiceBusTopic_importBasic (206.31s)
=== RUN   TestAccAzureRMServiceBusTopic_importBasicDisabled
--- PASS: TestAccAzureRMServiceBusTopic_importBasicDisabled (207.14s)
=== RUN   TestAccAzureRMServiceBusTopic_basic
--- PASS: TestAccAzureRMServiceBusTopic_basic (202.54s)
=== RUN   TestAccAzureRMServiceBusTopic_basicDisabled
--- PASS: TestAccAzureRMServiceBusTopic_basicDisabled (207.77s)
=== RUN   TestAccAzureRMServiceBusTopic_basicDisableEnable
--- PASS: TestAccAzureRMServiceBusTopic_basicDisableEnable (251.32s)
=== RUN   TestAccAzureRMServiceBusTopic_update
--- PASS: TestAccAzureRMServiceBusTopic_update (219.43s)
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioningStandard
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioningStandard (233.38s)
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioningPremium
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioningPremium (527.34s)
=== RUN   TestAccAzureRMServiceBusTopic_enableDuplicateDetection
--- PASS: TestAccAzureRMServiceBusTopic_enableDuplicateDetection (250.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2306.085s
```