### PR TITLE
`azurerm_virtual_machine` - fixes a crash caused by an empty `os_profile_windows_config` block

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -368,10 +368,12 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"provision_vm_agent": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"enable_automatic_upgrades": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"winrm": {
 							Type:     schema.TypeList,
@@ -892,13 +894,17 @@ func resourceArmVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int
 
 func resourceArmVirtualMachineStorageOsProfileWindowsConfigHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	if m["provision_vm_agent"] != nil {
-		buf.WriteString(fmt.Sprintf("%t-", m["provision_vm_agent"].(bool)))
+
+	if v != nil {
+		m := v.(map[string]interface{})
+		if m["provision_vm_agent"] != nil {
+			buf.WriteString(fmt.Sprintf("%t-", m["provision_vm_agent"].(bool)))
+		}
+		if m["enable_automatic_upgrades"] != nil {
+			buf.WriteString(fmt.Sprintf("%t-", m["enable_automatic_upgrades"].(bool)))
+		}
 	}
-	if m["enable_automatic_upgrades"] != nil {
-		buf.WriteString(fmt.Sprintf("%t-", m["enable_automatic_upgrades"].(bool)))
-	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -209,6 +209,22 @@ func TestAccAzureRMVirtualMachine_dataDiskTypeConflict(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_bugAzureRM33(t *testing.T) {
+	ri := acctest.RandInt()
+	rs := acctest.RandString(7)
+	config := testAccAzureRMVirtualMachine_bugAzureRM33(ri, rs, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
 func testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_explicit(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -929,6 +945,76 @@ resource "azurerm_virtual_machine" "test" {
     }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachine_bugAzureRM33(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm%s"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_F1"
+
+    storage_image_reference {
+      publisher = "MicrosoftWindowsServer"
+      offer     = "WindowsServer"
+      sku       = "2012-Datacenter"
+      version   = "latest"
+    }
+
+    storage_os_disk {
+      name              = "myosdisk1"
+      caching           = "ReadWrite"
+      create_option     = "FromImage"
+      managed_disk_type = "Standard_LRS"
+    }
+
+    os_profile {
+	computer_name = "acctvm%s"
+	admin_username = "testadmin"
+	admin_password = "Password1234!"
+    }
+
+    os_profile_windows_config {}
+
+    tags {
+    	environment = "Production"
+    	cost-center = "Ops"
+    }
+}
+`, rInt, location, rInt, rInt, rInt, rString, rString)
 }
 
 func testCheckAzureRMVirtualMachineManagedDiskExists(managedDiskID *string, shouldExist bool) resource.TestCheckFunc {


### PR DESCRIPTION
Running the (newly-added) test `TestAccAzureRMVirtualMachine_bugAzureRM33` prior to this commit fails:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 458 [running]:
github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmVirtualMachineStorageOsProfileWindowsConfigHash(0x0, 0x0, 0xc420405338)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine.go:895 +0x3b9
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).hash(0xc420405320, 0x0, 0x0, 0x18b0160, 0xc4201cd350)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:180 +0x3d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).add(0xc420405320, 0x0, 0x0, 0xc4201f2500, 0x0, 0xc4204055e0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/set.go:167 +0x81
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).readSet(0xc42047ab10, 0xc4203dea30, 0x1, 0x1, 0xc4201f25a0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:289 +0x3b0
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).readField(0xc42047ab10, 0xc4203dea30, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:115 +0x93c
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).ReadField(0xc42047ab10, 0xc4203dea30, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x20, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:27 +0xe3
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*MultiLevelFieldReader).ReadFieldExact(0xc4204049c0, 0xc4203dea30, 0x1, 0x1, 0x19961ce, 0x6, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_multi.go:31 +0xef
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).get(0xc420128000, 0xc4203dea30, 0x1, 0x1, 0xc4203dea12, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:475 +0x13a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).getChange(0xc420128000, 0x19a3f97, 0x19, 0x1881201, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:451 +0x135
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).diffChange(0xc420128000, 0x19a3f97, 0x19, 0x1994a76, 0x1, 0x0, 0x0, 0x81)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:428 +0x61
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.schemaMap.diffSet(0xc4201cd440, 0x19a3f97, 0x19, 0xc4201f25a0, 0xc42045b338, 0xc420128000, 0xc420128000, 0x0, 0x0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/schema.go:929 +0x5d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.schemaMap.diff(0xc4201cd440, 0x19a3f97, 0x19, 0xc4201f25a0, 0xc420404860, 0xc420128000, 0xc42045b400, 0x0, 0x0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/schema.go:691 +0x4b1
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.schemaMap.Diff(0xc4201cd440, 0xc4204d0280, 0xc420220150, 0x0, 0x0, 0xc4204a7040)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/schema.go:389 +0x1c2
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Diff(0xc4201c9c80, 0xc4204d0280, 0xc420220150, 0x17, 0xc4200f59e8, 0x1)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:211 +0x15b
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Diff(0xc4201bc1c0, 0xc4203e8a00, 0xc4204d0280, 0xc420220150, 0xed11c039e, 0xc42032f200, 0x27)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:255 +0x84
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalDiff).Eval(0xc4203e8af0, 0x1e47f40, 0xc42009a000, 0x2, 0x2, 0x1995624, 0x4)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_diff.go:108 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x1e3b820, 0xc4203e8af0, 0x1e47f40, 0xc42009a000, 0x1922da0, 0x0, 0x0, 0x0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc42040e180, 0x1e47f40, 0xc42009a000, 0x2, 0x2, 0x1995624, 0x4)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0xc1
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x1e3bde0, 0xc42040e180, 0x1e47f40, 0xc42009a000, 0x18a12c0, 0xc42038e5bc, 0x1886960, 0xc42038e5e0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.Eval(0x1e3bde0, 0xc42040e180, 0x1e47f40, 0xc42009a000, 0xc42040e180, 0x1e3bde0, 0xc42040e180, 0x4d)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x19565a0, 0xc42047e988, 0x0, 0x0)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc4200a7110, 0x19565a0, 0xc42047e988, 0xc420236740)
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x392
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/Users/tharvey/code/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x9ca
exit status 2
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1.959s
```

This now passes when running against this commit:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMVirtualMachine_bugAzureRM33
=== RUN   TestAccAzureRMVirtualMachine_bugAzureRM33
--- PASS: TestAccAzureRMVirtualMachine_bugAzureRM33 (1114.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1114.937s
```

Fixes #33 - where an empty `os_profile_windows_config` block would cause a crash.