### PR TITLE
Adding validation for both the App Service/App Service Plan resources names

### DIFF
--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/arm/web"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -22,16 +23,13 @@ func resourceArmAppService() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAppServiceName,
 			},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+			"resource_group_name": resourceGroupNameSchema(),
 
 			"location": locationSchema(),
 
@@ -628,4 +626,14 @@ func flattenAppServiceAppSettings(input *map[string]*string) map[string]string {
 	}
 
 	return output
+}
+
+func validateAppServiceName(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z-]+$`).Match([]byte(value)); !matched {
+		es = append(es, fmt.Errorf("%q may only contain alphanumeric characters and dashes", k))
+	}
+
+	return
 }

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/arm/web"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -22,9 +23,10 @@ func resourceArmAppServicePlan() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAppServicePlanName,
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),
@@ -268,4 +270,14 @@ func flattenAppServiceProperties(props *web.AppServicePlanProperties) []interfac
 
 	result = append(result, properties)
 	return result
+}
+
+func validateAppServicePlanName(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z-]+$`).Match([]byte(value)); !matched {
+		es = append(es, fmt.Errorf("%q may only contain alphanumeric characters and dashes", k))
+	}
+
+	return
 }

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+func TestAzureRMAppServicePlanName_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "ab",
+			ErrCount: 0,
+		},
+		{
+			Value:    "abc",
+			ErrCount: 0,
+		},
+		{
+			Value:    "webapp1",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello-world",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello_world",
+			ErrCount: 1,
+		},
+		{
+			Value:    "helloworld21!",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAppServicePlanName(tc.Value, "azurerm_app_service_plan")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the App Service Plan Name to trigger a validation error for '%s'", tc.Value)
+		}
+	}
+}
+
 func TestAccAzureRMAppServicePlan_basicWindows(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMAppServicePlan_basicWindows(ri, testLocation())

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+func TestAzureRMAppServiceName_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "ab",
+			ErrCount: 0,
+		},
+		{
+			Value:    "abc",
+			ErrCount: 0,
+		},
+		{
+			Value:    "webapp1",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello-world",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello_world",
+			ErrCount: 1,
+		},
+		{
+			Value:    "helloworld21!",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAppServiceName(tc.Value, "azurerm_app_service")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the App Service Name to trigger a validation error for '%s'", tc.Value)
+		}
+	}
+}
+
 func TestAccAzureRMAppService_basic(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()


### PR DESCRIPTION
Highlighted in the comments of #407, if an underscore is present in the name then Azure returns a 400 - which isn't particularly user-friendly - this should catch it with validation which matches the portal.

```
$ acctests azurerm TestAzureRMAppServicePlanName_validation
=== RUN   TestAzureRMAppServicePlanName_validation
--- PASS: TestAzureRMAppServicePlanName_validation (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    0.029s

$ acctests azurerm TestAzureRMAppServiceName_validation
=== RUN   TestAzureRMAppServiceName_validation
--- PASS: TestAzureRMAppServiceName_validation (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    0.019s
```