### PR TITLE
Fixes crash when no certificate_permissions are defined

### DIFF
--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -343,11 +343,6 @@ func flattenKeyVaultAccessPolicies(policies *[]keyvault.AccessPolicyEntry) []int
 	for _, policy := range *policies {
 		policyRaw := make(map[string]interface{})
 
-		certificatePermissionsRaw := make([]interface{}, 0, len(*policy.Permissions.Keys))
-		for _, certificatePermission := range *policy.Permissions.Certificates {
-			certificatePermissionsRaw = append(certificatePermissionsRaw, string(certificatePermission))
-		}
-
 		keyPermissionsRaw := make([]interface{}, 0, len(*policy.Permissions.Keys))
 		for _, keyPermission := range *policy.Permissions.Keys {
 			keyPermissionsRaw = append(keyPermissionsRaw, string(keyPermission))
@@ -363,9 +358,16 @@ func flattenKeyVaultAccessPolicies(policies *[]keyvault.AccessPolicyEntry) []int
 		if policy.ApplicationID != nil {
 			policyRaw["application_id"] = policy.ApplicationID.String()
 		}
-		policyRaw["certificate_permissions"] = certificatePermissionsRaw
 		policyRaw["key_permissions"] = keyPermissionsRaw
 		policyRaw["secret_permissions"] = secretPermissionsRaw
+
+		if policy.Permissions.Certificates != nil {
+			certificatePermissionsRaw := make([]interface{}, 0, len(*policy.Permissions.Certificates))
+			for _, certificatePermission := range *policy.Permissions.Certificates {
+				certificatePermissionsRaw = append(certificatePermissionsRaw, string(certificatePermission))
+			}
+			policyRaw["certificate_permissions"] = certificatePermissionsRaw
+		}
 
 		result = append(result, policyRaw)
 	}


### PR DESCRIPTION
Fixes the terraform crash when no certificate_permissions have been defined (e.g. when migrating an older config which did not support the certificate_permissions key)

Also fixes a bug where the Permissions.Keys was referenced as the source of the Certificates list