### PR TITLE
`azurerm_cdn_endpoint` - `origin_host_header` can now be set to empty

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -59,7 +59,6 @@ func resourceArmCdnEndpoint() *schema.Resource {
 			"origin_host_header": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"is_http_allowed": {

--- a/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
@@ -89,6 +89,13 @@ func TestAccAzureRMCdnEndpoint_updateHostHeader(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAzureRMCdnEndpoint_hostHeader(data, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "origin_host_header", ""),
+				),
+			},
+			{
 				Config: testAccAzureRMCdnEndpoint_hostHeader(data, "www.example2.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnEndpointExists(data.ResourceName),
@@ -517,7 +524,7 @@ resource "azurerm_cdn_endpoint" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, domain)
+`, data.RandomInteger, "westus", data.RandomInteger, data.RandomInteger, domain)
 }
 
 func testAccAzureRMCdnEndpoint_withTags(data acceptance.TestData) string {

--- a/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
@@ -524,7 +524,7 @@ resource "azurerm_cdn_endpoint" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, "westus", data.RandomInteger, data.RandomInteger, domain)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, domain)
 }
 
 func testAccAzureRMCdnEndpoint_withTags(data acceptance.TestData) string {


### PR DESCRIPTION
This PR is the fix for property origin_host_header which mentioned in the issue terraform-providers/terraform-provider-azurerm#1595

For updating origin_host_header, terraform should allow empty value for this property since it can be updated to "" after tested. So I submitted this PR to fix it.

For updating origin_path, seems it's an API issue so that I raised an issue on Azure/azure-rest-api-specs#9660. I think we should add tag "upstream-microsoft" for this problem.