### PR TITLE
`azurerm_api_management` - Add http2 protocol support for API Management

### DIFF
--- a/azurerm/internal/services/apimanagement/resource_arm_api_management.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management.go
@@ -213,7 +213,7 @@ func resourceArmApiManagementService() *schema.Resource {
 						"enable_http2": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
+							Default:  false,
 						},
 					},
 				},

--- a/azurerm/internal/services/apimanagement/resource_arm_api_management.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management.go
@@ -28,6 +28,7 @@ var apimFrontendProtocolSsl3 = "Microsoft.WindowsAzure.ApiManagement.Gateway.Sec
 var apimFrontendProtocolTls10 = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"
 var apimFrontendProtocolTls11 = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11"
 var apimTripleDesCiphers = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168"
+var apimHttp2Protocol = "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2"
 
 func resourceArmApiManagementService() *schema.Resource {
 	return &schema.Resource{
@@ -196,6 +197,23 @@ func resourceArmApiManagementService() *schema.Resource {
 								string(apimanagement.CertificateAuthority),
 								string(apimanagement.Root),
 							}, false),
+						},
+					},
+				},
+			},
+
+			"protocols": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						"enable_http2": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -658,8 +676,12 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 		d.Set("scm_url", props.ScmURL)
 		d.Set("public_ip_addresses", props.PublicIPAddresses)
 
-		if err := d.Set("security", flattenApiManagementCustomProperties(props.CustomProperties)); err != nil {
+		if err := d.Set("security", flattenApiManagementSecurityCustomProperties(props.CustomProperties)); err != nil {
 			return fmt.Errorf("Error setting `security`: %+v", err)
+		}
+
+		if err := d.Set("protocols", flattenApiManagementProtocolsCustomProperties(props.CustomProperties)); err != nil {
+			return fmt.Errorf("Error setting `protocols`: %+v", err)
 		}
 
 		hostnameConfigs := flattenApiManagementHostnameConfigurations(props.HostnameConfigurations, d)
@@ -1094,7 +1116,7 @@ func expandApiManagementCustomProperties(d *schema.ResourceData) map[string]*str
 		backendProtocolSsl3 = c.(bool)
 	}
 
-	return map[string]*string{
+	customProperties := map[string]*string{
 		apimBackendProtocolSsl3:   utils.String(strconv.FormatBool(backendProtocolSsl3)),
 		apimBackendProtocolTls10:  utils.String(strconv.FormatBool(backendProtocolTls10)),
 		apimBackendProtocolTls11:  utils.String(strconv.FormatBool(backendProtocolTls11)),
@@ -1103,9 +1125,17 @@ func expandApiManagementCustomProperties(d *schema.ResourceData) map[string]*str
 		apimFrontendProtocolTls11: utils.String(strconv.FormatBool(frontendProtocolTls11)),
 		apimTripleDesCiphers:      utils.String(strconv.FormatBool(tripleDesCiphers)),
 	}
+
+	if vp := d.Get("protocols").(([]interface{})); len(vp) > 0 {
+		if p, ok := d.GetOkExists("protocols.0.enable_http2"); ok {
+			customProperties[apimHttp2Protocol] = utils.String(strconv.FormatBool(p.(bool)))
+		}
+	}
+
+	return customProperties
 }
 
-func flattenApiManagementCustomProperties(input map[string]*string) []interface{} {
+func flattenApiManagementSecurityCustomProperties(input map[string]*string) []interface{} {
 	output := make(map[string]interface{})
 
 	output["enable_backend_ssl30"] = parseApiManagementNilableDictionary(input, apimBackendProtocolSsl3)
@@ -1124,6 +1154,14 @@ func flattenApiManagementCustomProperties(input map[string]*string) []interface{
 	output["disable_frontend_tls11"] = parseApiManagementNilableDictionary(input, apimFrontendProtocolTls11) // TODO: Remove in 2.0
 	output["disable_triple_des_chipers"] = parseApiManagementNilableDictionary(input, apimTripleDesCiphers)  // TODO: Remove in 2.0
 	output["disable_triple_des_ciphers"] = parseApiManagementNilableDictionary(input, apimTripleDesCiphers)  // TODO: Remove in 2.0
+
+	return []interface{}{output}
+}
+
+func flattenApiManagementProtocolsCustomProperties(input map[string]*string) []interface{} {
+	output := make(map[string]interface{})
+
+	output["enable_http2"] = parseApiManagementNilableDictionary(input, apimHttp2Protocol)
 
 	return []interface{}{output}
 }

--- a/azurerm/internal/services/apimanagement/resource_arm_api_management.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management.go
@@ -205,11 +205,10 @@ func resourceArmApiManagementService() *schema.Resource {
 			"protocols": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
+				Computed: true, //  TODO: remove in 2.0
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-
 						"enable_http2": {
 							Type:     schema.TypeBool,
 							Optional: true,

--- a/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
+++ b/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
@@ -104,7 +104,7 @@ func TestAccAzureRMApiManagement_customProps(t *testing.T) {
 				Config: testAccAzureRMApiManagement_customProps(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0.enable_http2", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0.enable_http2", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -126,6 +126,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 					testCheckAzureRMApiManagementExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Acceptance", "Test"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_addresses.#"),
+					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0.enable_http2", "true"),
 				),
 			},
 			{
@@ -427,10 +428,6 @@ resource "azurerm_api_management" "test" {
   publisher_email     = "pub1@email.com"
 
   sku_name = "Developer_1"
-
-  protocols {
-    enable_http2 = true
-  }
 
   security {
     enable_frontend_tls10     = true

--- a/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
+++ b/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
@@ -429,7 +429,7 @@ resource "azurerm_api_management" "test" {
   sku_name = "Developer_1"
 
   protocols {
-	enable_http2 = true
+    enable_http2 = true
   }
 
   security {
@@ -517,7 +517,7 @@ resource "azurerm_api_management" "test" {
   }
 
   protocols {
-	enable_http2 = true
+    enable_http2 = true
   }
 
   security {

--- a/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
+++ b/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_test.go
@@ -104,6 +104,7 @@ func TestAccAzureRMApiManagement_customProps(t *testing.T) {
 				Config: testAccAzureRMApiManagement_customProps(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0.enable_http2", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -427,6 +428,10 @@ resource "azurerm_api_management" "test" {
 
   sku_name = "Developer_1"
 
+  protocols {
+	enable_http2 = true
+  }
+
   security {
     enable_frontend_tls10     = true
     enable_triple_des_ciphers = true
@@ -509,6 +514,10 @@ resource "azurerm_api_management" "test" {
     encoded_certificate  = "${filebase64("testdata/api_management_api_test.pfx")}"
     certificate_password = "terraform"
     store_name           = "Root"
+  }
+
+  protocols {
+	enable_http2 = true
   }
 
   security {

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -167,7 +167,7 @@ A `proxy` block supports the following:
 
 A `protocols` block supports the following:
 
-* `enable_http2` - (Optional) Should HTTP/2 support be enabled on the client-facing side of the gateway? Defaults to `false`.
+* `enable_http2` - (Optional) Should HTTP/2 be supported by the API Management Service? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -167,7 +167,7 @@ A `proxy` block supports the following:
 
 A `protocols` block supports the following:
 
-* `enable_http2` - (Optional) Should HTTP/2 support be enabled on the client-facing side of the gateway?
+* `enable_http2` - (Optional) Should HTTP/2 support be enabled on the client-facing side of the gateway? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `policy` - (Optional) A `policy` block as defined below.
 
+* `protocols` - (Optional) A `protocols` block as defined below.
+
 * `security` - (Optional) A `security` block as defined below.
 
 * `sign_in` - (Optional) A `sign_in` block as defined below.
@@ -160,6 +162,12 @@ A `proxy` block supports the following:
 -> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
 
 * `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
+
+---
+
+A `protocols` block supports the following:
+
+* `enable_http2` - (Optional) Should HTTP/2 support be enabled on the client-facing side of the gateway?
 
 ---
 


### PR DESCRIPTION
This PR will fix issue #3621 and add support to enable http2 protocol for API Management.