### PR TITLE
`azurerm_role_assignment` - generating a name if one isn't specified

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/authorization"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/satori/uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -22,7 +23,8 @@ func resourceArmRoleAssignment() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -55,6 +57,10 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 	scope := d.Get("scope").(string)
 	roleDefinitionId := d.Get("role_definition_id").(string)
 	principalId := d.Get("principal_id").(string)
+
+	if name == "" {
+		name = uuid.NewV1().String()
+	}
 
 	properties := authorization.RoleAssignmentCreateParameters{
 		Properties: &authorization.RoleAssignmentProperties{

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -2,12 +2,11 @@ package azurerm
 
 import (
 	"fmt"
-
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/arm/authorization"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/satori/uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -59,7 +58,12 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 	principalId := d.Get("principal_id").(string)
 
 	if name == "" {
-		name = uuid.NewV1().String()
+		uuid, err := uuid.GenerateUUID()
+		if err != nil {
+			return fmt.Errorf("Error generating UUID for Role Assignment: %+v", err)
+		}
+
+		name = uuid
 	}
 
 	properties := authorization.RoleAssignmentCreateParameters{

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -11,6 +11,26 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+func TestAccAzureRMRoleAssignment_emptyName(t *testing.T) {
+	resourceName := "azurerm_role_assignment.test"
+	config := testAccAzureRMRoleAssignment_emptyName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRoleAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRoleAssignmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMRoleAssignment_builtin(t *testing.T) {
 	id := uuid.New().String()
 	config := testAccAzureRMRoleAssignment_builtin(id)
@@ -99,6 +119,24 @@ func testCheckAzureRMRoleAssignmentDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAzureRMRoleAssignment_emptyName() string {
+	return `
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "test" {}
+
+data "azurerm_builtin_role_definition" "test" {
+  name = "Reader"
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope              = "${data.azurerm_subscription.primary.id}"
+  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_builtin_role_definition.test.id}"
+  principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
+}
+`
 }
 
 func testAccAzureRMRoleAssignment_builtin(id string) string {

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -23,7 +23,6 @@ data "azurerm_builtin_role_definition" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
-  name               = "00000000-0000-0000-0000-000000000000"
   scope              = "${data.azurerm_subscription.primary.id}"
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_builtin_role_definition.test.id}"
   principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
@@ -94,7 +93,7 @@ resource "azurerm_role_assignment" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) A unique UUID/GUID for this Role Assignment. Changing this forces a new resource to be created.
+* `name` - (Optional) A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
 
 * `scope` - (Required) The scope at which the Role Assignment applies too, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Making the Name optional for a Role Assignment, and generating a name (UUID) if one isn't specified

Fixes #667