### PR TITLE
Fix address issue in `azurerm_virtual_machine_scale_set` when setting the winrm block

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -161,7 +161,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 							Optional: true,
 						},
 						"winrm": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -1420,7 +1420,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(d *schema.Resourc
 	}
 
 	if v := osProfileConfig["winrm"]; v != nil {
-		winRm := v.(*schema.Set).List()
+		winRm := v.([]interface{})
 		if len(winRm) > 0 {
 			winRmListeners := make([]compute.WinRMListener, 0, len(winRm))
 			for _, winRmConfig := range winRm {


### PR DESCRIPTION
This pull request fixes an issue in `azurerm_virtual_machine_scale_set` when setting the winrm block in the os_profile_windows_config block. The same address issue has occurred which have been fixed for `azurerm_virtual_machine` in ddd84eed898c115ad4c57e4900a279b4abed982d.

### Affected Resource(s)

- `azurerm_virtual_machine_scale_set`

### Acceptance tests

```
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows (518.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	518.432s
```

### References

- Commit ddd84eed898c115ad4c57e4900a279b4abed982d fixes this issue for the `azurerm_virtual_machine` resource
- Fixes issue #219 (in combination with pull request #266)