### PR TITLE
`azurerm_monitor_diagnostic_setting` - `log_analytics_destination_type` supports `AzureDiagnostics`

### DIFF
--- a/azurerm/internal/services/monitor/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/internal/services/monitor/resource_arm_monitor_diagnostic_setting.go
@@ -83,10 +83,13 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 			},
 
 			"log_analytics_destination_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     false,
-				ValidateFunc: validation.StringInSlice([]string{"Dedicated"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Dedicated",
+					"AzureDiagnostics", // Not documented in azure API, but some resource has skew. See: https://github.com/Azure/azure-rest-api-specs/issues/9281
+				}, false),
 			},
 
 			"log": {


### PR DESCRIPTION
Workaround Azure API skew on diagnostics setting of `log_analytics_destination_type`, which should helps issue #6676.