### PR TITLE
CosmosDB: fixing the validation on the name field

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -398,7 +398,7 @@ func resourceAzureRMCosmosDBAccountFailoverPolicyHash(v interface{}) int {
 func validateAzureRmCosmosDBAccountName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	r, _ := regexp.Compile("^([a-z0-9\\-]+)$")
+	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
 	if !r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("CosmosDB Account Name can only contain lower-case characters, numbers and the `-` character."))
 	}

--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -398,7 +398,7 @@ func resourceAzureRMCosmosDBAccountFailoverPolicyHash(v interface{}) int {
 func validateAzureRmCosmosDBAccountName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	r, _ := regexp.Compile("[a-z0-9-]")
+	r, _ := regexp.Compile("^([a-z0-9\\-]+)$")
 	if !r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("CosmosDB Account Name can only contain lower-case characters, numbers and the `-` character."))
 	}

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -25,6 +25,14 @@ func TestAccAzureRMCosmosDBAccountName_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    "cosmosDBAccount1",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hello-world",
+			ErrCount: 0,
+		},
+		{
 			Value:    str,
 			ErrCount: 0,
 		},


### PR DESCRIPTION
Following on from #262 - this fixes the validation to ensure upper-case characters are rejected in the `plan` phase rather than the `apply` phase.