### PR TITLE
Add validation to sql server name

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/arm/cosmos-db"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -29,7 +28,7 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAzureRmCosmosDBAccountName,
+				ValidateFunc: validateDBAccountName,
 			},
 
 			"location": {
@@ -409,20 +408,4 @@ func resourceAzureRMCosmosDBAccountFailoverPolicyHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-%d", location, priority))
 
 	return hashcode.String(buf.String())
-}
-
-func validateAzureRmCosmosDBAccountName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
-	if !r.MatchString(value) {
-		errors = append(errors, fmt.Errorf("CosmosDB Account Name can only contain lower-case characters, numbers and the `-` character."))
-	}
-
-	length := len(value)
-	if length > 50 || 3 > length {
-		errors = append(errors, fmt.Errorf("CosmosDB Account Name can only be between 3 and 50 seconds."))
-	}
-
-	return
 }

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -60,47 +60,6 @@ func testSweepCosmosDBAccount(region string) error {
 	return nil
 }
 
-func TestAccAzureRMCosmosDBAccountName_validation(t *testing.T) {
-	str := acctest.RandString(50)
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "ab",
-			ErrCount: 1,
-		},
-		{
-			Value:    "abc",
-			ErrCount: 0,
-		},
-		{
-			Value:    "cosmosDBAccount1",
-			ErrCount: 1,
-		},
-		{
-			Value:    "hello-world",
-			ErrCount: 0,
-		},
-		{
-			Value:    str,
-			ErrCount: 0,
-		},
-		{
-			Value:    str + "a",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAzureRmCosmosDBAccountName(tc.Value, "azurerm_cosmosdb_account")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AzureRM CosmosDB Name to trigger a validation error for '%s'", tc.Value)
-		}
-	}
-}
-
 func TestAccAzureRMCosmosDBAccount_boundedStaleness(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 	ri := acctest.RandInt()

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -170,19 +170,3 @@ func resourceArmSqlServerDelete(d *schema.ResourceData, meta interface{}) error 
 
 	return nil
 }
-
-func validateAzureRmSQLDBAccountName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
-	if !r.MatchString(value) {
-		errors = append(errors, fmt.Errorf("SQLDB Account Name can only contain lower-case characters, numbers and the `-` character."))
-	}
-
-	length := len(value)
-	if length > 50 || 3 > length {
-		errors = append(errors, fmt.Errorf("SQLDB Account Name can only be between 3 and 50 seconds."))
-	}
-
-	return
-}

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/arm/sql"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -22,9 +23,10 @@ func resourceArmSqlServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureRmSQLDBAccountName,
 			},
 
 			"location": locationSchema(),
@@ -167,4 +169,20 @@ func resourceArmSqlServerDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	return nil
+}
+
+func validateAzureRmSQLDBAccountName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
+	if !r.MatchString(value) {
+		errors = append(errors, fmt.Errorf("SQLDB Account Name can only contain lower-case characters, numbers and the `-` character."))
+	}
+
+	length := len(value)
+	if length > 50 || 3 > length {
+		errors = append(errors, fmt.Errorf("SQLDB Account Name can only be between 3 and 50 seconds."))
+	}
+
+	return
 }

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/arm/sql"
 	"github.com/hashicorp/terraform/helper/schema"

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -26,7 +26,7 @@ func resourceArmSqlServer() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAzureRmSQLDBAccountName,
+				ValidateFunc: validateDBAccountName,
 			},
 
 			"location": locationSchema(),

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -70,23 +69,6 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMSqlServer_upperCaseName(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccAzureRMSqlServer_upperCaseName(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlServerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      config,
-				ExpectError: regexp.MustCompile("SQLDB Account Name can only contain lower-case characters"),
 			},
 		},
 	})

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -69,6 +70,23 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSqlServer_upperCaseName(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMSqlServer_upperCaseName(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("SQLDB Account Name can only contain lower-case characters"),
 			},
 		},
 	})
@@ -216,6 +234,24 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMSqlServer_upperCaseName(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG_%d"
+    location = "%s"
+}
+
+resource "azurerm_sql_server" "test" {
+    name = "AccTestSQLserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     location = "${azurerm_resource_group.test.location}"
     version = "12.0"

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -225,24 +225,6 @@ resource "azurerm_sql_server" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMSqlServer_upperCaseName(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "%s"
-}
-
-resource "azurerm_sql_server" "test" {
-    name = "AccTestSQLserver%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "${azurerm_resource_group.test.location}"
-    version = "12.0"
-    administrator_login = "mradministrator"
-    administrator_login_password = "thisIsDog11"
-}
-`, rInt, location, rInt)
-}
-
 func testAccAzureRMSqlServer_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/azurerm/validators.go
+++ b/azurerm/validators.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
@@ -44,5 +45,21 @@ func validateUUID(v interface{}, k string) (ws []string, errors []error) {
 	if _, err := uuid.FromString(v.(string)); err != nil {
 		errors = append(errors, fmt.Errorf("%q is an invalid UUUID: %s", k, err))
 	}
+	return
+}
+
+func validateDBAccountName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
+	if !r.MatchString(value) {
+		errors = append(errors, fmt.Errorf("Account Name can only contain lower-case characters, numbers and the `-` character."))
+	}
+
+	length := len(value)
+	if length > 50 || 3 > length {
+		errors = append(errors, fmt.Errorf("Account Name can only be between 3 and 50 seconds."))
+	}
+
 	return
 }

--- a/azurerm/validators_test.go
+++ b/azurerm/validators_test.go
@@ -1,6 +1,10 @@
 package azurerm
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+)
 
 func TestValidateRFC3339Date(t *testing.T) {
 	cases := []struct {
@@ -84,4 +88,51 @@ func TestValidateIntInSlice(t *testing.T) {
 		}
 	}
 
+}
+
+func TestDBAccountName_validation(t *testing.T) {
+	str := acctest.RandString(50)
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "ab",
+			ErrCount: 1,
+		},
+		{
+			Value:    "abc",
+			ErrCount: 0,
+		},
+		{
+			Value:    "cosmosDBAccount1",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hello-world",
+			ErrCount: 0,
+		},
+		{
+			Value:    str,
+			ErrCount: 0,
+		},
+		{
+			Value:    str + "a",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDBAccountName(tc.Value, "azurerm_cosmosdb_account")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AzureRM CosmosDB Name to trigger a validation error for '%s'", tc.Value)
+		}
+
+		_, errors = validateDBAccountName(tc.Value, "azurerm_sql_server")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AzureRM SQL Server Name to trigger a validation error for '%s'", tc.Value)
+		}
+	}
 }

--- a/azurerm/validators_test.go
+++ b/azurerm/validators_test.go
@@ -128,11 +128,5 @@ func TestDBAccountName_validation(t *testing.T) {
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AzureRM CosmosDB Name to trigger a validation error for '%s'", tc.Value)
 		}
-
-		_, errors = validateDBAccountName(tc.Value, "azurerm_sql_server")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AzureRM SQL Server Name to trigger a validation error for '%s'", tc.Value)
-		}
 	}
 }


### PR DESCRIPTION
This PR adds validation to sql server name. From #314 

```
make testacc TEST=./azurerm TESTARGS="-run=TestAccAzureRMSqlServer_upperCaseName"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMSqlServer_upperCaseName -timeout 120m
=== RUN   TestAccAzureRMSqlServer_upperCaseName
--- PASS: TestAccAzureRMSqlServer_upperCaseName (0.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	0.034s
```