### PR TITLE
`azurerm_cosmos_db_account`: allow setting the Kind to MongoDB/GlobalDocumentDB

### DIFF
--- a/azurerm/import_arm_cosmosdb_account_test.go
+++ b/azurerm/import_arm_cosmosdb_account_test.go
@@ -79,6 +79,30 @@ func TestAccAzureRMCosmosDBAccount_importEventualConsistency(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDBAccount_importMongoDB(t *testing.T) {
+	resourceName := "azurerm_cosmosdb_account.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMCosmosDBAccount_mongoDB(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMCosmosDBAccount_importSession(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMCosmosDBAccountName_validation(t *testing.T) {
 }
 
 func TestAccAzureRMCosmosDBAccount_boundedStaleness(t *testing.T) {
-
+	resourceName := "azurerm_cosmosdb_account.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMCosmosDBAccount_boundedStaleness(ri, testLocation())
 
@@ -64,7 +64,8 @@ func TestAccAzureRMCosmosDBAccount_boundedStaleness(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCosmosDBAccountExists("azurerm_cosmosdb_account.test"),
+					testCheckAzureRMCosmosDBAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "kind", "GlobalDocumentDB"),
 				),
 			},
 		},

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `offer_type` - (Required) Specifies the Offer Type to use for this CosmosDB Account - currently this can only be set to `Standard`.
 
+* `kind` - (Optional) Specifies the Kind of CosmosDB to create - possible values are `GlobalDocumentDB` and `MongoDB`. Defaults to `GlobalDocumentDB`. Changing this forces a new resource to be created.
+
 * `consistency_policy` - (Required) Specifies a `consistency_policy` resource, used to define the consistency policy for this CosmosDB account.
 
 * `failover_policy` - (Required) Specifies a `failover_policy` resource, used to define where data should be replicated.


### PR DESCRIPTION
Allow setting the `kind` field to either `MongoDB` or `GlobalDocumentDB` (which it's defaulted too for existing users)

Fixes #290

New test passes - just running the lot:
```
$ acctests azurerm TestAccAzureRMCosmosDBAccount_mongoDB
=== RUN   TestAccAzureRMCosmosDBAccount_mongoDB
--- PASS: TestAccAzureRMCosmosDBAccount_mongoDB (670.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    670.928s
```