### PR TITLE
Function app consumption plan bug

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -505,7 +505,7 @@ func getBasicFunctionAppAppSettings(d *schema.ResourceData, appServiceTier strin
 func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, meta interface{}) (string, error) {
 	id, err := parseAzureResourceID(appServicePlanId)
 	if err != nil {
-		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID '%s': %+v", appServicePlanId, err)
+		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", appServicePlanId, err)
 	}
 
 	log.Printf("[DEBUG] Retrieving App Server Plan %s", id.Path["serverfarms"])
@@ -513,7 +513,7 @@ func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, met
 	appServicePlansClient := meta.(*ArmClient).appServicePlansClient
 	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.Path["serverfarms"])
 	if err != nil {
-		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID '%s': %+v", appServicePlanId, err)
+		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanId, err)
 	}
 
 	return *appServicePlan.Sku.Tier, nil

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -516,7 +516,12 @@ func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, met
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanId, err)
 	}
 
-	return *appServicePlan.Sku.Tier, nil
+	if sku := appServicePlan.Sku; sku != nil {
+		if tier := sku.Tier; tier != nil {
+			return *tier, nil
+		}
+	}
+	return "", fmt.Errorf("No `sku` block was returned for App Service Plan ID %q", appServicePlanId)
 }
 
 func expandFunctionAppAppSettings(d *schema.ResourceData, appServiceTier string) map[string]*string {

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -495,8 +495,8 @@ func getBasicFunctionAppAppSettings(d *schema.ResourceData, appServiceTier strin
 		{Name: &contentFileConnStringPropName, Value: &storageConnection},
 	}
 
-	// If the application plan is dynamic (consumption), we do not want to include WEBSITE_CONTENT components
-	if strings.EqualFold(appServiceTier, "dynamic") {
+	// If the application plan is NOT dynamic (consumption plan), we do NOT want to include WEBSITE_CONTENT components
+	if !strings.EqualFold(appServiceTier, "dynamic") {
 		return basicSettings
 	}
 	return append(basicSettings, consumptionSettings...)

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -217,7 +217,6 @@ func resourceArmFunctionAppCreate(d *schema.ResourceData, meta interface{}) erro
 	httpsOnly := d.Get("https_only").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 	appServiceTier, err := getFunctionAppServiceTier(ctx, appServicePlanID, meta)
-
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -27,6 +27,7 @@ func TestAccAzureRMFunctionApp_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
+					testCheckAzureRMFunctionAppHasNoContentShare(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "version", "~1"),
 				),
 			},
@@ -328,6 +329,7 @@ func TestAccAzureRMFunctionApp_consumptionPlan(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
+					testCheckAzureRMFunctionAppHasContentShare(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
 				),
 			},
@@ -447,6 +449,70 @@ func testCheckAzureRMFunctionAppExists(name string) resource.TestCheckFunc {
 			}
 
 			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMFunctionAppHasContentShare(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		functionAppName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Function App: %s", functionAppName)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).appServicesClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		appSettingsResp, err := client.ListApplicationSettings(ctx, resourceGroup, functionAppName)
+		if err != nil {
+			return fmt.Errorf("Error making Read request on AzureRM Function App AppSettings %q: %+v", functionAppName, err)
+		}
+
+		for k, _ := range appSettingsResp.Properties {
+			if strings.EqualFold("WEBSITE_CONTENTSHARE", k) {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Function App %q does not contain the Website Content Share!", functionAppName)
+	}
+}
+
+func testCheckAzureRMFunctionAppHasNoContentShare(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		functionAppName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Function App: %s", functionAppName)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).appServicesClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		appSettingsResp, err := client.ListApplicationSettings(ctx, resourceGroup, functionAppName)
+		if err != nil {
+			return fmt.Errorf("Error making Read request on AzureRM Function App AppSettings %q: %+v", functionAppName, err)
+		}
+
+		for k, v := range appSettingsResp.Properties {
+			if strings.EqualFold("WEBSITE_CONTENTSHARE", k) && v != nil && *v != "" {
+				return fmt.Errorf("Function App %q contains the Website Content Share!", functionAppName)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
This PR fixes #1453 by disabling the `WEBSITE_CONTENT` app setting when a dynamic App service plan is used. All `TestAccAzureRMFunctionApp`* tests are successful. 

It is very hard to write a test for this scenario because the default app settings variables get deleted on resource read and are not transported to the terraform schema. This means it is not possible not to do a `TestCheckResourceAttr` or similar. Have manually inspected the resources and the settings are applied correctly with these fixes.

As an aside, the function app logic will need refactoring as it is fairly inefficient and not DRY. Create calls update, likely to update the app_settings, but update basically reruns the same ARM call that Create just made, slowing down the progress by approx 20 to 30 seconds. 

Because of this double logic you'll see the app service plan needing to be retrieved twice and introduced throughout. There is no cleaner way without refactoring extensively.