### PR TITLE
Fixing the `Microsoft.Insights` Resource Provider Registration

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -268,7 +268,7 @@ func registerAzureResourceProvidersWithSubscription(providerList []resources.Pro
 			"Microsoft.EventGrid":         struct{}{},
 			"Microsoft.EventHub":          struct{}{},
 			"Microsoft.KeyVault":          struct{}{},
-			"Microsoft.Insights":          struct{}{},
+			"microsoft.insights":          struct{}{},
 			"Microsoft.Network":           struct{}{},
 			"Microsoft.Resources":         struct{}{},
 			"Microsoft.Search":            struct{}{},

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -56,11 +57,17 @@ func testAltLocation() string {
 	return os.Getenv("ARM_TEST_LOCATION_ALT")
 }
 
-func testArmEnvironment() (*azure.Environment, error) {
+func testArmEnvironmentName() string {
 	envName, exists := os.LookupEnv("ARM_ENVIRONMENT")
 	if !exists {
 		envName = "public"
 	}
+
+	return envName
+}
+
+func testArmEnvironment() (*azure.Environment, error) {
+	envName := testArmEnvironmentName()
 
 	// detect cloud from environment
 	env, envErr := azure.EnvironmentFromName(envName)
@@ -74,4 +81,41 @@ func testArmEnvironment() (*azure.Environment, error) {
 	}
 
 	return &env, nil
+}
+
+func TestAzureRMResourceProviderRegistration(t *testing.T) {
+	testAccPreCheck(t)
+
+	environment := testArmEnvironmentName()
+	config := Config{
+		SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
+		ClientID:                 os.Getenv("ARM_CLIENT_ID"),
+		TenantID:                 os.Getenv("ARM_TENANT_ID"),
+		ClientSecret:             os.Getenv("ARM_CLIENT_SECRET"),
+		Environment:              environment,
+		SkipProviderRegistration: false,
+	}
+
+	armClient, err := config.getArmClient()
+	if err != nil {
+		t.Fatalf("Error building ARM Client: %+v", err)
+	}
+
+	client := armClient.providers
+	providerList, err := client.List(nil, "")
+	if err != nil {
+		t.Fatalf("Unable to list provider registration status, it is possible that this is due to invalid "+
+			"credentials or the service principal does not have permission to use the Resource Manager API, Azure "+
+			"error: %s", err)
+	}
+
+	err = registerAzureResourceProvidersWithSubscription(*providerList.Value, client)
+	if err != nil {
+		t.Fatalf("Error registering Resource Providers: %+v", err)
+	}
+
+	needingRegistration := determineAzureResourceProvidersToRegister(*providerList.Value)
+	if len(needingRegistration) > 0 {
+		t.Fatalf("'%d' Resource Providers are still Pending Registration: %s", len(needingRegistration), spew.Sprint(needingRegistration))
+	}
 }

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -83,10 +84,17 @@ func testArmEnvironment() (*azure.Environment, error) {
 	return &env, nil
 }
 
-func TestAzureRMResourceProviderRegistration(t *testing.T) {
-	testAccPreCheck(t)
-
+func TestAccAzureRMResourceProviderRegistration(t *testing.T) {
 	environment := testArmEnvironmentName()
+
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf(
+			"Integration test skipped unless env '%s' set",
+			resource.TestEnvVar))
+		return
+	}
+
+	// we deliberately don't use the main config - since we care about
 	config := Config{
 		SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
 		ClientID:                 os.Getenv("ARM_CLIENT_ID"),


### PR DESCRIPTION
Upon some investigation it appears the Resource Provider API is case-sensitive - this PR fixes the registration for `Microsoft.Insights` to be `microsoft.insights` so we don't re-register every time the plugin's re-initialized

Before:

```
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Cdn
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Compute
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.ContainerRegistry
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.ContainerService
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.DocumentDB
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.EventGrid
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.EventHub
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.KeyVault
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Network
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Search
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.ServiceBus
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Sql
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Storage
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Skipping provider registration for namespace Microsoft.Resources
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] Registering provider with namespace Microsoft.Insights
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:14 [DEBUG] AzureRM Request:
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: POST /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/register?api-version=2016-09-01 HTTP/1.1
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: Host: management.azure.com
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: User-Agent: HashiCorp-Terraform-v0.10.0-dev
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: Content-Length: 0
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm: Accept-Encoding: gzip
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm:
2017/08/29 07:06:14 [DEBUG] plugin: terraform-provider-azurerm:
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_subnet.test", waiting for: "azurerm_virtual_network.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_lb.test", waiting for: "azurerm_public_ip.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_lb_nat_pool.lbnatpool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_resource_group.test", waiting for: "provider.azurerm"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_lb_backend_address_pool.bpepool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_public_ip.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_virtual_machine_scale_set.test", waiting for: "azurerm_lb_nat_pool.lbnatpool"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "azurerm_virtual_network.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:18 [DEBUG] dag/walk: vertex "provider.azurerm (close)", waiting for: "azurerm_virtual_machine_scale_set.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "provider.azurerm (close)", waiting for: "azurerm_virtual_machine_scale_set.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_resource_group.test", waiting for: "provider.azurerm"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_virtual_machine_scale_set.test", waiting for: "azurerm_lb_nat_pool.lbnatpool"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_lb.test", waiting for: "azurerm_public_ip.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_lb_backend_address_pool.bpepool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_virtual_network.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_subnet.test", waiting for: "azurerm_virtual_network.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_lb_nat_pool.lbnatpool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:23 [DEBUG] dag/walk: vertex "azurerm_public_ip.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_lb.test", waiting for: "azurerm_public_ip.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_subnet.test", waiting for: "azurerm_virtual_network.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_lb_backend_address_pool.bpepool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "provider.azurerm (close)", waiting for: "azurerm_virtual_machine_scale_set.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_virtual_machine_scale_set.test", waiting for: "azurerm_lb_nat_pool.lbnatpool"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_lb_nat_pool.lbnatpool", waiting for: "azurerm_lb.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_virtual_network.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_resource_group.test", waiting for: "provider.azurerm"
2017/08/29 07:06:28 [DEBUG] dag/walk: vertex "azurerm_public_ip.test", waiting for: "azurerm_resource_group.test"
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:06:29 [DEBUG] AzureRM Response for https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/register?api-version=2016-09-01:
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: HTTP/1.1 500 Internal Server Error
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Connection: close
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Content-Length: 312
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Cache-Control: no-cache
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Content-Type: application/json; charset=utf-8
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Date: Tue, 29 Aug 2017 06:06:28 GMT
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Expires: -1
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Pragma: no-cache
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: Strict-Transport-Security: max-age=31536000; includeSubDomains
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: X-Ms-Correlation-Request-Id: 03654298-3f5d-4c78-bbf2-e3d8a8c7d23f
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: X-Ms-Failure-Cause: gateway
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: X-Ms-Ratelimit-Remaining-Subscription-Writes: 1199
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: X-Ms-Request-Id: 03654298-3f5d-4c78-bbf2-e3d8a8c7d23f
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: X-Ms-Routing-Request-Id: UKWEST:20170829T060628Z:03654298-3f5d-4c78-bbf2-e3d8a8c7d23f
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm:
2017/08/29 07:06:29 [DEBUG] plugin: terraform-provider-azurerm: {"error":{"code":"InternalServerError","message":"Encountered internal server error. Diagnostic information: timestamp '20170829T060628Z', subscription id 'c0a607b2-6372-4ef3-abdb-dbe52a7b56ba', tracking id '03654298-3f5d-4c78-bbf2-e3d8a8c7d23f', request correlation id '03654298-3f5d-4c78-bbf2-e3d8a8c7d23f'."}}
```

After:
```
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Cache
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Cdn
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Compute
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.ContainerRegistry
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.ContainerService
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.DocumentDB
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.EventGrid
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.EventHub
2017/08/29 07:15:36 [TRACE] [walkRefresh] Exiting eval tree: provider.azurerm
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace microsoft.insights
2017/08/29 07:15:36 [DEBUG] dag/walk: walking "azurerm_resource_group.test"
2017/08/29 07:15:36 [DEBUG] vertex 'root.azurerm_resource_group.test': walking
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.KeyVault
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Network
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Search
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.ServiceBus
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Sql
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Storage
2017/08/29 07:15:36 [DEBUG] plugin: terraform-provider-azurerm: 2017/08/29 07:15:36 [DEBUG] Skipping provider registration for namespace Microsoft.Resources
```