### PR TITLE
Improve the provider initialization

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -173,8 +173,6 @@ type Config struct {
 	// Bearer Auth
 	AccessToken  *adal.Token
 	IsCloudShell bool
-
-	validateCredentialsOnce sync.Once
 }
 
 func (c *Config) validateServicePrincipal() error {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -84,6 +84,11 @@ The following arguments are supported:
   * `german`
   * `china`
 
+* `skip_credentials_validation` - (Optional) Prevents the provider from validating
+  the given credentials. When set to `true`, `skip_provider_registration` is assumed.
+  It can also be sourced from the `ARM_SKIP_CREDENTIALS_VALIDATION` environment
+  variable, defaults to `false`.
+
 * `skip_provider_registration` - (Optional) Prevents the provider from registering
   the ARM provider namespaces, this can be used if you don't wish to give the Active
   Directory Application permission to register resource providers. It can also be


### PR DESCRIPTION
The `registerAzureResourceProvidersWithSubscription` function is being called exactly once while executing the `providerConfigure` func.

In turn the `providerConfigure` func is also called exactly once while executing a Terraform command (e.g. plan, apply).

So when executing TF commands from the commandline there is absolutely no added value for using a `sync.Once` as the registration call is only being executed once anyway.

If on the other hand you use the TF packages in a long running microservice process (like we do), having this `sync.Once` actually causes issues when using multiple different (and regularly changing) provider credentials (as only the first used credentials will register the providers).

So since it adds nothing, but does cause issues in specific setups, we refactored the provider to not use the `sync.Once` anymore.

Additionally we added an option to skip the credential validation call. This is nice if you make multiple validation or plan calls in a row from a microservice so you can skip the expensive HTTP call (as you already know the credentials are valid).