### PR TITLE
Add Managed Service Identity (MSI) support to VM Scale Sets

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -836,8 +836,6 @@ func resourceArmVirtualMachineScaleSetDelete(d *schema.ResourceData, meta interf
 }
 
 func flattenAzureRmVirtualMachineScaleSetIdentity(identity *compute.VirtualMachineScaleSetIdentity) []interface{} {
-	log.Printf("[DEBUG] entered flattenAzureRmVirtualMachineScaleSetIdentity")
-
 	if identity == nil {
 		return make([]interface{}, 0)
 	}

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -731,7 +731,7 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 	if err := d.Set("identity", flattenAzureRmVirtualMachineScaleSetIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("[DEBUG] Error flattening `identity`: %+v", err)
 	}
-	
+
 	properties := resp.VirtualMachineScaleSetProperties
 
 	d.Set("upgrade_policy_mode", properties.UpgradePolicy.Mode)

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -34,7 +34,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 			"location": locationSchema(),
 
 			"resource_group_name": resourceGroupNameSchema(),
-q
+
 			"zones": zonesSchema(),
 
 			"identity": {

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -728,8 +728,10 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set Sku error: %#v", err)
 	}
 
-	d.Set("identity", flattenAzureRmVirtualMachineScaleSetIdentity(resp.Identity))
-
+	if err := d.Set("identity", flattenAzureRmVirtualMachineScaleSetIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("[DEBUG] Error flattening `identity`: %+v", err)
+	}
+	
 	properties := resp.VirtualMachineScaleSetProperties
 
 	d.Set("upgrade_policy_mode", properties.UpgradePolicy.Mode)

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -663,10 +663,7 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
-		log.Printf("[DEBUG] attempting to enable MSI")
 		scaleSetParams.Identity = expandAzureRmVirtualMachineScaleSetIdentity(d)
-	} else {
-		log.Printf("[DEBUG] MSI failed")
 	}
 
 	if _, ok := d.GetOk("plan"); ok {

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -1,11 +1,11 @@
 package azurerm
 
 import (
-	"fmt"
+  "fmt"
 	"net/http"
 	"regexp"
 	"testing"
-
+  
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -429,10 +429,7 @@ func TestAccAzureRMVirtualMachineScaleSet_MSI(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualMachineScaleSetExists(resourceName),
-					testCheckAzureRMVirtualMachineScaleSetMSI(resourceName),
-				),
+				Check: resource.TestCheckResourceAttrSet(resourceName, "identity.0.principal_id"),
 			},
 		},
 	})

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -1,11 +1,11 @@
 package azurerm
 
 import (
-  "fmt"
+	"fmt"
 	"net/http"
 	"regexp"
 	"testing"
-  
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -429,7 +429,7 @@ func TestAccAzureRMVirtualMachineScaleSet_MSI(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.TestCheckResourceAttrSet(resourceName, "identity.0.principal_id"),
+				Check:  resource.TestCheckResourceAttrSet(resourceName, "identity.0.principal_id"),
 			},
 		},
 	})

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -418,6 +418,26 @@ func TestAccAzureRMVirtualMachineScaleSet_overprovision(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_MSI(t *testing.T) {
+	resourceName := "azurerm-vmss-msi-test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSetMSITemplate(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists(resourceName),
+					testCheckAzureRMVirtualMachineScaleSetMSI(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineScaleSet_extension(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMVirtualMachineScaleSetExtensionTemplate(ri, testLocation())
@@ -765,6 +785,27 @@ func testCheckAzureRMVirtualMachineScaleSetSinglePlacementGroup(name string, exp
 	}
 }
 
+func testCheckAzureRMVirtualMachineScaleSetMSI(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
+		if err != nil {
+			return err
+		}
+
+		identityType := resp.Identity.Type
+		if identityType != "SystemAssigned" {
+			return fmt.Errorf("Bad: Identity Type is not SystemAssigned for scale set %v", name)
+		}
+
+    principalID := *resp.Identity.PrincipalID
+		if len(principalID) == 0 {
+			return fmt.Errorf("Bad: Could not get principal_id for scale set %v", name)
+		}
+
+		return nil
+	}
+}
+
 func testCheckAzureRMVirtualMachineScaleSetExtension(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
@@ -878,7 +919,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     tier = "Standard"
     capacity = 2
   }
-
+  
   os_profile {
     computer_name_prefix = "testvm-%d"
     admin_username = "myadmin"
@@ -2264,6 +2305,101 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     tier     = "Standard"
     capacity = 1
   }
+
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
+  }
+
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetMSITemplate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa%d"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctvmss-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+  overprovision       = false
+
+  sku {
+    name     = "Standard_D1_v2"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  identity {
+    type     = "systemAssigned"
+  }
+  
+  extension {
+    name                       = "MSILinuxExtension"
+    publisher                  = "Microsoft.ManagedIdentity"
+    type                       = "ManagedIdentityExtensionForLinux"
+    type_handler_version       = "1.0"
+    settings                   = "{\"port\": 50342}"
+  }  
 
   os_profile {
     computer_name_prefix = "testvm-%d"

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -793,8 +793,8 @@ func testCheckAzureRMVirtualMachineScaleSetMSI(name string) resource.TestCheckFu
 		}
 
 		identityType := resp.Identity.Type
-		if identityType != "SystemAssigned" {
-			return fmt.Errorf("Bad: Identity Type is not SystemAssigned for scale set %v", name)
+		if identityType != "systemAssigned" {
+			return fmt.Errorf("Bad: Identity Type is not systemAssigned for scale set %v", name)
 		}
 
 		principalID := *resp.Identity.PrincipalID

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -419,7 +419,7 @@ func TestAccAzureRMVirtualMachineScaleSet_overprovision(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualMachineScaleSet_MSI(t *testing.T) {
-	resourceName := "azurerm-vmss-msi-test"
+	resourceName := "azurerm_virtual_machine_scale_set.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMVirtualMachineScaleSetMSITemplate(ri, testLocation())
 	resource.Test(t, resource.TestCase{

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -797,7 +797,7 @@ func testCheckAzureRMVirtualMachineScaleSetMSI(name string) resource.TestCheckFu
 			return fmt.Errorf("Bad: Identity Type is not SystemAssigned for scale set %v", name)
 		}
 
-    principalID := *resp.Identity.PrincipalID
+		principalID := *resp.Identity.PrincipalID
 		if len(principalID) == 0 {
 			return fmt.Errorf("Bad: Could not get principal_id for scale set %v", name)
 		}

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -270,6 +270,41 @@ The following arguments are supported:
 * `tier` - (Optional) Specifies the tier of virtual machines in a scale set. Possible values, `standard` or `basic`.
 * `capacity` - (Required) Specifies the number of virtual machines in the scale set.
 
+`identity` supports the following:
+
+* `type` - (Required) Specifies the identity type of the virtual machine. The only allowable value is `SystemAssigned`. To enable Managed Service Identity (MSI) on all machines in the scale set, an extension with the type "ManagedIdentityExtensionForWindows" or "ManagedIdentityExtensionForLinux" must also be added. The scale set's Service Principal ID (SPN) can be retrieved after the scale set has been created.
+
+```hcl
+resource "azurerm_virtual_machine_scale_set" "vmss_test" {
+  name                = "vm-scaleset"
+  resource_group_name = "${azurerm_resource_group.vmss_test.name}"
+  location            = "${azurerm_resource_group.vmss_test.location}"
+
+  sku {
+    name     = "${var.vm_sku}"
+    tier     = "Standard"
+    capacity = "${var.instance_count}"
+  }
+
+  identity {
+    type     = "systemAssigned"
+  }
+
+  extension {
+    name                       = "MSILinuxExtension"
+    publisher                  = "Microsoft.ManagedIdentity"
+    type                       = "ManagedIdentityExtensionForLinux"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+    settings                   = "{\"port\": 50342}"
+    protected_settings         = "{}"
+  }
+
+  output "principal_id" {
+    value = "${lookup(azurerm_virtual_machine.vmss_test.identity[0], "principal_id")}"
+  }
+```
+
 `os_profile` supports the following:
 
 * `computer_name_prefix` - (Required) Specifies the computer name prefix for all of the virtual machines in the scale set. Computer name prefixes must be 1 to 9 characters long for windows images and 1 - 58 for linux. Changing this forces a new resource to be created.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -272,13 +272,13 @@ The following arguments are supported:
 
 `identity` supports the following:
 
-* `type` - (Required) Specifies the identity type of the virtual machine. The only allowable value is `SystemAssigned`. To enable Managed Service Identity (MSI) on all machines in the scale set, an extension with the type "ManagedIdentityExtensionForWindows" or "ManagedIdentityExtensionForLinux" must also be added. The scale set's Service Principal ID (SPN) can be retrieved after the scale set has been created.
+* `type` - (Required) Specifies the identity type to be assigned to the scale set. The only allowable value is `SystemAssigned`. To enable Managed Service Identity (MSI) on all machines in the scale set, an extension with the type "ManagedIdentityExtensionForWindows" or "ManagedIdentityExtensionForLinux" must also be added. The scale set's Service Principal ID (SPN) can be retrieved after the scale set has been created.
 
 ```hcl
-resource "azurerm_virtual_machine_scale_set" "vmss_test" {
+resource "azurerm_virtual_machine_scale_set" "test" {
   name                = "vm-scaleset"
-  resource_group_name = "${azurerm_resource_group.vmss_test.name}"
-  location            = "${azurerm_resource_group.vmss_test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
 
   sku {
     name     = "${var.vm_sku}"
@@ -295,13 +295,11 @@ resource "azurerm_virtual_machine_scale_set" "vmss_test" {
     publisher                  = "Microsoft.ManagedIdentity"
     type                       = "ManagedIdentityExtensionForLinux"
     type_handler_version       = "1.0"
-    auto_upgrade_minor_version = true
     settings                   = "{\"port\": 50342}"
-    protected_settings         = "{}"
   }
 
   output "principal_id" {
-    value = "${lookup(azurerm_virtual_machine.vmss_test.identity[0], "principal_id")}"
+    value = "${lookup(azurerm_virtual_machine.test.identity[0], "principal_id")}"
   }
 ```
 


### PR DESCRIPTION
This builds on earlier work enabling MSI for VMs. Adds the identity attribute and principal_id property to the VM scale set resource.