### PR TITLE
Use filter for azuread_service_principal and azuread_application data sources 

### DIFF
--- a/azurerm/data_source_azuread_application.go
+++ b/azurerm/data_source_azuread_application.go
@@ -73,6 +73,8 @@ func dataSourceArmAzureADApplicationRead(d *schema.ResourceData, meta interface{
 	var application graphrbac.Application
 
 	if oId, ok := d.GetOk("object_id"); ok {
+
+		// use the object_id to find the Azure AD application
 		objectId := oId.(string)
 		resp, err := client.Get(ctx, objectId)
 		if err != nil {

--- a/azurerm/data_source_azuread_application.go
+++ b/azurerm/data_source_azuread_application.go
@@ -2,10 +2,10 @@ package azurerm
 
 import (
 	"fmt"
-
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
 )
 
 func dataSourceArmAzureADApplication() *schema.Resource {
@@ -85,12 +85,17 @@ func dataSourceArmAzureADApplicationRead(d *schema.ResourceData, meta interface{
 
 		application = resp
 	} else {
-		resp, err := client.ListComplete(ctx, "")
+
+		// use the name to find the Azure AD application
+		name := d.Get("name").(string)
+		filter := "displayName eq '" + name + "'"
+		log.Printf("[DEBUG] [data_source_azuread_application] Using filter %q", filter)
+
+		resp, err := client.ListComplete(ctx, filter)
+
 		if err != nil {
 			return fmt.Errorf("Error listing Azure AD Applications: %+v", err)
 		}
-
-		name := d.Get("name").(string)
 
 		var app *graphrbac.Application
 		for _, v := range *resp.Response().Value {

--- a/azurerm/data_source_azuread_application.go
+++ b/azurerm/data_source_azuread_application.go
@@ -90,7 +90,7 @@ func dataSourceArmAzureADApplicationRead(d *schema.ResourceData, meta interface{
 
 		// use the name to find the Azure AD application
 		name := d.Get("name").(string)
-		filter := "displayName eq '" + name + "'"
+		filter := fmt.Sprintf("displayName eq '%s'", name)
 		log.Printf("[DEBUG] [data_source_azuread_application] Using filter %q", filter)
 
 		resp, err := client.ListComplete(ctx, filter)

--- a/azurerm/data_source_azuread_service_principal.go
+++ b/azurerm/data_source_azuread_service_principal.go
@@ -2,10 +2,10 @@ package azurerm
 
 import (
 	"fmt"
-
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
 )
 
 func dataSourceArmActiveDirectoryServicePrincipal() *schema.Resource {
@@ -44,6 +44,8 @@ func dataSourceArmActiveDirectoryServicePrincipalRead(d *schema.ResourceData, me
 	var servicePrincipal *graphrbac.ServicePrincipal
 
 	if v, ok := d.GetOk("object_id"); ok {
+
+		//use the object_id to find the Azure AD service principal
 		objectId := v.(string)
 		app, err := client.Get(ctx, objectId)
 		if err != nil {
@@ -55,47 +57,61 @@ func dataSourceArmActiveDirectoryServicePrincipalRead(d *schema.ResourceData, me
 		}
 
 		servicePrincipal = &app
-	} else {
-		apps, err := client.ListComplete(ctx, "")
+
+	} else if _, ok := d.GetOk("display_name"); ok {
+
+		// use the display_name to find the Azure AD service principal
+		displayName := d.Get("display_name").(string)
+		filter := "displayName eq '" + displayName + "'"
+		log.Printf("[DEBUG] [data_source_azuread_service_principal] Using filter %q", filter)
+
+		apps, err := client.ListComplete(ctx, filter)
 		if err != nil {
 			return fmt.Errorf("Error listing Service Principals: %+v", err)
 		}
 
-		if v, ok := d.GetOk("display_name"); ok {
-			displayName := v.(string)
-
-			for _, app := range *apps.Response().Value {
-				if app.DisplayName == nil {
-					continue
-				}
-
-				if *app.DisplayName == displayName {
-					servicePrincipal = &app
-					break
-				}
+		for _, app := range *apps.Response().Value {
+			if app.DisplayName == nil {
+				continue
 			}
 
-			if servicePrincipal == nil {
-				return fmt.Errorf("A Service Principal with the Display Name %q was not found", displayName)
-			}
-		} else {
-			applicationId := d.Get("application_id").(string)
-
-			for _, app := range *apps.Response().Value {
-				if app.AppID == nil {
-					continue
-				}
-
-				if *app.AppID == applicationId {
-					servicePrincipal = &app
-					break
-				}
-			}
-
-			if servicePrincipal == nil {
-				return fmt.Errorf("A Service Principal for Application ID %q was not found", applicationId)
+			if *app.DisplayName == displayName {
+				servicePrincipal = &app
+				break
 			}
 		}
+
+		if servicePrincipal == nil {
+			return fmt.Errorf("A Service Principal with the Display Name %q was not found", displayName)
+		}
+
+	} else {
+
+		// use the application_id to find the Azure AD service principal
+		applicationId := d.Get("application_id").(string)
+		filter := "appId eq '" + applicationId + "'"
+		log.Printf("[DEBUG] [data_source_azuread_service_principal] Using filter %q", filter)
+
+		apps, err := client.ListComplete(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("Error listing Service Principals: %+v", err)
+		}
+
+		for _, app := range *apps.Response().Value {
+			if app.AppID == nil {
+				continue
+			}
+
+			if *app.AppID == applicationId {
+				servicePrincipal = &app
+				break
+			}
+		}
+
+		if servicePrincipal == nil {
+			return fmt.Errorf("A Service Principal for Application ID %q was not found", applicationId)
+		}
+
 	}
 
 	d.SetId(*servicePrincipal.ObjectID)

--- a/azurerm/data_source_azuread_service_principal.go
+++ b/azurerm/data_source_azuread_service_principal.go
@@ -62,7 +62,7 @@ func dataSourceArmActiveDirectoryServicePrincipalRead(d *schema.ResourceData, me
 
 		// use the display_name to find the Azure AD service principal
 		displayName := d.Get("display_name").(string)
-		filter := "displayName eq '" + displayName + "'"
+		filter := fmt.Sprintf("displayName eq '%s'", displayName)
 		log.Printf("[DEBUG] [data_source_azuread_service_principal] Using filter %q", filter)
 
 		apps, err := client.ListComplete(ctx, filter)
@@ -89,7 +89,7 @@ func dataSourceArmActiveDirectoryServicePrincipalRead(d *schema.ResourceData, me
 
 		// use the application_id to find the Azure AD service principal
 		applicationId := d.Get("application_id").(string)
-		filter := "appId eq '" + applicationId + "'"
+		filter := fmt.Sprintf("appId eq '%s'", applicationId)
 		log.Printf("[DEBUG] [data_source_azuread_service_principal] Using filter %q", filter)
 
 		apps, err := client.ListComplete(ctx, filter)


### PR DESCRIPTION
This fixes #1844

This adds a filter to the ListAll() method to limit the results that are returned by the API to only include objects that match the data source query.