### PR TITLE
Making the `azurerm_client_config` data source work with AzureCLI auth

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -46,10 +46,11 @@ import (
 // ArmClient contains the handles to all the specific Azure Resource Manager
 // resource classes' respective clients.
 type ArmClient struct {
-	clientId       string
-	tenantId       string
-	subscriptionId string
-	environment    azure.Environment
+	clientId              string
+	tenantId              string
+	subscriptionId        string
+	usingServicePrincipal bool
+	environment           azure.Environment
 
 	StopContext context.Context
 
@@ -233,10 +234,11 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 
 	// client declarations:
 	client := ArmClient{
-		clientId:       c.ClientID,
-		tenantId:       c.TenantID,
-		subscriptionId: c.SubscriptionID,
-		environment:    env,
+		clientId:              c.ClientID,
+		tenantId:              c.TenantID,
+		subscriptionId:        c.SubscriptionID,
+		environment:           env,
+		usingServicePrincipal: c.ClientSecret != "",
 	}
 
 	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, c.TenantID)

--- a/azurerm/data_source_arm_client_config.go
+++ b/azurerm/data_source_arm_client_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/arm/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -38,28 +39,35 @@ func dataSourceArmClientConfig() *schema.Resource {
 
 func dataSourceArmClientConfigRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
-	spClient := client.servicePrincipalsClient
-	// Application & Service Principal is 1:1 per tenant. Since we know the appId (client_id)
-	// here, we can query for the Service Principal whose appId matches.
-	filter := fmt.Sprintf("appId eq '%s'", client.clientId)
-	listResult, listErr := spClient.List(filter)
 
-	if listErr != nil {
-		return fmt.Errorf("Error listing Service Principals: %#v", listErr)
+	var servicePrincipal *graphrbac.ServicePrincipal
+	if client.usingServicePrincipal {
+		spClient := client.servicePrincipalsClient
+		// Application & Service Principal is 1:1 per tenant. Since we know the appId (client_id)
+		// here, we can query for the Service Principal whose appId matches.
+		filter := fmt.Sprintf("appId eq '%s'", client.clientId)
+		listResult, listErr := spClient.List(filter)
+
+		if listErr != nil {
+			return fmt.Errorf("Error listing Service Principals: %#v", listErr)
+		}
+
+		if listResult.Value == nil || len(*listResult.Value) != 1 {
+			return fmt.Errorf("Unexpected Service Principal query result: %#v", listResult.Value)
+		}
+
+		servicePrincipal = &(*listResult.Value)[0]
 	}
-
-	if listResult.Value == nil || len(*listResult.Value) != 1 {
-		return fmt.Errorf("Unexpected Service Principal query result: %#v", listResult.Value)
-	}
-
-	servicePrincipal := (*listResult.Value)[0]
 
 	d.SetId(time.Now().UTC().String())
 	d.Set("client_id", client.clientId)
 	d.Set("tenant_id", client.tenantId)
 	d.Set("subscription_id", client.subscriptionId)
-	d.Set("service_principal_application_id", *servicePrincipal.AppID)
-	d.Set("service_principal_object_id", *servicePrincipal.ObjectID)
+
+	if principal := servicePrincipal; principal != nil {
+		d.Set("service_principal_application_id", principal.AppID)
+		d.Set("service_principal_object_id", principal.ObjectID)
+	}
 
 	return nil
 }

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -17,7 +17,7 @@ provider.
 data "azurerm_client_config" "current" {}
 
 output "account_id" {
-  value = "${data.azurerm_client_config.current.account_id}"
+  value = "${data.azurerm_client_config.current.service_principal_application_id}"
 }
 ```
 
@@ -30,6 +30,11 @@ There are no arguments available for this data source.
 * `client_id` is set to the Azure Client ID (Application Object ID).
 * `tenant_id` is set to the Azure Tenant ID.
 * `subscription_id` is set to the Azure Subscription ID.
+
+---
+
+~> **Note:** the following fields are only available when authenticating via a Service Principal (as opposed to using the Azure CLI):
+
 * `service_principal_application_id` is the Service Principal Application ID.
 * `service_principal_object_id` is the Service Principal Object ID.
 


### PR DESCRIPTION
Fixes #392

Unfortunately testing this is tricky, since we rely on a Service Principal to run the acceptance tests (and not AzureCLI auth) - however I've verified this works as expected in both cases

Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMClientConfig_basic
=== RUN   TestAccDataSourceAzureRMClientConfig_basic
--- PASS: TestAccDataSourceAzureRMClientConfig_basic (12.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	12.673s
```