### PR TITLE
[MS] Added default caching value as expected by API - fixing #224

### DIFF
--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -83,7 +83,7 @@ func resourceArmImage() *schema.Resource {
 						"caching": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  compute.None,
+							Default:  string(compute.None),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(compute.None),
 								string(compute.ReadOnly),
@@ -127,7 +127,7 @@ func resourceArmImage() *schema.Resource {
 						"caching": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
+							Default:  string(compute.None),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(compute.None),
 								string(compute.ReadOnly),

--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -83,7 +83,7 @@ func resourceArmImage() *schema.Resource {
 						"caching": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
+							Default:  compute.None,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(compute.None),
 								string(compute.ReadOnly),
@@ -301,7 +301,7 @@ func flattenAzureRmStorageProfileOsDisk(d *schema.ResourceData, storageProfile *
 			result["managed_disk_id"] = *osDisk.ManagedDisk.ID
 		}
 		result["blob_uri"] = *osDisk.BlobURI
-		result["caching"] = osDisk.Caching
+		result["caching"] = string(osDisk.Caching)
 		if osDisk.DiskSizeGB != nil {
 			result["size_gb"] = *osDisk.DiskSizeGB
 		}


### PR DESCRIPTION
The managed disk was recreated on every run if "caching" parameter was missing. This PR should address that (bug documented here https://github.com/terraform-providers/terraform-provider-azurerm/issues/224)