### PR TITLE
Add test case for multiple network profiles in virtual machine scale set model

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -327,6 +327,24 @@ func TestAccAzureRMVirtualMachineScaleSet_NonStandardCasing(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
 func testGetAzureRMVirtualMachineScaleSet(s *terraform.State, resourceName string) (result *compute.VirtualMachineScaleSet, err error) {
 	// Ensure we have enough information in state to look up in API
 	rs, ok := s.RootModule().Resources[resourceName]
@@ -1974,4 +1992,108 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name = "acctvmss-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+
+  sku {
+    name = "Standard_D1_v2"
+    tier = "Standard"
+    capacity = 2
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username = "myadmin"
+    admin_password = "Passwword1234"
+  }
+
+  network_profile {
+      name = "primary-%d"
+      primary = true
+      ip_configuration {
+        name = "primary"
+        subnet_id = "${azurerm_subnet.test.id}"
+      }
+  }
+
+  network_profile {
+      name = "secondary-%d"
+      primary = false
+      ip_configuration {
+        name = "secondary"
+        subnet_id = "${azurerm_subnet.test.id}"
+      }
+  }
+
+  storage_profile_os_disk {
+    name = "osDiskProfile"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }


### PR DESCRIPTION
This pull request add the test case `TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles` which tests creating a virtual machine scale set with multiple `network_profiles`. This is currently allowed by the Terraform schema and the documentation of the `azurerm_virtual_machine_scale_set` resource but fails since the currently used version of the Azure SDK for Go applies the Azure API version `2016-04-30-preview` for managing virtual machine scale sets.

The pull request #367 upgrades to v11 of the Azure SDK for Go which uses the Azure API version `2017-03-30` for managing virtual machine scale sets. Thus, this test will turn green after #367 is merged confirming the feature of using multiple network profiles.

```
make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles -timeout 120m
=== RUN   TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles
--- FAIL: TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles (96.34s)
	testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:

		* azurerm_virtual_machine_scale_set.test: 1 error(s) occurred:

		* azurerm_virtual_machine_scale_set.test: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="MinimumApiVersionNotSpecifiedForMultiNetworkInterfaceConfigurationOnVMScaleSet" Message="Specified api-version 2016-04-30-preview does not meet the minimum required api-version 2017-03-30 for multiple network interface configurations on VM Scale Set. Use api-version 2017-03-30 or higher to use multiple network interface configurations on VM Scale Set." Details=[]
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	96.363s
make: *** [testacc] Error 1
```
