### PR TITLE
New Resource: azurerm_log_analytics_datasource_windows_performance_counter

### DIFF
--- a/azurerm/internal/services/loganalytics/client/client.go
+++ b/azurerm/internal/services/loganalytics/client/client.go
@@ -7,12 +7,16 @@ import (
 )
 
 type Client struct {
+	DataSourcesClient    *operationalinsights.DataSourcesClient
 	LinkedServicesClient *operationalinsights.LinkedServicesClient
 	SolutionsClient      *operationsmanagement.SolutionsClient
 	WorkspacesClient     *operationalinsights.WorkspacesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
+	DataSourcesClient := operationalinsights.NewDataSourcesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&DataSourcesClient.Client, o.ResourceManagerAuthorizer)
+
 	WorkspacesClient := operationalinsights.NewWorkspacesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&WorkspacesClient.Client, o.ResourceManagerAuthorizer)
 
@@ -23,6 +27,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&LinkedServicesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
+		DataSourcesClient:    &DataSourcesClient,
 		LinkedServicesClient: &LinkedServicesClient,
 		SolutionsClient:      &SolutionsClient,
 		WorkspacesClient:     &WorkspacesClient,

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_datasource.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_datasource.go
@@ -1,0 +1,38 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type LogAnalyticsDataSourceId struct {
+	ResourceGroup string
+	Workspace     string
+	Name          string
+}
+
+func LogAnalyticsDataSourceID(input string) (*LogAnalyticsDataSourceId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Log Analytics Data Source ID %q: %+v", input, err)
+	}
+
+	server := LogAnalyticsDataSourceId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if server.Workspace, err = id.PopSegment("workspaces"); err != nil {
+		return nil, err
+	}
+
+	if server.Name, err = id.PopSegment("datasources"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &server, nil
+}

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_datasource_test.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_datasource_test.go
@@ -1,0 +1,85 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestLogAnalyticsDataSourceID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *LogAnalyticsDataSourceId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Workspace Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces",
+			Error: true,
+		},
+		{
+			Name:  "Workspace Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1",
+			Error: true,
+		},
+		{
+			Name:  "Missing DataSource Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources",
+			Error: true,
+		},
+		{
+			Name:  "DataSource Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1",
+			Error: true,
+			Expect: &LogAnalyticsDataSourceId{
+				ResourceGroup: "resGroup1",
+				Workspace:     "workspace1",
+				Name:          "datasource1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := LogAnalyticsDataSourceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.Workspace != v.Expect.Workspace {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Workspace, actual.Workspace)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/loganalytics/registration.go
+++ b/azurerm/internal/services/loganalytics/registration.go
@@ -27,7 +27,9 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_log_analytics_linked_service": resourceArmLogAnalyticsLinkedService(),
-		"azurerm_log_analytics_solution":       resourceArmLogAnalyticsSolution(),
-		"azurerm_log_analytics_workspace":      resourceArmLogAnalyticsWorkspace()}
+		"azurerm_log_analytics_linked_service":                         resourceArmLogAnalyticsLinkedService(),
+		"azurerm_log_analytics_solution":                               resourceArmLogAnalyticsSolution(),
+		"azurerm_log_analytics_workspace":                              resourceArmLogAnalyticsWorkspace(),
+		"azurerm_log_analytics_datasource_windows_performance_counter": resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter(),
+	}
 }

--- a/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
+++ b/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
@@ -59,13 +59,15 @@ func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter() *schema.Resour
 			},
 
 			"counter_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"instance_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"interval_seconds": {
@@ -75,8 +77,9 @@ func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter() *schema.Resour
 			},
 
 			"object_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}

--- a/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
+++ b/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
@@ -168,8 +168,8 @@ func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterRead(d *schema.Re
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("workspace_name", id.Workspace)
-	if mprop := resp.Properties; mprop != nil {
-		propStr, err := structure.FlattenJsonToString(mprop.(map[string]interface{}))
+	if props := resp.Properties; props != nil {
+		propStr, err := structure.FlattenJsonToString(props.(map[string]interface{}))
 		if err != nil {
 			return fmt.Errorf("failed to flatten properties map to json for Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
 		}

--- a/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
+++ b/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_windows_performance_counter.go
@@ -1,0 +1,203 @@
+package loganalytics
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterCreateUpdate,
+		Read:   resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterRead,
+		Update: resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterCreateUpdate,
+		Delete: resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.LogAnalyticsDataSourceID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"workspace_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     ValidateAzureRmLogAnalyticsWorkspaceName,
+			},
+
+			"counter_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"instance_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"interval_seconds": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(10, math.MaxInt32),
+			},
+
+			"object_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+type dataSourceWindowsPerformanceCounterProperty struct {
+	CounterName     string `json:"counterName"`
+	InstanceName    string `json:"instanceName"`
+	IntervalSeconds int    `json:"intervalSeconds"`
+	ObjectName      string `json:"objectName"`
+}
+
+func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	workspaceName := d.Get("workspace_name").(string)
+
+	if d.IsNewResource() {
+		resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("failed to check for existing Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_log_analytics_datasource_windows_performance_counter", *resp.ID)
+		}
+	}
+
+	prop := &dataSourceWindowsPerformanceCounterProperty{
+		CounterName:     d.Get("counter_name").(string),
+		InstanceName:    d.Get("instance_name").(string),
+		IntervalSeconds: d.Get("interval_seconds").(int),
+		ObjectName:      d.Get("object_name").(string),
+	}
+
+	params := operationalinsights.DataSource{
+		Kind:       operationalinsights.WindowsPerformanceCounter,
+		Properties: prop,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, workspaceName, name, params); err != nil {
+		return fmt.Errorf("failed to create Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Log Analytics DataSource Windows Performance Counter %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("Cannot read ID for Log Analytics DataSource Windows Performance Counter %q (Resource Group %q)", name, resourceGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterRead(d, meta)
+}
+
+func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Log Analytics DataSource Windows Performance Counter %q was not found in Resource Group %q in Workspace %q - removing from state!", id.Name, id.ResourceGroup, id.Workspace)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("failed to retrieve Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("workspace_name", id.Workspace)
+	if mprop := resp.Properties; mprop != nil {
+		propStr, err := structure.FlattenJsonToString(mprop.(map[string]interface{}))
+		if err != nil {
+			return fmt.Errorf("failed to flatten properties map to json for Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+		}
+
+		prop := &dataSourceWindowsPerformanceCounterProperty{}
+		if err := json.Unmarshal([]byte(propStr), &prop); err != nil {
+			return fmt.Errorf("failed to decode properties json for Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+		}
+
+		d.Set("counter_name", prop.CounterName)
+		d.Set("instance_name", prop.InstanceName)
+		d.Set("interval_seconds", prop.IntervalSeconds)
+		d.Set("object_name", prop.ObjectName)
+	}
+
+	return nil
+}
+
+func resourceArmLogAnalyticsDataSourceWindowsPerformanceCounterDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+		return fmt.Errorf("failed to delete Log Analytics DataSource Windows Performance Counter %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
+++ b/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
@@ -1,0 +1,235 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_windows_performance_counter", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
+					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "*"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_windows_performance_counter", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
+					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "inst1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_windows_performance_counter", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
+					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "*"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
+					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "inst1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_windows_performance_counter", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Log Analytics Data Source Windows Performance Counter not found: %s", resourceName)
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Log Analytics Data Source Windows Performance Counter %q (Resource Group %q) does not exist", id.Name, id.ResourceGroup)
+			}
+			return fmt.Errorf("failed to get on LogAnalytics.DataSourcesClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_log_analytics_datasource_windows_performance_counter" {
+			continue
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("failed to get on LogAnalytics.DataSourcesClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
+  name = "acctestLADS-WPC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name = azurerm_log_analytics_workspace.test.name
+  counter_name = "CPU"
+  object_name = "CPU"
+  interval_seconds = 10
+  instance_name = "*"
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
+  name = "acctestLADS-WPC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name = azurerm_log_analytics_workspace.test.name
+  counter_name = "Mem"
+  object_name = "Mem"
+  interval_seconds = 20
+  instance_name = "inst1"
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_windows_performance_counter" "import" {
+  name = azurerm_log_analytics_datasource_windows_performance_counter.test.name
+  resource_group_name = azurerm_log_analytics_datasource_windows_performance_counter.test.resource_group_name
+  workspace_name = azurerm_log_analytics_datasource_windows_performance_counter.test.workspace_name
+  counter_name = azurerm_log_analytics_datasource_windows_performance_counter.test.counter_name
+  object_name = azurerm_log_analytics_datasource_windows_performance_counter.test.object_name
+  interval_seconds = azurerm_log_analytics_datasource_windows_performance_counter.test.interval_seconds
+  instance_name = azurerm_log_analytics_datasource_windows_performance_counter.test.instance_name
+}
+`, template)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
+++ b/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
@@ -169,13 +169,13 @@ func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data ac
 %s
 
 resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
-  name = "acctestLADS-WPC-%d"
+  name                = "acctestLADS-WPC-%d"
   resource_group_name = azurerm_resource_group.test.name
-  workspace_name = azurerm_log_analytics_workspace.test.name
-  counter_name = "CPU"
-  object_name = "CPU"
-  interval_seconds = 10
-  instance_name = "*"
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+  counter_name        = "CPU"
+  object_name         = "CPU"
+  interval_seconds    = 10
+  instance_name       = "*"
 }
 `, template, data.RandomInteger)
 }
@@ -186,13 +186,13 @@ func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data
 %s
 
 resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
-  name = "acctestLADS-WPC-%d"
+  name                = "acctestLADS-WPC-%d"
   resource_group_name = azurerm_resource_group.test.name
-  workspace_name = azurerm_log_analytics_workspace.test.name
-  counter_name = "Mem"
-  object_name = "Mem"
-  interval_seconds = 20
-  instance_name = "inst1"
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+  counter_name        = "Mem"
+  object_name         = "Mem"
+  interval_seconds    = 20
+  instance_name       = "inst1"
 }
 `, template, data.RandomInteger)
 }
@@ -203,13 +203,13 @@ func testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImpor
 %s
 
 resource "azurerm_log_analytics_datasource_windows_performance_counter" "import" {
-  name = azurerm_log_analytics_datasource_windows_performance_counter.test.name
+  name                = azurerm_log_analytics_datasource_windows_performance_counter.test.name
   resource_group_name = azurerm_log_analytics_datasource_windows_performance_counter.test.resource_group_name
-  workspace_name = azurerm_log_analytics_datasource_windows_performance_counter.test.workspace_name
-  counter_name = azurerm_log_analytics_datasource_windows_performance_counter.test.counter_name
-  object_name = azurerm_log_analytics_datasource_windows_performance_counter.test.object_name
-  interval_seconds = azurerm_log_analytics_datasource_windows_performance_counter.test.interval_seconds
-  instance_name = azurerm_log_analytics_datasource_windows_performance_counter.test.instance_name
+  workspace_name      = azurerm_log_analytics_datasource_windows_performance_counter.test.workspace_name
+  counter_name        = azurerm_log_analytics_datasource_windows_performance_counter.test.counter_name
+  object_name         = azurerm_log_analytics_datasource_windows_performance_counter.test.object_name
+  interval_seconds    = azurerm_log_analytics_datasource_windows_performance_counter.test.interval_seconds
+  instance_name       = azurerm_log_analytics_datasource_windows_performance_counter.test.instance_name
 }
 `, template)
 }

--- a/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
+++ b/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_windows_performance_counter_test.go
@@ -24,10 +24,10 @@ func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(t *test
 				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
 					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "CPU"),
-					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
 					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "*"),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
 				),
 			},
 			data.ImportStep(),
@@ -47,10 +47,10 @@ func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(t *t
 				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
 					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "Mem"),
-					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
 					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "inst1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
 				),
 			},
 			data.ImportStep(),
@@ -70,10 +70,10 @@ func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update(t *tes
 				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
 					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "CPU"),
-					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
 					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "*"),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "CPU"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "10"),
 				),
 			},
 			data.ImportStep(),
@@ -81,10 +81,10 @@ func TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update(t *tes
 				Config: testAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsDataSourceWindowsPerformanceCounterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
 					resource.TestCheckResourceAttr(data.ResourceName, "object_name", "Mem"),
-					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
 					resource.TestCheckResourceAttr(data.ResourceName, "instance_name", "inst1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "counter_name", "Mem"),
+					resource.TestCheckResourceAttr(data.ResourceName, "interval_seconds", "20"),
 				),
 			},
 			data.ImportStep(),
@@ -172,10 +172,10 @@ resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
   name                = "acctestLADS-WPC-%d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_name      = azurerm_log_analytics_workspace.test.name
-  counter_name        = "CPU"
   object_name         = "CPU"
-  interval_seconds    = 10
   instance_name       = "*"
+  counter_name        = "CPU"
+  interval_seconds    = 10
 }
 `, template, data.RandomInteger)
 }
@@ -189,10 +189,10 @@ resource "azurerm_log_analytics_datasource_windows_performance_counter" "test" {
   name                = "acctestLADS-WPC-%d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_name      = azurerm_log_analytics_workspace.test.name
-  counter_name        = "Mem"
   object_name         = "Mem"
-  interval_seconds    = 20
   instance_name       = "inst1"
+  counter_name        = "Mem"
+  interval_seconds    = 20
 }
 `, template, data.RandomInteger)
 }
@@ -206,10 +206,10 @@ resource "azurerm_log_analytics_datasource_windows_performance_counter" "import"
   name                = azurerm_log_analytics_datasource_windows_performance_counter.test.name
   resource_group_name = azurerm_log_analytics_datasource_windows_performance_counter.test.resource_group_name
   workspace_name      = azurerm_log_analytics_datasource_windows_performance_counter.test.workspace_name
-  counter_name        = azurerm_log_analytics_datasource_windows_performance_counter.test.counter_name
   object_name         = azurerm_log_analytics_datasource_windows_performance_counter.test.object_name
-  interval_seconds    = azurerm_log_analytics_datasource_windows_performance_counter.test.interval_seconds
   instance_name       = azurerm_log_analytics_datasource_windows_performance_counter.test.instance_name
+  counter_name        = azurerm_log_analytics_datasource_windows_performance_counter.test.counter_name
+  interval_seconds    = azurerm_log_analytics_datasource_windows_performance_counter.test.interval_seconds
 }
 `, template)
 }
@@ -221,7 +221,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-la-%d"
   location = "%s"
 }
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1568,6 +1568,10 @@
               <a href="#">Log Analytics Resources</a>
               <ul class="nav">
                 <li>
+                  <a href="/docs/providers/azurerm/r/log_analytics_datasource_windows_performance_counter.html">azurerm_log_analytics_datasource_windows_performance_counter</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_linked_service.html">azurerm_log_analytics_linked_service</a>
                 </li>
 

--- a/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
+++ b/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
@@ -33,10 +33,10 @@ resource "azurerm_log_analytics_datasource_windows_performance_counter" "example
   name                = "example-lad-wpc"
   resource_group_name = azurerm_resource_group.example.name
   workspace_name      = azurerm_log_analytics_workspace.example.name
-  counter_name        = "CPU"
   object_name         = "CPU"
-  interval_seconds    = 10
   instance_name       = "*"
+  counter_name        = "CPU"
+  interval_seconds    = 10
 }
 ```
 
@@ -50,13 +50,13 @@ The following arguments are supported:
 
 * `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics Windows Performance Counter DataSource should exist. Changing this forces a new Log Analytics Windows Performance Counter DataSource to be created.
 
-* `counter_name` - (Required) The friendly name of the performance counter.
+* `object_name` - (Required) The object name of the Log Analytics Windows Performance Counter DataSource.
 
 * `instance_name` - (Required) The name of the virtual machine instance to which the Windows Performance Counter DataSource be applied. Specify a `*` will apply to all instances.
 
-* `interval_seconds` - (Required) The time of sample interval in seconds. Supports values between 10 and 2147483647.
+* `counter_name` - (Required) The friendly name of the performance counter.
 
-* `object_name` - (Required) The object name of the Log Analytics Windows Performance Counter DataSource.
+* `interval_seconds` - (Required) The time of sample interval in seconds. Supports values between 10 and 2147483647.
 
 ## Attributes Reference
 

--- a/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
+++ b/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
@@ -30,13 +30,13 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_log_analytics_datasource_windows_performance_counter" "example" {
-  name = "example-lad-wpc"
+  name                = "example-lad-wpc"
   resource_group_name = azurerm_resource_group.example.name
-  workspace_name = azurerm_log_analytics_workspace.example.name
-  counter_name = "CPU"
-  object_name = "CPU"
-  interval_seconds = 10
-  instance_name = "*"
+  workspace_name      = azurerm_log_analytics_workspace.example.name
+  counter_name        = "CPU"
+  object_name         = "CPU"
+  interval_seconds    = 10
+  instance_name       = "*"
 }
 ```
 

--- a/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
+++ b/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "Log Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_log_analytics_datasource_windows_performance_counter"
+description: |-
+  Manages a Log Analytics (formally Operational Insights) Windows Performance Counter DataSource.
+---
+
+# azurerm_log_analytics_datasource_windows_performance_counter
+
+Manages a Log Analytics (formally Operational Insights) Windows Performance Counter DataSource.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-law"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_datasource_windows_performance_counter" "example" {
+  name = "example-lad-wpc"
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name = azurerm_log_analytics_workspace.example.name
+  counter_name = "CPU"
+  object_name = "CPU"
+  interval_seconds = 10
+  instance_name = "*"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Name which should be used for this Log Analytics Windows Performance Counter DataSource. Changing this forces a new Log Analytics Windows Performance Counter DataSource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Log Analytics Windows Performance Counter DataSource should exist. Changing this forces a new Log Analytics Windows Performance Counter DataSource to be created.
+
+* `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics Windows Performance Counter DataSource should exist. Changing this forces a new Log Analytics Windows Performance Counter DataSource to be created.
+
+* `counter_name` - (Required) The friendly name of the performance counter.
+
+* `instance_name` - (Required) The name of the virtual machine instance to which the Windows Performance Counter DataSource be applied. Specify a `*` will apply to all instances.
+
+* `interval_seconds` - (Required) The time of sample interval in seconds. Supports values between 10 and 2147483647.
+
+* `object_name` - (Required) The object name of the Log Analytics Windows Performance Counter DataSource.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Log Analytics Windows Performance Counter DataSource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Windows Performance Counter DataSource.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Log Analytics Windows Performance Counter DataSource.
+* `update` - (Defaults to 30 minutes) Used when updating the Log Analytics Windows Performance Counter DataSource.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Log Analytics Windows Performance Counter DataSource.
+
+## Import
+
+Log Analytics Windows Performance Counter DataSources can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_log_analytics_datasource_windows_performance_counter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1
+```


### PR DESCRIPTION
This is one of the datasource requested by #3182.

There is a trade-off of interface design, is that for this specific ds, it has several different counters, and user specify one by setting the object_name. So it means user can only set one counter each time. While there are acutally kinds of counters out there.
So maybe we can give user a list to specify them at once. But later I feel it has several problems:

1. we need to iterate the list to call API one by one, unless using some concurrency (which is rare in terraform provider)
2. we need to define different names for those counters, since each counter has its own resource name/id. This is weired and maybe breaking some contract in terraform.

Another point is that currently the `name`, `object_name`, `counter_name`, `instance_name` allow arbitrary string, hence I'm using the `StringIsNotEmpty` validation for them.

Test Result:

```bash
💤  terraform-provider-azurerm [log_analytics_workspace_datasource] ⚡  make testacc TEST=./azurerm/internal/services/loganalytics/tests TESTARGS="-run='TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/loganalytics/tests -v -run='TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic
=== RUN   TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete
=== RUN   TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update
=== RUN   TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport
=== CONT  TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic
=== CONT  TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport
=== CONT  TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update
=== CONT  TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete
--- PASS: TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_complete (180.08s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_basic (180.31s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_requiresImport (193.07s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceWindowsPerformanceCounter_update (238.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/tests  238.765s
```