### PR TITLE
`azurerm_eventhub_consumer_group` - adding validation for the user metadata field

### DIFF
--- a/azurerm/resource_arm_eventhub_consumer_group.go
+++ b/azurerm/resource_arm_eventhub_consumer_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/eventhub"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -43,8 +44,9 @@ func resourceArmEventHubConsumerGroup() *schema.Resource {
 			"location": deprecatedLocationSchema(),
 
 			"user_metadata": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 		},
 	}


### PR DESCRIPTION
Turns out the field can be up to 1024 chars