### PR TITLE
Bug Fix: `azurerm_dev_test_virtual_network`

### DIFF
--- a/azurerm/resource_arm_dev_test_virtual_network_test.go
+++ b/azurerm/resource_arm_dev_test_virtual_network_test.go
@@ -109,7 +109,7 @@ func TestAccAzureRMDevTestVirtualNetwork_subnet(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDevTestVirtualNetworkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "subnet.0.use_public_ip_address", "Allow"),
+					resource.TestCheckResourceAttr(resourceName, "subnet.0.use_public_ip_address", "Deny"),
 					resource.TestCheckResourceAttr(resourceName, "subnet.0.use_in_virtual_machine_creation", "Allow"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -233,7 +233,7 @@ resource "azurerm_dev_test_virtual_network" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   subnet {
-    use_public_ip_address           = "Allow"
+    use_public_ip_address           = "Deny"
     use_in_virtual_machine_creation = "Allow"
   }
 }


### PR DESCRIPTION
For some reason, `subnets` only gets modified during update and not create so I've split out the CreateUpdate function into their own create/update functions. 

Addressing #2152
```
--- PASS: TestAccAzureRMDevTestVirtualNetwork_subnet (520.77s)
--- PASS: TestAccAzureRMDevTestVirtualNetwork_basic (520.77s)
```