### PR TITLE
`azurerm_app_service` `ip_restriction` - support for `name` & `priority`

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -324,7 +324,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 							"priority": {
 								Type:         schema.TypeInt,
 								Optional:     true,
-								Computed:     true,
+								Default:      65000,
 								ValidateFunc: validation.IntBetween(1, 2147483647),
 							},
 						},

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -325,7 +325,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 								Type:         schema.TypeInt,
 								Optional:     true,
 								Computed:     true,
-								ValidateFunc: validation.IntBetween(1, 65000),
+								ValidateFunc: validation.IntBetween(1, 2147483647),
 							},
 						},
 					},

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -324,6 +324,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 							"priority": {
 								Type:         schema.TypeInt,
 								Optional:     true,
+								Computed:     true,
 								ValidateFunc: validation.IntAtLeast(1),
 							},
 						},

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -319,12 +319,13 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 							"name": {
 								Type:         schema.TypeString,
 								Optional:     true,
+								Computed:     true,
 								ValidateFunc: validation.StringIsNotEmpty,
 							},
 							"priority": {
 								Type:         schema.TypeInt,
 								Optional:     true,
-								Default:      65000,
+								Computed:     true,
 								ValidateFunc: validation.IntBetween(1, 2147483647),
 							},
 						},

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -316,6 +316,16 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 								Optional:     true,
 								ValidateFunc: validation.StringIsNotEmpty,
 							},
+							"name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							"priority": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(1),
+							},
 						},
 					},
 				},
@@ -677,6 +687,14 @@ func SchemaAppServiceDataSourceSiteConfig() *schema.Schema {
 							},
 							"virtual_network_subnet_id": {
 								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"priority": {
+								Type:     schema.TypeInt,
 								Computed: true,
 							},
 						},
@@ -1419,6 +1437,8 @@ func ExpandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 
 			ipAddress := restriction["ip_address"].(string)
 			vNetSubnetID := restriction["virtual_network_subnet_id"].(string)
+			name := restriction["name"].(string)
+			priority := restriction["priority"].(int)
 			if vNetSubnetID != "" && ipAddress != "" {
 				return siteConfig, fmt.Errorf(fmt.Sprintf("only one of `ip_address` or `virtual_network_subnet_id` can be set for `site_config.0.ip_restriction.%d`", i))
 			}
@@ -1438,6 +1458,14 @@ func ExpandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 
 			if vNetSubnetID != "" {
 				ipSecurityRestriction.VnetSubnetResourceID = &vNetSubnetID
+			}
+
+			if name != "" {
+				ipSecurityRestriction.Name = &name
+			}
+
+			if priority != 0 {
+				ipSecurityRestriction.Priority = utils.Int32(int32(priority))
 			}
 
 			restrictions = append(restrictions, ipSecurityRestriction)
@@ -1563,6 +1591,12 @@ func FlattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 			}
 			if vNetSubnetID := v.VnetSubnetResourceID; vNetSubnetID != nil {
 				block["virtual_network_subnet_id"] = *vNetSubnetID
+			}
+			if name := v.Name; name != nil {
+				block["name"] = *name
+			}
+			if priority := v.Priority; priority != nil {
+				block["priority"] = *priority
 			}
 			restrictions = append(restrictions, block)
 		}

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -325,7 +325,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 								Type:         schema.TypeInt,
 								Optional:     true,
 								Computed:     true,
-								ValidateFunc: validation.IntAtLeast(1),
+								ValidateFunc: validation.IntBetween(1, 65000),
 							},
 						},
 					},

--- a/azurerm/internal/services/web/tests/data_source_app_service_test.go
+++ b/azurerm/internal/services/web/tests/data_source_app_service_test.go
@@ -137,6 +137,8 @@ func TestAccDataSourceAzureRMAppService_ipRestriction(t *testing.T) {
 				Config: testAccDataSourceAppService_ipRestriction(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
 				),
 			},
 		},
@@ -271,7 +273,7 @@ data "azurerm_app_service" "test" {
 }
 
 func testAccDataSourceAppService_ipRestriction(data acceptance.TestData) string {
-	config := testAccAzureRMAppService_oneIpRestriction(data)
+	config := testAccAzureRMAppService_completeIpRestriction(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_slot_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_slot_test.go
@@ -857,7 +857,7 @@ func TestAccAzureRMAppServiceSlot_remoteDebugging(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceSlotExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.remote_debugging_enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.remote_debugging_version", "VS2015"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.remote_debugging_version", "VS2019"),
 				),
 			},
 		},
@@ -3109,7 +3109,7 @@ resource "azurerm_app_service_slot" "test" {
 
   site_config {
     remote_debugging_enabled = true
-    remote_debugging_version = "VS2015"
+    remote_debugging_version = "VS2019"
   }
 
   tags = {

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -525,6 +525,32 @@ func TestAccAzureRMAppService_completeIpRestriction(t *testing.T) {
 				Config: testAccAzureRMAppService_completeIpRestriction(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMAppService_manyCompleteIpRestrictions(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.ip_address", "20.20.20.0/24"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.name", "test-restriction-2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.priority", "1234"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMAppService_completeIpRestriction(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
@@ -2636,6 +2662,51 @@ resource "azurerm_app_service" "test" {
       ip_address = "10.10.10.10/32"
       name       = "test-restriction"
       priority   = 123
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_manyCompleteIpRestrictions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  site_config {
+    ip_restriction {
+      ip_address = "10.10.10.10/32"
+      name       = "test-restriction"
+      priority   = 123
+	}
+
+    ip_restriction {
+	  ip_address = "20.20.20.0/24"
+      name       = "test-restriction-2"
+      priority   = 1234
     }
   }
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -2659,9 +2659,9 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-	  ip_address = "10.10.10.10/32"
-	  name       = "test-restriction"
-	  priority   = 123
+      ip_address = "10.10.10.10/32"
+      name       = "test-restriction"
+      priority   = 123
 	}
   }
 }
@@ -2698,15 +2698,15 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-	  ip_address = "10.10.10.10/32"
-	  name       = "test-restriction"
-	  priority   = 123
+      ip_address = "10.10.10.10/32"
+      name       = "test-restriction"
+      priority   = 123
 	}
 
     ip_restriction {
-	  ip_address = "20.20.20.0/24"
-	  name       = "test-restriction-2"
-	  priority   = 1234
+      ip_address = "20.20.20.0/24"
+      name       = "test-restriction-2"
+      priority   = 1234
 	}
   }
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -2633,9 +2633,9 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-	  ip_address = "10.10.10.10/32"
-	  name       = "test-restriction"
-	  priority   = 123
+      ip_address = "10.10.10.10/32"
+      name       = "test-restriction"
+      priority   = 123
     }
   }
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -2662,7 +2662,7 @@ resource "azurerm_app_service" "test" {
       ip_address = "10.10.10.10/32"
       name       = "test-restriction"
       priority   = 123
-	}
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -2701,13 +2701,13 @@ resource "azurerm_app_service" "test" {
       ip_address = "10.10.10.10/32"
       name       = "test-restriction"
       priority   = 123
-	}
+    }
 
     ip_restriction {
       ip_address = "20.20.20.0/24"
       name       = "test-restriction-2"
       priority   = 1234
-	}
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -2659,10 +2659,10 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-      ip_address = "10.10.10.10/32"
-      name       = "test-restriction"
-      priority   = 123
-    }
+	  ip_address = "10.10.10.10/32"
+	  name       = "test-restriction"
+	  priority   = 123
+	}
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -2698,16 +2698,16 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-      ip_address = "10.10.10.10/32"
-      name       = "test-restriction"
-      priority   = 123
+	  ip_address = "10.10.10.10/32"
+	  name       = "test-restriction"
+	  priority   = 123
 	}
 
     ip_restriction {
 	  ip_address = "20.20.20.0/24"
-      name       = "test-restriction-2"
-      priority   = 1234
-    }
+	  name       = "test-restriction-2"
+	  priority   = 1234
+	}
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -514,6 +514,27 @@ func TestAccAzureRMAppService_oneIpRestriction(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_completeIpRestriction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppService_completeIpRestriction(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMAppService_oneVNetSubnetIpRestriction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	resource.ParallelTest(t, resource.TestCase{
@@ -2576,6 +2597,45 @@ resource "azurerm_app_service" "test" {
   site_config {
     ip_restriction {
       ip_address = "10.10.10.10/32"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_completeIpRestriction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  site_config {
+    ip_restriction {
+	  ip_address = "10.10.10.10/32"
+	  name       = "test-restriction"
+	  priority   = 123
     }
   }
 }

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -85,6 +85,10 @@ A `ip_restriction` block exports the following:
 
 * `subnet_mask` - The Subnet mask used for this IP Restriction.
 
+* `name` - The name for this IP Restriction.
+
+* `priority` - The priority for this IP Restriction.
+
 ---
 
 `site_config` supports the following:

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -311,7 +311,7 @@ A `ip_restriction` block supports the following:
 
 * `name` - (Optional) The name for this IP Restriction.
 
-* `priority` - (Optional) The priority for this IP Restriction. Restrictions are enforced in priority order.
+* `priority` - (Optional) The priority for this IP Restriction. Restrictions are enforced in priority order. By default, priority is set to 65000 if not specified.
 
 ---
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -309,6 +309,10 @@ A `ip_restriction` block supports the following:
 
 -> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
 
+* `name` - (Optional) The name for this IP Restriction.
+
+* `priority` - (Optional) The priority for this IP Restriction. Restrictions are enforced in priority order.
+
 ---
 
 A `microsoft` block supports the following:


### PR DESCRIPTION
Fixes: #6388

Adds the `name` and `priority` options to the `azurerm_app_service` resource's `ip_restriction` option.

```
=== RUN   TestAccAzureRMAppService_completeIpRestriction
=== PAUSE TestAccAzureRMAppService_completeIpRestriction
=== CONT  TestAccAzureRMAppService_completeIpRestriction
--- PASS: TestAccAzureRMAppService_completeIpRestriction (143.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests   143.564s
```

```
=== RUN   TestAccDataSourceAzureRMAppService_ipRestriction
=== PAUSE TestAccDataSourceAzureRMAppService_ipRestriction
=== CONT  TestAccDataSourceAzureRMAppService_ipRestriction
--- PASS: TestAccDataSourceAzureRMAppService_ipRestriction (147.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests   147.645s
```