### PR TITLE
New Resource: `azurerm_app_service`

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -629,15 +629,6 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	sqlepc.Sender = sender
 	client.sqlElasticPoolsClient = sqlepc
 
-<<<<<<< HEAD
-=======
-	ac := web.NewAppsClientWithBaseURI(endpoint, c.SubscriptionID)
-	setUserAgent(&ac.Client)
-	ac.Authorizer = auth
-	ac.Sender = autorest.CreateSender(withRequestLogging())
-	client.appsClient = ac
-
->>>>>>> setting tags
 	sqlsrv := sql.NewServersClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&sqlsrv.Client)
 	sqlsrv.Authorizer = auth
@@ -650,6 +641,12 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	aspc.Sender = sender
 	client.appServicePlansClient = aspc
 
+	ac := web.NewAppsClientWithBaseURI(endpoint, c.SubscriptionID)
+	setUserAgent(&ac.Client)
+	ac.Authorizer = auth
+	ac.Sender = autorest.CreateSender(withRequestLogging())
+	client.appsClient = ac
+
 	ai := appinsights.NewComponentsClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&ai.Client)
 	ai.Authorizer = auth
@@ -661,12 +658,6 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	spc.Authorizer = graphAuth
 	spc.Sender = sender
 	client.servicePrincipalsClient = spc
-
-	ac := web.NewAppsClientWithBaseURI(endpoint, c.SubscriptionID)
-	setUserAgent(&ac.Client)
-	ac.Authorizer = auth
-	ac.Sender = sender
-	client.appsClient = ac
 
 	kvc := keyvault.NewVaultsClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&kvc.Client)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -133,7 +133,7 @@ type ArmClient struct {
 	sqlServersClient       sql.ServersClient
 
 	appServicePlansClient web.AppServicePlansClient
-	appsClient            web.AppsClient
+	appServicesClient     web.AppsClient
 
 	appInsightsClient appinsights.ComponentsClient
 
@@ -645,7 +645,7 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	setUserAgent(&ac.Client)
 	ac.Authorizer = auth
 	ac.Sender = autorest.CreateSender(withRequestLogging())
-	client.appsClient = ac
+	client.appServicesClient = ac
 
 	ai := appinsights.NewComponentsClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&ai.Client)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -133,12 +133,11 @@ type ArmClient struct {
 	sqlServersClient       sql.ServersClient
 
 	appServicePlansClient web.AppServicePlansClient
+	appsClient web.AppsClient
 
 	appInsightsClient appinsights.ComponentsClient
 
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
-
-	appsClient web.AppsClient
 }
 
 func withRequestLogging() autorest.SendDecorator {
@@ -630,6 +629,15 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	sqlepc.Sender = sender
 	client.sqlElasticPoolsClient = sqlepc
 
+<<<<<<< HEAD
+=======
+	ac := web.NewAppsClientWithBaseURI(endpoint, c.SubscriptionID)
+	setUserAgent(&ac.Client)
+	ac.Authorizer = auth
+	ac.Sender = autorest.CreateSender(withRequestLogging())
+	client.appsClient = ac
+
+>>>>>>> setting tags
 	sqlsrv := sql.NewServersClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&sqlsrv.Client)
 	sqlsrv.Authorizer = auth

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -133,7 +133,7 @@ type ArmClient struct {
 	sqlServersClient       sql.ServersClient
 
 	appServicePlansClient web.AppServicePlansClient
-	appsClient web.AppsClient
+	appsClient            web.AppsClient
 
 	appInsightsClient appinsights.ComponentsClient
 

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -1,0 +1,32 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMAppService_importBasic(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_basic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -1,5 +1,6 @@
 package azurerm
 
+/*
 import (
 	"testing"
 
@@ -31,53 +32,4 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 		},
 	})
 }
-
-func TestAccAzureRMAppService_importComplete(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_complete(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: config,
-			},
-
-			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_importCompleteAlwaysOn(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_completeAlwaysOn(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: config,
-			},
-
-			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
-			},
-		},
-	})
-}
+*/

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -23,9 +23,9 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
 			},
 		},

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -23,9 +23,9 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
 			},
 		},

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -23,9 +23,10 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
 			},
 		},
 	})

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -26,7 +26,32 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
+				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importComplete(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_complete(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
 			},
 		},
 	})

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -56,3 +56,28 @@ func TestAccAzureRMAppService_importComplete(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMAppService_importCompleteAlwaysOn(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_completeAlwaysOn(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
+			},
+		},
+	})
+}

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_basic(ri)
+	config := testAccAzureRMAppService_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -1,6 +1,5 @@
 package azurerm
 
-/*
 import (
 	"testing"
 
@@ -19,17 +18,451 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAppServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration", "delete_metrics"},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
-*/
+
+func TestAccAzureRMAppService_import32Bit(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_32Bit(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importAlwaysOn(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_alwaysOn(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importAppSettings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_appSettings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importClientAffinityEnabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_clientAffinityEnabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importConnectionStrings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_connectionStrings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importDefaultDocuments(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_defaultDocuments(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importEnabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_enabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importLocalMySql(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_localMySql(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importManagedPipelineMode(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_managedPipelineMode(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importRemoteDebugging(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_remoteDebugging(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsDotNet2(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v2.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsDotNet4(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v4.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsJava7Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsJava8Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsJava7Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsJava8Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsPHP7(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsPHP(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWindowsPython(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsPython(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_importWebSockets(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_webSockets(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azurerm_application_insights":        resourceArmApplicationInsights(),
+			"azurerm_app_service": resourceArmAppService(),
 			"azurerm_app_service_plan":            resourceArmAppServicePlan(),
 			"azurerm_availability_set":            resourceArmAvailabilitySet(),
 			"azurerm_cdn_endpoint":                resourceArmCdnEndpoint(),

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -71,7 +71,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azurerm_application_insights":        resourceArmApplicationInsights(),
-			"azurerm_app_service": resourceArmAppService(),
+			"azurerm_app_service":                 resourceArmAppService(),
 			"azurerm_app_service_plan":            resourceArmAppServicePlan(),
 			"azurerm_availability_set":            resourceArmAvailabilitySet(),
 			"azurerm_cdn_endpoint":                resourceArmCdnEndpoint(),

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -137,11 +137,14 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on AzureRM App Service %s: %+v", name, err)
 	}
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -191,13 +191,6 @@ func resourceArmAppService() *schema.Resource {
 				ForceNew: true, // due to a bug in the Azure API :(
 			},
 
-			"reserved": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true, // due to a bug in the Azure API :(
-			},
-
 			"app_settings": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -273,11 +266,6 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOk("client_affinity_enabled"); ok {
 		enabled := v.(bool)
 		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
-	}
-
-	if v, ok := d.GetOk("reserved"); ok {
-		reserved := v.(bool)
-		siteEnvelope.SiteProperties.Reserved = utils.Bool(reserved)
 	}
 
 	// NOTE: these seem like sensible defaults, in lieu of any better documentation.
@@ -418,7 +406,6 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
-		d.Set("reserved", props.Reserved)
 	}
 
 	d.Set("app_settings", appSettingsResp.Properties)

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -1,0 +1,165 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/arm/web"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmAppService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceCreateUpdate,
+		Read:   resourceArmAppServiceRead,
+		Update: resourceArmAppServiceCreateUpdate,
+		Delete: resourceArmAppServiceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"skip_dns_registration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"skip_custom_domain_verification": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"force_dns_registration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"ttl_in_seconds": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"app_service_plan_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"always_on": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"location": locationSchema(),
+			"tags":     tagsSchema(),
+		},
+	}
+}
+
+func resourceArmAppServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	appClient := client.appsClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM Web App creation.")
+
+	resGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+	location := d.Get("location").(string)
+	skipDNSRegistration := d.Get("skip_dns_registration").(bool)
+	skipCustomDomainVerification := d.Get("skip_custom_domain_verification").(bool)
+	forceDNSRegistration := d.Get("force_dns_registration").(bool)
+	ttlInSeconds := d.Get("ttl_in_seconds").(string)
+	tags := d.Get("tags").(map[string]interface{})
+
+	siteConfig := web.SiteConfig{}
+	if v, ok := d.GetOk("always_on"); ok {
+		alwaysOn := v.(bool)
+		siteConfig.AlwaysOn = &alwaysOn
+	}
+
+	siteProps := web.SiteProperties{
+		SiteConfig: &siteConfig,
+	}
+	if v, ok := d.GetOk("app_service_plan_id"); ok {
+		serverFarmID := v.(string)
+		siteProps.ServerFarmID = &serverFarmID
+	}
+
+	siteEnvelope := web.Site{
+		Location:       &location,
+		Tags:           expandTags(tags),
+		SiteProperties: &siteProps,
+	}
+
+	_, error := appClient.CreateOrUpdate(resGroup, name, siteEnvelope, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds, make(chan struct{}))
+	err := <-error
+	if err != nil {
+		return err
+	}
+
+	read, err := appClient.Get(resGroup, name)
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read App Service %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmAppServiceRead(d, meta)
+}
+
+func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
+	appClient := meta.(*ArmClient).appsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Reading App Service details %s", id)
+
+	resGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	resp, err := appClient.Get(resGroup, name)
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %s: %s", name, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+
+	return nil
+}
+
+func resourceArmAppServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	appClient := meta.(*ArmClient).appsClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	log.Printf("[DEBUG] Deleting App Service %s: %s", resGroup, name)
+
+	deleteMetrics := true
+	deleteEmptyServerFarm := true
+	skipDNSRegistration := true
+
+	_, err = appClient.Delete(resGroup, name, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
+
+	return err
+}

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -54,6 +54,7 @@ func resourceArmAppService() *schema.Resource {
 			"site_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -65,7 +66,7 @@ func resourceArmAppService() *schema.Resource {
 						"always_on": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 					},
 				},
@@ -151,9 +152,9 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
-	// if siteProps := resp.SiteProperties; siteProps != nil {
-	// 	d.Set("site_config", flattenAzureRmAppServiceSiteProps(siteProps))
-	// }
+	if siteProps := resp.SiteProperties; siteProps != nil {
+		d.Set("site_config", flattenAzureRmAppServiceSiteProps(siteProps))
+	}
 
 	flattenAndSetTags(d, resp.Tags)
 
@@ -208,8 +209,12 @@ func flattenAzureRmAppServiceSiteProps(siteProps *web.SiteProperties) []interfac
 		site_config["app_service_plan_id"] = *siteProps.ServerFarmID
 	}
 
-	if siteProps.SiteConfig.AlwaysOn != nil {
-		site_config["app_service_plan_id"] = *siteProps.ServerFarmID
+	siteConfig := siteProps.SiteConfig
+	log.Printf("[DEBUG] SiteConfig is %s", siteConfig)
+	if siteConfig != nil {
+		if siteConfig.AlwaysOn != nil {
+			site_config["always_on"] = *siteConfig.AlwaysOn
+		}
 	}
 
 	result = append(result, site_config)

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -51,7 +51,7 @@ func resourceArmAppService() *schema.Resource {
 						"always_on": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
+							Default:  false,
 						},
 
 						"default_documents": {
@@ -75,7 +75,6 @@ func resourceArmAppService() *schema.Resource {
 						"java_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"1.7",
 								"1.8",
@@ -85,7 +84,6 @@ func resourceArmAppService() *schema.Resource {
 						"java_container": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"JETTY",
 								"TOMCAT",
@@ -96,7 +94,6 @@ func resourceArmAppService() *schema.Resource {
 						"java_container_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 
 						"linux_app_framework_version": {
@@ -143,7 +140,6 @@ func resourceArmAppService() *schema.Resource {
 						"php_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"5.5",
 								"5.6",
@@ -155,7 +151,6 @@ func resourceArmAppService() *schema.Resource {
 						"python_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"2.7",
 								"3.4",
@@ -546,6 +541,14 @@ func flattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.JavaVersion != nil {
 		result["java_version"] = *input.JavaVersion
+	}
+
+	if input.JavaContainer != nil {
+		result["java_container"] = *input.JavaContainer
+	}
+
+	if input.JavaContainerVersion != nil {
+		result["java_container_version"] = *input.JavaContainerVersion
 	}
 
 	if input.LinuxFxVersion != nil {

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -15,6 +15,9 @@ func resourceArmAppService() *schema.Resource {
 		Read:   resourceArmAppServiceRead,
 		Update: resourceArmAppServiceCreateUpdate,
 		Delete: resourceArmAppServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"resource_group_name": {

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -3,54 +3,44 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"net/http"
-	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/arm/web"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmAppService() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmAppServiceCreateUpdate,
+		Create: resourceArmAppServiceCreate,
 		Read:   resourceArmAppServiceRead,
-		Update: resourceArmAppServiceCreateUpdate,
+		Update: resourceArmAppServiceUpdate,
 		Delete: resourceArmAppServiceDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"skip_dns_registration": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
-			"skip_custom_domain_verification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+
+			"location": locationSchema(),
+
+			"app_service_plan_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
-			"force_dns_registration": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"ttl_in_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
+
 			"site_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -58,12 +48,127 @@ func resourceArmAppService() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"app_service_plan_id": {
+						"always_on": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"default_documents": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"dotnet_framework_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
+							Default:  "v4.0",
+							ValidateFunc: validation.StringInSlice([]string{
+								"v2.0",
+								"v4.0",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
-						"always_on": {
+
+						"java_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"1.7",
+								"1.8",
+							}, false),
+						},
+
+						"java_container": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"JETTY",
+								"TOMCAT",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"java_container_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"linux_app_framework_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							// TODO: should this be ForceNew?
+							ValidateFunc: validation.StringInSlice([]string{
+								"dotnetcore|1.0",
+								"dotnetcore|1.1",
+								"node|4.4",
+								"node|4.5",
+								"node|6.2",
+								"node|6.6",
+								"node|6.9",
+								"node|6.10",
+								"node|6.11",
+								"node|8.0",
+								"node|8.1",
+								"php|5.6",
+								"php|7.0",
+								"ruby|2.3",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"local_mysql_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"managed_pipeline_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.Classic),
+								string(web.Integrated),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"php_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"5.5",
+								"5.6",
+								"7.0",
+								"7.1",
+							}, false),
+						},
+
+						"python_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"2.7",
+								"3.4",
+							}, false),
+						},
+
+						"use_32_bit_worker_process": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"websockets_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
@@ -71,49 +176,140 @@ func resourceArmAppService() *schema.Resource {
 					},
 				},
 			},
-			"location": locationSchema(),
-			"tags":     tagsSchema(),
-			"delete_metrics": {
+
+			"client_affinity_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true, // due to a bug in the Azure API :(
+			},
+
+			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true, // due to a bug in the Azure API :(
 			},
+
+			"reserved": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true, // due to a bug in the Azure API :(
+			},
+
+			"app_settings": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
+
+			"connection_string": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.APIHub),
+								string(web.Custom),
+								string(web.DocDb),
+								string(web.EventHub),
+								string(web.MySQL),
+								string(web.NotificationHub),
+								string(web.PostgreSQL),
+								string(web.RedisCache),
+								string(web.ServiceBus),
+								string(web.SQLAzure),
+								string(web.SQLServer),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+					},
+				},
+			},
+
+			"tags": tagsForceNewSchema(), // due to a bug in the Azure API :(
 		},
 	}
 }
 
-func resourceArmAppServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	appClient := meta.(*ArmClient).appsClient
+func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
 
-	log.Printf("[INFO] preparing arguments for Azure ARM App Service creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM App Service creation.")
 
-	resGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
-	skipDNSRegistration := d.Get("skip_dns_registration").(bool)
-	skipCustomDomainVerification := d.Get("skip_custom_domain_verification").(bool)
-	forceDNSRegistration := d.Get("force_dns_registration").(bool)
-	ttlInSeconds := 0
-	if v, ok := d.GetOk("ttl_in_seconds"); ok {
-		ttlInSeconds = v.(int)
-	}
+	resGroup := d.Get("resource_group_name").(string)
 	location := d.Get("location").(string)
+	appServicePlanId := d.Get("app_service_plan_id").(string)
+	enabled := d.Get("enabled").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
-	siteProps := expandAzureRmAppServiceSiteProps(d)
+	siteConfig := expandAppServiceSiteConfig(d)
+	appSettings := expandAppServiceAppSettings(d)
 
 	siteEnvelope := web.Site{
-		Location:       &location,
-		Tags:           expandTags(tags),
-		SiteProperties: siteProps,
+		Location: &location,
+		Tags:     expandTags(tags),
+		SiteProperties: &web.SiteProperties{
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			SiteConfig:   &siteConfig,
+		},
 	}
 
-	_, error := appClient.CreateOrUpdate(resGroup, name, siteEnvelope, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, strconv.Itoa(ttlInSeconds), make(chan struct{}))
-	err := <-error
+	if v, ok := d.GetOk("client_affinity_enabled"); ok {
+		enabled := v.(bool)
+		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
+	}
+
+	if v, ok := d.GetOk("reserved"); ok {
+		reserved := v.(bool)
+		siteEnvelope.SiteProperties.Reserved = utils.Bool(reserved)
+	}
+
+	// NOTE: these seem like sensible defaults, in lieu of any better documentation.
+	skipDNSRegistration := false
+	forceDNSRegistration := false
+	skipCustomDomainVerification := true
+	ttlInSeconds := "60"
+	_, createErr := client.CreateOrUpdate(resGroup, name, siteEnvelope, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds, make(chan struct{}))
+	err := <-createErr
 	if err != nil {
 		return err
 	}
 
-	read, err := appClient.Get(resGroup, name)
+	settings := web.StringDictionary{
+		Properties: appSettings,
+	}
+	_, err = client.UpdateApplicationSettings(resGroup, name, settings)
+	if err != nil {
+		return fmt.Errorf("Error updating Application Settings for App Service %q: %+v", name, err)
+	}
+
+	connectionStrings := expandAppServiceConnectionStrings(d)
+	properties := web.ConnectionStringDictionary{
+		Properties: connectionStrings,
+	}
+
+	_, err = client.UpdateConnectionStrings(resGroup, name, properties)
+	if err != nil {
+		return fmt.Errorf("Error updating Connection Strings for App Service %q: %+v", name, err)
+	}
+
+	read, err := client.Get(resGroup, name)
 	if err != nil {
 		return err
 	}
@@ -126,34 +322,111 @@ func resourceArmAppServiceCreateUpdate(d *schema.ResourceData, meta interface{})
 	return resourceArmAppServiceRead(d, meta)
 }
 
-func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
-	appClient := meta.(*ArmClient).appsClient
+func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Reading App Service details %s", id)
+	resGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	if d.HasChange("site_config") {
+		// update the main configuration
+		siteConfig := expandAppServiceSiteConfig(d)
+		siteConfigResource := web.SiteConfigResource{
+			SiteConfig: &siteConfig,
+		}
+		_, err := client.CreateOrUpdateConfiguration(resGroup, name, siteConfigResource)
+		if err != nil {
+			return fmt.Errorf("Error updating Configuration for App Service %q: %+v", name, err)
+		}
+	}
+
+	if d.HasChange("app_settings") {
+		// update the AppSettings
+		appSettings := expandAppServiceAppSettings(d)
+		settings := web.StringDictionary{
+			Properties: appSettings,
+		}
+
+		_, err := client.UpdateApplicationSettings(resGroup, name, settings)
+		if err != nil {
+			return fmt.Errorf("Error updating Application Settings for App Service %q: %+v", name, err)
+		}
+	}
+
+	if d.HasChange("connection_string") {
+		// update the ConnectionStrings
+		connectionStrings := expandAppServiceConnectionStrings(d)
+		properties := web.ConnectionStringDictionary{
+			Properties: connectionStrings,
+		}
+
+		_, err := client.UpdateConnectionStrings(resGroup, name, properties)
+		if err != nil {
+			return fmt.Errorf("Error updating Connection Strings for App Service %q: %+v", name, err)
+		}
+	}
+
+	return resourceArmAppServiceRead(d, meta)
+}
+
+func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	resGroup := id.ResourceGroup
 	name := id.Path["sites"]
 
-	resp, err := appClient.Get(resGroup, name)
+	resp, err := client.Get(resGroup, name)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if utils.ResponseWasNotFound(resp.Response) {
+			// TODO: debug logging
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service %s: %+v", name, err)
 	}
 
+	configResp, err := client.GetConfiguration(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Configuration %s: %+v", name, err)
+	}
+
+	appSettingsResp, err := client.ListApplicationSettings(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service AppSettings %s: %+v", name, err)
+	}
+
+	connectionStringsResp, err := client.ListConnectionStrings(resGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service ConnectionStrings %s: %+v", name, err)
+	}
+
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
-	if siteProps := resp.SiteProperties; siteProps != nil {
-		d.Set("site_config", flattenAzureRmAppServiceSiteProps(siteProps))
+	if props := resp.SiteProperties; props != nil {
+		d.Set("app_service_plan_id", props.ServerFarmID)
+		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
+		d.Set("enabled", props.Enabled)
+		d.Set("reserved", props.Reserved)
+	}
+
+	d.Set("app_settings", appSettingsResp.Properties)
+	d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties))
+
+	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
+	if err := d.Set("site_config", siteConfig); err != nil {
+		return err
 	}
 
 	flattenAndSetTags(d, resp.Tags)
@@ -162,7 +435,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmAppServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	appClient := meta.(*ArmClient).appsClient
+	client := meta.(*ArmClient).appServicesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -171,53 +444,194 @@ func resourceArmAppServiceDelete(d *schema.ResourceData, meta interface{}) error
 	resGroup := id.ResourceGroup
 	name := id.Path["sites"]
 
-	log.Printf("[DEBUG] Deleting App Service %s: %s", resGroup, name)
+	log.Printf("[DEBUG] Deleting App Service %q (resource group %q)", name, resGroup)
 
-	deleteMetrics := d.Get("delete_metrics").(bool)
-	deleteEmptyServerFarm := true
-	skipDNSRegistration := d.Get("skip_dns_registration").(bool)
-
-	_, err = appClient.Delete(resGroup, name, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
-
-	return err
-}
-
-func expandAzureRmAppServiceSiteProps(d *schema.ResourceData) *web.SiteProperties {
-	configs := d.Get("site_config").([]interface{})
-	siteProps := web.SiteProperties{}
-	if len(configs) == 0 {
-		return &siteProps
-	}
-	config := configs[0].(map[string]interface{})
-
-	siteConfig := web.SiteConfig{}
-	alwaysOn := config["always_on"].(bool)
-	siteConfig.AlwaysOn = utils.Bool(alwaysOn)
-
-	siteProps.SiteConfig = &siteConfig
-
-	serverFarmID := config["app_service_plan_id"].(string)
-	siteProps.ServerFarmID = &serverFarmID
-
-	return &siteProps
-}
-
-func flattenAzureRmAppServiceSiteProps(siteProps *web.SiteProperties) []interface{} {
-	result := make([]interface{}, 0, 1)
-	site_config := make(map[string]interface{}, 0)
-
-	if siteProps.ServerFarmID != nil {
-		site_config["app_service_plan_id"] = *siteProps.ServerFarmID
-	}
-
-	siteConfig := siteProps.SiteConfig
-	log.Printf("[DEBUG] SiteConfig is %s", siteConfig)
-	if siteConfig != nil {
-		if siteConfig.AlwaysOn != nil {
-			site_config["always_on"] = *siteConfig.AlwaysOn
+	deleteMetrics := true
+	deleteEmptyServerFarm := false
+	skipDNSRegistration := true
+	resp, err := client.Delete(resGroup, name, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return err
 		}
 	}
 
-	result = append(result, site_config)
-	return result
+	return nil
+}
+
+func expandAppServiceSiteConfig(d *schema.ResourceData) web.SiteConfig {
+	configs := d.Get("site_config").([]interface{})
+	siteConfig := web.SiteConfig{}
+
+	if len(configs) == 0 {
+		return siteConfig
+	}
+
+	config := configs[0].(map[string]interface{})
+
+	if v, ok := config["always_on"]; ok {
+		siteConfig.AlwaysOn = utils.Bool(v.(bool))
+	}
+
+	if v, ok := config["default_documents"]; ok {
+		input := v.([]interface{})
+
+		documents := make([]string, 0)
+		for _, document := range input {
+			documents = append(documents, document.(string))
+		}
+
+		siteConfig.DefaultDocuments = &documents
+	}
+
+	if v, ok := config["dotnet_framework_version"]; ok {
+		siteConfig.NetFrameworkVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["java_version"]; ok {
+		siteConfig.JavaVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["java_container"]; ok {
+		siteConfig.JavaContainer = utils.String(v.(string))
+	}
+
+	if v, ok := config["java_container_version"]; ok {
+		siteConfig.JavaContainerVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["linux_app_framework_version"]; ok {
+		siteConfig.LinuxFxVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["local_mysql_enabled"]; ok {
+		siteConfig.LocalMySQLEnabled = utils.Bool(v.(bool))
+	}
+
+	if v, ok := config["managed_pipeline_mode"]; ok {
+		siteConfig.ManagedPipelineMode = web.ManagedPipelineMode(v.(string))
+	}
+
+	if v, ok := config["php_version"]; ok {
+		siteConfig.PhpVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["python_version"]; ok {
+		siteConfig.PythonVersion = utils.String(v.(string))
+	}
+
+	if v, ok := config["use_32_bit_worker_process"]; ok {
+		siteConfig.Use32BitWorkerProcess = utils.Bool(v.(bool))
+	}
+
+	if v, ok := config["websockets_enabled"]; ok {
+		siteConfig.WebSocketsEnabled = utils.Bool(v.(bool))
+	}
+
+	return siteConfig
+}
+
+func flattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
+	results := make([]interface{}, 0)
+	result := make(map[string]interface{}, 0)
+
+	if input == nil {
+		log.Printf("[DEBUG] SiteConfig is nil")
+		return results
+	}
+
+	if input.AlwaysOn != nil {
+		result["always_on"] = *input.AlwaysOn
+	}
+
+	if input.DefaultDocuments != nil {
+		documents := make([]string, 0)
+		for _, document := range *input.DefaultDocuments {
+			documents = append(documents, document)
+		}
+
+		result["default_documents"] = documents
+	}
+
+	if input.NetFrameworkVersion != nil {
+		result["dotnet_framework_version"] = *input.NetFrameworkVersion
+	}
+
+	if input.JavaVersion != nil {
+		result["java_version"] = *input.JavaVersion
+	}
+
+	if input.LinuxFxVersion != nil {
+		result["linux_app_framework_version"] = *input.LinuxFxVersion
+	}
+
+	if input.LocalMySQLEnabled != nil {
+		result["local_mysql_enabled"] = *input.LocalMySQLEnabled
+	}
+
+	result["managed_pipeline_mode"] = string(input.ManagedPipelineMode)
+
+	if input.PhpVersion != nil {
+		result["php_version"] = *input.PhpVersion
+	}
+
+	if input.PythonVersion != nil {
+		result["python_version"] = *input.PythonVersion
+	}
+
+	if input.Use32BitWorkerProcess != nil {
+		result["use_32_bit_worker_process"] = *input.Use32BitWorkerProcess
+	}
+
+	if input.WebSocketsEnabled != nil {
+		result["websockets_enabled"] = *input.WebSocketsEnabled
+	}
+
+	results = append(results, result)
+	return results
+}
+
+func expandAppServiceAppSettings(d *schema.ResourceData) *map[string]*string {
+	input := d.Get("app_settings").(map[string]interface{})
+	output := make(map[string]*string, len(input))
+
+	for k, v := range input {
+		output[k] = utils.String(v.(string))
+	}
+
+	return &output
+}
+
+func expandAppServiceConnectionStrings(d *schema.ResourceData) *map[string]*web.ConnStringValueTypePair {
+	input := d.Get("connection_string").([]interface{})
+	output := make(map[string]*web.ConnStringValueTypePair, len(input))
+
+	for _, v := range input {
+		vals := v.(map[string]interface{})
+
+		csName := vals["name"].(string)
+		csType := vals["type"].(string)
+		csValue := vals["value"].(string)
+
+		output[csName] = &web.ConnStringValueTypePair{
+			Value: utils.String(csValue),
+			Type:  web.ConnectionStringType(csType),
+		}
+	}
+
+	return &output
+}
+
+func flattenAppServiceConnectionStrings(input *map[string]*web.ConnStringValueTypePair) interface{} {
+	results := make([]interface{}, 0)
+
+	for k, v := range *input {
+		result := make(map[string]interface{}, 0)
+		result["name"] = k
+		result["type"] = string(v.Type)
+		result["value"] = v.Value
+		results = append(results, result)
+	}
+
+	return results
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -240,7 +240,6 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := expandAppServiceSiteConfig(d)
-	appSettings := expandAppServiceAppSettings(d)
 
 	siteEnvelope := web.Site{
 		Location: &location,
@@ -266,24 +265,6 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	err := <-createErr
 	if err != nil {
 		return err
-	}
-
-	settings := web.StringDictionary{
-		Properties: appSettings,
-	}
-	_, err = client.UpdateApplicationSettings(resGroup, name, settings)
-	if err != nil {
-		return fmt.Errorf("Error updating Application Settings for App Service %q: %+v", name, err)
-	}
-
-	connectionStrings := expandAppServiceConnectionStrings(d)
-	properties := web.ConnectionStringDictionary{
-		Properties: connectionStrings,
-	}
-
-	_, err = client.UpdateConnectionStrings(resGroup, name, properties)
-	if err != nil {
-		return fmt.Errorf("Error updating Connection Strings for App Service %q: %+v", name, err)
 	}
 
 	read, err := client.Get(resGroup, name)
@@ -365,7 +346,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := client.Get(resGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			// TODO: debug logging
+			log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -95,30 +95,6 @@ func resourceArmAppService() *schema.Resource {
 							Optional: true,
 						},
 
-						"linux_app_framework_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							// TODO: should this be ForceNew?
-							ValidateFunc: validation.StringInSlice([]string{
-								"dotnetcore|1.0",
-								"dotnetcore|1.1",
-								"node|4.4",
-								"node|4.5",
-								"node|6.2",
-								"node|6.6",
-								"node|6.9",
-								"node|6.10",
-								"node|6.11",
-								"node|8.0",
-								"node|8.1",
-								"php|5.6",
-								"php|7.0",
-								"ruby|2.3",
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
-
 						"local_mysql_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -500,10 +476,6 @@ func expandAppServiceSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.JavaContainerVersion = utils.String(v.(string))
 	}
 
-	if v, ok := config["linux_app_framework_version"]; ok {
-		siteConfig.LinuxFxVersion = utils.String(v.(string))
-	}
-
 	if v, ok := config["local_mysql_enabled"]; ok {
 		siteConfig.LocalMySQLEnabled = utils.Bool(v.(bool))
 	}
@@ -575,10 +547,6 @@ func flattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.JavaContainerVersion != nil {
 		result["java_container_version"] = *input.JavaContainerVersion
-	}
-
-	if input.LinuxFxVersion != nil {
-		result["linux_app_framework_version"] = *input.LinuxFxVersion
 	}
 
 	if input.LocalMySQLEnabled != nil {

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -397,8 +397,12 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enabled", props.Enabled)
 	}
 
-	d.Set("app_settings", appSettingsResp.Properties)
-	d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties))
+	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
+		return err
+	}
+	if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
+		return err
+	}
 
 	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
 	if err := d.Set("site_config", siteConfig); err != nil {
@@ -621,9 +625,18 @@ func flattenAppServiceConnectionStrings(input *map[string]*web.ConnStringValueTy
 		result := make(map[string]interface{}, 0)
 		result["name"] = k
 		result["type"] = string(v.Type)
-		result["value"] = v.Value
+		result["value"] = *v.Value
 		results = append(results, result)
 	}
 
 	return results
+}
+
+func flattenAppServiceAppSettings(input *map[string]*string) map[string]string {
+	output := make(map[string]string, 0)
+	for k, v := range *input {
+		output[k] = *v
+	}
+
+	return output
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -170,14 +170,20 @@ func resourceArmAppService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-				ForceNew: true, // due to a bug in the Azure API :(
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
 			},
 
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				ForceNew: true, // due to a bug in the Azure API :(
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
 			},
 
 			"app_settings": {
@@ -222,7 +228,9 @@ func resourceArmAppService() *schema.Resource {
 				},
 			},
 
-			"tags": tagsForceNewSchema(), // due to a bug in the Azure API :(
+			// TODO: (tombuildsstuff) support Update once the API is fixed:
+			// https://github.com/Azure/azure-rest-api-specs/issues/1697
+			"tags": tagsForceNewSchema(),
 		},
 	}
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -165,6 +165,7 @@ func resourceArmAppService() *schema.Resource {
 						"remote_debugging_version": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"VS2012",
 								"VS2013",

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAzureRMAppService_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_basic(ri)
+	config := testAccAzureRMAppService_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,21 +83,21 @@ func testCheckAzureRMAppServiceExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAzureRMAppService_basic(rInt int) string {
+func testAccAzureRMAppService_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West Europe"
+    location = "%s"
 }
 
 resource "azurerm_app_service" "test" {
     name                = "acctestAS-%d"
-    location            = "West Europe"
+    location            = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
 		tags {
 			environment = "Production"
 		}
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1,0 +1,103 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMAppService_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_basic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists("azurerm_app_service.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).appsClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("App Service still exists:\n%#v", resp)
+		}
+	}
+
+	return nil
+}
+
+func testCheckAzureRMAppServiceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		appServiceName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for App Service: %s", appServiceName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).appsClient
+
+		resp, err := conn.Get(resourceGroup, appServiceName)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on appsClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: App Service %q (resource group: %q) does not exist", appServiceName, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMAppService_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West Europe"
+}
+
+resource "azurerm_app_service" "test" {
+    name                = "acctestAS-%d"
+    location            = "West Europe"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+		tags {
+			environment = "Production"
+		}
+}
+`, rInt, rInt)
+}

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMAppService_32Bit(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "use_32_bit_worker_process", "true"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
 				),
 			},
 		},
@@ -65,7 +65,7 @@ func TestAccAzureRMAppService_alwaysOn(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "always_on", "true"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
 				),
 			},
 		},
@@ -301,27 +301,6 @@ func TestAccAzureRMAppService_managedPipelineMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_reserved(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_reserved(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "reserved", "true"),
 				),
 			},
 		},
@@ -1100,34 +1079,6 @@ resource "azurerm_app_service" "test" {
   site_config {
   	managed_pipeline_mode = "Classic"
   }
-}
-`, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMAppService_reserved(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-  reserved            = true
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccAzureRMAppService_basic(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMAppService_basic(ri, testLocation())
 
@@ -22,16 +23,17 @@ func TestAccAzureRMAppService_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists("azurerm_app_service.test"),
+					testCheckAzureRMAppServiceExists(resourceName),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMAppService_complete(t *testing.T) {
+func TestAccAzureRMAppService_32Bit(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_complete(ri, testLocation())
+	config := testAccAzureRMAppService_32Bit(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -41,16 +43,18 @@ func TestAccAzureRMAppService_complete(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists("azurerm_app_service.test"),
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "use_32_bit_worker_process", "true"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAzureRMAppService_completeAlwaysOn(t *testing.T) {
+func TestAccAzureRMAppService_alwaysOn(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_completeAlwaysOn(ri, testLocation())
+	config := testAccAzureRMAppService_alwaysOn(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,7 +64,550 @@ func TestAccAzureRMAppService_completeAlwaysOn(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists("azurerm_app_service.test"),
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "always_on", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_appSettings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_appSettings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_clientAffinityEnabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_clientAffinityEnabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_connectionStrings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_connectionStrings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_defaultDocuments(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_defaultDocuments(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_enabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxEnabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_linuxDotNetCore(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxDotNetCore(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "dotnetcore|1.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_linuxNode(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxNode(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "node|8.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_linuxPHP(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxPHP(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "php|7.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_linuxRuby(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxRuby(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "ruby|2.3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_localMySql(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_localMySql(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_managedPipelineMode(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_managedPipelineMode(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_reserved(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_reserved(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "reserved", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_tagsUpdate(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_tags(ri, testLocation())
+	updatedConfig := testAccAzureRMAppService_tagsUpdated(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_linuxUpdate(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_linuxDotNetCore(ri, testLocation())
+	updatedConfig := testAccAzureRMAppService_linuxRuby(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "dotnetcore|1.1"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "ruby|2.3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsDotNet2(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v2.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsDotNet4(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v4.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsDotNetUpdate(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v2.0")
+	updatedConfig := testAccAzureRMAppService_windowsDotNet(ri, testLocation(), "v4.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsJava7Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "Jetty", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "Jetty"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsJava8Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "Jetty", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "Jetty"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
+}
+func TestAccAzureRMAppService_windowsJava7Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "TomCat", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TomCat"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsJava8Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "TomCat", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TomCat"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsPHP7(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsPHP(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_windowsPython(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_windowsPython(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_webSockets(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_webSockets(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
 				),
 			},
 		},
@@ -68,7 +615,7 @@ func TestAccAzureRMAppService_completeAlwaysOn(t *testing.T) {
 }
 
 func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).appsClient
+	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_app_service" {
@@ -78,7 +625,7 @@ func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		resp, err := conn.Get(resourceGroup, name)
+		resp, err := client.Get(resourceGroup, name)
 
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
@@ -107,15 +654,15 @@ func testCheckAzureRMAppServiceExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for App Service: %s", appServiceName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).appsClient
+		client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
-		resp, err := conn.Get(resourceGroup, appServiceName)
+		resp, err := client.Get(resourceGroup, appServiceName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: App Service %q (resource group: %q) does not exist", appServiceName, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on appsClient: %+v", err)
+			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
 		}
 
 		return nil
@@ -129,25 +676,6 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-	tags {
-		environment = "Production"
-	}
-}
-`, rInt, location, rInt)
-}
-
-func testAccAzureRMAppService_complete(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
 resource "azurerm_app_service_plan" "test" {
   name                = "acctestASP-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -163,16 +691,12 @@ resource "azurerm_app_service" "test" {
   name                = "acctestAS-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-	site_config {
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-		always_on           = false
-	}
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
 }
 `, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMAppService_completeAlwaysOn(rInt int, location string) string {
+func testAccAzureRMAppService_alwaysOn(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
@@ -194,11 +718,636 @@ resource "azurerm_app_service" "test" {
   name                = "acctestAS-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
 
-	site_config {
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-		always_on           = true
-	}
+  site_config {
+  	always_on = true
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_32Bit(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	use_32_bit_worker_process = true
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_appSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  app_settings {
+  	"foo" = "bar"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_clientAffinityEnabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                    = "acctestAS-%d"
+  location                = "${azurerm_resource_group.test.location}"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  app_service_plan_id     = "${azurerm_app_service_plan.test.id}"
+  client_affinity_enabled = true
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_connectionStrings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  connection_string {
+  	name  = "Example"
+  	value = "some-postgresql-connection-string"
+  	type  = "PostgreSQL"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_defaultDocuments(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	default_documents = [
+		"first.html",
+		"second.jsp",
+		"third.aspx",
+  	]
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_linuxDotNetCore(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	linux_app_framework_version = "dotnetcore|1.1"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_linuxNode(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	linux_app_framework_version = "node|8.1"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_linuxPHP(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	linux_app_framework_version = "php|7.0"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_linuxRuby(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	linux_app_framework_version = "ruby|2.3"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_linuxEnabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  enabled             = false
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_localMySql(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	local_mysql_enabled = true
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_managedPipelineMode(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+  	managed_pipeline_mode = "Classic"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_reserved(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  reserved            = true
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_tags(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  tags {
+  	"Hello" = "World"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_tagsUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  tags {
+  	"Hello"     = "World"
+  	"Terraform" = "AcceptanceTests"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_windowsDotNet(rInt int, location, version string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    dotnet_framework_version = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, version)
+}
+
+func testAccAzureRMAppService_windowsJava(rInt int, location, javaVersion, container, containerVersion string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    java_version           = "%s"
+    java_container         = "%s"
+    java_container_version = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, javaVersion, container, containerVersion)
+}
+
+func testAccAzureRMAppService_windowsPHP(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    php_version = "7.1"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_windowsPython(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    python_version = "3.4"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_webSockets(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    websockets_enabled = true
+  }
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -464,7 +464,7 @@ func TestAccAzureRMAppService_windowsDotNetUpdate(t *testing.T) {
 func TestAccAzureRMAppService_windowsJava7Jetty(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "Jetty", "9.3")
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -476,7 +476,7 @@ func TestAccAzureRMAppService_windowsJava7Jetty(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "Jetty"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
 				),
 			},
@@ -487,7 +487,7 @@ func TestAccAzureRMAppService_windowsJava7Jetty(t *testing.T) {
 func TestAccAzureRMAppService_windowsJava8Jetty(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "Jetty", "9.3")
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -499,7 +499,7 @@ func TestAccAzureRMAppService_windowsJava8Jetty(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "Jetty"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
 				),
 			},

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -163,7 +163,7 @@ func TestAccAzureRMAppService_defaultDocuments(t *testing.T) {
 func TestAccAzureRMAppService_enabled(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxEnabled(ri, testLocation())
+	config := testAccAzureRMAppService_enabled(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -175,90 +175,6 @@ func TestAccAzureRMAppService_enabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_linuxDotNetCore(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxDotNetCore(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "dotnetcore|1.1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_linuxNode(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxNode(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "node|8.1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_linuxPHP(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxPHP(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "php|7.0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_linuxRuby(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxRuby(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "ruby|2.3"),
 				),
 			},
 		},
@@ -333,35 +249,6 @@ func TestAccAzureRMAppService_tagsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppService_linuxUpdate(t *testing.T) {
-	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_linuxDotNetCore(ri, testLocation())
-	updatedConfig := testAccAzureRMAppService_linuxRuby(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "dotnetcore|1.1"),
-				),
-			},
-			{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.linux_app_framework_version", "ruby|2.3"),
 				),
 			},
 		},
@@ -886,7 +773,7 @@ resource "azurerm_app_service" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMAppService_linuxDotNetCore(rInt int, location string) string {
+func testAccAzureRMAppService_enabled(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
@@ -897,7 +784,6 @@ resource "azurerm_app_service_plan" "test" {
   name                = "acctestASP-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  kind                = "Linux"
 
   sku {
     tier = "Standard"
@@ -910,135 +796,7 @@ resource "azurerm_app_service" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-  	linux_app_framework_version = "dotnetcore|1.1"
-  }
-}
-`, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMAppService_linuxNode(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  kind                = "Linux"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-  	linux_app_framework_version = "node|8.1"
-  }
-}
-`, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMAppService_linuxPHP(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  kind                = "Linux"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-  	linux_app_framework_version = "php|7.0"
-  }
-}
-`, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMAppService_linuxRuby(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  kind                = "Linux"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-  	linux_app_framework_version = "ruby|2.3"
-  }
-}
-`, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMAppService_linuxEnabled(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  kind                = "Linux"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-  enabled             = false
+  enabled = false
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -509,7 +509,7 @@ func TestAccAzureRMAppService_windowsJava8Jetty(t *testing.T) {
 func TestAccAzureRMAppService_windowsJava7Tomcat(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "TomCat", "9.0")
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -521,7 +521,7 @@ func TestAccAzureRMAppService_windowsJava7Tomcat(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TomCat"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
 				),
 			},
@@ -532,7 +532,7 @@ func TestAccAzureRMAppService_windowsJava7Tomcat(t *testing.T) {
 func TestAccAzureRMAppService_windowsJava8Tomcat(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "TomCat", "9.0")
+	config := testAccAzureRMAppService_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -544,7 +544,7 @@ func TestAccAzureRMAppService_windowsJava8Tomcat(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TomCat"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
 				),
 			},

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -63,6 +63,10 @@
                   <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-app-service") %>>
+                  <a href="/docs/providers/azurerm/r/app_service.html">azurerm_app_service</a>
+                </li>
+
               </ul>
             </li>
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -59,12 +59,12 @@
               <a href="#">App Service (Web Apps) Resources</a>
               <ul class="nav nav-visible">
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-plan") %>>
-                  <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
+                <li<%= sidebar_current("docs-azurerm-resource-app-service-x") %>>
+                  <a href="/docs/providers/azurerm/r/app_service.html">azurerm_app_service</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service") %>>
-                  <a href="/docs/providers/azurerm/r/app_service.html">azurerm_app_service</a>
+                <li<%= sidebar_current("docs-azurerm-resource-app-service-plan") %>>
+                  <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
               </ul>

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -1,0 +1,64 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service"
+sidebar_current: "docs-azurerm-resource-app-service"
+description: |-
+  Create an App Service component.
+---
+
+# azurerm\_app\_service
+
+Create an App Service component.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "api-rg-pro"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service" "test" {
+    name                = "api-appservice-pro"
+    location            = "West Europe"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the App Service Plan component. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Plan component.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `app_service_plan_id` - (Optional) The resource ID of the app service plan.
+
+* `always_on` - (Optional) Alows the app to be loaded all the time.
+
+* `skip_dns_registration` - (Optional) If true, DNS registration is skipped.
+
+* `skip_custom_domain_verification` - (Optional) If true, custom (non .azurewebsites.net) domains associated with web app are not verified.
+
+* `force_dns_registration` - (Optional) If true, web app hostname is force registered with DNS.
+
+* `ttl_in_seconds` - (Optional) Time to live in seconds for web app's default domain name.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the App Service component.
+
+## Import
+
+App Service instances can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_app_service.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/instance1
+```

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -3,12 +3,12 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service"
 sidebar_current: "docs-azurerm-resource-app-service"
 description: |-
-  Create an App Service component.
+  Manage an App Service (within an App Service Plan).
 ---
 
 # azurerm\_app\_service
 
-Create an App Service component.
+Manage an App Service (within an App Service Plan).
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_app_service" "test" {
     name                = "api-appservice-pro"
-    location            = "West Europe"
+    location            = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 ```
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+`site_config` supports the following:
+
 * `app_service_plan_id` - (Optional) The resource ID of the app service plan.
 
 * `always_on` - (Optional) Alows the app to be loaded all the time.
@@ -45,7 +47,7 @@ The following arguments are supported:
 
 * `force_dns_registration` - (Optional) If true, web app hostname is force registered with DNS.
 
-* `ttl_in_seconds` - (Optional) Time to live in seconds for web app's default domain name.
+* `ttl_in_seconds` - (Optional) Time to live in seconds for app service's default domain name.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -1,27 +1,48 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service"
-sidebar_current: "docs-azurerm-resource-app-service"
+sidebar_current: "docs-azurerm-resource-app-service-x"
 description: |-
-  Manage an App Service (within an App Service Plan).
+  Manages an App Service (within an App Service Plan).
+
 ---
 
 # azurerm\_app\_service
 
-Manage an App Service (within an App Service Plan).
+Manages an App Service (within an App Service Plan).
 
 ## Example Usage
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "api-rg-pro"
+  name     = "some-resource-group"
   location = "West Europe"
 }
 
+resource "azurerm_app_service_plan" "test" {
+  name                = "some-app-service-plan"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
 resource "azurerm_app_service" "test" {
-    name                = "api-appservice-pro"
-    location            = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "my-app-service"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+  }
+
+  app_settings {
+    "SOME_KEY" = "some-value"
+  }
 }
 ```
 
@@ -35,31 +56,60 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this App Service. Changing this forces a new resource to be created.
+
+* `app_settings` - (Optional) A key-value pair of App Settings.
+
+* `connection_string` - (Optional) An `connection_string` block as defined below.
+
+* `client_affinity_enabled` - (Optional) TODO: COMPLETE ME. Changing this forces a new resource to be created.
+
+* `enabled` - (Optional) TODO: COMPLETE ME. Changing this forces a new resource to be created.
+
+* `site_config` - (Optional) A `site_config` object as defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+
+---
+
+`connection_string` supports the following:
+
+* `name` - (Required) The name of the Connection String.
+* `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
+* `value` - (Required) The value for the Connection String.
+
+---
+
 `site_config` supports the following:
 
-* `app_service_plan_id` - (Optional) The resource ID of the app service plan.
+* `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
+* `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
+* `dotnet_framework_version` - (Optional) The version of the .net framework used in this App Service. Possible values are `v2.0` (which corresponds to `v3.5`) and `v4.0` (which is `v4.7` at the time of writing). Defaults to `v4.0`.
 
-* `always_on` - (Optional) Alows the app to be loaded all the time.
+* `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
+* `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
+* `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified. Possible values are `JETTY` and `TOMCAT`.
 
-* `skip_dns_registration` - (Optional) If true, DNS registration is skipped.
+* `local_mysql_enabled` - (Optional) Is "MySQL In App" Enabled? This runs a local MySQL instance with your app and shares resources from the App Service plan.
+~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish to use Azure Database for MySQL.
 
-* `skip_custom_domain_verification` - (Optional) If true, custom (non .azurewebsites.net) domains associated with web app are not verified.
-
-* `force_dns_registration` - (Optional) If true, web app hostname is force registered with DNS.
-
-* `ttl_in_seconds` - (Optional) Time to live in seconds for app service's default domain name.
-
-* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
+* `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0` and `7.1`.
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7` and `3.4`.
+* `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
+* `remote_debugging_version` - (Optional) Which version of Visual Studio should the Remote Debugger be compatible with? Possible values are `VS2012`, `VS2013`, `VS2015` and `VS2017`.
+* `use_32_bit_worker_process` - (Optional) Should the App Service run in 32 bit mode, rather than 64 bit mode?
+* `websockets_enabled` - (Optional) Should WebSockets be enabled?
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of the App Service component.
+* `id` - The ID of the App Service.
 
 ## Import
 
-App Service instances can be imported using the `resource id`, e.g.
+App Services can be imported using the `resource id`, e.g.
 
 ```
 terraform import azurerm_app_service.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/instance1

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -7,11 +7,11 @@ description: |-
 
 ---
 
-# azurerm\_app\_service
+# azurerm_app_service
 
 Manages an App Service (within an App Service Plan).
 
-## Example Usage
+## Example Usage (.net 4.x)
 
 ```hcl
 resource "azurerm_resource_group" "test" {
@@ -43,6 +43,45 @@ resource "azurerm_app_service" "test" {
   app_settings {
     "SOME_KEY" = "some-value"
   }
+
+  connection_string {
+    name  = "Database"
+    type  = "SQLServer"
+    value = "Server=some-server.mydomain.com;Integrated Security=SSPI"
+  }
+}
+```
+
+## Example Usage (Java 1.8)
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "some-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "some-app-service-plan"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "my-app-service"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    java_version           = "1.8"
+    java_container         = "JETTY"
+    java_container_version = "9.3"
+  }
 }
 ```
 
@@ -62,9 +101,9 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
-* `client_affinity_enabled` - (Optional) TODO: COMPLETE ME. Changing this forces a new resource to be created.
+* `client_affinity_enabled` - (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
 
-* `enabled` - (Optional) TODO: COMPLETE ME. Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the App Service Enabled? Changing this forces a new resource to be created.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
@@ -88,7 +127,7 @@ The following arguments are supported:
 
 * `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
-* `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified. Possible values are `JETTY` and `TOMCAT`.
+* `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified.
 
 * `local_mysql_enabled` - (Optional) Is "MySQL In App" Enabled? This runs a local MySQL instance with your app and shares resources from the App Service plan.
 ~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish to use Azure Database for MySQL.


### PR DESCRIPTION
This PR extends the work done by @lstolyarov in #2 to support provisioning App Services within an App Service Plan.

There's a couple of limitations with this PR due to API issues (which I'll open Rest API Specs issues about shortly):
 - [it's currently not possible to update three fields: `client_affinity_enabled`, `enabled` and `tags` - as the Update endpoint has issues - such I've made them `ForceNew` for the moment](https://github.com/Azure/azure-rest-api-specs/issues/1697)
 - [it's currently only possible to provision Windows App Services, so I've removed references to Linux App Services for the moment (until the correct API fields are returned)](https://github.com/Azure/azure-rest-api-specs/issues/1698)

Fixes #35