### PR TITLE
New Data Source: `azurerm_image`

### DIFF
--- a/azurerm/data_source_image.go
+++ b/azurerm/data_source_image.go
@@ -1,0 +1,128 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmImage() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmImageRead,
+		Schema: map[string]*schema.Schema{
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": locationForDataSourceSchema(),
+
+			"os_disk": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"blob_uri": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"caching": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"managed_disk_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size_gb": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"data_disk": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"blob_uri": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"caching": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"lun": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"managed_disk_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size_gb": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).imageClient
+
+	resGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.Get(resGroup, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("[ERROR] Error making Read request on Azure Image %q (resource group %q): %+v", name, resGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	if profile := resp.StorageProfile; profile != nil {
+		if disk := profile.OsDisk; disk != nil {
+			if err := d.Set("os_disk", flattenAzureRmImageOSDisk(d, disk)); err != nil {
+				return fmt.Errorf("[DEBUG] Error setting AzureRM Image OS Disk error: %+v", err)
+			}
+		}
+
+		if disks := resp.StorageProfile.DataDisks; disks != nil {
+			if err := d.Set("data_disk", flattenAzureRmImageDataDisks(d, disks)); err != nil {
+				return fmt.Errorf("[DEBUG] Error setting AzureRM Image Data Disks error: %+v", err)
+			}
+		}
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_image_test.go
+++ b/azurerm/data_source_image_test.go
@@ -1,0 +1,171 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMImage_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_image.test"
+
+	config := testAccDataSourceAzureRMImageBasic(acctest.RandInt(), acctest.RandString(4), testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "resource_group_name"),
+					resource.TestCheckResourceAttr(dataSourceName, "os_disk.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "os_disk.0.blob_uri"),
+					resource.TestCheckResourceAttr(dataSourceName, "os_disk.0.caching", "None"),
+					resource.TestCheckResourceAttr(dataSourceName, "os_disk.0.os_type", "Linux"),
+					resource.TestCheckResourceAttr(dataSourceName, "os_disk.0.os_state", "Generalized"),
+					resource.TestCheckResourceAttr(dataSourceName, "os_disk.0.size_gb", "30"),
+					resource.TestCheckResourceAttr(dataSourceName, "data_disk.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "Dev"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.cost-center", "Ops"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMImageBasic(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctestpip%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "Dynamic"
+  domain_name_label            = "acctestpip%d"
+}
+
+resource "azurerm_network_interface" "testsource" {
+  name                = "acctestnic-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags {
+    environment = "Dev"
+  }
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "blob"
+}
+
+resource "azurerm_virtual_machine" "testsource" {
+  name                  = "acctestvm-%d"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    disk_size_gb  = "30"
+  }
+
+  os_profile {
+    computer_name  = "acctest-%d"
+    admin_username = "tfuser"
+    admin_password = "P@ssW0RD7890"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
+}
+
+resource "azurerm_image" "test" {
+  name                = "acctest-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    size_gb  = 30
+    caching  = "None"
+  }
+
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
+
+  depends_on = ["azurerm_virtual_machine.testsource"]
+}
+
+data "azurerm_image" "test" {
+  name                = "${azurerm_image.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+output "location" {
+  value = "${data.azurerm_image.test.location}"
+}
+
+`, rInt, location, rInt, rInt, rInt, rInt, rString, rInt, rInt, rInt)
+}

--- a/azurerm/data_source_managed_disk_test.go
+++ b/azurerm/data_source_managed_disk_test.go
@@ -18,9 +18,8 @@ func TestAccDataSourceAzureRMManagedDisk_basic(t *testing.T) {
 	config := testAccDataSourceAzureRMManagedDiskBasic(name, resourceGroupName, testLocation())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -69,6 +69,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_client_config":  dataSourceArmClientConfig(),
+			"azurerm_image":          dataSourceArmImage(),
 			"azurerm_managed_disk":   dataSourceArmManagedDisk(),
 			"azurerm_platform_image": dataSourceArmPlatformImage(),
 			"azurerm_public_ip":      dataSourceArmPublicIP(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -27,6 +27,10 @@
                     <a href="/docs/providers/azurerm/d/client_config.html">azurerm_client_config</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-image") %>>
+                    <a href="/docs/providers/azurerm/d/image.html">azurerm_image</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-managed-disk") %>>
                     <a href="/docs/providers/azurerm/d/managed_disk.html">azurerm_managed_disk</a>
                 </li>

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_image"
+sidebar_current: "docs-azurerm-datasource-image"
+description: |-
+  Get information about an Image
+
+---
+
+# azurerm_image
+
+Use this data source to access information about an Image.
+
+## Example Usage
+
+```hcl
+data "azurerm_image" "search" {
+  name                = "search-api"
+  resource_group_name = "packerimages"
+}
+
+output "image_id" {
+  value = "${data.azurerm_image.search.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Image.
+* `resource_group_name` - (Required) The Name of the Resource Group where this Image exists.
+
+## Attributes Reference
+
+* `location` - the Azure Location where this Image exists.
+* `os_disk` - a `os_disk` block as defined below.
+* `data_disk` - a collection of `data_disk` blocks as defined below.
+* `tags` - a mapping of tags to assigned to the resource.
+
+`os_disk` supports the following:
+
+* `blob_uri` - the URI in Azure storage of the blob used to create the image.
+* `caching` - the caching mode for the OS Disk, such as `ReadWrite`, `ReadOnly`, or `None`.
+* `managed_disk_id` - the ID of the Managed Disk used as the OS Disk Image.
+* `os_state` - the State of the OS used in the Image, such as `Generalized`.
+* `os_type` - the type of Operating System used on the OS Disk. such as `Linux` or `Windows`.
+* `size_gb` - the size of the OS Disk in GB.
+
+`data_disk` supports the following:
+
+* `blob_uri` - the URI in Azure storage of the blob used to create the image.
+* `caching` - the caching mode for the Data Disk, such as `ReadWrite`, `ReadOnly`, or `None`.
+* `lun` - the logical unit number of the data disk.
+* `managed_disk_id` - the ID of the Managed Disk used as the Data Disk Image.
+* `size_gb` - the size of this Data Disk in GB.


### PR DESCRIPTION
Added a new data source `azurerm_image` - fixes #371 

Tests:

```
$  acctests azurerm TestAccDataSourceAzureRMImage_basic
=== RUN   TestAccDataSourceAzureRMImage_basic
--- PASS: TestAccDataSourceAzureRMImage_basic (504.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	504.387s
```