### PR TITLE
Adding validation to `azurerm_key_vault`'s name

### DIFF
--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -135,15 +134,13 @@ func testCheckAzureRMKeyVaultDestroy(s *terraform.State) error {
 
 		resp, err := client.Get(resourceGroup, name)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if responseWasNotFound(resp.Response) {
 				return nil
 			}
 			return err
 		}
 
-		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Key Vault still exists:\n%#v", resp.Properties)
-		}
+		return fmt.Errorf("Key Vault still exists:\n%#v", resp.Properties)
 	}
 
 	return nil
@@ -167,11 +164,11 @@ func testCheckAzureRMKeyVaultExists(name string) resource.TestCheckFunc {
 
 		resp, err := client.Get(resourceGroup, vaultName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on keyVaultClient: %+v", err)
-		}
+			if responseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Vault %q (resource group: %q) does not exist", vaultName, resourceGroup)
+			}
 
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Vault %q (resource group: %q) does not exist", vaultName, resourceGroup)
+			return fmt.Errorf("Bad: Get on keyVaultClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -10,6 +10,64 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAzureRMKeyVault_name(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       "hi",
+			ExpectError: true,
+		},
+		{
+			Input:       "hello",
+			ExpectError: false,
+		},
+		{
+			Input:       "hello-world",
+			ExpectError: false,
+		},
+		{
+			Input:       "hello-world-21",
+			ExpectError: false,
+		},
+		{
+			Input:       "hello_world_21",
+			ExpectError: true,
+		},
+		{
+			Input:       "Hello-World",
+			ExpectError: false,
+		},
+		{
+			Input:       "20202020",
+			ExpectError: false,
+		},
+		{
+			Input:       "ABC123!@£",
+			ExpectError: true,
+		},
+		{
+			Input:       "abcdefghijklmnopqrstuvwxyz",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateKeyVaultName(tc.Input, "")
+
+		hasError := len(errors) > 0
+
+		if tc.ExpectError && !hasError {
+			t.Fatalf("Expected the Key Vault Name to trigger a validation error for '%s'", tc.Input)
+		}
+	}
+}
+
 func TestAccAzureRMKeyVault_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMKeyVault_basic(ri, testLocation())


### PR DESCRIPTION
Adding validation to the Name for the `azurerm_key_vault` resource - so that we catch errors at `plan` rather than during `apply`

Fixes #265