### PR TITLE
`azurerm_virtual_network_gateway` - per api requirements, `public_ip_address_id` is required 

### DIFF
--- a/azurerm/internal/services/network/resource_arm_virtual_network_gateway.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_network_gateway.go
@@ -150,7 +150,7 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 
 						"public_ip_address_id": {
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 					},

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -172,7 +172,7 @@ The `ip_configuration` block supports:
     the associated subnet is named `GatewaySubnet`. Therefore, each virtual
     network can contain at most a single Virtual Network Gateway.
 
-* `public_ip_address_id` - (Optional) The ID of the public ip address to associate
+* `public_ip_address_id` - (Required) The ID of the public ip address to associate
     with the Virtual Network Gateway.
 
 The `vpn_client_configuration` block supports:


### PR DESCRIPTION
Changing public_ip_address_id from Optional to Required as it throws errors if you try deploying without Public IP Address.

Error Message:
Error Creating/Updating AzureRM Virtual Network Gateway "test" (Resource Group "test2"): network.VirtualNetworkGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="PublicIpForGatewayIsRequired" Message="Public IP address reference is required for gateway IP configration /subscriptions/SUBSCRIPTIONID/resourceGroups/test2/providers/Microsoft.Network/virtualNetworkGateways/test." Details=[]

  on gatewayTest.tf line 26, in resource "azurerm_virtual_network_gateway" "example":
  26: resource "azurerm_virtual_network_gateway" "example" {