### PR TITLE
`azurerm_route_table` - removing routes when none are specified

### DIFF
--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -48,6 +48,35 @@ func TestAccAzureRMRouteTable_singleRoute(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRouteTable_removeRoute(t *testing.T) {
+	resourceName := "azurerm_route_table.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
+	updatedConfig := testAccAzureRMRouteTable_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMRouteTable_disappears(t *testing.T) {
 	resourceName := "azurerm_route_table.test"
 	ri := acctest.RandInt()


### PR DESCRIPTION
Removing Route's when none are defined. Fixes #39

New test:

```
$ acctests azurerm TestAccAzureRMRouteTable_removeRoute
=== RUN   TestAccAzureRMRouteTable_removeRoute
--- PASS: TestAccAzureRMRouteTable_removeRoute (93.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    93.914s
```

Running the suite now