### PR TITLE
`azurerm_virtual_network_gatway` - `vpn_client_protocols` is now also computed to prevent permanent diffs

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -238,6 +238,7 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 						"vpn_client_protocols": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{


### PR DESCRIPTION
fixes terraform-providers/terraform-provider-azurerm#1817

After tested, I found seems the api behavior has been changed. `root_certificate` wouldn't be automatically generated while not specifying. So no need to fix it. So I just fix `vpn_client_protocols` in this PR.