### PR TITLE
New Data Source: `azurerm_network_security_group`

### DIFF
--- a/azurerm/data_source_network_security_group.go
+++ b/azurerm/data_source_network_security_group.go
@@ -1,0 +1,113 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmNetworkSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmNetworkSecurityGroupRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": locationForDataSourceSchema(),
+
+			"security_rule": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"source_port_range": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"destination_port_range": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"source_address_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"destination_address_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"access": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"priority": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).secGroupClient
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.Get(resourceGroup, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+		}
+		return fmt.Errorf("Error making Read request on Network Security Group %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	if props := resp.SecurityGroupPropertiesFormat; props != nil {
+		d.Set("security_rule", flattenNetworkSecurityRules(props.SecurityRules))
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_network_security_group_test.go
+++ b/azurerm/data_source_network_security_group_test.go
@@ -1,0 +1,164 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMNetworkSecurityGroup_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_network_security_group.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	config := testAccDataSourceAzureRMNetworkSecurityGroupBasic(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMNetworkSecurityGroup_rules(t *testing.T) {
+	dataSourceName := "data.azurerm_network_security_group.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	config := testAccDataSourceAzureRMNetworkSecurityGroupWithRules(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.name", "test123"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.priority", "100"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.direction", "Inbound"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.access", "Allow"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.protocol", "Tcp"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.source_port_range", "*"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.destination_port_range", "*"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.source_address_prefix", "*"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.0.destination_address_prefix", "*"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMNetworkSecurityGroup_tags(t *testing.T) {
+	dataSourceName := "data.azurerm_network_security_group.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	config := testAccDataSourceAzureRMNetworkSecurityGroupTags(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_rule.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "staging"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMNetworkSecurityGroupBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+data "azurerm_network_security_group" "test" {
+  name                = "${azurerm_network_security_group.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAzureRMNetworkSecurityGroupWithRules(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  security_rule {
+    name                       = "test123"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+data "azurerm_network_security_group" "test" {
+  name                = "${azurerm_network_security_group.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAzureRMNetworkSecurityGroupTags(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  tags {
+    environment = "staging"
+  }
+}
+
+data "azurerm_network_security_group" "test" {
+  name                = "${azurerm_network_security_group.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -70,6 +70,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_image":                   dataSourceArmImage(),
 			"azurerm_key_vault_access_policy": dataSourceArmKeyVaultAccessPolicy(),
 			"azurerm_managed_disk":            dataSourceArmManagedDisk(),
+			"azurerm_network_security_group":  dataSourceArmNetworkSecurityGroup(),
 			"azurerm_platform_image":          dataSourceArmPlatformImage(),
 			"azurerm_public_ip":               dataSourceArmPublicIP(),
 			"azurerm_resource_group":          dataSourceArmResourceGroup(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -43,6 +43,10 @@
                     <a href="/docs/providers/azurerm/d/managed_disk.html">azurerm_managed_disk</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-network-security-group") %>>
+                    <a href="/docs/providers/azurerm/d/network_security_group.html">azurerm_network_security_group</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-platform-image") %>>
                     <a href="/docs/providers/azurerm/d/platform_image.html">azurerm_platform_image</a>
                 </li>

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_network_security_group"
+sidebar_current: "docs-azurerm-datasource-network-security-group"
+description: |-
+  Get information about the specified Network Security Group.
+---
+
+# azurerm_network_security_group
+
+Use this data source to access the properties of a Network Security Group.
+
+## Example Usage
+
+```hcl
+data "azurerm_network_security_group" "test" {
+  name                = "${azurerm_network_security_group.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+output "location" {
+  value = "${data.azurerm_network_security_group.test.location}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the Name of the Network Security Group.
+* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Network Security Group exists
+
+
+## Attributes Reference
+
+* `id` - The ID of the Network Security Group.
+
+* `location` - The supported Azure location where the resource exists.
+
+* `security_rule` - One or more `security_rule` blocks as defined below.
+
+* `tags` - A mapping of tags to assign to the resource.
+
+
+The `security_rule` block supports:
+
+* `name` - The name of the security rule.
+
+* `description` - The description for this rule.
+
+* `protocol` - The network protocol this rule applies to.
+
+* `source_port_range` - The Source Port or Range.
+
+* `destination_port_range` - The Destination Port or Range.
+
+* `source_address_prefix` - CIDR or source IP range or * to match any IP.
+
+* `destination_address_prefix` - CIDR or destination IP range or * to match any IP.
+
+* `access` - Is network traffic is allowed or denied?
+
+* `priority` - The priority of the rule
+
+* `direction` - The direction specifies if rule will be evaluated on incoming or outgoing traffic.

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the network security group. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the availability set. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the network security group. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
As proposed in #621.

Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMNetworkSecurityGroup_
=== RUN   TestAccDataSourceAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccDataSourceAzureRMNetworkSecurityGroup_basic (85.37s)
=== RUN   TestAccDataSourceAzureRMNetworkSecurityGroup_rules
--- PASS: TestAccDataSourceAzureRMNetworkSecurityGroup_rules (81.30s)
=== RUN   TestAccDataSourceAzureRMNetworkSecurityGroup_tags
--- PASS: TestAccDataSourceAzureRMNetworkSecurityGroup_tags (83.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    250.432s
```