### PR TITLE
[BUG] Analysis Services IPv4 rule name casing issue fix

### DIFF
--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -3,13 +3,13 @@ package analysisservices
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"log"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -1,9 +1,12 @@
 package analysisservices
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices"
@@ -99,6 +102,7 @@ func resourceArmAnalysisServicesServer() *schema.Resource {
 						},
 					},
 				},
+				Set: hashAnalysisServicesServerIpv4FirewallRule,
 			},
 
 			"querypool_connection_mode": {
@@ -383,19 +387,19 @@ func expandAnalysisServicesServerFirewallSettings(d *schema.ResourceData) *analy
 	return &firewallSettings
 }
 
-func flattenAnalysisServicesServerFirewallSettings(serverProperties *analysisservices.ServerProperties) (enablePowerBi *bool, fwRules []interface{}) {
+func flattenAnalysisServicesServerFirewallSettings(serverProperties *analysisservices.ServerProperties) (*bool, *schema.Set) {
 	if serverProperties == nil || serverProperties.IPV4FirewallSettings == nil {
-		return utils.Bool(false), make([]interface{}, 0)
+		return utils.Bool(false), schema.NewSet(hashAnalysisServicesServerIpv4FirewallRule, make([]interface{}, 0))
 	}
 
 	firewallSettings := serverProperties.IPV4FirewallSettings
 
-	enablePowerBi = utils.Bool(false)
+	enablePowerBi := utils.Bool(false)
 	if firewallSettings.EnablePowerBIService != nil {
 		enablePowerBi = firewallSettings.EnablePowerBIService
 	}
 
-	fwRules = make([]interface{}, 0)
+	fwRules := make([]interface{}, 0)
 	if firewallSettings.FirewallRules != nil {
 		for _, fwRule := range *firewallSettings.FirewallRules {
 			output := make(map[string]interface{})
@@ -415,5 +419,16 @@ func flattenAnalysisServicesServerFirewallSettings(serverProperties *analysisser
 		}
 	}
 
-	return enablePowerBi, fwRules
+	return enablePowerBi, schema.NewSet(hashAnalysisServicesServerIpv4FirewallRule, fwRules)
+}
+
+func hashAnalysisServicesServerIpv4FirewallRule(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["range_end"].(string)))
+
+	return hashcode.String(buf.String())
 }

--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -428,7 +428,7 @@ func hashAnalysisServicesServerIpv4FirewallRule(v interface{}) int {
 
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
 	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
-	buf.WriteString(fmt.Sprintf("%s", m["range_end"].(string)))
+	buf.WriteString(m["range_end"].(string))
 
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
I needed to change the hash function of an `ipv4_firewall_rule` to a custom one in order to prevent situations like the following:

```hcl
azurerm_analysis_services_server.analysis_services will be updated in-place
  ~ resource "azurerm_analysis_services_server" "analysis_services" {
        admin_users               = []
        enable_power_bi_service   = true
        id                        = "/subscriptions/dc8fbfc0-2769-421c-921e-f0dae437fa79/resourceGroups/dl4-analysis-services-rg/providers/Microsoft.AnalysisServices/servers/myanalysisservices"
        location                  = "northeurope"
        name                      = "myanalysisservices"
        querypool_connection_mode = "All"
        resource_group_name       = "dl4-analysis-services-rg"
        server_full_name          = "asazure://northeurope.asazure.windows.net/myanalysisservices"
        sku                       = "S1"
        tags                      = {}
      + ipv4_firewall_rule {
          + name        = "DWHMGMT-QDM-VM"
          + range_end   = "13.74.177.213"
          + range_start = "13.74.177.213"
        }
      - ipv4_firewall_rule {
          - name        = "dwhmgmt-qdm-vm" -> null
          - range_end   = "13.74.177.213" -> null
          - range_start = "13.74.177.213" -> null
        }
    }
```

When applying the changes above nothing really changed on server side as it didn't see a difference in the name.

@tombuildsstuff suggested to try to convert it to a list instead but I already switched the rules to Set a few weeks ago because the order sometimes randomly changed. That's why I think a Set is the best option here.