### PR TITLE
`azurerm_app_service_plan` - support for Linux App Services

### DIFF
--- a/azurerm/import_arm_app_service_plan_test.go
+++ b/azurerm/import_arm_app_service_plan_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAzureRMAppServicePlan_importBasic(t *testing.T) {
+func TestAccAzureRMAppServicePlan_importBasicWindows(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_basic(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_basicWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,11 +30,11 @@ func TestAccAzureRMAppServicePlan_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_importStandard(t *testing.T) {
+func TestAccAzureRMAppServicePlan_importWindowsStandard(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_standard(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_standardWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,11 +53,11 @@ func TestAccAzureRMAppServicePlan_importStandard(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_importPremium(t *testing.T) {
+func TestAccAzureRMAppServicePlan_importPremiumWindows(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_premium(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_premiumWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -76,11 +76,11 @@ func TestAccAzureRMAppServicePlan_importPremium(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_importComplete(t *testing.T) {
+func TestAccAzureRMAppServicePlan_importCompleteWindows(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_complete(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_completeWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/web"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -33,6 +34,18 @@ func resourceArmAppServicePlan() *schema.Resource {
 			},
 
 			"location": locationSchema(),
+
+			"kind": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Windows",
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Linux",
+					"Windows",
+				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+			},
 
 			"sku": {
 				Type:     schema.TypeList,
@@ -96,6 +109,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	resGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
+	kind := d.Get("kind").(string)
 	tags := d.Get("tags").(map[string]interface{})
 
 	sku := expandAzureRmAppServicePlanSku(d)
@@ -104,6 +118,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	appServicePlan := web.AppServicePlan{
 		Location:                 &location,
 		AppServicePlanProperties: properties,
+		Kind: &kind,
 		Tags: expandTags(tags),
 		Sku:  &sku,
 	}
@@ -153,6 +168,7 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	d.Set("kind", resp.Kind)
 
 	if props := resp.AppServicePlanProperties; props != nil {
 		d.Set("properties", flattenAppServiceProperties(props))

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAppServicePlan_basic(t *testing.T) {
+func TestAccAzureRMAppServicePlan_basicWindows(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_basic(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_basicWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,9 +29,9 @@ func TestAccAzureRMAppServicePlan_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_standard(t *testing.T) {
+func TestAccAzureRMAppServicePlan_basicLinux(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_standard(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_basicLinux(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -48,9 +48,9 @@ func TestAccAzureRMAppServicePlan_standard(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_premium(t *testing.T) {
+func TestAccAzureRMAppServicePlan_standardWindows(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_premium(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_standardWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,12 +67,31 @@ func TestAccAzureRMAppServicePlan_premium(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_premiumUpdated(t *testing.T) {
+func TestAccAzureRMAppServicePlan_premiumWindows(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServicePlan_premiumWindows(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServicePlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServicePlanExists("azurerm_app_service_plan.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServicePlan_premiumWindowsUpdated(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 	ri := acctest.RandInt()
 	location := testLocation()
-	config := testAccAzureRMAppServicePlan_premium(ri, location)
-	updatedConfig := testAccAzureRMAppServicePlan_premiumUpdated(ri, location)
+	config := testAccAzureRMAppServicePlan_premiumWindows(ri, location)
+	updatedConfig := testAccAzureRMAppServicePlan_premiumWindowsUpdated(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,10 +116,10 @@ func TestAccAzureRMAppServicePlan_premiumUpdated(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServicePlan_complete(t *testing.T) {
+func TestAccAzureRMAppServicePlan_completeWindows(t *testing.T) {
 	resourceName := "azurerm_app_service_plan.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppServicePlan_complete(ri, testLocation())
+	config := testAccAzureRMAppServicePlan_completeWindows(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -175,7 +194,7 @@ func testCheckAzureRMAppServicePlanExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAzureRMAppServicePlan_basic(rInt int, location string) string {
+func testAccAzureRMAppServicePlan_basicWindows(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -195,7 +214,28 @@ resource "azurerm_app_service_plan" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMAppServicePlan_standard(rInt int, location string) string {
+func testAccAzureRMAppServicePlan_basicLinux(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMAppServicePlan_standardWindows(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -215,7 +255,7 @@ resource "azurerm_app_service_plan" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMAppServicePlan_premium(rInt int, location string) string {
+func testAccAzureRMAppServicePlan_premiumWindows(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -235,7 +275,7 @@ resource "azurerm_app_service_plan" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMAppServicePlan_premiumUpdated(rInt int, location string) string {
+func testAccAzureRMAppServicePlan_premiumWindowsUpdated(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -256,7 +296,7 @@ resource "azurerm_app_service_plan" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMAppServicePlan_complete(rInt int, location string) string {
+func testAccAzureRMAppServicePlan_completeWindows(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -267,6 +307,7 @@ resource "azurerm_app_service_plan" "test" {
   name                = "acctestASP-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Windows"
 
   sku {
     tier = "Standard"

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` and `Linux`. Changing this forces a new resource to be created.
+* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` and `Linux`. Defaults to `Windows`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as documented below.
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` and `Linux`. Changing this forces a new resource to be created.
+
 * `sku` - (Required) A `sku` block as documented below.
 
 * `properties` - (Optional) A `properties` block as documented below.


### PR DESCRIPTION
Adding support for selecting the Operating System for App Service Plans - to allow Linux App Services to be created