### PR TITLE
`azurerm_network_interface` - support for multiple IP Configurations / setting the primary

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -531,6 +531,21 @@ func expandAzureRmNetworkInterfaceIpConfigurations(d *schema.ResourceData) ([]ne
 		ipConfigs = append(ipConfigs, ipConfig)
 	}
 
+	// if we've got multiple IP Configurations - one must be designated Primary
+	if len(ipConfigs) > 1 {
+		hasPrimary := false
+		for _, config := range ipConfigs {
+			if config.Primary != nil && *config.Primary {
+				hasPrimary = true
+				break
+			}
+		}
+
+		if !hasPrimary {
+			return nil, nil, nil, fmt.Errorf("If multiple `ip_configurations` are specified - one must be designated as `primary`.")
+		}
+	}
+
 	return ipConfigs, &subnetNamesToLock, &virtualNetworkNamesToLock, nil
 }
 

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -38,7 +38,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 			"network_security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"mac_address": {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -499,7 +499,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
+  name                = "acctestvn-%d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -513,7 +513,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                 = "acceptanceTestNetworkInterface1"
+  name                 = "acctestni-%d"
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   enable_ip_forwarding = true
@@ -524,7 +524,7 @@ resource "azurerm_network_interface" "test" {
     private_ip_address_allocation = "dynamic"
   }
 }
-`, rInt, location)
+`, rInt, location, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_withTags(rInt int, location string) string {
@@ -535,7 +535,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
+  name                = "acctestvn-%d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -549,7 +549,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                = "acceptanceTestNetworkInterface1"
+  name                = "acctestni-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -564,7 +564,7 @@ resource "azurerm_network_interface" "test" {
     cost_center = "MSFT"
   }
 }
-`, rInt, location)
+`, rInt, location, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_withTagsUpdate(rInt int, location string) string {
@@ -575,7 +575,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
+  name                = "acctestvn-%d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -589,7 +589,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                = "acceptanceTestNetworkInterface1"
+  name                = "acctestni-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -603,7 +603,7 @@ resource "azurerm_network_interface" "test" {
     environment = "staging"
   }
 }
-`, rInt, location)
+`, rInt, location, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_multipleLoadBalancers(rInt int, location string) string {
@@ -614,7 +614,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
+  name                = "acctestvn-%d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -628,14 +628,14 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "testext" {
-  name                         = "testpublicipext"
+  name                         = "acctestpip1-%d"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "testext" {
-  name                = "testlbext"
+  name                = "acctestlb-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -664,14 +664,14 @@ resource "azurerm_lb_nat_rule" "testext" {
 }
 
 resource "azurerm_public_ip" "testint" {
-  name                         = "testpublicipint"
+  name                         = "acctestpip2-%d"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "testint" {
-  name                = "testlbint"
+  name                = "acctestlb-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -700,8 +700,8 @@ resource "azurerm_lb_nat_rule" "testint" {
   frontend_ip_configuration_name = "publicipint"
 }
 
-resource "azurerm_network_interface" "test1" {
-  name                 = "acceptanceTestNetworkInterface1"
+resource "azurerm_network_interface" "test" {
+  name                 = "acctestni-%d"
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   enable_ip_forwarding = true
@@ -719,7 +719,7 @@ resource "azurerm_network_interface" "test1" {
 }
 
 resource "azurerm_network_interface" "test2" {
-  name                 = "acceptanceTestNetworkInterface2"
+  name                 = "acctestnic2-%d"
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   enable_ip_forwarding = true
@@ -735,7 +735,7 @@ resource "azurerm_network_interface" "test2" {
     ]
   }
 }
-`, rInt, location)
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_bug7986(rInt int, location string) string {
@@ -850,7 +850,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
+  name                = "acctestvn-%d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -883,5 +883,5 @@ resource "azurerm_network_interface" "test" {
   }
 }
 
-`, rInt, location, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -98,7 +98,7 @@ func TestAccAzureRMNetworkInterface_removeNetworkSecurityGroupId(t *testing.T) {
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetworkInterfaceExists(resourceName),
-					resource.TestCheckNoResourceAttr(resourceName, "network_security_group_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_security_group_id", ""),
 				),
 			},
 		},

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -92,7 +92,6 @@ func TestAccAzureRMNetworkInterface_removeNetworkSecurityGroupId(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetworkInterfaceExists(resourceName),
-
 				),
 			},
 			{

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -627,7 +627,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "testext" {
-  name                         = "acctestpip1-%d"
+  name                         = "acctestpip-%d"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "static"
@@ -663,14 +663,14 @@ resource "azurerm_lb_nat_rule" "testext" {
 }
 
 resource "azurerm_public_ip" "testint" {
-  name                         = "acctestpip2-%d"
+  name                         = "testpublicipint"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "testint" {
-  name                = "acctestlb-%d"
+  name                = "testlbint"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -699,8 +699,8 @@ resource "azurerm_lb_nat_rule" "testint" {
   frontend_ip_configuration_name = "publicipint"
 }
 
-resource "azurerm_network_interface" "test" {
-  name                 = "acctestni-%d"
+resource "azurerm_network_interface" "test1" {
+  name                 = "acctestnic1-%d"
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   enable_ip_forwarding = true
@@ -734,7 +734,7 @@ resource "azurerm_network_interface" "test2" {
     ]
   }
 }
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_bug7986(rInt int, location string) string {

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -92,6 +92,8 @@ The `ip_configuration` block supports:
 
 * `load_balancer_inbound_nat_rules_ids` - (Optional) List of Load Balancer Inbound Nat Rules IDs involving this NIC
 
+* `primary` - (Optional) Is this the Primary Network Interface? If set to `true` this should be the first `ip_configuration` in the array.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -3,12 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azure_network_interface"
 sidebar_current: "docs-azurerm-resource-network-interface"
 description: |-
-  Manages the Network Interface cards that link the Virtual Machines and Virtual Network.
+  Manages a Network Interface located in a Virtual Network, usually attached to a Virtual Machine.
+
 ---
 
 # azurerm\_network\_interface
 
-Network interface cards are virtual network cards that form the link between virtual machines and the virtual network
+Manages a Network Interface located in a Virtual Network, usually attached to a Virtual Machine.
 
 ## Example Usage
 
@@ -71,7 +72,7 @@ The following arguments are supported:
 
 * `dns_servers` - (Optional) List of DNS servers IP addresses to use for this NIC, overrides the VNet-level server list
 
-* `ip_configuration` - (Required) Collection of ipConfigurations associated with this NIC. Each `ip_configuration` block supports fields documented below.
+* `ip_configuration` - (Required) One or more `ip_configuration` associated with this NIC as documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -95,7 +96,7 @@ The `ip_configuration` block supports:
 
 The following attributes are exported:
 
-* `id` - The virtual NetworkConfiguration ID.
+* `id` - The Virtual Network Interface ID.
 * `mac_address` - The media access control (MAC) address of the network interface.
 * `private_ip_address` - The private ip address of the network interface.
 * `virtual_machine_id` - Reference to a VM with which this NIC has been associated.


### PR DESCRIPTION
- [x] Swapping `ip_configuration` from a Set -> List
- [x] Switching over to using constants within the SDK
- [x] Adding support for setting the Primary `ip_configuration`. Migrated across hashicorp/terraform#12277
- [x] Detecting changes in the `network_security_group_id`. Fixes #60 
- [x] Tests covering multiple `ip_configurations`. Fixes #26 & a deadlock issue
- [x] Refactoring the tests to use Dynamic ID's
- [x] Update Documentation
- [x] Confirm no state migration needed between Master -> this branch
