### PR TITLE
only update the password if it has changed

### DIFF
--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -77,7 +77,6 @@ func resourceArmSqlServerCreateUpdate(d *schema.ResourceData, meta interface{}) 
 	resGroup := d.Get("resource_group_name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	adminUsername := d.Get("administrator_login").(string)
-	adminPassword := d.Get("administrator_login_password").(string)
 	version := d.Get("version").(string)
 
 	tags := d.Get("tags").(map[string]interface{})
@@ -87,10 +86,14 @@ func resourceArmSqlServerCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		Location: utils.String(location),
 		Tags:     metadata,
 		ServerProperties: &sql.ServerProperties{
-			Version:                    utils.String(version),
-			AdministratorLogin:         utils.String(adminUsername),
-			AdministratorLoginPassword: utils.String(adminPassword),
+			Version:            utils.String(version),
+			AdministratorLogin: utils.String(adminUsername),
 		},
+	}
+
+	if d.HasChange("administrator_login_password") {
+		adminPassword := d.Get("administrator_login_password").(string)
+		parameters.ServerProperties.AdministratorLoginPassword = utils.String(adminPassword)
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, parameters)


### PR DESCRIPTION
When updating an `azurerm_sql_server` resource, all of the properties are pushed to the Azure API, even if nothing has changed.

This PR addresses _only_ the `administrator_login_password` field, and not any other fields.

Motivation: When creating an `azurerm_sql_server` instance, the API _requires_ setting a new password. But this means it is both in source code and the state file. So our approach is to set it to something random, and then later, in a separate process (e.g. using data from Key Vault) set it to something secure. The problem comes when something else changes on the resource the results in an update (e.g. adding a tag). The existing random password is then sent along with the update.

I am not 100% sure this won't introduce a different bug since the read API doesn't return the password. So I am not sure how the diff routine works in that case. Meaning usually terraform will complain if you change something server side, but in this case, terraform has no way of knowing if it has changed.