### PR TITLE
Force recreation if storage_data_disk.creation_option changes (#218)

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -245,6 +245,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"create_option": {
 							Type:             schema.TypeString,
 							Required:         true,
+							ForceNew:         true,
 							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -225,6 +225,33 @@ func TestAccAzureRMVirtualMachine_bugAzureRM33(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_changeStorageDataDiskCreationOption(t *testing.T) {
+	var afterCreate, afterUpdate compute.VirtualMachine
+	ri := acctest.RandInt()
+	preConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_empty(ri, testLocation())
+	postConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_attach(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &afterCreate),
+				),
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &afterUpdate),
+					testAccCheckVirtualMachineRecreated(t, &afterCreate, &afterUpdate),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_explicit(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -450,6 +477,90 @@ resource "azurerm_virtual_machine" "test" {
 
     os_profile_linux_config {
 	disable_password_authentication = false
+    }
+
+    tags {
+    	environment = "Production"
+    	cost-center = "Ops"
+    }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_empty(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_D1_v2"
+
+    delete_os_disk_on_termination = true
+    delete_data_disks_on_termination = true
+
+    storage_image_reference {
+        publisher = "Canonical"
+        offer = "UbuntuServer"
+        sku = "14.04.2-LTS"
+        version = "latest"
+    }
+
+    storage_os_disk {
+        name = "osd-%d"
+        caching = "ReadWrite"
+        create_option = "FromImage"
+        disk_size_gb = "50"
+        managed_disk_type = "Standard_LRS"
+    }
+
+    storage_data_disk {
+        name = "acctmd-%d"
+        create_option = "Empty"
+        disk_size_gb = "1"
+        managed_disk_type = "Standard_LRS"
+        lun = 0
+    }
+
+    os_profile {
+        computer_name = "hn%d"
+        admin_username = "testadmin"
+        admin_password = "Password1234!"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = false
     }
 
     tags {

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -490,82 +490,82 @@ resource "azurerm_virtual_machine" "test" {
 func testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_empty(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "%s"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%d"
-    address_space = ["10.0.0.0/16"]
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_network_interface" "test" {
-    name = "acctni-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfiguration1"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-    }
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
 }
 
 resource "azurerm_virtual_machine" "test" {
-    name = "acctvm-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    network_interface_ids = ["${azurerm_network_interface.test.id}"]
-    vm_size = "Standard_D1_v2"
+  name                  = "acctvm-%d"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.test.id}"]
+  vm_size               = "Standard_D1_v2"
 
-    delete_os_disk_on_termination = true
+  delete_os_disk_on_termination = true
 
-    storage_image_reference {
-        publisher = "Canonical"
-        offer = "UbuntuServer"
-        sku = "14.04.2-LTS"
-        version = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name = "osd-%d"
-        caching = "ReadWrite"
-        create_option = "FromImage"
-        disk_size_gb = "50"
-        managed_disk_type = "Standard_LRS"
-    }
+  storage_os_disk {
+    name              = "osd-%d"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    disk_size_gb      = "50"
+    managed_disk_type = "Standard_LRS"
+  }
 
-    storage_data_disk {
-        name = "acctmd-%d"
-        create_option = "Empty"
-        disk_size_gb = "1"
-        managed_disk_type = "Standard_LRS"
-        lun = 0
-    }
+  storage_data_disk {
+    name              = "acctmd-%d"
+    create_option     = "Empty"
+    disk_size_gb      = "1"
+    managed_disk_type = "Standard_LRS"
+    lun               = 0
+  }
 
-    os_profile {
-        computer_name = "hn%d"
-        admin_username = "testadmin"
-        admin_password = "Password1234!"
-    }
+  os_profile {
+    computer_name  = "hn%d"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
 
-    os_profile_linux_config {
-        disable_password_authentication = false
-    }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-    tags {
-    	environment = "Production"
-    	cost-center = "Ops"
-    }
+  tags {
+    environment = "Production"
+    cost-center = "Ops"
+  }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -227,9 +227,11 @@ func TestAccAzureRMVirtualMachine_bugAzureRM33(t *testing.T) {
 
 func TestAccAzureRMVirtualMachine_changeStorageDataDiskCreationOption(t *testing.T) {
 	var afterCreate, afterUpdate compute.VirtualMachine
+	resourceName := "azurerm_virtual_machine.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_empty(ri, testLocation())
-	postConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_attach(ri, testLocation())
+	location := testLocation()
+	preConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_empty(ri, location)
+	postConfig := testAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_attach(ri, location)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -238,14 +240,16 @@ func TestAccAzureRMVirtualMachine_changeStorageDataDiskCreationOption(t *testing
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &afterCreate),
+					testCheckAzureRMVirtualMachineExists(resourceName, &afterCreate),
+					resource.TestCheckResourceAttr(resourceName, "storage_data_disk.0.create_option", "Empty"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &afterUpdate),
+					testCheckAzureRMVirtualMachineExists(resourceName, &afterUpdate),
 					testAccCheckVirtualMachineRecreated(t, &afterCreate, &afterUpdate),
+					resource.TestCheckResourceAttr(resourceName, "storage_data_disk.0.create_option", "Attach"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -528,7 +528,6 @@ resource "azurerm_virtual_machine" "test" {
     vm_size = "Standard_D1_v2"
 
     delete_os_disk_on_termination = true
-    delete_data_disks_on_termination = true
 
     storage_image_reference {
         publisher = "Canonical"


### PR DESCRIPTION
Re-opening #218 

Rebased and added a commit to the end of #218 which apparently closed the original PR - re-opening this here

Original issue body from #218:

----

I'm not sure how to test this change, please provide any feedback to help me with it.

Azure Resource Manager API doesn't support changes to this field. It
should recreate the virtual machine and attach the disks again.

### Actual Behaviour:

module.xpto.azurerm_virtual_machine.prometheus_virtual_machine:
Modifying... (ID: /subscriptions/xxxxx...ute/virtualMachines/vm)
  delete_data_disks_on_termination:  "" => "false"
  delete_os_disk_on_termination:     "" => "true"
  storage_data_disk.0.create_option: "Empty" => "Attach"
  storage_data_disk.1.create_option: "Empty" => "Attach"
  tags.%:                            "0" => "1"
  tags.role:                         "" => "xpto"
Error applying plan:

1 error(s) occurred:

* module.xpto.azurerm_virtual_machine.vm: 1 error(s) occurred:

* azurerm_virtual_machine.prometheus_virtual_machine:
compute.VirtualMachinesClient#CreateOrUpdate: Failure responding to
request: StatusCode=409 -- Original Error: autorest/azure: Service
returned an error. Status=409 Code="PropertyChangeNotAllowed"
Message="Changing property 'dataDisk.createOption' is not allowed."