### PR TITLE
Added Speech Services Kind

### DIFF
--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -59,6 +59,7 @@ func resourceArmCognitiveAccount() *schema.Resource {
 					"Recommendations",
 					"SpeakerRecognition",
 					"Speech",
+					"SpeechServices",
 					"SpeechTranslation",
 					"TextAnalytics",
 					"TextTranslation",

--- a/azurerm/resource_arm_cognitive_account_test.go
+++ b/azurerm/resource_arm_cognitive_account_test.go
@@ -38,6 +38,33 @@ func TestAccAzureRMCognitiveAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCognitiveAccount_speechServices(t *testing.T) {
+	resourceName := "azurerm_cognitive_account.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMCognitiveAccount_speechServices(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppCognitiveAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCognitiveAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "kind", "SpeechServices"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMCognitiveAccount_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -191,6 +218,27 @@ resource "azurerm_cognitive_account" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   kind                = "Face"
+
+  sku {
+    name = "S0"
+    tier = "Standard"
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMCognitiveAccount_speechServices(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "SpeechServices"
 
   sku {
     name = "S0"

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `Emotion`, `Face`, `LUIS`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
+* `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `Emotion`, `Face`, `LUIS`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as defined below.
 


### PR DESCRIPTION
When trying to provision a resource of `Speech` kind, there are errors. To correct for this, I added kind `SpeechServices` which should be compatible with the kind being used by Azure currently for that resource.