### PR TITLE
New Data Source: `azurerm_platform_image`

### DIFF
--- a/azurerm/data_source_platform_image.go
+++ b/azurerm/data_source_platform_image.go
@@ -1,0 +1,64 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmPlatformImage() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmPlatformImageRead,
+		Schema: map[string]*schema.Schema{
+			"location": locationSchema(),
+
+			"publisher": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"offer": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"sku": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmPlatformImageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).vmImageClient
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
+	publisher := d.Get("publisher").(string)
+	offer := d.Get("offer").(string)
+	sku := d.Get("sku").(string)
+
+	result, err := client.List(location, publisher, offer, sku, "", utils.Int32(int32(1000)), "name")
+	if err != nil {
+		return fmt.Errorf("Error reading Platform Images: %+v", err)
+	}
+
+	// the last value is the latest, apparently.
+	latestVersion := (*result.Value)[len(*result.Value)-1]
+
+	d.SetId(*latestVersion.ID)
+
+	d.Set("location", azureRMNormalizeLocation(*latestVersion.Location))
+	d.Set("publisher", publisher)
+	d.Set("offer", offer)
+	d.Set("sku", sku)
+	d.Set("version", latestVersion.Name)
+
+	return nil
+}

--- a/azurerm/data_source_platform_image_test.go
+++ b/azurerm/data_source_platform_image_test.go
@@ -1,0 +1,41 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMPlatformImage_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_platform_image.test"
+	config := testAccDataSourceAzureRMPlatformImageBasic(testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+					resource.TestCheckResourceAttr(dataSourceName, "publisher", "Canonical"),
+					resource.TestCheckResourceAttr(dataSourceName, "offer", "UbuntuServer"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku", "16.04-LTS"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMPlatformImageBasic(location string) string {
+	return fmt.Sprintf(`
+data "azurerm_platform_image" "test" {
+  location  = "%s"
+  publisher = "Canonical"
+  offer     = "UbuntuServer"
+  sku       = "16.04-LTS"
+}
+`, location)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -69,9 +69,10 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_client_config":  dataSourceArmClientConfig(),
-			"azurerm_resource_group": dataSourceArmResourceGroup(),
-			"azurerm_public_ip":      dataSourceArmPublicIP(),
 			"azurerm_managed_disk":   dataSourceArmManagedDisk(),
+			"azurerm_platform_image": dataSourceArmPlatformImage(),
+			"azurerm_public_ip":      dataSourceArmPublicIP(),
+			"azurerm_resource_group": dataSourceArmResourceGroup(),
 			"azurerm_subscription":   dataSourceArmSubscription(),
 		},
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -31,6 +31,10 @@
                     <a href="/docs/providers/azurerm/d/managed_disk.html">azurerm_managed_disk</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-platform-image") %>>
+                    <a href="/docs/providers/azurerm/d/platform_image.html">azurerm_platform_image</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-public-ip") %>>
                     <a href="/docs/providers/azurerm/d/public_ip.html">azurerm_public_ip</a>
                 </li>

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_platform_image"
+sidebar_current: "docs-azurerm-datasource-platform-image"
+description: |-
+  Get information about the specified Platform Image.
+---
+
+# azurerm_platform_image
+
+Use this data source to access the properties of an Azure Platform Image.
+
+## Example Usage
+
+```hcl
+data "azurerm_platform_image" "test" {
+  location  = "West Europe"
+  publisher = "Canonical"
+  offer     = "UbuntuServer"
+  sku       = "16.04-LTS"
+}
+
+output "version" {
+  value = "${data.azurerm_platform_image.test.version}"
+}
+```
+
+## Argument Reference
+
+* `location` - (Required) Specifies the Location to pull information about this Platform Image from.
+* `publisher` - (Required) Specifies the Publisher associated with the Platform Image.
+* `offer` - (Required) Specifies the Offer associated with the Platform Image.
+* `sku` - (Required) Specifies the SKU of the Platform Image.
+
+
+## Attributes Reference
+
+* `id` - The ID of the Platform Image.
+* `version` - The latest version of the Platform Image.


### PR DESCRIPTION
Adding a Data Source for Platform Images, to be able to obtain the latest version number of a Platform Image

Tests pass:
```
$ acctests azurerm TestAccDataSourceAzureRMPlatformImage_basic
=== RUN   TestAccDataSourceAzureRMPlatformImage_basic
--- PASS: TestAccDataSourceAzureRMPlatformImage_basic (12.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	12.219s
```