### PR TITLE
New Data Source: `azurerm_eventhub_namespace`

### DIFF
--- a/azurerm/data_source_eventhub_namespace.go
+++ b/azurerm/data_source_eventhub_namespace.go
@@ -62,7 +62,7 @@ func dataSourceEventHubNamespace() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tagsSchema(),
+			"tags": tagsForDataSourceSchema(),
 		},
 	}
 }

--- a/azurerm/data_source_eventhub_namespace.go
+++ b/azurerm/data_source_eventhub_namespace.go
@@ -1,0 +1,112 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceEventHubNamespace() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceEventHubNamespaceRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": locationForDataSourceSchema(),
+
+			"sku": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"auto_inflate_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"maximum_throughput_units": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"default_primary_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_secondary_connection_string": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_primary_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_secondary_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).eventHubNamespacesClient
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.Get(resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request on EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", resp.Name)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("sku", string(resp.Sku.Name))
+	d.Set("capacity", resp.Sku.Capacity)
+
+	keys, err := client.ListKeys(resourceGroup, name, eventHubNamespaceDefaultAuthorizationRule)
+	if err != nil {
+		log.Printf("[ERROR] Unable to List default keys for EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+	} else {
+		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
+		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
+		d.Set("default_primary_key", keys.PrimaryKey)
+		d.Set("default_secondary_key", keys.SecondaryKey)
+	}
+
+	if props := resp.EHNamespaceProperties; props != nil {
+		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
+		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_eventhub_namespace.go
+++ b/azurerm/data_source_eventhub_namespace.go
@@ -93,7 +93,7 @@ func dataSourceEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) e
 
 	keys, err := client.ListKeys(resourceGroup, name, eventHubNamespaceDefaultAuthorizationRule)
 	if err != nil {
-		log.Printf("[ERROR] Unable to List default keys for EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+		log.Printf("[WARN] Unable to List default keys for EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
 	} else {
 		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)

--- a/azurerm/data_source_eventhub_namespace_test.go
+++ b/azurerm/data_source_eventhub_namespace_test.go
@@ -1,0 +1,96 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMEventHubNamespace_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_eventhub_namespace.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEventHubNamespace_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "sku", "Basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMEventHubNamespace_complete(t *testing.T) {
+	dataSourceName := "data.azurerm_eventhub_namespace.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEventHubNamespace_complete(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "sku", "Standard"),
+					resource.TestCheckResourceAttr(dataSourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "auto_inflate_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "maximum_throughput_units", "20"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceEventHubNamespace_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Basic"
+}
+
+data "azurerm_eventhub_namespace" "test" {
+  name                = "${azurerm_eventhub_namespace.test.name}"
+  resource_group_name = "${azurerm_eventhub_namespace.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceEventHubNamespace_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                     = "acctesteventhubnamespace-%d"
+  location                 = "${azurerm_resource_group.test.location}"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  sku                      = "Standard"
+  capacity                 = "2"
+  auto_inflate_enabled     = true
+  maximum_throughput_units = 20
+}
+
+data "azurerm_eventhub_namespace" "test" {
+  name                = "${azurerm_eventhub_namespace.test.name}"
+  resource_group_name = "${azurerm_eventhub_namespace.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_app_service_plan":        dataSourceAppServicePlan(),
 			"azurerm_builtin_role_definition": dataSourceArmBuiltInRoleDefinition(),
 			"azurerm_client_config":           dataSourceArmClientConfig(),
+			"azurerm_eventhub_namespace":      dataSourceEventHubNamespace(),
 			"azurerm_image":                   dataSourceArmImage(),
 			"azurerm_key_vault_access_policy": dataSourceArmKeyVaultAccessPolicy(),
 			"azurerm_managed_disk":            dataSourceArmManagedDisk(),

--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -169,7 +169,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 
 	keys, err := namespaceClient.ListKeys(resGroup, name, eventHubNamespaceDefaultAuthorizationRule)
 	if err != nil {
-		log.Printf("[ERROR] Unable to List default keys for EventHub Namespace %q: %+v", name, err)
+		log.Printf("[WARN] Unable to List default keys for EventHub Namespace %q: %+v", name, err)
 	} else {
 		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)

--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -3,9 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"strings"
-
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/eventhub"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -39,9 +36,12 @@ func resourceArmEventHubNamespace() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"sku": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validateEventHubNamespaceSku,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(eventhub.Basic),
+					string(eventhub.Standard),
+				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
@@ -49,7 +49,7 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      1,
-				ValidateFunc: validateEventHubNamespaceCapacity,
+				ValidateFunc: validation.IntBetween(1, 20),
 			},
 
 			"auto_inflate_enabled": {
@@ -93,7 +93,7 @@ func resourceArmEventHubNamespace() *schema.Resource {
 func resourceArmEventHubNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	namespaceClient := client.eventHubNamespacesClient
-	log.Printf("[INFO] preparing arguments for Azure ARM EventHub Namespace creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace creation.")
 
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
@@ -122,8 +122,8 @@ func resourceArmEventHubNamespaceCreate(d *schema.ResourceData, meta interface{}
 		parameters.EHNamespaceProperties.MaximumThroughputUnits = utils.Int32(int32(maximumThroughputUnits))
 	}
 
-	_, error := namespaceClient.CreateOrUpdate(resGroup, name, parameters, make(chan struct{}))
-	err := <-error
+	_, createErr := namespaceClient.CreateOrUpdate(resGroup, name, parameters, make(chan struct{}))
+	err := <-createErr
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func resourceArmEventHubNamespaceCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read EventHub Namespace %s (resource group %s) ID", name, resGroup)
+		return fmt.Errorf("Cannot read EventHub Namespace %q (resource group %q) ID", name, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -158,7 +158,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure EventHub Namespace %s: %+v", name, err)
+		return fmt.Errorf("Error making Read request on EventHub Namespace %q: %+v", name, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -169,7 +169,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 
 	keys, err := namespaceClient.ListKeys(resGroup, name, eventHubNamespaceDefaultAuthorizationRule)
 	if err != nil {
-		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %+v", name, err)
+		log.Printf("[ERROR] Unable to List default keys for EventHub Namespace %q: %+v", name, err)
 	} else {
 		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
@@ -201,36 +201,13 @@ func resourceArmEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}
 	resp := <-deleteResp
 	err = <-error
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil
-	}
-
 	if err != nil {
-		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Namespace '%s': %+v", name, err)
+		if utils.ResponseWasNotFound(resp) {
+			return nil
+		}
+
+		return fmt.Errorf("Error issuing delete request of EventHub Namespace %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	return nil
-}
-
-func validateEventHubNamespaceSku(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	skus := map[string]bool{
-		"basic":    true,
-		"standard": true,
-	}
-
-	if !skus[value] {
-		errors = append(errors, fmt.Errorf("EventHub Namespace SKU can only be Basic or Standard"))
-	}
-	return
-}
-
-func validateEventHubNamespaceCapacity(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	maxCapacity := 20
-
-	if value > maxCapacity || value < 1 {
-		errors = append(errors, fmt.Errorf("EventHub Namespace Capacity must be 20 or fewer Throughput Units for Basic or Standard SKU"))
-	}
-	return
 }

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -46,45 +46,12 @@ func TestAccAzureRMEventHubNamespaceCapacity_validation(t *testing.T) {
 		_, errors := validateEventHubNamespaceCapacity(tc.Value, "azurerm_eventhub_namespace")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM EventHub Namespace Capacity '%d' to trigger a validation error", tc.Value)
-		}
-	}
-}
-
-func TestAccAzureRMEventHubNamespaceSku_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Basic",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Standard",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Premium",
-			ErrCount: 1,
-		},
-		{
-			Value:    "Random",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateEventHubNamespaceSku(tc.Value, "azurerm_eventhub_namespace")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM EventHub Namespace Sku '%s' to trigger a validation error", tc.Value)
+			t.Fatalf("Expected the AzureRM EventHub Namespace Capacity '%d' to trigger a validation error", tc.Value)
 		}
 	}
 }
 
 func TestAccAzureRMEventHubNamespace_basic(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMEventHubNamespace_basic(ri, testLocation())
 
@@ -104,7 +71,6 @@ func TestAccAzureRMEventHubNamespace_basic(t *testing.T) {
 }
 
 func TestAccAzureRMEventHubNamespace_standard(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMEventHubNamespace_standard(ri, testLocation())
 

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -11,46 +11,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMEventHubNamespaceCapacity_validation(t *testing.T) {
-	cases := []struct {
-		Value    int
-		ErrCount int
-	}{
-		{
-			Value:    21,
-			ErrCount: 1,
-		},
-		{
-			Value:    1,
-			ErrCount: 0,
-		},
-		{
-			Value:    2,
-			ErrCount: 0,
-		},
-		{
-			Value:    3,
-			ErrCount: 0,
-		},
-		{
-			Value:    4,
-			ErrCount: 0,
-		},
-		{
-			Value:    0,
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateEventHubNamespaceCapacity(tc.Value, "azurerm_eventhub_namespace")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AzureRM EventHub Namespace Capacity '%d' to trigger a validation error", tc.Value)
-		}
-	}
-}
-
 func TestAccAzureRMEventHubNamespace_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMEventHubNamespace_basic(ri, testLocation())

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -27,13 +27,16 @@
                     <a href="/docs/providers/azurerm/d/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
-                <ul class="nav nav-visible">
-                  <li<%= sidebar_current("docs-azurerm-datasource-builtin-role-definition") %>>
-                      <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
-                  </li>
+                <li<%= sidebar_current("docs-azurerm-datasource-builtin-role-definition") %>>
+                    <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
+                </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-client-config") %>>
                     <a href="/docs/providers/azurerm/d/client_config.html">azurerm_client_config</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azurerm-datasource-eventhub-namespace") %>>
+                    <a href="/docs/providers/azurerm/d/eventhub_namespace.html">azurerm_eventhub_namespace</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-image") %>>

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -30,7 +30,7 @@ output "app_service_plan_id" {
 
 ## Attributes Reference
 
-* `id` - The ID of the built-in App Service Plan.
+* `id` - The ID of the App Service Plan.
 
 * `location` - The Azure location where the App Service Plan exists
 

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_eventhub_namespace"
+sidebar_current: "docs-azurerm-datasource-eventhub-namespace"
+description: |-
+  Get information about an EventHub Namespace.
+---
+
+# Data Source: azurerm_eventhub_namespace
+
+Use this data source to obtain information about an EventHub Namespace.
+
+## Example Usage
+
+```hcl
+data "azurerm_eventhub_namespace" "test" {
+  name                = "search-eventhubns"
+  resource_group_name = "search-service"
+}
+
+output "eventhub_namespace_id" {
+  value = "${data.azurerm_eventhub_namespace.test.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the EventHub Namespace.
+* `resource_group_name` - (Required) The Name of the Resource Group where the EventHub Namespace exists.
+
+## Attributes Reference
+
+* `id` - The ID of the EventHub Namespace.
+
+* `location` - The Azure location where the EventHub Namespace exists
+
+* `sku` - Defines which tier to use.
+
+* `capacity` - The Capacity / Throughput Units for a `Standard` SKU namespace.
+
+* `auto_inflate_enabled` - Is Auto Inflate enabled for the EventHub Namespace?
+
+* `maximum_throughput_units` -  Specifies the maximum number of throughput units when Auto Inflate is Enabled.
+
+* `tags` - A mapping of tags to assign to the EventHub Namespace.
+
+The following attributes are exported only if there is an authorization rule named
+`RootManageSharedAccessKey` which is created automatically by Azure.
+
+* `default_primary_connection_string` - The primary connection string for the authorization
+    rule `RootManageSharedAccessKey`.
+
+* `default_secondary_connection_string` - The secondary connection string for the
+    authorization rule `RootManageSharedAccessKey`.
+
+* `default_primary_key` - The primary access key for the authorization rule `RootManageSharedAccessKey`.
+
+* `default_secondary_key` - The secondary access key for the authorization rule `RootManageSharedAccessKey`.


### PR DESCRIPTION
Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMEventHubNamespace_
=== RUN   TestAccDataSourceAzureRMEventHubNamespace_basic
--- PASS: TestAccDataSourceAzureRMEventHubNamespace_basic (264.97s)
=== RUN   TestAccDataSourceAzureRMEventHubNamespace_complete
--- PASS: TestAccDataSourceAzureRMEventHubNamespace_complete (327.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	592.023s
```