### PR TITLE
Remove client side validation for azure network plugin

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -39,12 +39,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 					return nil
 				}
 
-				podCidr := profile["pod_cidr"].(string)
-
-				if networkPlugin == "azure" && podCidr != "" {
-					return fmt.Errorf("The `pod_cidr` field in the `network_profile` block can not be specified when `network_plugin` is set to `azure`. Please remove `pod_cidr` or set `network_plugin` to `kubenet`.")
-				}
-
 				dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
 				dnsServiceIP := profile["dns_service_ip"].(string)
 				serviceCidr := profile["service_cidr"].(string)

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -193,6 +193,7 @@ The following arguments are supported:
 * `kubernetes_version` - (Optional) Version of Kubernetes specified when creating the AKS managed cluster. If not specified, the latest recommended version will be used at provisioning time (but won't auto-upgrade).
 
 * `network_profile` - (Optional) A Network Profile block as documented below.
+-> **NOTE:** If `network_profile` is not defined, `kubenet` profile will be used by default.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -266,6 +267,7 @@ A `network_profile` block supports the following:
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. This is required when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
 * `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. Changing this forces a new resource to be created.
+-> **NOTE:** When `network_plugin` is set to `azure` - the `pod_cidr` filed should be ignored.
 
 Here's an example of configuring the `kubenet` Networking Profile:
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -266,8 +266,7 @@ A `network_profile` block supports the following:
 
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. This is required when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
-* `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. Changing this forces a new resource to be created.
--> **NOTE:** When `network_plugin` is set to `azure` - the `pod_cidr` filed should be ignored.
+* `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. This field can only be set when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
 Here's an example of configuring the `kubenet` Networking Profile:
 


### PR DESCRIPTION
This PR removes the validation logic to handle non-empty `pod_cidr` while `network_plugin` is `azure`, coz it causes #1783 .

Actually, AKS team added the below logic to reject non-empty `pod_cidr` explicitly to avoid confusing the `Terraform Plan`:
Please see https://github.com/Azure/acs-engine/pull/3562 for details.

For some reason, the fix is not deployed successfully, I am working with AKS team to get it work correctly.

Acceptance Test Results:
```
=== RUN   TestAccAzureRMKubernetesCluster_basic
--- PASS: TestAccAzureRMKubernetesCluster_basic (1220.45s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_addonProfileRouting
--- PASS: TestAccAzureRMKubernetesCluster_addonProfileRouting (1347.21s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet (1384.35s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_importBasic
--- PASS: TestAccAzureRMKubernetesCluster_importBasic (1407.42s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_addonProfileOMS
--- PASS: TestAccAzureRMKubernetesCluster_addonProfileOMS (1424.06s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingAzure
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingAzure (1556.93s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete (1565.04s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete (1576.40s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_internalNetwork
--- PASS: TestAccAzureRMKubernetesCluster_internalNetwork (1757.12s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_upgradeConfig
--- PASS: TestAccAzureRMKubernetesCluster_upgradeConfig (1907.46s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_addAgent
--- PASS: TestAccAzureRMKubernetesCluster_addAgent (1969.38s)
PASS
ok    ../azurerm/test-azurerm    1969.453s
```

Synced with AKS team, the fix is planned for v0.21.0-rc1:
https://github.com/Azure/acs-engine/commit/13210037db4ac99abd7e8b8633ec5c35c4985fb3
