### PR TITLE
Nil refence fix for issue #464

### DIFF
--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -226,10 +226,18 @@ func flattenNetworkSecurityRules(rules *[]network.SecurityRule) []interface{} {
 			sgRule["name"] = *rule.Name
 
 			if props := rule.SecurityRulePropertiesFormat; props != nil {
-				sgRule["destination_address_prefix"] = *props.DestinationAddressPrefix
-				sgRule["destination_port_range"] = *props.DestinationPortRange
-				sgRule["source_address_prefix"] = *props.SourceAddressPrefix
-				sgRule["source_port_range"] = *props.SourcePortRange
+				if props.DestinationAddressPrefix != nil {
+					sgRule["destination_address_prefix"] = *props.DestinationAddressPrefix
+				}
+				if props.DestinationPortRange != nil {
+					sgRule["destination_port_range"] = *props.DestinationPortRange
+				}
+				if props.SourceAddressPrefix != nil {
+					sgRule["source_address_prefix"] = *props.SourceAddressPrefix
+				}
+				if props.SourcePortRange != nil {
+					sgRule["source_port_range"] = *props.SourcePortRange
+				}
 				sgRule["priority"] = int(*props.Priority)
 				sgRule["access"] = string(props.Access)
 				sgRule["direction"] = string(props.Direction)


### PR DESCRIPTION
This nil check is needed to prevent a terraform crash that occurs when a user tries to update a network rule that was manually changed through the Azure Portal.   Fix is to check if properties on the props object is nil before you try to assign those string values to the  sgRule dictionary.