### PR TITLE
`azurerm_route` / `azurerm_route_table` - additions

### DIFF
--- a/azurerm/import_arm_route_table_test.go
+++ b/azurerm/import_arm_route_table_test.go
@@ -29,3 +29,49 @@ func TestAccAzureRMRouteTable_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMRouteTable_importSingleRoute(t *testing.T) {
+	resourceName := "azurerm_route_table.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRouteTable_importMultipleRoutes(t *testing.T) {
+	resourceName := "azurerm_route_table.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRouteTable_multipleRoutes(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_route.go
+++ b/azurerm/resource_arm_route.go
@@ -2,18 +2,18 @@ package azurerm
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmRoute() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmRouteCreate,
+		Create: resourceArmRouteCreateUpdate,
 		Read:   resourceArmRouteRead,
-		Update: resourceArmRouteCreate,
+		Update: resourceArmRouteCreateUpdate,
 		Delete: resourceArmRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -40,12 +40,16 @@ func resourceArmRoute() *schema.Resource {
 			},
 
 			"next_hop_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateRouteTableNextHopType,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.ToLower(old) == strings.ToLower(new)
-				},
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.RouteNextHopTypeVirtualNetworkGateway),
+					string(network.RouteNextHopTypeVnetLocal),
+					string(network.RouteNextHopTypeInternet),
+					string(network.RouteNextHopTypeVirtualAppliance),
+					string(network.RouteNextHopTypeNone),
+				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"next_hop_in_ip_address": {
@@ -57,9 +61,8 @@ func resourceArmRoute() *schema.Resource {
 	}
 }
 
-func resourceArmRouteCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
-	routesClient := client.routesClient
+func resourceArmRouteCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).routesClient
 
 	name := d.Get("name").(string)
 	rtName := d.Get("route_table_name").(string)
@@ -86,18 +89,18 @@ func resourceArmRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		RoutePropertiesFormat: &properties,
 	}
 
-	_, error := routesClient.CreateOrUpdate(resGroup, rtName, name, route, make(chan struct{}))
-	err := <-error
+	_, createErr := client.CreateOrUpdate(resGroup, rtName, name, route, make(chan struct{}))
+	err := <-createErr
 	if err != nil {
 		return err
 	}
 
-	read, err := routesClient.Get(resGroup, rtName, name)
+	read, err := client.Get(resGroup, rtName, name)
 	if err != nil {
 		return err
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Route %s/%s (resource group %s) ID", rtName, name, resGroup)
+		return fmt.Errorf("Cannot read Route %q/%q (resource group %q) ID", rtName, name, resGroup)
 	}
 	d.SetId(*read.ID)
 
@@ -105,7 +108,7 @@ func resourceArmRouteCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmRouteRead(d *schema.ResourceData, meta interface{}) error {
-	routesClient := meta.(*ArmClient).routesClient
+	client := meta.(*ArmClient).routesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -115,31 +118,33 @@ func resourceArmRouteRead(d *schema.ResourceData, meta interface{}) error {
 	rtName := id.Path["routeTables"]
 	routeName := id.Path["routes"]
 
-	resp, err := routesClient.Get(resGroup, rtName, routeName)
+	resp, err := client.Get(resGroup, rtName, routeName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure Route %s: %s", routeName, err)
+		return fmt.Errorf("Error making Read request on Azure Route %q: %+v", routeName, err)
 	}
 
 	d.Set("name", routeName)
 	d.Set("resource_group_name", resGroup)
 	d.Set("route_table_name", rtName)
-	d.Set("address_prefix", resp.RoutePropertiesFormat.AddressPrefix)
-	d.Set("next_hop_type", string(resp.RoutePropertiesFormat.NextHopType))
 
-	if resp.RoutePropertiesFormat.NextHopIPAddress != nil {
-		d.Set("next_hop_in_ip_address", resp.RoutePropertiesFormat.NextHopIPAddress)
+	if props := resp.RoutePropertiesFormat; props != nil {
+		d.Set("address_prefix", props.AddressPrefix)
+		d.Set("next_hop_type", string(props.NextHopType))
+
+		if ip := props.NextHopIPAddress; ip != nil {
+			d.Set("next_hop_in_ip_address", props.NextHopIPAddress)
+		}
 	}
 
 	return nil
 }
 
 func resourceArmRouteDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
-	routesClient := client.routesClient
+	client := meta.(*ArmClient).routesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -152,8 +157,8 @@ func resourceArmRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	azureRMLockByName(rtName, routeTableResourceName)
 	defer azureRMUnlockByName(rtName, routeTableResourceName)
 
-	_, error := routesClient.Delete(resGroup, rtName, routeName, make(chan struct{}))
-	err = <-error
+	_, deleteErr := client.Delete(resGroup, rtName, routeName, make(chan struct{}))
+	err = <-deleteErr
 
 	return err
 }

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -1,14 +1,12 @@
 package azurerm
 
 import (
-	"bytes"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -36,7 +34,7 @@ func resourceArmRouteTable() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"route": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -52,9 +50,16 @@ func resourceArmRouteTable() *schema.Resource {
 						},
 
 						"next_hop_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateRouteTableNextHopType,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.RouteNextHopTypeVirtualNetworkGateway),
+								string(network.RouteNextHopTypeVnetLocal),
+								string(network.RouteNextHopTypeInternet),
+								string(network.RouteNextHopTypeVirtualAppliance),
+								string(network.RouteNextHopTypeNone),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
 						"next_hop_in_ip_address": {
@@ -64,7 +69,6 @@ func resourceArmRouteTable() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceArmRouteTableRouteHash,
 			},
 
 			"subnets": {
@@ -80,10 +84,9 @@ func resourceArmRouteTable() *schema.Resource {
 }
 
 func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
-	routeTablesClient := client.routeTablesClient
+	client := meta.(*ArmClient).routeTablesClient
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Route Table creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM Route Table creation.")
 
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
@@ -97,9 +100,9 @@ func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if _, ok := d.GetOk("route"); ok {
-		routes, routeErr := expandAzureRmRouteTableRoutes(d)
+		routes, routeErr := expandRouteTableRoutes(d)
 		if routeErr != nil {
-			return fmt.Errorf("Error Building list of Route Table Routes: %s", routeErr)
+			return fmt.Errorf("Error Expanding list of Route Table Routes: %+v", routeErr)
 		}
 
 		if len(routes) > 0 {
@@ -109,18 +112,18 @@ func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	_, error := routeTablesClient.CreateOrUpdate(resGroup, name, routeSet, make(chan struct{}))
-	err := <-error
+	_, createErr := client.CreateOrUpdate(resGroup, name, routeSet, make(chan struct{}))
+	err := <-createErr
 	if err != nil {
 		return err
 	}
 
-	read, err := routeTablesClient.Get(resGroup, name, "")
+	read, err := client.Get(resGroup, name, "")
 	if err != nil {
 		return err
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Route Table %s (resource group %s) ID", name, resGroup)
+		return fmt.Errorf("Cannot read Route Table %q (resource group %q) ID", name, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -129,7 +132,7 @@ func resourceArmRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
-	routeTablesClient := meta.(*ArmClient).routeTablesClient
+	client := meta.(*ArmClient).routeTablesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -138,31 +141,28 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	resGroup := id.ResourceGroup
 	name := id.Path["routeTables"]
 
-	resp, err := routeTablesClient.Get(resGroup, name, "")
+	resp, err := client.Get(resGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure Route Table %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure Route Table %q: %+v", name, err)
 	}
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
-	if resp.RouteTablePropertiesFormat.Routes != nil {
-		d.Set("route", schema.NewSet(resourceArmRouteTableRouteHash, flattenAzureRmRouteTableRoutes(resp.RouteTablePropertiesFormat.Routes)))
-	}
+	if props := resp.RouteTablePropertiesFormat; props != nil {
+		if err := d.Set("route", flattenRouteTableRoutes(props.Routes)); err != nil {
+			return err
+		}
 
-	subnets := []string{}
-	if resp.RouteTablePropertiesFormat.Subnets != nil {
-		for _, subnet := range *resp.RouteTablePropertiesFormat.Subnets {
-			id := subnet.ID
-			subnets = append(subnets, *id)
+		if err := d.Set("subnets", flattenRouteTableSubnets(props.Subnets)); err != nil {
+			return err
 		}
 	}
-	d.Set("subnets", subnets)
 
 	flattenAndSetTags(d, resp.Tags)
 
@@ -179,25 +179,32 @@ func resourceArmRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	resGroup := id.ResourceGroup
 	name := id.Path["routeTables"]
 
-	_, error := routeTablesClient.Delete(resGroup, name, make(chan struct{}))
-	err = <-error
+	deleteResp, deleteErr := routeTablesClient.Delete(resGroup, name, make(chan struct{}))
+	resp := <-deleteResp
+	err = <-deleteErr
 
-	return err
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func expandAzureRmRouteTableRoutes(d *schema.ResourceData) ([]network.Route, error) {
-	configs := d.Get("route").(*schema.Set).List()
+func expandRouteTableRoutes(d *schema.ResourceData) ([]network.Route, error) {
+	configs := d.Get("route").([]interface{})
 	routes := make([]network.Route, 0, len(configs))
 
 	for _, configRaw := range configs {
 		data := configRaw.(map[string]interface{})
 
-		address_prefix := data["address_prefix"].(string)
-		next_hop_type := data["next_hop_type"].(string)
+		addressPrefix := data["address_prefix"].(string)
+		nextHopType := data["next_hop_type"].(string)
 
 		properties := network.RoutePropertiesFormat{
-			AddressPrefix: &address_prefix,
-			NextHopType:   network.RouteNextHopType(next_hop_type),
+			AddressPrefix: &addressPrefix,
+			NextHopType:   network.RouteNextHopType(nextHopType),
 		}
 
 		if v := data["next_hop_in_ip_address"].(string); v != "" {
@@ -216,45 +223,38 @@ func expandAzureRmRouteTableRoutes(d *schema.ResourceData) ([]network.Route, err
 	return routes, nil
 }
 
-func flattenAzureRmRouteTableRoutes(routes *[]network.Route) []interface{} {
-	results := make([]interface{}, 0, len(*routes))
+func flattenRouteTableRoutes(input *[]network.Route) []interface{} {
+	results := make([]interface{}, 0)
 
-	for _, route := range *routes {
-		r := make(map[string]interface{})
-		r["name"] = *route.Name
-		r["address_prefix"] = *route.RoutePropertiesFormat.AddressPrefix
-		r["next_hop_type"] = string(route.RoutePropertiesFormat.NextHopType)
-		if route.RoutePropertiesFormat.NextHopIPAddress != nil {
-			r["next_hop_in_ip_address"] = *route.RoutePropertiesFormat.NextHopIPAddress
+	if routes := input; routes != nil {
+		for _, route := range *routes {
+			r := make(map[string]interface{})
+
+			r["name"] = *route.Name
+
+			if props := route.RoutePropertiesFormat; props != nil {
+				r["address_prefix"] = *props.AddressPrefix
+				r["next_hop_type"] = string(props.NextHopType)
+				if ip := props.NextHopIPAddress; ip != nil {
+					r["next_hop_in_ip_address"] = *ip
+				}
+			}
+
+			results = append(results, r)
 		}
-		results = append(results, r)
 	}
 
 	return results
 }
 
-func resourceArmRouteTableRouteHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["address_prefix"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["next_hop_type"].(string))))
+func flattenRouteTableSubnets(input *[]network.Subnet) []string {
+	output := []string{}
 
-	return hashcode.String(buf.String())
-}
-
-func validateRouteTableNextHopType(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	hopTypes := map[string]bool{
-		"virtualnetworkgateway": true,
-		"vnetlocal":             true,
-		"internet":              true,
-		"virtualappliance":      true,
-		"none":                  true,
+	if subnets := input; subnets != nil {
+		for _, subnet := range *subnets {
+			output = append(output, *subnet.ID)
+		}
 	}
 
-	if !hopTypes[value] {
-		errors = append(errors, fmt.Errorf("Route Table NextHopType Protocol can only be VirtualNetworkGateway, VnetLocal, Internet or VirtualAppliance"))
-	}
-	return
+	return output
 }

--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -2,66 +2,36 @@ package azurerm
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestResourceAzureRMRouteTableNextHopType_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Random",
-			ErrCount: 1,
-		},
-		{
-			Value:    "VirtualNetworkGateway",
-			ErrCount: 0,
-		},
-		{
-			Value:    "VNETLocal",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Internet",
-			ErrCount: 0,
-		},
-		{
-			Value:    "VirtualAppliance",
-			ErrCount: 0,
-		},
-		{
-			Value:    "None",
-			ErrCount: 0,
-		},
-		{
-			Value:    "VIRTUALNETWORKGATEWAY",
-			ErrCount: 0,
-		},
-		{
-			Value:    "virtualnetworkgateway",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateRouteTableNextHopType(tc.Value, "azurerm_route_table")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Route Table nextHopType to trigger a validation error")
-		}
-	}
-}
-
 func TestAccAzureRMRouteTable_basic(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMRouteTable_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRouteTable_singleRoute(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,7 +49,7 @@ func TestAccAzureRMRouteTable_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRouteTable_disappears(t *testing.T) {
-
+	resourceName := "azurerm_route_table.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMRouteTable_basic(ri, testLocation())
 
@@ -91,8 +61,8 @@ func TestAccAzureRMRouteTable_disappears(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
-					testCheckAzureRMRouteTableDisappears("azurerm_route_table.test"),
+					testCheckAzureRMRouteTableExists(resourceName),
+					testCheckAzureRMRouteTableDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -101,7 +71,7 @@ func TestAccAzureRMRouteTable_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMRouteTable_withTags(t *testing.T) {
-
+	resourceName := "azurerm_route_table.test"
 	ri := acctest.RandInt()
 	preConfig := testAccAzureRMRouteTable_withTags(ri, testLocation())
 	postConfig := testAccAzureRMRouteTable_withTagsUpdate(ri, testLocation())
@@ -114,23 +84,18 @@ func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "tags.cost_center", "MSFT"),
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "tags.environment", "staging"),
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -138,9 +103,9 @@ func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 }
 
 func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
-
+	resourceName := "azurerm_route_table.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMRouteTable_basic(ri, testLocation())
+	preConfig := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
 	postConfig := testAccAzureRMRouteTable_multipleRoutes(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
@@ -151,17 +116,24 @@ func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "route.#", "1"),
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.name", "route1"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefix", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.next_hop_type", "VnetLocal"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRouteTableExists("azurerm_route_table.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_route_table.test", "route.#", "2"),
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.name", "route1"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefix", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.next_hop_type", "VnetLocal"),
+					resource.TestCheckResourceAttr(resourceName, "route.1.name", "route2"),
+					resource.TestCheckResourceAttr(resourceName, "route.1.address_prefix", "10.2.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.1.next_hop_type", "VnetLocal"),
 				),
 			},
 		},
@@ -173,24 +145,24 @@ func testCheckAzureRMRouteTableExists(name string) resource.TestCheckFunc {
 
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %q", name)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for route table: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for route table: %q", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).routeTablesClient
 
 		resp, err := conn.Get(resourceGroup, name, "")
 		if err != nil {
-			return fmt.Errorf("Bad: Get on routeTablesClient: %+v", err)
-		}
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Route Table %q (resource group: %q) does not exist", name, resourceGroup)
+			}
 
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Route Table %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: Get on routeTablesClient: %+v", err)
 		}
 
 		return nil
@@ -199,24 +171,25 @@ func testCheckAzureRMRouteTableExists(name string) resource.TestCheckFunc {
 
 func testCheckAzureRMRouteTableDisappears(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %q", name)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for route table: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for route table: %q", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).routeTablesClient
-
-		_, error := conn.Delete(resourceGroup, name, make(chan struct{}))
-		err := <-error
+		client := testAccProvider.Meta().(*ArmClient).routeTablesClient
+		deleteResp, deleteErr := client.Delete(resourceGroup, name, make(chan struct{}))
+		resp := <-deleteResp
+		err := <-deleteErr
 		if err != nil {
-			return fmt.Errorf("Bad: Delete on routeTablesClient: %+v", err)
+			if !utils.ResponseWasNotFound(resp) {
+				return fmt.Errorf("Bad: Delete on routeTablesClient: %+v", err)
+			}
 		}
 
 		return nil
@@ -224,7 +197,7 @@ func testCheckAzureRMRouteTableDisappears(name string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMRouteTableDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).routeTablesClient
+	client := testAccProvider.Meta().(*ArmClient).routeTablesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_route_table" {
@@ -234,15 +207,16 @@ func testCheckAzureRMRouteTableDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		resp, err := conn.Get(resourceGroup, name, "")
-
+		resp, err := client.Get(resourceGroup, name, "")
 		if err != nil {
-			return nil
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
 		}
 
-		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Route Table still exists:\n%#v", resp.RouteTablePropertiesFormat)
-		}
+		return fmt.Errorf("Route Table still exists:\n%#v", resp.RouteTablePropertiesFormat)
 	}
 
 	return nil
@@ -259,11 +233,26 @@ resource "azurerm_route_table" "test" {
     name = "acctestrt%d"
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMRouteTable_singleRoute(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acctestrt%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
 
     route {
     	name = "route1"
-	address_prefix = "10.1.0.0/16"
-	next_hop_type = "vnetlocal"
+		address_prefix = "10.1.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 }
 `, rInt, location, rInt)
@@ -283,14 +272,14 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-	address_prefix = "10.1.0.0/16"
-	next_hop_type = "vnetlocal"
+		address_prefix = "10.1.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 
     route {
     	name = "route2"
-	address_prefix = "10.2.0.0/16"
-	next_hop_type = "vnetlocal"
+		address_prefix = "10.2.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 }
 `, rInt, location, rInt)
@@ -315,8 +304,8 @@ resource "azurerm_route_table" "test" {
     }
 
     tags {
-	environment = "Production"
-	cost_center = "MSFT"
+		environment = "Production"
+		cost_center = "MSFT"
     }
 }
 `, rInt, location, rInt)
@@ -341,7 +330,7 @@ resource "azurerm_route_table" "test" {
     }
 
     tags {
-	environment = "staging"
+		environment = "staging"
     }
 }
 `, rInt, location, rInt)

--- a/azurerm/resource_arm_route_test.go
+++ b/azurerm/resource_arm_route_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMRoute_basic(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMRoute_basic(ri, testLocation())
 
@@ -31,7 +31,6 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRoute_disappears(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMRoute_basic(ri, testLocation())
 
@@ -53,7 +52,6 @@ func TestAccAzureRMRoute_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
-
 	ri := acctest.RandInt()
 	location := testLocation()
 	preConfig := testAccAzureRMRoute_basic(ri, location)
@@ -86,25 +84,24 @@ func testCheckAzureRMRouteExists(name string) resource.TestCheckFunc {
 
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %q", name)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		rtName := rs.Primary.Attributes["route_table_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for route: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for route: %q", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).routesClient
 
 		resp, err := conn.Get(resourceGroup, rtName, name)
 		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Route %q (resource group: %q) does not exist", name, resourceGroup)
+			}
 			return fmt.Errorf("Bad: Get on routesClient: %+v", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Route %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -388,7 +388,7 @@
                   <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-route") %>>
+                <li<%= sidebar_current("docs-azurerm-resource-network-route-x") %>>
                   <a href="/docs/providers/azurerm/r/route.html">azurerm_route</a>
                 </li>
 

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -3,12 +3,12 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route-x"
 sidebar_current: "docs-azurerm-resource-network-route"
 description: |-
-  Creates and Managed a Route within a Route Table.
+  Manages a Route within a Route Table.
 ---
 
 # azurerm_route
 
-Creates and Managed a Route within a Route Table.
+Manages a Route within a Route Table.
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_route_table" "test" {
   name                = "acceptanceTestRouteTable1"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
@@ -28,9 +28,8 @@ resource "azurerm_route" "test" {
   name                = "acceptanceTestRoute1"
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
-
-  address_prefix = "10.1.0.0/16"
-  next_hop_type  = "vnetlocal"
+  address_prefix      = "10.1.0.0/16"
+  next_hop_type       = "vnetlocal"
 }
 ```
 
@@ -38,21 +37,17 @@ resource "azurerm_route" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the route. Changing this forces a
-    new resource to be created.
+* `name` - (Required) The name of the route. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the route.
+* `resource_group_name` - (Required) The name of the resource group in which to create the route. Changing this forces a new resource to be created.
 
+* `route_table_name` - (Required) The name of the route table within which create the route. Changing this forces a new resource to be created.
 
-* `route_table_name` - (Required) The name of the route table to which to create the route
+* `address_prefix` - (Required) The destination CIDR to which the route applies, such as `10.1.0.0/16`
 
-* `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16
+* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`
 
-* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to.
-                               Possible values are VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance and None
-
-* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance.
+* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.
 
 ## Attributes Reference
 
@@ -62,8 +57,8 @@ The following attributes are exported:
 
 ## Import
 
-
 Routes can be imported using the `resource id`, e.g.
+
 ```
 terraform import azurerm_route.testRoute /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1/routes/myroute1
 ```

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_route"
+page_title: "Azure Resource Manager: azurerm_route-x"
 sidebar_current: "docs-azurerm-resource-network-route"
 description: |-
-  Creates a new Route Resource
+  Creates and Managed a Route within a Route Table.
 ---
 
-# azurerm\_route
+# azurerm_route
 
-Creates a new Route Resource
+Creates and Managed a Route within a Route Table.
 
 ## Example Usage
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -3,12 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route_table"
 sidebar_current: "docs-azurerm-resource-network-route-table"
 description: |-
-  Creates a new Route Table Resource
+  Manages a Route Table
+
 ---
 
-# azurerm\_route\_table
+# azurerm_route_table
 
-Creates a new Route Table Resource
+Manages a Route Table
 
 ## Example Usage
 
@@ -20,7 +21,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_route_table" "test" {
   name                = "acceptanceTestSecurityGroup1"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   route {
@@ -39,16 +40,13 @@ resource "azurerm_route_table" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the route table. Changing this forces a
-    new resource to be created.
+* `name` - (Required) The name of the route table. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the route table.
+* `resource_group_name` - (Required) The name of the resource group in which to create the route table. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `route` - (Optional) Can be specified multiple times to define multiple
-                                   routes. Each `route` block supports fields documented below.
+* `route` - (Optional) Can be specified multiple times to define multiple routes. Each `route` block supports fields documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -58,10 +56,10 @@ The `route` block supports:
 
 * `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16
 
-* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to.
-                               Possible values are VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance and None
+* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal``, `Internet`, `VirtualAppliance` and `None`.
 
-* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance.
+* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance``.
+
 
 ## Attributes Reference
 
@@ -72,8 +70,8 @@ The following attributes are exported:
 
 ## Import
 
-
 Route Tables can be imported using the `resource id`, e.g.
+
 ```
 terraform import azurerm_route_table.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1
 ```


### PR DESCRIPTION
- `azurerm_route_table`
  - switching over to using the enum values in the Azure SDK for Go, rather than our own hard-coded strings
  - refactoring the resource to avoid a potential crash
  - migrating `Route` over from a Set to a List

- `azurerm_route`
  - switching over to using the enum values in the Azure SDK for Go, rather than our own hard-coded strings
  - refactoring the resource to avoid a potential crash
  - updating the documentation
  - fixing the sidebar highlight