### PR TITLE
`azurerm_container_group`: Splitting `command` into `commands`

### DIFF
--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -458,7 +458,7 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 	volumeConfigs := make([]interface{}, 0)
 
 	if volumeMounts == nil {
-	 	return volumeConfigs
+		return volumeConfigs
 	}
 
 	for _, vm := range *volumeMounts {
@@ -480,7 +480,6 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 				if cgv.Name == nil || vm.Name == nil {
 					continue
 				}
-
 
 				if *cgv.Name == *vm.Name {
 					if file := cgv.AzureFile; file != nil {

--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-04-01/containerinstance"
@@ -237,11 +238,9 @@ func resourceArmContainerGroup() *schema.Resource {
 }
 
 func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
 	ctx := meta.(*ArmClient).StopContext
-	containerGroupsClient := client.containerGroupsClient
+	containerGroupsClient := meta.(*ArmClient).containerGroupsClient
 
-	// container group properties
 	resGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
@@ -292,23 +291,22 @@ func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmContainerGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
 	ctx := meta.(*ArmClient).StopContext
-	containterGroupsClient := client.containerGroupsClient
+	client := meta.(*ArmClient).containerGroupsClient
 
 	id, err := parseAzureResourceID(d.Id())
-
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Path["containerGroups"]
 
-	resp, err := containterGroupsClient.Get(ctx, resGroup, name)
+	resp, err := client.Get(ctx, resourceGroup, name)
 
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Container Group %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
 			d.SetId("")
 			return nil
 		}
@@ -316,56 +314,53 @@ func resourceArmContainerGroupRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
+	d.Set("resource_group_name", resourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azureRMNormalizeLocation(*location))
 	}
-	flattenAndSetTags(d, resp.Tags)
-
-	if err := d.Set("image_registry_credential", flattenContainerImageRegistryCredentials(d, resp.ImageRegistryCredentials)); err != nil {
-		return fmt.Errorf("Error setting `capabilities`: %+v", err)
-	}
-
-	d.Set("os_type", string(resp.OsType))
-	if address := resp.IPAddress; address != nil {
-		d.Set("ip_address_type", address.Type)
-		d.Set("ip_address", address.IP)
-		d.Set("dns_name_label", address.DNSNameLabel)
-		d.Set("fqdn", address.Fqdn)
-	}
-	d.Set("restart_policy", string(resp.RestartPolicy))
 
 	if props := resp.ContainerGroupProperties; props != nil {
 		containerConfigs := flattenContainerGroupContainers(d, resp.Containers, props.IPAddress.Ports, props.Volumes)
-		if err = d.Set("container", containerConfigs); err != nil {
+		if err := d.Set("container", containerConfigs); err != nil {
 			return fmt.Errorf("Error setting `container`: %+v", err)
 		}
+
+		if err := d.Set("image_registry_credential", flattenContainerImageRegistryCredentials(d, props.ImageRegistryCredentials)); err != nil {
+			return fmt.Errorf("Error setting `capabilities`: %+v", err)
+		}
+
+		if address := props.IPAddress; address != nil {
+			d.Set("ip_address_type", address.Type)
+			d.Set("ip_address", address.IP)
+			d.Set("dns_name_label", address.DNSNameLabel)
+			d.Set("fqdn", address.Fqdn)
+		}
+
+		d.Set("restart_policy", string(props.RestartPolicy))
+		d.Set("os_type", string(props.OsType))
 	}
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }
 
 func resourceArmContainerGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
 	ctx := meta.(*ArmClient).StopContext
-	containterGroupsClient := client.containerGroupsClient
+	client := meta.(*ArmClient).containerGroupsClient
 
 	id, err := parseAzureResourceID(d.Id())
-
 	if err != nil {
 		return err
 	}
 
-	// container group properties
-	resGroup := id.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Path["containerGroups"]
 
-	resp, err := containterGroupsClient.Delete(ctx, resGroup, name)
+	resp, err := client.Delete(ctx, resourceGroup, name)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return nil
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error deleting Container Group %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
-		return err
 	}
 
 	return nil
@@ -446,12 +441,14 @@ func flattenContainerGroupContainers(d *schema.ResourceData, containers *[]conta
 
 func flattenContainerEnvironmentVariables(input *[]containerinstance.EnvironmentVariable) map[string]interface{} {
 	output := make(map[string]interface{})
+	if input == nil {
+		return output
+	}
 
 	for _, envVar := range *input {
-		k := *envVar.Name
-		v := *envVar.Value
-
-		output[k] = v
+		if envVar.Name != nil && envVar.Value != nil {
+			output[*envVar.Name] = *envVar.Value
+		}
 	}
 
 	return output
@@ -460,22 +457,41 @@ func flattenContainerEnvironmentVariables(input *[]containerinstance.Environment
 func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, containerGroupVolumes *[]containerinstance.Volume, containerVolumesConfig *[]interface{}) []interface{} {
 	volumeConfigs := make([]interface{}, 0)
 
+	if volumeMounts == nil {
+	 	return volumeConfigs
+	}
+
 	for _, vm := range *volumeMounts {
 		volumeConfig := make(map[string]interface{})
-		volumeConfig["name"] = *vm.Name
-		volumeConfig["mount_path"] = *vm.MountPath
+		if vm.Name != nil {
+			volumeConfig["name"] = *vm.Name
+		}
+		if vm.MountPath != nil {
+			volumeConfig["mount_path"] = *vm.MountPath
+		}
 		if vm.ReadOnly != nil {
 			volumeConfig["read_only"] = *vm.ReadOnly
 		}
 
 		// find corresponding volume in container group volumes
 		// and use the data
-		for _, cgv := range *containerGroupVolumes {
-			if *cgv.Name == *vm.Name {
-				if cgv.AzureFile != nil {
-					volumeConfig["share_name"] = *(*cgv.AzureFile).ShareName
-					volumeConfig["storage_account_name"] = *(*cgv.AzureFile).StorageAccountName
-					// skip storage_account_key, is always nil
+		if containerGroupVolumes != nil {
+			for _, cgv := range *containerGroupVolumes {
+				if cgv.Name == nil || vm.Name == nil {
+					continue
+				}
+
+
+				if *cgv.Name == *vm.Name {
+					if file := cgv.AzureFile; file != nil {
+						if file.ShareName != nil {
+							volumeConfig["share_name"] = *file.ShareName
+						}
+						if file.StorageAccountName != nil {
+							volumeConfig["storage_account_name"] = *file.StorageAccountName
+						}
+						// skip storage_account_key, is always nil
+					}
 				}
 			}
 		}
@@ -486,7 +502,7 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 			for _, cvr := range *containerVolumesConfig {
 				cv := cvr.(map[string]interface{})
 				rawName := cv["name"].(string)
-				if *vm.Name == rawName {
+				if vm.Name != nil && *vm.Name == rawName {
 					storageAccountKey := cv["storage_account_key"].(string)
 					volumeConfig["storage_account_key"] = storageAccountKey
 				}
@@ -501,27 +517,26 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 
 func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstance.Container, *[]containerinstance.Port, *[]containerinstance.Volume) {
 	containersConfig := d.Get("container").([]interface{})
-	containers := make([]containerinstance.Container, 0, len(containersConfig))
-	containerGroupPorts := make([]containerinstance.Port, 0, len(containersConfig))
+	containers := make([]containerinstance.Container, 0)
+	containerGroupPorts := make([]containerinstance.Port, 0)
 	containerGroupVolumes := make([]containerinstance.Volume, 0)
 
 	for _, containerConfig := range containersConfig {
 		data := containerConfig.(map[string]interface{})
 
-		// required
 		name := data["name"].(string)
 		image := data["image"].(string)
 		cpu := data["cpu"].(float64)
 		memory := data["memory"].(float64)
 
 		container := containerinstance.Container{
-			Name: &name,
+			Name: utils.String(name),
 			ContainerProperties: &containerinstance.ContainerProperties{
-				Image: &image,
+				Image: utils.String(image),
 				Resources: &containerinstance.ResourceRequirements{
 					Requests: &containerinstance.ResourceRequests{
-						MemoryInGB: &memory,
-						CPU:        &cpu,
+						MemoryInGB: utils.Float(memory),
+						CPU:        utils.Float(cpu),
 					},
 				},
 			},
@@ -531,10 +546,11 @@ func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstanc
 			port := int32(v.(int))
 
 			// container port (port number)
-			containerPort := containerinstance.ContainerPort{
-				Port: &port,
+			container.Ports = &[]containerinstance.ContainerPort{
+				{
+					Port: &port,
+				},
 			}
-			container.Ports = &[]containerinstance.ContainerPort{containerPort}
 
 			// container group port (port number + protocol)
 			containerGroupPort := containerinstance.Port{
@@ -586,7 +602,7 @@ func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstanc
 
 func expandContainerEnvironmentVariables(input interface{}) *[]containerinstance.EnvironmentVariable {
 	envVars := input.(map[string]interface{})
-	output := make([]containerinstance.EnvironmentVariable, 0, len(envVars))
+	output := make([]containerinstance.EnvironmentVariable, 0)
 
 	for k, v := range envVars {
 		ev := containerinstance.EnvironmentVariable{
@@ -620,15 +636,14 @@ func expandContainerImageRegistryCredentials(d *schema.ResourceData) *[]containe
 	return &output
 }
 
-func flattenContainerImageRegistryCredentials(d *schema.ResourceData, credsPtr *[]containerinstance.ImageRegistryCredential) []interface{} {
-	if credsPtr == nil {
+func flattenContainerImageRegistryCredentials(d *schema.ResourceData, input *[]containerinstance.ImageRegistryCredential) []interface{} {
+	if input == nil {
 		return nil
 	}
 	configsOld := d.Get("image_registry_credential").([]interface{})
 
-	creds := *credsPtr
-	output := make([]interface{}, 0, len(creds))
-	for i, cred := range creds {
+	output := make([]interface{}, 0)
+	for i, cred := range *input {
 		credConfig := make(map[string]interface{})
 		if cred.Server != nil {
 			credConfig["server"] = *cred.Server
@@ -659,8 +674,8 @@ func expandContainerVolumes(input interface{}) (*[]containerinstance.VolumeMount
 		return nil, nil
 	}
 
-	volumeMounts := make([]containerinstance.VolumeMount, 0, len(volumesRaw))
-	containerGroupVolumes := make([]containerinstance.Volume, 0, len(volumesRaw))
+	volumeMounts := make([]containerinstance.VolumeMount, 0)
+	containerGroupVolumes := make([]containerinstance.Volume, 0)
 
 	for _, volumeRaw := range volumesRaw {
 		volumeConfig := volumeRaw.(map[string]interface{})
@@ -673,20 +688,20 @@ func expandContainerVolumes(input interface{}) (*[]containerinstance.VolumeMount
 		storageAccountKey := volumeConfig["storage_account_key"].(string)
 
 		vm := containerinstance.VolumeMount{
-			Name:      &name,
-			MountPath: &mountPath,
-			ReadOnly:  &readOnly,
+			Name:      utils.String(name),
+			MountPath: utils.String(mountPath),
+			ReadOnly:  utils.Bool(readOnly),
 		}
 
 		volumeMounts = append(volumeMounts, vm)
 
 		cv := containerinstance.Volume{
-			Name: &name,
+			Name: utils.String(name),
 			AzureFile: &containerinstance.AzureFileVolume{
-				ShareName:          &shareName,
-				ReadOnly:           &readOnly,
-				StorageAccountName: &storageAccountName,
-				StorageAccountKey:  &storageAccountKey,
+				ShareName:          utils.String(shareName),
+				ReadOnly:           utils.Bool(readOnly),
+				StorageAccountName: utils.String(storageAccountName),
+				StorageAccountKey:  utils.String(storageAccountKey),
 			},
 		}
 

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -166,6 +166,10 @@ func TestAccAzureRMContainerGroup_linuxComplete(t *testing.T) {
 					testCheckAzureRMContainerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "container.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.command", "/bin/bash -c ls"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.0", "/bin/bash"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.1", "-c"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.2", "ls"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.foo1", "bar1"),
@@ -234,6 +238,10 @@ func TestAccAzureRMContainerGroup_windowsComplete(t *testing.T) {
 					testCheckAzureRMContainerGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "container.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.command", "cmd.exe echo hi"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.0", "cmd.exe"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.1", "echo"),
+					resource.TestCheckResourceAttr(resourceName, "container.0.commands.2", "hi"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "container.0.environment_variables.foo1", "bar1"),
@@ -461,7 +469,7 @@ resource "azurerm_container_group" "test" {
 		"foo"  = "bar"
 		"foo1" = "bar1"
 	}
-	command = "cmd.exe echo hi"
+	commands = ["cmd.exe", "echo", "hi"]
   }
 
   tags {
@@ -528,7 +536,7 @@ resource "azurerm_container_group" "test" {
 			"foo1" = "bar1"
 		}
 
-		command = "/bin/bash -c ls"
+		commands = ["/bin/bash", "-c", "ls"]
 	}
 
 	tags {

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -121,7 +121,7 @@ The `container` block supports:
 
 * `command` - (Optional) A command line to be run on the container. Changing this forces a new resource to be created.
 
-~> **NOTE:** The field `command` has been deprecated in favour of `commands` to better match the API.
+~> **NOTE:** The field `command` has been deprecated in favor of `commands` to better match the API.
 
 * `commands` - (Optional) A list of commands which should be run on the container. Changing this forces a new resource to be created.
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -55,7 +55,7 @@ resource "azurerm_container_group" "aci-helloworld" {
       "NODE_ENV" = "testing"
     }
 
-    command = "/bin/bash -c '/path to/myscript.sh'"
+    commands = ["/bin/bash", "-c", "'/path to/myscript.sh'"]
 
     volume {
       name       = "logs"
@@ -120,6 +120,10 @@ The `container` block supports:
 * `environment_variables` - (Optional) A list of environment variables to be set on the container. Specified as a map of name/value pairs. Changing this forces a new resource to be created.
 
 * `command` - (Optional) A command line to be run on the container. Changing this forces a new resource to be created.
+
+~> **NOTE:** The field `command` has been deprecated in favour of `commands` to better match the API.
+
+* `commands` - (Optional) A list of commands which should be run on the container. Changing this forces a new resource to be created.
 
 * `volume` - (Optional) The definition of a volume mount for this container as documented in the `volume` block below. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Given the following config:

```
resource "azurerm_resource_group" "test" {
  name     = "tharvey-containergroup"
  location = "West Europe"
}

resource "azurerm_container_group" "test" {
  name                = "tom-devcg"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"
  ip_address_type     = "public"
  dns_name_label      = "tom-devcg"
  os_type             = "windows"
  restart_policy      = "Never"

  container {
    name   = "windowsservercore"
    image  = "microsoft/windowsservercore:latest"
    cpu    = "2.0"
    memory = "3.5"
    port   = "80"

    environment_variables {
      "foo"  = "bar"
      "foo1" = "bar1"
    }

    command = "cmd.exe echo hi"
  }

  tags {
    environment = "Testing"
  }
}
```

Plan between applied changes from current master -> this PR:

```
$ envchain azurerm terraform plan


Warning: azurerm_container_group.test: "container.0.command": [DEPRECATED] Use `commands` instead.



Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-.../resourceGroups/tharvey-containergroup)
azurerm_container_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...inerInstance/containerGroups/tom-devcg)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

When updating `command` to be `commands`:

```
commands = ["cmd.exe", "echo", "hi"]
```

the following plan is generated:

```
$ envchain azurerm terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-.../resourceGroups/tharvey-containergroup)
azurerm_container_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...inerInstance/containerGroups/tom-devcg)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

Supersedes #1508