### PR TITLE
additions to `azurerm_storage_account`

### DIFF
--- a/azurerm/import_arm_storage_account_test.go
+++ b/azurerm/import_arm_storage_account_test.go
@@ -31,3 +31,128 @@ func TestAccAzureRMStorageAccount_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMStorageAccount_importPremium(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMStorageAccount_premium(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageAccount_importNonStandardCasing(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMStorageAccount_nonStandardCasing(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageAccount_importBlobEncryption(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMStorageAccount_blobEncryption(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageAccount_importFileEncryption(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMStorageAccount_fileEncryption(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageAccount_importEnableHttpsTrafficOnly(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMStorageAccount_enableHttpsTrafficOnly(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_storage_account_migration.go
+++ b/azurerm/resource_arm_storage_account_migration.go
@@ -1,0 +1,38 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStorageAccountMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Storage Account State v0; migrating to v1")
+		return migrateStorageAccountStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStorageAccountStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Storage Account Attributes before Migration: %#v", is.Attributes)
+
+	accountType := is.Attributes["account_type"]
+	split := strings.Split(accountType, "_")
+	is.Attributes["account_tier"] = split[0]
+	is.Attributes["account_replication_type"] = split[1]
+
+	log.Printf("[DEBUG] ARM Storage Account Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/azurerm/resource_arm_storage_account_migration_test.go
+++ b/azurerm/resource_arm_storage_account_migration_test.go
@@ -1,0 +1,59 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAzureRMStorageAccountMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion       int
+		ID                 string
+		InputAttributes    map[string]string
+		ExpectedAttributes map[string]string
+		Meta               interface{}
+	}{
+		"v0_1_with_standard": {
+			StateVersion: 0,
+			ID:           "some_id",
+			InputAttributes: map[string]string{
+				"account_type": "Standard_LRS",
+			},
+			ExpectedAttributes: map[string]string{
+				"account_tier":             "Standard",
+				"account_replication_type": "LRS",
+			},
+		},
+		"v0_1_with_premium": {
+			StateVersion: 0,
+			ID:           "some_id",
+			InputAttributes: map[string]string{
+				"account_type": "Premium_GRS",
+			},
+			ExpectedAttributes: map[string]string{
+				"account_tier":             "Premium",
+				"account_replication_type": "GRS",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.InputAttributes,
+		}
+		is, err := resourceStorageAccountMigrateState(tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.ExpectedAttributes {
+			actual := is.Attributes[k]
+			if actual != v {
+				t.Fatalf("Bad Storage Account Migrate for %q: %q\n\n expected: %q", k, actual, v)
+			}
+		}
+	}
+}

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -49,11 +49,9 @@ The following arguments are supported:
     and `BlobStorage`. Changing this forces a new resource to be created. Defaults
     to `Storage`.
 
-* `account_type` - (Required) Defines the type of storage account to be
-    created. Valid options are `Standard_LRS`, `Standard_ZRS`, `Standard_GRS`,
-    `Standard_RAGRS`, `Premium_LRS`. Changing this is sometimes valid - see the Azure
-    documentation for more information on which types of accounts can be converted
-    into other types.
+* `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. Changing this forces a new resource to be created
+
+* `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Valid options are `LRS`, `GRS`, `RAGRS` and `ZRS`.
 
 * `access_tier` - (Required for `BlobStorage` accounts) Defines the access tier
     for `BlobStorage` accounts. Valid options are `Hot` and `Cold`, defaults to
@@ -63,13 +61,25 @@ The following arguments are supported:
     Services are enabled for Blob storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/)
     for more information.
 
+* `enable_file_encryption` - (Optional) Boolean flag which controls if Encryption
+    Services are enabled for File storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/)
+    for more information.
+
 * `enable_https_traffic_only` - (Optional) Boolean flag which forces HTTPS if enabled, see [here] (https://docs.microsoft.com/en-us/azure/storage/storage-require-secure-transfer/)
     for more information.
 
+* `custom_domain` - (Optional) A `custom_domain` block as documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-Note that although the Azure API supports setting custom domain names for
-storage accounts, this is not currently supported.
+---
+
+* `custom_domain` supports the following:
+
+* `name` - (Optional) The Custom Domain Name to use for the Storage Account, which will be validated by Azure.
+* `use_subdomain` - (Optional) Should the Custom Domain Name be validated by using indirect CNAME validation?
+
+~> **Note:** [More information on Validation is available here](https://docs.microsoft.com/en-gb/azure/storage/blobs/storage-custom-domain-name)
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Support for File Encryption. Fixes #80
- Adding additional Import tests
- Support for Custom Domains on Storage Accounts. Fixes #15
- Splitting the storage account Tier and Replication out into separate fields. [Suggested by @cchildress in #117](https://github.com/terraform-providers/terraform-provider-azurerm/pull/117#issuecomment-310184010) (which also fixes #110)

Unfortunately testing Custom Domains is harder than anticipated - since it needs a static DNS name and storage name, which need to be globally unique. For this reason I've manually confirmed this works, but haven't included an acceptance test for it at the moment.