### PR TITLE
Fix panic in `azurerm_virtual_machine_scale_set` resource with `additional_unattend_config` block

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -660,7 +660,7 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 
 	if properties.VirtualMachineProfile.OsProfile.LinuxConfiguration != nil {
 		if err := d.Set("os_profile_linux_config", flattenAzureRmVirtualMachineScaleSetOsProfileLinuxConfig(properties.VirtualMachineProfile.OsProfile.LinuxConfiguration)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set OS Profile Windows config error: %#v", err)
+			return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set OS Profile Linux config error: %#v", err)
 		}
 	}
 

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -177,7 +177,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 							},
 						},
 						"additional_unattend_config": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -1445,7 +1445,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(d *schema.Resourc
 		}
 	}
 	if v := osProfileConfig["additional_unattend_config"]; v != nil {
-		additionalConfig := v.(*schema.Set).List()
+		additionalConfig := v.([]interface{})
 		if len(additionalConfig) > 0 {
 			additionalConfigContent := make([]compute.AdditionalUnattendContent, 0, len(additionalConfig))
 			for _, addConfig := range additionalConfig {

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -776,7 +776,10 @@ func flattenAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(config *compute.
 			c["pass"] = i.PassName
 			c["component"] = i.ComponentName
 			c["setting_name"] = i.SettingName
-			c["content"] = *i.Content
+
+			if i.Content != nil {
+				c["content"] = *i.Content
+			}
 
 			content = append(content, c)
 		}

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -98,6 +98,24 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName(ri, testLocation())
@@ -935,6 +953,90 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name = "acctvmss-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+
+  sku {
+    name = "Standard_D1_v2"
+    tier = "Standard"
+    capacity = 2
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm"
+    admin_username = "myadmin"
+    admin_password = "Passwword1234"
+  }
+
+  os_profile_windows_config {
+	enable_automatic_upgrades = false
+	provision_vm_agent = true
+
+	additional_unattend_config {
+	  pass = "oobeSystem"
+	  component = "Microsoft-Windows-Shell-Setup"
+	  setting_name = "AutoLogon"
+	  content = "<AutoLogon><Username>myadmin</Username><Password><Value>Passwword1234</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount></AutoLogon>"
+	}
+
+	additional_unattend_config {
+      pass = "oobeSystem"
+      component = "Microsoft-Windows-Shell-Setup"
+      setting_name = "FirstLogonCommands"
+      content = "<FirstLogonCommands><SynchronousCommand><CommandLine>shutdown /r /t 0 /c \"initial reboot\"</CommandLine><Description>reboot</Description><Order>1</Order></SynchronousCommand></FirstLogonCommands>"
+    }
+  }
+
+  network_profile {
+    name = "TestNetworkProfile-%d"
+    primary = true
+    ip_configuration {
+      name = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
+  }
+
+  storage_profile_os_disk {
+    name 		  = ""
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_profile_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter-Server-Core"
+    version   = "latest"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName(rInt int, location string) string {


### PR DESCRIPTION
This pull request fixes a nil pointer dereference panic in the `azurerm_virtual_machine_scale_set` resource. The panic occurs when at least one `additional_unattend_config` block is defined in the `os_profile_windows_config` block. A similar issue has been fixed for the `azurerm_virtual_machine` resource in [terraform #7453](https://github.com/hashicorp/terraform/pull/7453).

### Affected Resource(s)

- `azurerm_virtual_machine_scale_set`

### Panic Output

```
panic: runtime error: invalid memory address or nil pointer dereference
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a2f473]
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm:
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: goroutine 1163 [running]:
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/azurerm.flattenAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(0xc4203310b0, 0x1c6f5a8, 0x12, 0x1ad6bc0)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine_scale_set.go:779 +0x3f3
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmVirtualMachineScaleSetRead(0xc420183ab0, 0x1b983e0, 0xc4203e2500, 0xc420509fc0, 0x0)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine_scale_set.go:656 +0x1c92
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmVirtualMachineScaleSetCreate(0xc420183ab0, 0x1b983e0, 0xc4203e2500, 0x24, 0x2315c00)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine_scale_set.go:603 +0x98b
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc4205d3440, 0xc420394640, 0xc42051afe0, 0x1b983e0, 0xc4203e2500, 0x1, 0x28, 0xc42035bf20)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:193 +0x449
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc420254f50, 0xc4203945f0, 0xc420394640, 0xc42051afe0, 0x261e4b0, 0x0, 0xc420129c80)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:259 +0x9b
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Apply(0xc4205091a0, 0xc42051af80, 0xc420451e80, 0x0, 0x0)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/Users/lekse/Projects/terraform/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:488 +0x57
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: reflect.Value.call(0xc4202d03c0, 0xc420121588, 0x13, 0x1c5febb, 0x4, 0xc420683f20, 0x3, 0x3, 0x0, 0xc4200396f8, ...)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8.3/libexec/src/reflect/value.go:434 +0x91f
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: reflect.Value.Call(0xc4202d03c0, 0xc420121588, 0x13, 0xc420039720, 0x3, 0x3, 0xc4200397c0, 0x13f5fbe, 0xc420884720)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8.3/libexec/src/reflect/value.go:302 +0xa4
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: net/rpc.(*service).call(0xc4209ff980, 0xc4209ff940, 0xc4206ac540, 0xc420122880, 0xc4204aa460, 0x1abf900, 0xc42051af80, 0x16, 0x1abf940, 0xc420451e80, ...)
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8.3/libexec/src/net/rpc/server.go:387 +0x144
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: created by net/rpc.(*Server).ServeCodec
2017-08-23T21:15:20.953+0200 [DEBUG] plugin.terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8.3/libexec/src/net/rpc/server.go:481 +0x404
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalWriteState
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalApplyProvisioners
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalIf
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalWriteState
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalWriteDiff
2017/08/23 21:15:20 [TRACE] root: eval: *terraform.EvalApplyPost
2017/08/23 21:15:20 [ERROR] root: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:

* azurerm_virtual_machine_scale_set.staging_app: unexpected EOF
2017/08/23 21:15:20 [ERROR] root: eval: *terraform.EvalSequence, err: 1 error(s) occurred:

* azurerm_virtual_machine_scale_set.staging_app: unexpected EOF
2017/08/23 21:15:20 [TRACE] [walkApply] Exiting eval tree: azurerm_virtual_machine_scale_set.staging_app
2017/08/23 21:15:20 [TRACE] dag/walk: upstream errored, not walking "provider.azurerm (close)"
2017/08/23 21:15:20 [TRACE] dag/walk: upstream errored, not walking "meta.count-boundary (count boundary fixup)"
2017/08/23 21:15:20 [TRACE] dag/walk: upstream errored, not walking "root"
2017-08-23T21:15:20.958+0200 [DEBUG] plugin: plugin process exited: path=/Users/lekse/Projects/terraform/bin/terraform-provider-azurerm
2017/08/23 21:15:20 [TRACE] Preserving existing state lineage "9cd3087b-7fee-4744-8b6a-4a7ccfbbfca2"
2017/08/23 21:15:20 [TRACE] Preserving existing state lineage "9cd3087b-7fee-4744-8b6a-4a7ccfbbfca2"
2017/08/23 21:15:20 [TRACE] Preserving existing state lineage "9cd3087b-7fee-4744-8b6a-4a7ccfbbfca2"
2017/08/23 21:15:20 [DEBUG] plugin: waiting for all plugin processes to complete...
2017-08-23T21:15:20.989+0200 [WARN ] plugin: error closing client during Kill: err="connection is shut down"
```

### Expected Behavior

- New virtual machine scale set resource is created in Azure
- New virtual machine scale set is stored in Terraform state
- `terraform apply` finishes successfully

### Actual Behavior

- New virtual machine scale set resource is created in Azure
- New virtual machine scale set is *not* stored in Terraform state
- `terraform apply` exits with panic

### Steps to Reproduce

1. Define a `azurerm_virtual_machine_scale_set` resource which contains at least one `additional_unattend_config` block in the `os_profile_windows_config` block
2. `terraform apply`

### Acceptance tests

```
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk (574.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	574.030s
```

### References

- [terraform #7453](https://github.com/hashicorp/terraform/pull/7453) (similar issue has been fixed for the `azurerm_virtual_machine` resource)
- Fixes #220 
- Fixes #219 