### PR TITLE
Support for the Windows_Client Hybrid Use Benefit

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -76,10 +76,14 @@ func resourceArmVirtualMachine() *schema.Resource {
 			},
 
 			"license_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validateLicenseType,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Windows_Client",
+					"Windows_Server",
+				}, true),
 			},
 
 			"vm_size": {
@@ -491,15 +495,6 @@ func resourceArmVirtualMachine() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 	}
-}
-
-func validateLicenseType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "" && value != "Windows_Server" {
-		errors = append(errors, fmt.Errorf(
-			"[ERROR] license_type must be 'Windows_Server' or empty"))
-	}
-	return
 }
 
 func resourceArmVirtualMachineCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Whilst verifying the Request for VM's - I noticed that it's also possible to specify a `licenceType` of `Windows_Client`. The valid options are available on [this page](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/virtualmachines-create-or-update#request) and [explained here](https://docs.microsoft.com/en-gb/azure/virtual-machines/windows/hybrid-use-benefit-licensing#deploy-a-vm-via-resource-manager-template)