### PR TITLE
Bugfix: Update of Windows vm and vmss with non-empty additional_unattend_config.content

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -1307,7 +1307,10 @@ func expandAzureRmVirtualMachineOsProfileWindowsConfig(d *schema.ResourceData) (
 					PassName:      compute.PassNames(pass),
 					ComponentName: compute.ComponentNames(component),
 					SettingName:   compute.SettingNames(settingName),
-					Content:       &content,
+				}
+
+				if content != "" {
+					addContent.Content = &content
 				}
 
 				additionalConfigContent = append(additionalConfigContent, addContent)

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -1455,7 +1455,10 @@ func expandAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(d *schema.Resourc
 					PassName:      compute.PassNames(pass),
 					ComponentName: compute.ComponentNames(component),
 					SettingName:   compute.SettingNames(settingName),
-					Content:       &content,
+				}
+
+				if content != "" {
+					addContent.Content = &content
 				}
 
 				additionalConfigContent = append(additionalConfigContent, addContent)

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -121,7 +121,7 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk(t *testing.T) {
 
 func TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(ri, testLocation())
+	config := testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(ri, testLocation(), "Standard_D1_v2")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -129,6 +129,31 @@ func TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(ri, testLocation(), "Standard_D1_v2")
+	postConfig := testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(ri, testLocation(), "Standard_D2_v2")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+			{
+				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
 				),
@@ -1080,7 +1105,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(rInt int, location string) string {
+func testAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk(rInt int, location string, vmSize string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
@@ -1108,7 +1133,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name = "Standard_D1_v2"
+    name = "%s"
     tier = "Standard"
     capacity = 2
   }
@@ -1161,7 +1186,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 }
-`, rInt, location, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt, vmSize, rInt)
 }
 
 func testAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName(rInt int, location string) string {


### PR DESCRIPTION
This pull request fixes a crash when updating a `azurerm_virtual_machine` or `azurerm_virtual_machine_scale_set` resource which has been previously created with a value set for `content` in the `additional_unattend_config`.

### Terraform Version

v0.10.5

### Terraform AzureRM Provider Version

0.2.2

### Affected Resources

- `azurerm_virtual_machine`
- `azurerm_virtual_machine_scale_set`

### Steps to reproduce

1. Create Windows virtual machine using `azurerm_virtual_machine` with a non-empty field `content` in the `additional_unattend_config` block such as

```
additional_unattend_config {
    pass = "oobeSystem"
    component = "Microsoft-Windows-Shell-Setup"
    setting_name = "AutoLogon"
    content = "<AutoLogon><Username>Operations</Username><Password><Value>dRaQuDH7vWZLWFf6</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount></AutoLogon>"
```

- Run `terraform apply`
- Change any parameter of the Windows VM resource in the Terraform configuration, e.g. the `vm_size`
- Run `terraform apply`

### Expected Behavior

- After the second `terraform apply`, the resource should be changed accordingly, e.g. a resize should have been performed

### Actual Behavior

- Terraform crashed with the following error message

```
* azurerm_virtual_machine.test: compute.VirtualMachinesClient#CreateOrUpdate: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="PropertyChangeNotAllowed" Message="Changing property 'windowsConfiguration.additionalUnattendContent.content' is not allowed."
```

### Cause analysis

- After creating a virtual machine resource, the content field will be returned as nil by the Azure Go SDK
- Therefore the field is saved as an empty string in the state
- The field must not be send to to Azure API as "" but rather as nil (or not in the request)
- Currently the Azure API assumes the field should be changed to an empty string "" which is not allowed

### Steps to reproduce via tests

#### azurerm_virtual_machine

This pull request includes a new test `TestAccAzureRMVirtualMachine_windowsMachineResize` which resizes a Windows virtual machine with additionalUnattendContent.content set.

Without the changes, the test fails:

```
make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMVirtualMachine_windowsMachineResize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachine_windowsMachineResize -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_windowsMachineResize
--- FAIL: TestAccAzureRMVirtualMachine_windowsMachineResize (462.73s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* azurerm_virtual_machine.test: 1 error(s) occurred:

		* azurerm_virtual_machine.test: compute.VirtualMachinesClient#CreateOrUpdate: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="PropertyChangeNotAllowed" Message="Changing property 'windowsConfiguration.additionalUnattendContent.content' is not allowed."
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	462.756s
make: *** [testacc] Error 1
```

With the changes, the test passes:

```
make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMVirtualMachine_windowsMachineResize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachine_windowsMachineResize -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_windowsMachineResize
--- PASS: TestAccAzureRMVirtualMachine_windowsMachineResize (603.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	603.036s
```

#### azurerm_virtual_machine_scale_set

This pull request includes a new test `TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize` which resizes a Windows virtual machine scale set with additionalUnattendContent.content set.

Without the changes, the test fails:

```
make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize -timeout 120m
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize
--- FAIL: TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize (514.91s)
	testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:

		* azurerm_virtual_machine_scale_set.test: 1 error(s) occurred:

		* azurerm_virtual_machine_scale_set.test: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="PropertyChangeNotAllowed" Message="Changing property 'windowsConfiguration.additionalUnattendContent.content' is not allowed."
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	514.938s
make: *** [testacc] Error 1
```

With the changes, the test passes:

```
make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize -timeout 120m
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize (572.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	572.578s
```
