### PR TITLE
Container Registry Migration: Fixing a crash when the storage_account block is nil

### DIFF
--- a/azurerm/resource_arm_container_registry_migrate.go
+++ b/azurerm/resource_arm_container_registry_migrate.go
@@ -75,8 +75,13 @@ func updateV1ToV2StorageAccountName(is *terraform.InstanceState, meta interface{
 	}
 
 	inputAccounts := result.Value.([]interface{})
-	inputAccount := inputAccounts[0].(map[string]interface{})
-	name := inputAccount["name"].(string)
+	inputAccount := inputAccounts[0]
+	if inputAccount == nil {
+		return nil
+	}
+
+	account := inputAccount.(map[string]interface{})
+	name := account["name"].(string)
 	storageAccountId, err := findAzureStorageAccountIdFromName(name, meta)
 	if err != nil {
 		return err


### PR DESCRIPTION
Confirmed that upgrading from 0.2.2 -> 0.3.2 crashes - and that going from 0.2.2 -> this branch is good.

Fixes #491