### PR TITLE
Hotfix: upgrade packages under go-autorest to be v9.4.1.

### DIFF
--- a/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/url"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/devicetoken.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/devicetoken.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 /*
   This file is largely based on rjw57/oauth2device's code, with the follow differences:
    * scope -> resource, and only allow a single one

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/msi.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/msi.go
@@ -2,5 +2,19 @@
 
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 // msiPath is the path to the MSI Extension settings file (to discover the endpoint)
 var msiPath = "/var/lib/waagent/ManagedIdentity-Settings"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/msi_windows.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/msi_windows.go
@@ -2,6 +2,20 @@
 
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"os"
 	"strings"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/persist.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/persist.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"encoding/json"
 	"fmt"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/sender.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"net/http"
 )

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"crypto/rand"
 	"crypto/rsa"

--- a/vendor/github.com/Azure/go-autorest/autorest/authorization.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/authorization.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/http"

--- a/vendor/github.com/Azure/go-autorest/autorest/autorest.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/autorest.go
@@ -57,6 +57,20 @@ generated clients, see the Client described below.
 */
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"net/http"
 	"time"
@@ -73,6 +87,9 @@ const (
 // ResponseHasStatusCode returns true if the status code in the HTTP Response is in the passed set
 // and false otherwise.
 func ResponseHasStatusCode(resp *http.Response, codes ...int) bool {
+	if resp == nil {
+		return false
+	}
 	return containsInt(codes, resp.StatusCode)
 }
 

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
@@ -1,7 +1,23 @@
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +39,152 @@ const (
 	operationSucceeded  string = "Succeeded"
 )
 
+var pollingCodes = [...]int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
+
+// Future provides a mechanism to access the status and results of an asynchronous request.
+// Since futures are stateful they should be passed by value to avoid race conditions.
+type Future struct {
+	req  *http.Request
+	resp *http.Response
+	ps   pollingState
+}
+
+// NewFuture returns a new Future object initialized with the specified request.
+func NewFuture(req *http.Request) Future {
+	return Future{req: req}
+}
+
+// Response returns the last HTTP response or nil if there isn't one.
+func (f Future) Response() *http.Response {
+	return f.resp
+}
+
+// Status returns the last status message of the operation.
+func (f Future) Status() string {
+	if f.ps.State == "" {
+		return "Unknown"
+	}
+	return f.ps.State
+}
+
+// PollingMethod returns the method used to monitor the status of the asynchronous operation.
+func (f Future) PollingMethod() PollingMethodType {
+	return f.ps.PollingMethod
+}
+
+// Done queries the service to see if the operation has completed.
+func (f *Future) Done(sender autorest.Sender) (bool, error) {
+	// exit early if this future has terminated
+	if f.ps.hasTerminated() {
+		return true, f.errorInfo()
+	}
+
+	resp, err := sender.Do(f.req)
+	f.resp = resp
+	if err != nil || !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
+		return false, err
+	}
+
+	err = updatePollingState(resp, &f.ps)
+	if err != nil {
+		return false, err
+	}
+
+	if f.ps.hasTerminated() {
+		return true, f.errorInfo()
+	}
+
+	f.req, err = newPollingRequest(f.ps)
+	return false, err
+}
+
+// GetPollingDelay returns a duration the application should wait before checking
+// the status of the asynchronous request and true; this value is returned from
+// the service via the Retry-After response header.  If the header wasn't returned
+// then the function returns the zero-value time.Duration and false.
+func (f Future) GetPollingDelay() (time.Duration, bool) {
+	if f.resp == nil {
+		return 0, false
+	}
+
+	retry := f.resp.Header.Get(autorest.HeaderRetryAfter)
+	if retry == "" {
+		return 0, false
+	}
+
+	d, err := time.ParseDuration(retry + "s")
+	if err != nil {
+		panic(err)
+	}
+
+	return d, true
+}
+
+// WaitForCompletion will return when one of the following conditions is met: the long
+// running operation has completed, the provided context is cancelled, or the client's
+// polling duration has been exceeded.  It will retry failed polling attempts based on
+// the retry value defined in the client up to the maximum retry attempts.
+func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, client.PollingDuration)
+	defer cancel()
+
+	done, err := f.Done(client)
+	for attempts := 0; !done; done, err = f.Done(client) {
+		if attempts >= client.RetryAttempts {
+			return autorest.NewErrorWithError(err, "azure", "WaitForCompletion", f.resp, "the number of retries has been exceeded")
+		}
+		// we want delayAttempt to be zero in the non-error case so
+		// that DelayForBackoff doesn't perform exponential back-off
+		var delayAttempt int
+		var delay time.Duration
+		if err == nil {
+			// check for Retry-After delay, if not present use the client's polling delay
+			var ok bool
+			delay, ok = f.GetPollingDelay()
+			if !ok {
+				delay = client.PollingDelay
+			}
+		} else {
+			// there was an error polling for status so perform exponential
+			// back-off based on the number of attempts using the client's retry
+			// duration.  update attempts after delayAttempt to avoid off-by-one.
+			delayAttempt = attempts
+			delay = client.RetryDuration
+			attempts++
+		}
+		// wait until the delay elapses or the context is cancelled
+		delayElapsed := autorest.DelayForBackoff(delay, delayAttempt, ctx.Done())
+		if !delayElapsed {
+			return autorest.NewErrorWithError(ctx.Err(), "azure", "WaitForCompletion", f.resp, "context has been cancelled")
+		}
+	}
+	return err
+}
+
+// if the operation failed the polling state will contain
+// error information and implements the error interface
+func (f *Future) errorInfo() error {
+	if !f.ps.hasSucceeded() {
+		return f.ps
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (f Future) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&f.ps)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (f *Future) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &f.ps)
+	if err != nil {
+		return err
+	}
+	f.req, err = newPollingRequest(f.ps)
+	return err
+}
+
 // DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
 // long-running operation. It will delay between requests for the duration specified in the
 // RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
@@ -34,8 +196,7 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 			if err != nil {
 				return resp, err
 			}
-			pollingCodes := []int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
-			if !autorest.ResponseHasStatusCode(resp, pollingCodes...) {
+			if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
 				return resp, nil
 			}
 
@@ -52,10 +213,11 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 					break
 				}
 
-				r, err = newPollingRequest(resp, ps)
+				r, err = newPollingRequest(ps)
 				if err != nil {
 					return resp, err
 				}
+				r.Cancel = resp.Request.Cancel
 
 				delay = autorest.GetRetryAfter(resp, delay)
 				resp, err = autorest.SendWithSender(s, r,
@@ -72,20 +234,15 @@ func getAsyncOperation(resp *http.Response) string {
 }
 
 func hasSucceeded(state string) bool {
-	return state == operationSucceeded
+	return strings.EqualFold(state, operationSucceeded)
 }
 
 func hasTerminated(state string) bool {
-	switch state {
-	case operationCanceled, operationFailed, operationSucceeded:
-		return true
-	default:
-		return false
-	}
+	return strings.EqualFold(state, operationCanceled) || strings.EqualFold(state, operationFailed) || strings.EqualFold(state, operationSucceeded)
 }
 
 func hasFailed(state string) bool {
-	return state == operationFailed
+	return strings.EqualFold(state, operationFailed)
 }
 
 type provisioningTracker interface {
@@ -146,36 +303,42 @@ func (ps provisioningStatus) hasProvisioningError() bool {
 	return ps.ProvisioningError != ServiceError{}
 }
 
-type pollingResponseFormat string
+// PollingMethodType defines a type used for enumerating polling mechanisms.
+type PollingMethodType string
 
 const (
-	usesOperationResponse  pollingResponseFormat = "OperationResponse"
-	usesProvisioningStatus pollingResponseFormat = "ProvisioningStatus"
-	formatIsUnknown        pollingResponseFormat = ""
+	// PollingAsyncOperation indicates the polling method uses the Azure-AsyncOperation header.
+	PollingAsyncOperation PollingMethodType = "AsyncOperation"
+
+	// PollingLocation indicates the polling method uses the Location header.
+	PollingLocation PollingMethodType = "Location"
+
+	// PollingUnknown indicates an unknown polling method and is the default value.
+	PollingUnknown PollingMethodType = ""
 )
 
 type pollingState struct {
-	responseFormat pollingResponseFormat
-	uri            string
-	state          string
-	code           string
-	message        string
+	PollingMethod PollingMethodType `json:"pollingMethod"`
+	URI           string            `json:"uri"`
+	State         string            `json:"state"`
+	Code          string            `json:"code"`
+	Message       string            `json:"message"`
 }
 
 func (ps pollingState) hasSucceeded() bool {
-	return hasSucceeded(ps.state)
+	return hasSucceeded(ps.State)
 }
 
 func (ps pollingState) hasTerminated() bool {
-	return hasTerminated(ps.state)
+	return hasTerminated(ps.State)
 }
 
 func (ps pollingState) hasFailed() bool {
-	return hasFailed(ps.state)
+	return hasFailed(ps.State)
 }
 
 func (ps pollingState) Error() string {
-	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.state, ps.code, ps.message)
+	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.State, ps.Code, ps.Message)
 }
 
 //	updatePollingState maps the operation status -- retrieved from either a provisioningState
@@ -190,7 +353,7 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- The first response will always be a provisioningStatus response; only the polling requests,
 	//    depending on the header returned, may be something otherwise.
 	var pt provisioningTracker
-	if ps.responseFormat == usesOperationResponse {
+	if ps.PollingMethod == PollingAsyncOperation {
 		pt = &operationResource{}
 	} else {
 		pt = &provisioningStatus{}
@@ -198,30 +361,30 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 
 	// If this is the first request (that is, the polling response shape is unknown), determine how
 	// to poll and what to expect
-	if ps.responseFormat == formatIsUnknown {
+	if ps.PollingMethod == PollingUnknown {
 		req := resp.Request
 		if req == nil {
 			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
 		}
 
 		// Prefer the Azure-AsyncOperation header
-		ps.uri = getAsyncOperation(resp)
-		if ps.uri != "" {
-			ps.responseFormat = usesOperationResponse
+		ps.URI = getAsyncOperation(resp)
+		if ps.URI != "" {
+			ps.PollingMethod = PollingAsyncOperation
 		} else {
-			ps.responseFormat = usesProvisioningStatus
+			ps.PollingMethod = PollingLocation
 		}
 
 		// Else, use the Location header
-		if ps.uri == "" {
-			ps.uri = autorest.GetLocation(resp)
+		if ps.URI == "" {
+			ps.URI = autorest.GetLocation(resp)
 		}
 
 		// Lastly, requests against an existing resource, use the last request URI
-		if ps.uri == "" {
+		if ps.URI == "" {
 			m := strings.ToUpper(req.Method)
 			if m == http.MethodPatch || m == http.MethodPut || m == http.MethodGet {
-				ps.uri = req.URL.String()
+				ps.URI = req.URL.String()
 			}
 		}
 	}
@@ -242,23 +405,23 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Unknown states are per-service inprogress states
 	// -- Otherwise, infer state from HTTP status code
 	if pt.hasTerminated() {
-		ps.state = pt.state()
+		ps.State = pt.state()
 	} else if pt.state() != "" {
-		ps.state = operationInProgress
+		ps.State = operationInProgress
 	} else {
 		switch resp.StatusCode {
 		case http.StatusAccepted:
-			ps.state = operationInProgress
+			ps.State = operationInProgress
 
 		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
-			ps.state = operationSucceeded
+			ps.State = operationSucceeded
 
 		default:
-			ps.state = operationFailed
+			ps.State = operationFailed
 		}
 	}
 
-	if ps.state == operationInProgress && ps.uri == "" {
+	if strings.EqualFold(ps.State, operationInProgress) && ps.URI == "" {
 		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
 	}
 
@@ -267,35 +430,30 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Response
 	// -- Otherwise, Unknown
 	if ps.hasFailed() {
-		if ps.responseFormat == usesOperationResponse {
+		if ps.PollingMethod == PollingAsyncOperation {
 			or := pt.(*operationResource)
-			ps.code = or.OperationError.Code
-			ps.message = or.OperationError.Message
+			ps.Code = or.OperationError.Code
+			ps.Message = or.OperationError.Message
 		} else {
 			p := pt.(*provisioningStatus)
 			if p.hasProvisioningError() {
-				ps.code = p.ProvisioningError.Code
-				ps.message = p.ProvisioningError.Message
+				ps.Code = p.ProvisioningError.Code
+				ps.Message = p.ProvisioningError.Message
 			} else {
-				ps.code = "Unknown"
-				ps.message = "None"
+				ps.Code = "Unknown"
+				ps.Message = "None"
 			}
 		}
 	}
 	return nil
 }
 
-func newPollingRequest(resp *http.Response, ps pollingState) (*http.Request, error) {
-	req := resp.Request
-	if req == nil {
-		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
-	}
-
-	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+func newPollingRequest(ps pollingState) (*http.Request, error) {
+	reqPoll, err := autorest.Prepare(&http.Request{},
 		autorest.AsGet(),
-		autorest.WithBaseURL(ps.uri))
+		autorest.WithBaseURL(ps.URI))
 	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.uri)
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.URI)
 	}
 
 	return reqPoll, nil

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
@@ -5,6 +5,20 @@ See the included examples for more detail.
 */
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"encoding/json"
 	"fmt"
@@ -165,7 +179,13 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				if decodeErr != nil {
 					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
 				} else if e.ServiceError == nil {
-					e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
+					// Check if error is unwrapped ServiceError
+					if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil || e.ServiceError.Message == "" {
+						e.ServiceError = &ServiceError{
+							Code:    "Unknown",
+							Message: "Unknown service error",
+						}
+					}
 				}
 
 				e.RequestID = ExtractRequestID(resp)

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/profile.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/profile.go
@@ -1,5 +1,19 @@
 package cli
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
@@ -1,5 +1,19 @@
 package cli
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"encoding/json"
 	"fmt"
@@ -48,8 +62,19 @@ func (t Token) ToADALToken() (converted adal.Token, err error) {
 }
 
 // AccessTokensPath returns the path where access tokens are stored from the Azure CLI
+// TODO(#199): add unit test.
 func AccessTokensPath() (string, error) {
-	return homedir.Expand("~/.azure/accessTokens.json")
+	// Azure-CLI allows user to customize the path of access tokens thorugh environment variable.
+	var accessTokenPath = os.Getenv("AZURE_ACCESS_TOKEN_FILE")
+	var err error
+
+	// Fallback logic to default path on non-cloud-shell environment.
+	// TODO(#200): remove the dependency on hard-coding path.
+	if accessTokenPath == "" {
+		accessTokenPath, err = homedir.Expand("~/.azure/accessTokens.json")
+	}
+
+	return accessTokenPath, err
 }
 
 // ParseExpirationDate parses either a Azure CLI or CloudShell date into a time object

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -1,9 +1,30 @@
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 )
+
+// EnvironmentFilepathName captures the name of the environment variable containing the path to the file
+// to be used while populating the Azure Environment.
+const EnvironmentFilepathName = "AZURE_ENVIRONMENT_FILEPATH"
 
 var environments = map[string]Environment{
 	"AZURECHINACLOUD":        ChinaCloud,
@@ -119,12 +140,37 @@ var (
 	}
 )
 
-// EnvironmentFromName returns an Environment based on the common name specified
+// EnvironmentFromName returns an Environment based on the common name specified.
 func EnvironmentFromName(name string) (Environment, error) {
+	// IMPORTANT
+	// As per @radhikagupta5:
+	// This is technical debt, fundamentally here because Kubernetes is not currently accepting
+	// contributions to the providers. Once that is an option, the provider should be updated to
+	// directly call `EnvironmentFromFile`. Until then, we rely on dispatching Azure Stack environment creation
+	// from this method based on the name that is provided to us.
+	if strings.EqualFold(name, "AZURESTACKCLOUD") {
+		return EnvironmentFromFile(os.Getenv(EnvironmentFilepathName))
+	}
+
 	name = strings.ToUpper(name)
 	env, ok := environments[name]
 	if !ok {
 		return env, fmt.Errorf("autorest/azure: There is no cloud environment matching the name %q", name)
 	}
+
 	return env, nil
+}
+
+// EnvironmentFromFile loads an Environment from a configuration file available on disk.
+// This function is particularly useful in the Hybrid Cloud model, where one must define their own
+// endpoints.
+func EnvironmentFromFile(location string) (unmarshaled Environment, err error) {
+	fileContents, err := ioutil.ReadFile(location)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(fileContents, &unmarshaled)
+
+	return
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
@@ -1,0 +1,203 @@
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package azure
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// DoRetryWithRegistration tries to register the resource provider in case it is unregistered.
+// It also handles request retries
+func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			rr := autorest.NewRetriableRequest(r)
+			for currentAttempt := 0; currentAttempt < client.RetryAttempts; currentAttempt++ {
+				err = rr.Prepare()
+				if err != nil {
+					return resp, err
+				}
+
+				resp, err = autorest.SendWithSender(s, rr.Request(),
+					autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+				)
+				if err != nil {
+					return resp, err
+				}
+
+				if resp.StatusCode != http.StatusConflict {
+					return resp, err
+				}
+				var re RequestError
+				err = autorest.Respond(
+					resp,
+					autorest.ByUnmarshallingJSON(&re),
+				)
+				if err != nil {
+					return resp, err
+				}
+				err = re
+
+				if re.ServiceError != nil && re.ServiceError.Code == "MissingSubscriptionRegistration" {
+					regErr := register(client, r, re)
+					if regErr != nil {
+						return resp, fmt.Errorf("failed auto registering Resource Provider: %s. Original error: %s", regErr, err)
+					}
+				}
+			}
+			return resp, fmt.Errorf("failed request: %s", err)
+		})
+	}
+}
+
+func getProvider(re RequestError) (string, error) {
+	if re.ServiceError != nil {
+		if re.ServiceError.Details != nil && len(*re.ServiceError.Details) > 0 {
+			detail := (*re.ServiceError.Details)[0].(map[string]interface{})
+			return detail["target"].(string), nil
+		}
+	}
+	return "", errors.New("provider was not found in the response")
+}
+
+func register(client autorest.Client, originalReq *http.Request, re RequestError) error {
+	subID := getSubscription(originalReq.URL.Path)
+	if subID == "" {
+		return errors.New("missing parameter subscriptionID to register resource provider")
+	}
+	providerName, err := getProvider(re)
+	if err != nil {
+		return fmt.Errorf("missing parameter provider to register resource provider: %s", err)
+	}
+	newURL := url.URL{
+		Scheme: originalReq.URL.Scheme,
+		Host:   originalReq.URL.Host,
+	}
+
+	// taken from the resources SDK
+	// with almost identical code, this sections are easier to mantain
+	// It is also not a good idea to import the SDK here
+	// https://github.com/Azure/azure-sdk-for-go/blob/9f366792afa3e0ddaecdc860e793ba9d75e76c27/arm/resources/resources/providers.go#L252
+	pathParameters := map[string]interface{}{
+		"resourceProviderNamespace": autorest.Encode("path", providerName),
+		"subscriptionId":            autorest.Encode("path", subID),
+	}
+
+	const APIVersion = "2016-09-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPost(),
+		autorest.WithBaseURL(newURL.String()),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}/register", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+	)
+
+	req, err := preparer.Prepare(&http.Request{})
+	if err != nil {
+		return err
+	}
+	req.Cancel = originalReq.Cancel
+
+	resp, err := autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+	)
+	if err != nil {
+		return err
+	}
+
+	type Provider struct {
+		RegistrationState *string `json:"registrationState,omitempty"`
+	}
+	var provider Provider
+
+	err = autorest.Respond(
+		resp,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&provider),
+		autorest.ByClosing(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// poll for registered provisioning state
+	now := time.Now()
+	for err == nil && time.Since(now) < client.PollingDuration {
+		// taken from the resources SDK
+		// https://github.com/Azure/azure-sdk-for-go/blob/9f366792afa3e0ddaecdc860e793ba9d75e76c27/arm/resources/resources/providers.go#L45
+		preparer := autorest.CreatePreparer(
+			autorest.AsGet(),
+			autorest.WithBaseURL(newURL.String()),
+			autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}", pathParameters),
+			autorest.WithQueryParameters(queryParameters),
+		)
+		req, err = preparer.Prepare(&http.Request{})
+		if err != nil {
+			return err
+		}
+		req.Cancel = originalReq.Cancel
+
+		resp, err := autorest.SendWithSender(client.Sender, req,
+			autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+		)
+		if err != nil {
+			return err
+		}
+
+		err = autorest.Respond(
+			resp,
+			WithErrorUnlessStatusCode(http.StatusOK),
+			autorest.ByUnmarshallingJSON(&provider),
+			autorest.ByClosing(),
+		)
+		if err != nil {
+			return err
+		}
+
+		if provider.RegistrationState != nil &&
+			*provider.RegistrationState == "Registered" {
+			break
+		}
+
+		delayed := autorest.DelayWithRetryAfter(resp, originalReq.Cancel)
+		if !delayed {
+			autorest.DelayForBackoff(client.PollingDelay, 0, originalReq.Cancel)
+		}
+	}
+	if !(time.Since(now) < client.PollingDuration) {
+		return errors.New("polling for resource provider registration has exceeded the polling duration")
+	}
+	return err
+}
+
+func getSubscription(path string) string {
+	parts := strings.Split(path, "/")
+	for i, v := range parts {
+		if v == "subscriptions" && (i+1) < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"fmt"
@@ -21,6 +35,9 @@ const (
 
 	// DefaultRetryAttempts is number of attempts for retry status codes (5xx).
 	DefaultRetryAttempts = 3
+
+	// DefaultRetryDuration is the duration to wait between retries.
+	DefaultRetryDuration = 30 * time.Second
 )
 
 var (
@@ -33,7 +50,8 @@ var (
 		Version(),
 	)
 
-	statusCodesForRetry = []int{
+	// StatusCodesForRetry are a defined group of status code for which the client will retry
+	StatusCodesForRetry = []int{
 		http.StatusRequestTimeout,      // 408
 		http.StatusTooManyRequests,     // 429
 		http.StatusInternalServerError, // 500
@@ -157,9 +175,10 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDelay:    DefaultPollingDelay,
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
-		RetryDuration:   30 * time.Second,
+		RetryDuration:   DefaultRetryDuration,
 		UserAgent:       defaultUserAgent,
 	}
+	c.Sender = c.sender()
 	c.AddToUserAgent(ua)
 	return c
 }
@@ -187,10 +206,9 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
-	resp, err := SendWithSender(c.sender(), r,
-		DoRetryForStatusCodes(c.RetryAttempts, c.RetryDuration, statusCodesForRetry...))
-	Respond(resp,
-		c.ByInspecting())
+
+	resp, err := SendWithSender(c.sender(), r)
+	Respond(resp, c.ByInspecting())
 	return resp, err
 }
 

--- a/vendor/github.com/Azure/go-autorest/autorest/date/date.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/date.go
@@ -5,6 +5,20 @@ time.Time types. And both convert to time.Time through a ToTime method.
 */
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/time.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/time.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"regexp"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"errors"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/unixtime.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/unixtime.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/binary"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"strings"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/error.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/error.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/http"

--- a/vendor/github.com/Azure/go-autorest/autorest/preparer.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/preparer.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"io"

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.7.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.7.go
@@ -1,17 +1,31 @@
 // +build !go1.8
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package autorest
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 )
 
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
-	req   *http.Request
-	br    *bytes.Reader
-	reset bool
+	req *http.Request
+	br  *bytes.Reader
 }
 
 // Prepare signals that the request is about to be sent.
@@ -19,21 +33,17 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
-		if rr.reset {
-			if rr.br != nil {
-				_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
-			}
-			rr.reset = false
-			if err != nil {
-				return err
-			}
+		if rr.br != nil {
+			_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
+			rr.req.Body = ioutil.NopCloser(rr.br)
+		}
+		if err != nil {
+			return err
 		}
 		if rr.br == nil {
 			// fall back to making a copy (only do this once)
 			err = rr.prepareFromByteReader()
 		}
-		// indicates that the request body needs to be reset
-		rr.reset = true
 	}
 	return err
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.8.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.8.go
@@ -1,19 +1,33 @@
 // +build go1.8
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package autorest
 
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
-	req   *http.Request
-	rc    io.ReadCloser
-	br    *bytes.Reader
-	reset bool
+	req *http.Request
+	rc  io.ReadCloser
+	br  *bytes.Reader
 }
 
 // Prepare signals that the request is about to be sent.
@@ -21,16 +35,14 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
-		if rr.reset {
-			if rr.rc != nil {
-				rr.req.Body = rr.rc
-			} else if rr.br != nil {
-				_, err = rr.br.Seek(0, io.SeekStart)
-			}
-			rr.reset = false
-			if err != nil {
-				return err
-			}
+		if rr.rc != nil {
+			rr.req.Body = rr.rc
+		} else if rr.br != nil {
+			_, err = rr.br.Seek(0, io.SeekStart)
+			rr.req.Body = ioutil.NopCloser(rr.br)
+		}
+		if err != nil {
+			return err
 		}
 		if rr.req.GetBody != nil {
 			// this will allow us to preserve the body without having to
@@ -43,8 +55,6 @@ func (rr *RetriableRequest) Prepare() (err error) {
 			// fall back to making a copy (only do this once)
 			err = rr.prepareFromByteReader()
 		}
-		// indicates that the request body needs to be reset
-		rr.reset = true
 	}
 	return err
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/sender.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"log"
@@ -207,7 +221,8 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 					return resp, err
 				}
 				resp, err = s.Do(rr.Request())
-				if err != nil || !ResponseHasStatusCode(resp, codes...) {
+				// we want to retry if err is not nil (e.g. transient network failure)
+				if err == nil && !ResponseHasStatusCode(resp, codes...) {
 					return resp, err
 				}
 				delayed := DelayWithRetryAfter(resp, r.Cancel)
@@ -223,6 +238,9 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 // DelayWithRetryAfter invokes time.After for the duration specified in the "Retry-After" header in
 // responses with status code 429
 func DelayWithRetryAfter(resp *http.Response, cancel <-chan struct{}) bool {
+	if resp == nil {
+		return false
+	}
 	retryAfter, _ := strconv.Atoi(resp.Header.Get("Retry-After"))
 	if resp.StatusCode == http.StatusTooManyRequests && retryAfter > 0 {
 		select {

--- a/vendor/github.com/Azure/go-autorest/autorest/to/convert.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/to/convert.go
@@ -3,6 +3,20 @@ Package to provides helpers to ease working with pointer values of marshalled st
 */
 package to
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 // String returns a string value for the passed string pointer. It returns the empty string if the
 // pointer is nil.
 func String(s *string) string {

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -1,11 +1,26 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
@@ -175,4 +190,15 @@ func createQuery(v url.Values) string {
 		}
 	}
 	return buf.String()
+}
+
+// ChangeToGet turns the specified http.Request into a GET (it assumes it wasn't).
+// This is mainly useful for long-running operations that use the Azure-AsyncOperation
+// header, so we change the initial PUT into a GET to retrieve the final result.
+func ChangeToGet(req *http.Request) *http.Request {
+	req.Method = "GET"
+	req.Body = nil
+	req.ContentLength = 0
+	req.Header.Del("Content-Length")
+	return req
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
@@ -3,6 +3,20 @@ Package validation provides methods for validating parameter value using reflect
 */
 package validation
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"reflect"
@@ -91,15 +105,12 @@ func validateStruct(x reflect.Value, v Constraint, name ...string) error {
 		return createError(x, v, fmt.Sprintf("field %q doesn't exist", v.Target))
 	}
 
-	if err := Validate([]Validation{
+	return Validate([]Validation{
 		{
 			TargetValue: getInterfaceValue(f),
 			Constraints: []Constraint{v},
 		},
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func validatePtr(x reflect.Value, v Constraint) error {

--- a/vendor/github.com/Azure/go-autorest/autorest/version.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/version.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"fmt"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -251,67 +251,67 @@
 			"versionExact": "v11.1.0-beta"
 		},
 		{
-			"checksumSHA1": "+4d+Y67AMKKuyR1EO33Zdt+RVx0=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "tXSzwlsAPETo3wSlIX6o8GqGZLY=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "7G4HgRaIT25bgz/hPtXG6Kv8Fho=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "Ktj3H1WpOqxnC9kdAA+F7Ol7/RQ=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/adal",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "2KdBFgT4qY+fMOkBTa5vA9V0AiM=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "zXyLmDVpkYkIsL0yinNLoW82IZc=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/azure",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "apxw17Dm1naEXMbVDCRnEDkQDQ8=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "+nXRwVB/JVEGe+oLsFhCmSkKPuI=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/azure/cli",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "LSF/pNrjhIxl6jiS6bKooBFCOxI=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "9nXCi9qQsYjxCeajJKWttxgEt0I=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/date",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "Ev8qCsbFjDlMlX0N2tYAhYQFpUc=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "SbBb2GcJNm5GjuPKGL2777QywR4=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/to",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
-			"checksumSHA1": "rGkTfIycpeix5TAbZS74ceGAPHI=",
-			"comment": "v8.4.0",
+			"checksumSHA1": "HfqZyKllcHQDvTwgCaYL1jUPmW0=",
+			"comment": "v9.4.1",
 			"path": "github.com/Azure/go-autorest/autorest/validation",
-			"revision": "f6be1abbb5abd0517522f850dd785990d373da7e",
-			"revisionTime": "2017-09-13T23:19:17Z",
-			"version": "v8.4.0",
-			"versionExact": "v8.4.0"
+			"revision": "c67b24a8e30d876542a85022ebbdecf0e5a935e8",
+			"revisionTime": "2017-11-17T21:15:24Z",
+			"version": "v9.4.1",
+			"versionExact": "v9.4.1"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",


### PR DESCRIPTION
Intergrate with latest version of go-autorest to read access tokens through new way
customized through environment variable. The old behavior on local shell will be kept.

Notice: for Azure Cloud Shell user, please make sure that they're using latest patched
provider.