### PR TITLE
Adding Import support to Search Service

### DIFF
--- a/azurerm/import_arm_search_service_test.go
+++ b/azurerm/import_arm_search_service_test.go
@@ -1,0 +1,32 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMSearchService_importBasic(t *testing.T) {
+	resourceName := "azurerm_search_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMSearchService_basic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -16,9 +16,12 @@ func resourceArmSearchService() *schema.Resource {
 		Read:   resourceArmSearchServiceRead,
 		Update: resourceArmSearchServiceCreate,
 		Delete: resourceArmSearchServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -26,24 +29,24 @@ func resourceArmSearchService() *schema.Resource {
 
 			"location": locationSchema(),
 
-			"resource_group_name": &schema.Schema{
+			"resource_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"sku": &schema.Schema{
+			"sku": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"replica_count": &schema.Schema{
+			"replica_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
 
-			"partition_count": &schema.Schema{
+			"partition_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
@@ -86,10 +89,10 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 
 	createResponse, err := createRequest.Execute()
 	if err != nil {
-		return fmt.Errorf("Error creating Search Service: %s", err)
+		return fmt.Errorf("Error creating Search Service: %+v", err)
 	}
 	if !createResponse.IsSuccessful() {
-		return fmt.Errorf("Error creating Search Service: %s", createResponse.Error)
+		return fmt.Errorf("Error creating Search Service: %+v", createResponse.Error)
 	}
 
 	getSearchServiceCommand := &search.GetSearchService{
@@ -102,10 +105,10 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 
 	readResponse, err := readRequest.Execute()
 	if err != nil {
-		return fmt.Errorf("Error reading Search Service: %s", err)
+		return fmt.Errorf("Error reading Search Service: %+v", err)
 	}
 	if !readResponse.IsSuccessful() {
-		return fmt.Errorf("Error reading Search Service: %s", readResponse.Error)
+		return fmt.Errorf("Error reading Search Service: %+v", readResponse.Error)
 	}
 	resp := readResponse.Parsed.(*search.GetSearchServiceResponse)
 
@@ -118,7 +121,7 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 		MinTimeout: 15 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Search Service (%s) to become available: %s", d.Get("name"), err)
+		return fmt.Errorf("Error waiting for Search Service (%s) to become available: %+v", d.Get("name"), err)
 	}
 
 	d.SetId(*resp.ID)
@@ -130,27 +133,43 @@ func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["searchServices"]
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &search.GetSearchService{}
 
 	readResponse, err := readRequest.Execute()
 	if err != nil {
-		return fmt.Errorf("Error reading Search Service: %s", err)
+		return fmt.Errorf("Error reading Search Service: %+v", err)
 	}
 	if !readResponse.IsSuccessful() {
 		log.Printf("[INFO] Error reading Search Service %q - removing from state", d.Id())
 		d.SetId("")
-		return fmt.Errorf("Error reading Search Service: %s", readResponse.Error)
+		return fmt.Errorf("Error reading Search Service: %+v", readResponse.Error)
 	}
 
 	resp := readResponse.Parsed.(*search.GetSearchServiceResponse)
-	d.Set("sku", resp.Sku)
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(resp.Location))
+	d.Set("sku", string(resp.Sku.Name))
+
 	if resp.PartitionCount != nil {
 		d.Set("partition_count", resp.PartitionCount)
 	}
+
 	if resp.ReplicaCount != nil {
 		d.Set("replica_count", resp.ReplicaCount)
 	}
+
+	flattenAndSetTags(d, &resp.Tags)
+
 	return nil
 }
 
@@ -163,10 +182,10 @@ func resourceArmSearchServiceDelete(d *schema.ResourceData, meta interface{}) er
 
 	deleteResponse, err := deleteRequest.Execute()
 	if err != nil {
-		return fmt.Errorf("Error deleting Search Service: %s", err)
+		return fmt.Errorf("Error deleting Search Service: %+v", err)
 	}
 	if !deleteResponse.IsSuccessful() {
-		return fmt.Errorf("Error deleting Search Service: %s", deleteResponse.Error)
+		return fmt.Errorf("Error deleting Search Service: %+v", deleteResponse.Error)
 	}
 
 	return nil

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -11,20 +11,20 @@ import (
 )
 
 func TestAccAzureRMSearchService_basic(t *testing.T) {
+	resourceName := "azurerm_search_service.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSearchService_basic, ri, ri)
+	config := testAccAzureRMSearchService_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_search_service.test", "tags.%", "2"),
+					testCheckAzureRMSearchServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 				),
 			},
 		},
@@ -32,34 +32,31 @@ func TestAccAzureRMSearchService_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSearchService_updateReplicaCountAndTags(t *testing.T) {
+	resourceName := "azurerm_search_service.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSearchService_basic, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMSearchService_updated, ri, ri)
+	preConfig := testAccAzureRMSearchService_basic(ri)
+	postConfig := testAccAzureRMSearchService_updated(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_search_service.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_search_service.test", "replica_count", "1"),
+					testCheckAzureRMSearchServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replica_count", "1"),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSearchServiceExists("azurerm_search_service.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_search_service.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_search_service.test", "replica_count", "2"),
+					testCheckAzureRMSearchServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replica_count", "2"),
 				),
 			},
 		},
@@ -81,10 +78,10 @@ func testCheckAzureRMSearchServiceExists(name string) resource.TestCheckFunc {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetSearchService: %s", err)
+			return fmt.Errorf("Bad: GetSearchService: %+v", err)
 		}
 		if !readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: GetSearchService: %s", readResponse.Error)
+			return fmt.Errorf("Bad: GetSearchService: %+v", readResponse.Error)
 		}
 
 		return nil
@@ -104,26 +101,28 @@ func testCheckAzureRMSearchServiceDestroy(s *terraform.State) error {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetSearchService: %s", err)
+			return fmt.Errorf("Bad: GetSearchService: %+v", err)
 		}
 
 		if readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: Search Service still exists: %s", readResponse.Error)
+			return fmt.Errorf("Bad: Search Service still exists: %+v", readResponse.Error)
 		}
 	}
 
 	return nil
 }
 
-var testAccAzureRMSearchService_basic = `
+func testAccAzureRMSearchService_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
     location = "West US"
 }
+
 resource "azurerm_search_service" "test" {
     name = "acctestsearchservice%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     sku = "standard"
 
     tags {
@@ -131,9 +130,12 @@ resource "azurerm_search_service" "test" {
     	database = "test"
     }
 }
-`
+`, rInt, rInt)
+}
 
-var testAccAzureRMSearchService_updated = `
+
+func testAccAzureRMSearchService_updated(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
     location = "West US"
@@ -141,7 +143,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_search_service" "test" {
     name = "acctestsearchservice%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     sku = "standard"
     replica_count = 2
 
@@ -149,4 +151,5 @@ resource "azurerm_search_service" "test" {
     	environment = "production"
     }
 }
-`
+`, rInt, rInt)
+}

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -133,7 +133,6 @@ resource "azurerm_search_service" "test" {
 `, rInt, rInt)
 }
 
-
 func testAccAzureRMSearchService_updated(rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_search_service" "test" {
   name                = "acceptanceTestSearchService1"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   sku                 = "standard"
 
   tags {
@@ -54,3 +54,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Search Service ID.
+
+## Import
+
+Search Services can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_search_service.service1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Search/searchServices/service1
+```


### PR DESCRIPTION
Adding Import support to `azurerm_search_service`

Tests pass: 

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMSearchService
=== RUN   TestAccAzureRMSearchService_importBasic
--- PASS: TestAccAzureRMSearchService_importBasic (88.71s)
=== RUN   TestAccAzureRMSearchService_basic
--- PASS: TestAccAzureRMSearchService_basic (310.06s)
=== RUN   TestAccAzureRMSearchService_updateReplicaCountAndTags

--- PASS: TestAccAzureRMSearchService_updateReplicaCountAndTags (1997.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2396.616s
```