### PR TITLE
New Resource: azurerm_policy_set_definition

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -321,8 +321,9 @@ type ArmClient struct {
 	appServicesClient     web.AppsClient
 
 	// Policy
-	policyAssignmentsClient policy.AssignmentsClient
-	policyDefinitionsClient policy.DefinitionsClient
+	policyAssignmentsClient    policy.AssignmentsClient
+	policyDefinitionsClient    policy.DefinitionsClient
+	policySetDefinitionsClient policy.SetDefinitionsClient
 }
 
 var (
@@ -1165,6 +1166,10 @@ func (c *ArmClient) registerPolicyClients(endpoint, subscriptionId string, auth 
 	policyDefinitionsClient := policy.NewDefinitionsClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&policyDefinitionsClient.Client, auth)
 	c.policyDefinitionsClient = policyDefinitionsClient
+
+	policySetDefinitionsClient := policy.NewSetDefinitionsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&policySetDefinitionsClient.Client, auth)
+	c.policySetDefinitionsClient = policySetDefinitionsClient
 }
 
 func (c *ArmClient) registerManagementGroupClients(endpoint string, auth autorest.Authorizer) {

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -263,6 +263,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_packet_capture":                                                         resourceArmPacketCapture(),
 			"azurerm_policy_assignment":                                                      resourceArmPolicyAssignment(),
 			"azurerm_policy_definition":                                                      resourceArmPolicyDefinition(),
+			"azurerm_policy_set_definition":                                                  resourceArmPolicySetDefinition(),
 			"azurerm_postgresql_configuration":                                               resourceArmPostgreSQLConfiguration(),
 			"azurerm_postgresql_database":                                                    resourceArmPostgreSQLDatabase(),
 			"azurerm_postgresql_firewall_rule":                                               resourceArmPostgreSQLFirewallRule(),

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -116,7 +116,7 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 	if metaDataString := d.Get("metadata").(string); metaDataString != "" {
 		metaData, err := structure.ExpandJsonFromString(metaDataString)
 		if err != nil {
-			return fmt.Errorf("unable to parse metadata: %s", err)
+			return fmt.Errorf("unable to expand metadata json: %s", err)
 		}
 		properties.Metadata = &metaData
 	}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -2,24 +2,20 @@ package azurerm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
-	"strings"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
-
-	"time"
-
 	"strconv"
-
-	"encoding/json"
+	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/policy"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -48,8 +44,8 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(policy.TypeBuiltIn),
 					string(policy.TypeCustom),
-					string(policy.TypeNotSpecified),
-				}, false)},
+				}, false),
+			},
 
 			"display_name": {
 				Type:         schema.TypeString,
@@ -198,7 +194,7 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", resp.Name)
 
 	if props := resp.SetDefinitionProperties; props != nil {
-		d.Set("policy_type", props.PolicyType)
+		d.Set("policy_type", string(props.PolicyType))
 		d.Set("display_name", props.DisplayName)
 		d.Set("description", props.Description)
 
@@ -275,7 +271,7 @@ func policySetDefinitionRefreshFunc(ctx context.Context, client policy.SetDefini
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, name)
 		if err != nil {
-			return nil, strconv.Itoa(res.StatusCode), fmt.Errorf("Error issuing read request in policyAssignmentRefreshFunc for Policy Assignment %q: %s", name, err)
+			return nil, strconv.Itoa(res.StatusCode), fmt.Errorf("Error issuing read request in policySetDefinitionRefreshFunc for Policy Set Definition %q: %s", name, err)
 		}
 
 		return res, strconv.Itoa(res.StatusCode), nil

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -1,0 +1,280 @@
+package azurerm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+
+	"time"
+
+	"strconv"
+
+	"encoding/json"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/policy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmPolicySetDefinition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmPolicySetDefinitionCreateUpdate,
+		Update: resourceArmPolicySetDefinitionCreateUpdate,
+		Read:   resourceArmPolicySetDefinitionRead,
+		Delete: resourceArmPolicySetDefinitionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(policy.TypeBuiltIn),
+					string(policy.TypeCustom),
+					string(policy.TypeNotSpecified),
+				}, true)},
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"metadata": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+			},
+
+			"parameters": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+			},
+
+			"policy_definitions": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: policyDefinitionsDiffSuppressFunc,
+			},
+		},
+	}
+}
+
+func policyDefinitionsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	var oldPolicyDefinitions []policy.DefinitionReference
+	errOld := json.Unmarshal([]byte(old), &oldPolicyDefinitions)
+	if errOld != nil {
+		return false
+	}
+
+	var newPolicyDefinitions []policy.DefinitionReference
+	errNew := json.Unmarshal([]byte(old), &newPolicyDefinitions)
+	if errNew != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldPolicyDefinitions, newPolicyDefinitions)
+}
+
+func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).policySetDefinitionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	policyType := d.Get("policy_type").(string)
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+
+	properties := policy.SetDefinitionProperties{
+		PolicyType:  policy.Type(policyType),
+		DisplayName: utils.String(displayName),
+		Description: utils.String(description),
+	}
+
+	if metaDataString := d.Get("metadata").(string); metaDataString != "" {
+		metaData, err := structure.ExpandJsonFromString(metaDataString)
+		if err != nil {
+			return fmt.Errorf("unable to parse metadata: %s", err)
+		}
+		properties.Metadata = &metaData
+	}
+
+	if parametersString := d.Get("parameters").(string); parametersString != "" {
+		parameters, err := structure.ExpandJsonFromString(parametersString)
+		if err != nil {
+			return fmt.Errorf("unable to parse parameters: %s", err)
+		}
+		properties.Parameters = &parameters
+	}
+
+	if policyDefinitionsString := d.Get("policy_definitions").(string); policyDefinitionsString != "" {
+		var policyDefinitions []policy.DefinitionReference
+		err := json.Unmarshal([]byte(policyDefinitionsString), &policyDefinitions)
+		if err != nil {
+			return fmt.Errorf("unable to parse parameters: %s", err)
+		}
+		properties.PolicyDefinitions = &policyDefinitions
+	}
+
+	definition := policy.SetDefinition{
+		Name:                    utils.String(name),
+		SetDefinitionProperties: &properties,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, name, definition); err != nil {
+		return err
+	}
+
+	// Policy Definitions are eventually consistent; wait for them to stabilize
+	log.Printf("[DEBUG] Waiting for Policy Set Definition %q to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{"404"},
+		Target:                    []string{"200"},
+		Refresh:                   policySetDefinitionRefreshFunc(ctx, client, name),
+		Timeout:                   5 * time.Minute,
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 10,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Policy Set Definition %q to become available: %s", name, err)
+	}
+
+	resp, err := client.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmPolicySetDefinitionRead(d, meta)
+}
+
+func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).policySetDefinitionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name, err := parsePolicySetDefinitionNameFromId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Error reading Policy Definition %q - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading Policy Definition %+v", err)
+	}
+
+	d.Set("name", resp.Name)
+
+	if props := resp.SetDefinitionProperties; props != nil {
+		d.Set("policy_type", props.PolicyType)
+		d.Set("display_name", props.DisplayName)
+		d.Set("description", props.Description)
+
+		if metadata := props.Metadata; metadata != nil {
+			metadataVal := metadata.(map[string]interface{})
+			metadataStr, err := structure.FlattenJsonToString(metadataVal)
+			if err != nil {
+				return fmt.Errorf("unable to flatten JSON for `metadata`: %s", err)
+			}
+
+			d.Set("metadata", metadataStr)
+		}
+
+		if parameters := props.Parameters; parameters != nil {
+			paramsVal := props.Parameters.(map[string]interface{})
+			parametersStr, err := structure.FlattenJsonToString(paramsVal)
+			if err != nil {
+				return fmt.Errorf("unable to flatten JSON for `parameters`: %s", err)
+			}
+
+			d.Set("parameters", parametersStr)
+		}
+
+		if policyDefinitions := props.PolicyDefinitions; policyDefinitions != nil {
+			policyDefinitionsRes, err := json.Marshal(props.PolicyDefinitions)
+			if err != nil {
+				return fmt.Errorf("unable to flatten JSON for `policy_defintions`: %s", err)
+			}
+
+			policyDefinitionsStr := string(policyDefinitionsRes)
+			d.Set("policy_definitions", policyDefinitionsStr)
+		}
+	}
+
+	return nil
+}
+
+func resourceArmPolicySetDefinitionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).policySetDefinitionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name, err := parsePolicySetDefinitionNameFromId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Delete(ctx, name)
+
+	if err != nil {
+		if utils.ResponseWasNotFound(resp) {
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Policy Definition %q: %+v", name, err)
+	}
+
+	return nil
+}
+
+func parsePolicySetDefinitionNameFromId(id string) (string, error) {
+	components := strings.Split(id, "/")
+
+	if len(components) == 0 {
+		return "", fmt.Errorf("Azure Policy Set Definition Id is empty or not formatted correctly: %s", id)
+	}
+
+	if len(components) != 7 {
+		return "", fmt.Errorf("Azure Policy Set Definition Id should have 6 segments, got %d: '%s'", len(components)-1, id)
+	}
+
+	return components[6], nil
+}
+
+func policySetDefinitionRefreshFunc(ctx context.Context, client policy.SetDefinitionsClient, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, name)
+		if err != nil {
+			return nil, strconv.Itoa(res.StatusCode), fmt.Errorf("Error issuing read request in policyAssignmentRefreshFunc for Policy Assignment %q: %s", name, err)
+		}
+
+		return res, strconv.Itoa(res.StatusCode), nil
+	}
+}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -148,7 +148,7 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, name, definition); err != nil {
-		return err
+		return fmt.Errorf("Error creating/updating Policy Set Definition %q: %s", name, err)
 	}
 
 	// Policy Definitions are eventually consistent; wait for them to stabilize

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -133,7 +133,7 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 		var policyDefinitions []policy.DefinitionReference
 		err := json.Unmarshal([]byte(policyDefinitionsString), &policyDefinitions)
 		if err != nil {
-			return fmt.Errorf("unable to parse parameters: %s", err)
+			return fmt.Errorf("unable to expand parameters json: %s", err)
 		}
 		properties.PolicyDefinitions = &policyDefinitions
 	}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+
 	"time"
 
 	"strconv"
@@ -33,9 +35,10 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"policy_type": {
@@ -49,8 +52,9 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 				}, true)},
 
 			"display_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"description": {

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -192,7 +192,7 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Policy Definition %+v", err)
+		return fmt.Errorf("Error reading Policy Set Definition %+v", err)
 	}
 
 	d.Set("name", resp.Name)

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -251,7 +251,7 @@ func resourceArmPolicySetDefinitionDelete(d *schema.ResourceData, meta interface
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting Policy Definition %q: %+v", name, err)
+		return fmt.Errorf("Error deleting Policy Set Definition %q: %+v", name, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -223,7 +223,7 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 		}
 
 		if policyDefinitions := props.PolicyDefinitions; policyDefinitions != nil {
-			policyDefinitionsRes, err := json.Marshal(props.PolicyDefinitions)
+			policyDefinitionsRes, err := json.Marshal(policyDefinitions)
 			if err != nil {
 				return fmt.Errorf("unable to flatten JSON for `policy_defintions`: %s", err)
 			}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -187,7 +187,7 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 	resp, err := client.Get(ctx, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Error reading Policy Definition %q - removing from state", d.Id())
+			log.Printf("[INFO] Error reading Policy Set Definition %q - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -94,7 +94,7 @@ func policyDefinitionsDiffSuppressFunc(k, old, new string, d *schema.ResourceDat
 	}
 
 	var newPolicyDefinitions []policy.DefinitionReference
-	errNew := json.Unmarshal([]byte(old), &newPolicyDefinitions)
+	errNew := json.Unmarshal([]byte(new), &newPolicyDefinitions)
 	if errNew != nil {
 		return false
 	}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -213,7 +213,7 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 		}
 
 		if parameters := props.Parameters; parameters != nil {
-			paramsVal := props.Parameters.(map[string]interface{})
+			paramsVal := parameters.(map[string]interface{})
 			parametersStr, err := structure.FlattenJsonToString(paramsVal)
 			if err != nil {
 				return fmt.Errorf("unable to flatten JSON for `parameters`: %s", err)

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -49,7 +49,7 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 					string(policy.TypeBuiltIn),
 					string(policy.TypeCustom),
 					string(policy.TypeNotSpecified),
-				}, true)},
+				}, false)},
 
 			"display_name": {
 				Type:         schema.TypeString,

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -124,7 +124,7 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 	if parametersString := d.Get("parameters").(string); parametersString != "" {
 		parameters, err := structure.ExpandJsonFromString(parametersString)
 		if err != nil {
-			return fmt.Errorf("unable to parse parameters: %s", err)
+			return fmt.Errorf("unable to expand parameters json: %s", err)
 		}
 		properties.Parameters = &parameters
 	}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -242,7 +242,6 @@ func resourceArmPolicySetDefinitionDelete(d *schema.ResourceData, meta interface
 	}
 
 	resp, err := client.Delete(ctx, name)
-
 	if err != nil {
 		if utils.ResponseWasNotFound(resp) {
 			return nil

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -167,7 +167,7 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 
 	resp, err := client.Get(ctx, name)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error retrieving Policy Set Definition %q: %s", name, err)
 	}
 
 	d.SetId(*resp.ID)

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -109,7 +109,6 @@ func testCheckAzureRMPolicySetDefinitionDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 
 		resp, err := client.Get(ctx, name)
-
 		if err != nil {
 			return nil
 		}

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAzureRMPolicySetDefinition_built_in_policy(t *testing.T) {
+func TestAccAzureRMPolicySetDefinition_builtIn(t *testing.T) {
 	resourceName := "azurerm_policy_set_definition.test"
 
 	ri := acctest.RandInt()
@@ -22,7 +22,7 @@ func TestAccAzureRMPolicySetDefinition_built_in_policy(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPolicySetDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMPolicySetDefinition_built_in_policy(ri),
+				Config: testAzureRMPolicySetDefinition_builtIn(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPolicySetDefinitionExists(resourceName),
 				),
@@ -36,7 +36,7 @@ func TestAccAzureRMPolicySetDefinition_built_in_policy(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMPolicySetDefinition_custom_policy(t *testing.T) {
+func TestAccAzureRMPolicySetDefinition_custom(t *testing.T) {
 	resourceName := "azurerm_policy_set_definition.test"
 
 	ri := acctest.RandInt()
@@ -47,7 +47,7 @@ func TestAccAzureRMPolicySetDefinition_custom_policy(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPolicySetDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMPolicySetDefinition_custom_policy(ri),
+				Config: testAzureRMPolicySetDefinition_custom(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPolicySetDefinitionExists(resourceName),
 				),
@@ -61,7 +61,7 @@ func TestAccAzureRMPolicySetDefinition_custom_policy(t *testing.T) {
 	})
 }
 
-func testAzureRMPolicySetDefinition_built_in_policy(ri int) string {
+func testAzureRMPolicySetDefinition_builtIn(ri int) string {
 	return fmt.Sprintf(`
 resource "azurerm_policy_set_definition" "test" {
   name         = "acctestpolset-%d"
@@ -97,7 +97,7 @@ POLICY_DEFINITIONS
 `, ri, ri)
 }
 
-func testAzureRMPolicySetDefinition_custom_policy(ri int) string {
+func testAzureRMPolicySetDefinition_custom(ri int) string {
 	return fmt.Sprintf(`
 resource "azurerm_policy_definition" "test" {
   name         = "acctestpol-%d"
@@ -185,7 +185,7 @@ func testCheckAzureRMPolicySetDefinitionExists(name string) resource.TestCheckFu
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("policy set does not exist: %s", name)
+			return fmt.Errorf("policy set definition does not exist: %s", name)
 		}
 
 		return nil
@@ -209,7 +209,7 @@ func testCheckAzureRMPolicySetDefinitionDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("policy set still exists: %s", *resp.Name)
+			return fmt.Errorf("policy set definition still exists: %s", *resp.Name)
 		}
 	}
 

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -114,7 +114,7 @@ func testCheckAzureRMPolicySetDefinitionDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("policy set still exists:%s", *resp.Name)
+			return fmt.Errorf("policy set still exists: %s", *resp.Name)
 		}
 	}
 

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -1,0 +1,122 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMPolicySetDefinition_basic(t *testing.T) {
+	resourceName := "azurerm_policy_set_definition.test"
+
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPolicySetDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicySetDefinition_basic(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicySetDefinitionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAzureRMPolicySetDefinition_basic(ri int) string {
+	return fmt.Sprintf(`
+resource "azurerm_policy_set_definition" "test" {
+  name         = "acctestpolset-%d"
+  policy_type  = "Custom"
+  display_name = "acctestpolset-%d"
+
+  parameters = <<PARAMETERS
+    {
+        "allowedLocations": {
+            "type": "Array",
+            "metadata": {
+                "description": "The list of allowed locations for resources.",
+                "displayName": "Allowed locations",
+                "strongType": "location"
+            }
+        }
+    }
+PARAMETERS
+
+  policy_definitions = <<POLICY_DEFINITIONS
+    [
+        {
+            "parameters": {
+                "listOfAllowedLocations": {
+                    "value": "[parameters('allowedLocations')]"
+                }
+            },
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
+        }
+    ]
+POLICY_DEFINITIONS
+}
+`, ri, ri)
+}
+
+func testCheckAzureRMPolicySetDefinitionExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		policySetName := rs.Primary.Attributes["name"]
+
+		client := testAccProvider.Meta().(*ArmClient).policySetDefinitionsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Get(ctx, policySetName)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on policySetDefinitionsClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("policy set does not exist: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMPolicySetDefinitionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).policySetDefinitionsClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_policy_set_definition" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+
+		resp, err := client.Get(ctx, name)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("policy set still exists:%s", *resp.Name)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -2,9 +2,10 @@ package azurerm
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/terraform"
 	"net/http"
 	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1031,6 +1031,10 @@
                 <li<%= sidebar_current("docs-azurerm-resource-policy-definition") %>>
                   <a href="/docs/providers/azurerm/r/policy_definition.html">azurerm_policy_definition</a>
                 </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-policy-set-definition") %>>
+                  <a href="/docs/providers/azurerm/r/policy_set_definition.html">azurerm_policy_set_definition</a>
+                </li>
               </ul>
             </li>
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -52,25 +52,19 @@ POLICY_DEFINITIONS
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the policy set definition. Changing this forces a
-    new resource to be created.
+* `name` - (Required) The name of the policy set definition. Changing this forces a new resource to be created.
 
-* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom`
-    or "NotSpecified". Changing this forces a new resource to be created.
+* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom` or "NotSpecified". Changing this forces a new resource to be created.
 
 * `display_name` - (Required) The display set name of the policy definition.
 
-* `policy_definitions` - (Required) The policy definitions for the policy set definition. This
-    is a json object representing the bundled policy definitions .
+* `policy_definitions` - (Required) The policy definitions for the policy set definition. This is a json object representing the bundled policy definitions .
 
 * `description` - (Optional) The description of the policy set definition.
 
-* `metadata` - (Optional) The metadata for the policy definition. This
-    is a json object representing additional metadata that should be stored
-    with the policy definition.
+* `metadata` - (Optional) The metadata for the policy definition. This is a json object representing additional metadata that should be stored with the policy definition.
 
-* `parameters` - (Optional) Parameters for the policy definition. This field
-    is a json object that allows you to parameterize your policy definition.
+* `parameters` - (Optional) Parameters for the policy definition. This field is a json object that allows you to parameterize your policy definition.
 
 ## Attributes Reference
 
@@ -83,5 +77,5 @@ The following attributes are exported:
 Policy Set Definitions can be imported using the `policy set name`, e.g.
 
 ```shell
-terraform import azurerm_policy_set_definition.testPolicy  /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policySetDefinitions/<POLICY_SET_NAME>
+terraform import azurerm_policy_set_definition.test  /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/testPolicySet
 ```

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -75,7 +75,7 @@ The following attributes are exported:
 
 ## Import
 
-Policy Set Definitions can be imported using the `policy set name`, e.g.
+Policy Set Definitions can be imported using the Resource ID, e.g.
 
 ```shell
 terraform import azurerm_policy_set_definition.test  /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/testPolicySet

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # azurerm_policy_set_definition
 
-Manages a policy set definition. Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
+Manages a policy set definition. 
+
+-> **NOTE:**  Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
 
 ## Example Usage
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_policy_set_definition"
+sidebar_current: "docs-azurerm-resource-policy-set-definition"
+description: |-
+  Manages a policy set definition. Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
+---
+
+# azurerm_policy_set_definition
+
+Manages a policy set definition. Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
+
+## Example Usage
+
+```hcl
+resource "azurerm_policy_set_definition" "test" {
+  name         = "testPolicySet"
+  policy_type  = "Custom"
+  display_name = "Test Policy Set"
+
+  parameters = <<PARAMETERS
+    {
+        "allowedLocations": {
+            "type": "Array",
+            "metadata": {
+                "description": "The list of allowed locations for resources.",
+                "displayName": "Allowed locations",
+                "strongType": "location"
+            }
+        }
+    }
+PARAMETERS
+
+  policy_definitions = <<POLICY_DEFINITIONS
+    [
+        {
+            "parameters": {
+                "listOfAllowedLocations": {
+                    "value": "[parameters('allowedLocations')]"
+                }
+            },
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
+        }
+    ]
+POLICY_DEFINITIONS
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the policy set definition. Changing this forces a
+    new resource to be created.
+
+* `policy_type` - (Required) The policy set type. The value can be "BuiltIn", "Custom"
+    or "NotSpecified". Changing this forces a new resource to be created.
+
+* `display_name` - (Required) The display set name of the policy definition.
+
+* `policy_definitions` - (Required) The policy definitions for the policy set definition. This
+    is a json object representing the bundled policy definitions .
+
+* `description` - (Optional) The description of the policy set definition.
+
+* `metadata` - (Optional) The metadata for the policy definition. This
+    is a json object representing additional metadata that should be stored
+    with the policy definition.
+
+* `parameters` - (Optional) Parameters for the policy definition. This field
+    is a json object that allows you to parameterize your policy definition.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The policy set definition id.
+
+## Import
+
+Policy Set Definitions can be imported using the `policy set name`, e.g.
+
+```shell
+terraform import azurerm_policy_set_definition.testPolicy  /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policySetDefinitions/<POLICY_SET_NAME>
+```

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -54,7 +54,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the policy set definition. Changing this forces a new resource to be created.
 
-* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom` or "NotSpecified". Changing this forces a new resource to be created.
+* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom` or `NotSpecified`
+. Changing this forces a new resource to be created.
 
 * `display_name` - (Required) The display set name of the policy definition.
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -3,7 +3,7 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_set_definition"
 sidebar_current: "docs-azurerm-resource-policy-set-definition"
 description: |-
-  Manages a policy set definition. Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
+  Manages a policy set definition.
 ---
 
 # azurerm_policy_set_definition

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -54,18 +54,17 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the policy set definition. Changing this forces a new resource to be created.
 
-* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom` or `NotSpecified`
-. Changing this forces a new resource to be created.
+* `policy_type` - (Required) The policy set type. Possible values are `BuiltIn` or `Custom`. Changing this forces a new resource to be created.
 
-* `display_name` - (Required) The display set name of the policy definition.
+* `display_name` - (Required) The display name of the policy set definition.
 
 * `policy_definitions` - (Required) The policy definitions for the policy set definition. This is a json object representing the bundled policy definitions .
 
 * `description` - (Optional) The description of the policy set definition.
 
-* `metadata` - (Optional) The metadata for the policy definition. This is a json object representing additional metadata that should be stored with the policy definition.
+* `metadata` - (Optional) The metadata for the policy set definition. This is a json object representing additional metadata that should be stored with the policy definition.
 
-* `parameters` - (Optional) Parameters for the policy definition. This field is a json object that allows you to parameterize your policy definition.
+* `parameters` - (Optional) Parameters for the policy set definition. This field is a json object that allows you to parameterize your policy definition.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the policy set definition. Changing this forces a
     new resource to be created.
 
-* `policy_type` - (Required) The policy set type. The value can be "BuiltIn", "Custom"
+* `policy_type` - (Required) The policy set type. The value can be `BuiltIn`, `Custom`
     or "NotSpecified". Changing this forces a new resource to be created.
 
 * `display_name` - (Required) The display set name of the policy definition.


### PR DESCRIPTION
This PR adds support for a new resource: Policy Set Definitions (aka Policy Initiatives).

Addresses issue #2193 

Test Results:

```sh
> $ make testacc TESTARGS='-run=TestAccAzureRMPolicySetDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMPolicySetDefinition -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-azurerm	[no test files]
=== RUN   TestAccAzureRMPolicySetDefinition_basic
=== PAUSE TestAccAzureRMPolicySetDefinition_basic
=== CONT  TestAccAzureRMPolicySetDefinition_basic
--- PASS: TestAccAzureRMPolicySetDefinition_basic (113.77s)
```

(fixed #2193)