### PR TITLE
authentication: requesting a token using the audience address

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -387,7 +387,7 @@ func getArmClient(c *authentication.Config, skipProviderRegistration bool) (*Arm
 
 	// Resource Manager endpoints
 	endpoint := env.ResourceManagerEndpoint
-	auth, err := c.GetAuthorizationToken(oauthConfig, endpoint)
+	auth, err := c.GetAuthorizationToken(oauthConfig, env.TokenAudience)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This brings the AzureRM Provider into line with Azure Stack:

```
$ acctests azurerm TestAccAzureRMResourceGroup_basic
=== RUN   TestAccAzureRMResourceGroup_basic
=== PAUSE TestAccAzureRMResourceGroup_basic
=== CONT  TestAccAzureRMResourceGroup_basic
--- PASS: TestAccAzureRMResourceGroup_basic (77.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	79.288s
```