### PR TITLE
resource/servicebus_subscription_rule: Fix the correlation_filter opt…

### DIFF
--- a/azurerm/resource_arm_servicebus_subscription_rule.go
+++ b/azurerm/resource_arm_servicebus_subscription_rule.go
@@ -268,15 +268,38 @@ func expandAzureRmServiceBusCorrelationFilter(d *schema.ResourceData) (*serviceb
 		return nil, fmt.Errorf("At least one property must be set in the `correlation_filter` block")
 	}
 
-	correlationFilter := servicebus.CorrelationFilter{
-		CorrelationID:    utils.String(correlationID),
-		MessageID:        utils.String(messageID),
-		To:               utils.String(to),
-		ReplyTo:          utils.String(replyTo),
-		Label:            utils.String(label),
-		SessionID:        utils.String(sessionID),
-		ReplyToSessionID: utils.String(replyToSessionID),
-		ContentType:      utils.String(contentType),
+	correlationFilter := servicebus.CorrelationFilter{}
+
+	if correlationID != "" {
+		correlationFilter.CorrelationID = utils.String(correlationID)
+	}
+
+	if messageID != "" {
+		correlationFilter.MessageID = utils.String(messageID)
+	}
+
+	if to != "" {
+		correlationFilter.To = utils.String(to)
+	}
+
+	if replyTo != "" {
+		correlationFilter.ReplyTo = utils.String(replyTo)
+	}
+
+	if label != "" {
+		correlationFilter.Label = utils.String(label)
+	}
+
+	if sessionID != "" {
+		correlationFilter.SessionID = utils.String(sessionID)
+	}
+
+	if replyToSessionID != "" {
+		correlationFilter.ReplyToSessionID = utils.String(replyToSessionID)
+	}
+
+	if contentType != "" {
+		correlationFilter.ContentType = utils.String(contentType)
 	}
 
 	return &correlationFilter, nil


### PR DESCRIPTION
…ional values

Fixes: #1537

This was a simple fix to make sure that we were not passing empty strings
to the API. When passing empty strings, it was including those strings
in the subscription rule

We should only set the part of the rule if it is required as, technically,
a rule of sys.To = `` is actually value