### PR TITLE
Clarify the error message for the validation of public IP domain name label

### DIFF
--- a/azurerm/resource_arm_public_ip.go
+++ b/azurerm/resource_arm_public_ip.go
@@ -225,7 +225,7 @@ func validatePublicIpDomainNameLabel(v interface{}, k string) (ws []string, erro
 	value := v.(string)
 	if !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and hyphens allowed in %q: %q",
+			"only lowercase alphanumeric characters and hyphens allowed in %q: %q",
 			k, value))
 	}
 


### PR DESCRIPTION
As per the regex, only lowercase characters are allowed.