### PR TITLE
`azurerm_eventhub_authorization_rule` - Fix intermittent 404 errors

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -3,6 +3,7 @@ package eventhub
 import (
 	"fmt"
 	"log"
+        "net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -3,6 +3,7 @@ package eventhub
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -3,10 +3,10 @@ package eventhub
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
@@ -102,22 +102,24 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 		},
 	}
 
-	if _, err := client.CreateOrUpdateAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name, parameters); err != nil {
-		return fmt.Errorf("Error creating/updating EventHub Authorization Rule %q (EventHub %q / Namespace %q / Resource Group %q): %s", name, eventHubName, namespaceName, resourceGroup, err)
-	}
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 
-	read, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
-	if err != nil {
-		return err
-	}
+		if _, err := client.CreateOrUpdateAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name, parameters); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error creating Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q): %+v", name, eventHubName, namespaceName, resourceGroup, err))
+		}
 
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read EventHub Authorization Rule %s (resource group %s) ID", name, resourceGroup)
-	}
+		read, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Expected instance of the authorization rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
+		}
+		if read.ID == nil {
+			return resource.NonRetryableError(fmt.Errorf("Cannot read Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) ID", name, eventHubName, namespaceName, resourceGroup))
+		}
 
-	d.SetId(*read.ID)
+		d.SetId(*read.ID)
 
-	return resourceArmEventHubAuthorizationRuleRead(d, meta)
+		return resource.NonRetryableError(resourceArmEventHubAuthorizationRuleRead(d, meta))
+	})
 }
 
 func resourceArmEventHubAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
@@ -192,10 +194,10 @@ func resourceArmEventHubAuthorizationRuleDelete(d *schema.ResourceData, meta int
 	locks.ByName(namespaceName, eventHubNamespaceResourceName)
 	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
 
-	resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Authorization Rule '%s': %+v", name, err)
+	if resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Authorization Rule '%s': %+v", name, err)
+		}
 	}
 
 	return nil

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -3,7 +3,6 @@ package eventhub
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -103,7 +103,6 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-
 		if _, err := client.CreateOrUpdateAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name, parameters); err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Error creating Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q): %+v", name, eventHubName, namespaceName, resourceGroup, err))
 		}
@@ -112,6 +111,7 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 		if err != nil {
 			return resource.RetryableError(fmt.Errorf("Expected instance of the authorization rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
 		}
+		
 		if read.ID == nil {
 			return resource.NonRetryableError(fmt.Errorf("Cannot read Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) ID", name, eventHubName, namespaceName, resourceGroup))
 		}

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -111,7 +111,7 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 		if err != nil {
 			return resource.RetryableError(fmt.Errorf("Expected instance of the authorization rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
 		}
-		
+
 		if read.ID == nil {
 			return resource.NonRetryableError(fmt.Errorf("Cannot read Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) ID", name, eventHubName, namespaceName, resourceGroup))
 		}

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -109,7 +109,10 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 
 		read, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
 		if err != nil {
-			return resource.RetryableError(fmt.Errorf("Expected instance of the authorization rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
+			if utils.ResponseWasNotFound(read.Response) {
+				return resource.RetryableError(fmt.Errorf("Expected instance of the Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
+			}
+			return resource.NonRetryableError(fmt.Errorf("Expected instance of Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) could not be found", name, eventHubName, namespaceName, resourceGroup))
 		}
 
 		if read.ID == nil {

--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -119,7 +119,7 @@ func resourceArmEventHubNamespaceAuthorizationRuleRead(d *schema.ResourceData, m
 		return err
 	}
 
-	name := id.Path["AuthorizationRules"] // this is different then eventhub where its authorizationRules
+	name := id.Path["authorizationRules"]
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
 
@@ -168,7 +168,7 @@ func resourceArmEventHubNamespaceAuthorizationRuleDelete(d *schema.ResourceData,
 		return err
 	}
 
-	name := id.Path["AuthorizationRules"] // this is different then eventhub where its authorizationRules
+	name := id.Path["authorizationRules"]
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
 


### PR DESCRIPTION
* Add retry for Event Hub Authorization Rule create to prevent 404 error, since adding Locks didn't seem to do the trick (Fixes #6983 #4893)
* Fix 404 error when deleting rules
* Update case for Namespace Authorization Rules API path to account for Azure Go SDK update (#6725) (Fixes #7132)