### PR TITLE
Ensuring we register the MySQL Resource Provider

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -404,6 +404,7 @@ func determineAzureResourceProvidersToRegister(providerList []resources.Provider
 		"Microsoft.ContainerInstance":   {},
 		"Microsoft.ContainerRegistry":   {},
 		"Microsoft.ContainerService":    {},
+		"Microsoft.DBforMySQL":          {},
 		"Microsoft.DBforPostgreSQL":     {},
 		"Microsoft.DocumentDB":          {},
 		"Microsoft.EventGrid":           {},


### PR DESCRIPTION
Tests pass:

```
$ acctests azurerm TestAccAzureRMResourceProviderRegistration
=== RUN   TestAccAzureRMResourceProviderRegistration
# ...
--- PASS: TestAccAzureRMResourceProviderRegistration (1.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1.955s
```