### PR TITLE
only use the default subscription if not set explicitly

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -253,13 +253,15 @@ func (c *Config) LoadTokensFromAzureCLI() error {
 		return fmt.Errorf("Azure CLI Authorization Profile was not found. Please ensure the Azure CLI is installed and then log-in with `az login`.")
 	}
 
-	// pull out the TenantID and Subscription ID from the Azure Profile
-	for _, subscription := range profile.Subscriptions {
-		if subscription.IsDefault {
-			c.SubscriptionID = subscription.ID
-			c.TenantID = subscription.TenantID
-			c.Environment = normalizeEnvironmentName(subscription.EnvironmentName)
-			break
+	// pull out the TenantID and Subscription ID from the Azure Profile, if not set
+	if c.SubscriptionID == "" && c.TenantID == "" {
+		for _, subscription := range profile.Subscriptions {
+			if subscription.IsDefault {
+				c.SubscriptionID = subscription.ID
+				c.TenantID = subscription.TenantID
+				c.Environment = normalizeEnvironmentName(subscription.EnvironmentName)
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
I found this after I was setting the the subscription and tenant Id in the provider config via:

```hcl
provider "azurerm" {
  subscription_id = "...."
  tenant_id       = "...."
}

```
 and then logging in with `az login`. However, it the terraform provider was still trying to use what ever my configured default subscription is. I expected it to use what I had it configured explicitly to use. This fixes that.