### PR TITLE
Add test for mistyped id

### DIFF
--- a/azurerm/import_arm_public_ip_test.go
+++ b/azurerm/import_arm_public_ip_test.go
@@ -1,6 +1,9 @@
 package azurerm
 
 import (
+	"fmt"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -25,6 +28,30 @@ func TestAccAzureRMPublicIpStatic_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMPublicIpStatic_importIdError(t *testing.T) {
+	resourceName := "azurerm_public_ip.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMPublicIPStatic_basic(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/publicIPAdresses/acctestpublicip-%d", os.Getenv("ARM_SUBSCRIPTION_ID"), ri, ri),
+				ExpectError:       regexp.MustCompile("Error parsing supplied resource id."),
 			},
 		},
 	})

--- a/azurerm/resource_arm_public_ip.go
+++ b/azurerm/resource_arm_public_ip.go
@@ -18,7 +18,17 @@ func resourceArmPublicIp() *schema.Resource {
 		Update: resourceArmPublicIpCreate,
 		Delete: resourceArmPublicIpDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				id, err := parseAzureResourceID(d.Id())
+				if err != nil {
+					return nil, err
+				}
+				name := id.Path["publicIPAddresses"]
+				if name == "" {
+					return nil, fmt.Errorf("Error parsing supplied resource id. Please check it and rerun:\n %s", d.Id())
+				}
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This PR fixes #267. If a user passes in a mistyped ID, Terraform will error.

```
make testacc TEST=./azurerm TESTARGS="-run=TestAccAzureRMPublicIpStatic_importIdError"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMPublicIpStatic_importIdError -timeout 120m
=== RUN   TestAccAzureRMPublicIpStatic_importIdError
--- PASS: TestAccAzureRMPublicIpStatic_importIdError (67.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	67.554s
```