### PR TITLE
`azurerm_key_vault_key` - support for `not_before_date` and `expiration_date`

### DIFF
--- a/azurerm/internal/services/keyvault/resource_arm_key_vault_key.go
+++ b/azurerm/internal/services/keyvault/resource_arm_key_vault_key.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -121,6 +123,18 @@ func resourceArmKeyVaultKey() *schema.Resource {
 				ConflictsWith: []string{"key_size"},
 			},
 
+			"not_before_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.RFC3339Time,
+			},
+
+			"expiration_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.RFC3339Time,
+			},
+
 			// Computed
 			"version": {
 				Type:     schema.TypeString,
@@ -224,6 +238,18 @@ func resourceArmKeyVaultKeyCreate(d *schema.ResourceData, meta interface{}) erro
 	// TODO: support `oct` once this is fixed
 	// https://github.com/Azure/azure-rest-api-specs/issues/1739#issuecomment-332236257
 
+	if v, ok := d.GetOk("not_before_date"); ok {
+		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
+		notBeforeUnixTime := date.UnixTime(notBeforeDate)
+		parameters.KeyAttributes.NotBefore = &notBeforeUnixTime
+	}
+
+	if v, ok := d.GetOk("expiration_date"); ok {
+		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
+		expirationUnixTime := date.UnixTime(expirationDate)
+		parameters.KeyAttributes.Expires = &expirationUnixTime
+	}
+
 	if _, err := client.CreateKey(ctx, keyVaultBaseUri, name, parameters); err != nil {
 		return fmt.Errorf("Error Creating Key: %+v", err)
 	}
@@ -277,6 +303,18 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 			Enabled: utils.Bool(true),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("not_before_date"); ok {
+		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
+		notBeforeUnixTime := date.UnixTime(notBeforeDate)
+		parameters.KeyAttributes.NotBefore = &notBeforeUnixTime
+	}
+
+	if v, ok := d.GetOk("expiration_date"); ok {
+		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
+		expirationUnixTime := date.UnixTime(expirationDate)
+		parameters.KeyAttributes.Expires = &expirationUnixTime
 	}
 
 	if _, err = client.UpdateKey(ctx, id.KeyVaultBaseUrl, id.Name, id.Version, parameters); err != nil {
@@ -351,6 +389,16 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		d.Set("curve", key.Crv)
+	}
+
+	if attributes := resp.Attributes; attributes != nil {
+		if v := attributes.NotBefore; v != nil {
+			d.Set("not_before_date", time.Time(*v).Format(time.RFC3339))
+		}
+
+		if v := attributes.Expires; v != nil {
+			d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
+		}
 	}
 
 	// Computed

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_key_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_key_test.go
@@ -167,6 +167,8 @@ func TestAccAzureRMKeyVaultKey_complete(t *testing.T) {
 				Config: testAccAzureRMKeyVaultKey_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKeyVaultKeyExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "not_before_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(data.ResourceName, "expiration_date", "2021-01-01T01:02:03Z"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.hello", "world"),
 				),
@@ -634,10 +636,12 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "key-%s"
-  key_vault_id = "${azurerm_key_vault.test.id}"
-  key_type     = "RSA"
-  key_size     = 2048
+  name            = "key-%s"
+  key_vault_id    = "${azurerm_key_vault.test.id}"
+  key_type        = "RSA"
+  key_size        = 2048
+  not_before_date = "2020-01-01T01:02:03Z"
+  expiration_date = "2021-01-01T01:02:03Z"
 
   key_opts = [
     "decrypt",

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -89,6 +89,10 @@ The following arguments are supported:
 
 * `key_opts` - (Required) A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case sensitive.
 
+* `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
+
+* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #5615

Adds the `not_before_date` and `expiration_date` options to the `azurerm_key_vault_key` resource.

```
--- PASS: TestAccAzureRMKeyVaultKey_disappears (207.17s)
--- PASS: TestAccAzureRMKeyVaultKey_basicRSAHSM (230.35s)
--- PASS: TestAccAzureRMKeyVaultKey_complete (238.66s)
--- PASS: TestAccAzureRMKeyVaultKey_basicECClassic (238.66s)
--- PASS: TestAccAzureRMKeyVaultKey_basicECHSM (239.90s)
--- PASS: TestAccAzureRMKeyVaultKey_basicEC (242.53s)
--- PASS: TestAccAzureRMKeyVaultKey_curveEC (247.80s)
--- PASS: TestAccAzureRMKeyVaultKey_update (260.65s)
--- PASS: TestAccAzureRMKeyVaultKey_disappearsWhenParentKeyVaultDeleted (267.47s)
--- PASS: TestAccAzureRMKeyVaultKey_basicRSA (269.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/tests      269.769s
```