### PR TITLE
`azurerm_cdn_endpoint` - defaulting the `http_port` and `https_port`

### DIFF
--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -81,13 +81,13 @@ func resourceArmCdnEndpoint() *schema.Resource {
 						"http_port": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Computed: true,
+							Default:  80,
 						},
 
 						"https_port": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Computed: true,
+							Default:  443,
 						},
 					},
 				},

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -3,7 +3,8 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_endpoint"
 sidebar_current: "docs-azurerm-resource-cdn-endpoint"
 description: |-
-  Create a CDN Endpoint entity.
+  Manages a CDN Endpoint.
+
 ---
 
 # azurerm\_cdn\_endpoint
@@ -20,15 +21,15 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_cdn_profile" "test" {
   name                = "acceptanceTestCdnProfile1"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Standard"
+  sku                 = "Standard_Verizon"
 }
 
 resource "azurerm_cdn_endpoint" "test" {
   name                = "acceptanceTestCdnEndpoint1"
   profile_name        = "${azurerm_cdn_profile.test.name}"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   origin {
@@ -77,9 +78,9 @@ The `origin` block supports:
 
 * `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address.
 
-* `http_port` - (Optional) The HTTP port of the origin. Defaults to null. When null, 80 will be used for HTTP.
+* `http_port` - (Optional) The HTTP port of the origin. Defaults to `80`.
 
-* `https_port` - (Optional) The HTTPS port of the origin. Defaults to null. When null, 443 will be used for HTTPS.
+* `https_port` - (Optional) The HTTPS port of the origin. Defaults to `443`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
As discovered by @changeworld in #288 - it appears `http_port` and `https_port` should be being defaulted to 80 and 443. From what I can tell this was previously done at the API - but are now mandatory parameters.

Also fixes the original documentation issue discovered in #288 

Tests pass:

```
$ acctests azurerm TestAccAzureRMCdnEndpoint
=== RUN   TestAccAzureRMCdnEndpoint_importWithTags
--- PASS: TestAccAzureRMCdnEndpoint_importWithTags (185.24s)
=== RUN   TestAccAzureRMCdnEndpoint_basic
--- PASS: TestAccAzureRMCdnEndpoint_basic (166.18s)
=== RUN   TestAccAzureRMCdnEndpoint_disappears
--- PASS: TestAccAzureRMCdnEndpoint_disappears (179.67s)
=== RUN   TestAccAzureRMCdnEndpoint_updateHostHeader
--- PASS: TestAccAzureRMCdnEndpoint_updateHostHeader (196.97s)
=== RUN   TestAccAzureRMCdnEndpoint_withTags
--- PASS: TestAccAzureRMCdnEndpoint_withTags (193.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	921.610s
```