### PR TITLE
`azurerm_storage_share_directory ` - `name` can now contain one nested directory

### DIFF
--- a/azurerm/helpers/validate/storage.go
+++ b/azurerm/helpers/validate/storage.go
@@ -12,7 +12,7 @@ func StorageShareDirectoryName(v interface{}, k string) (warnings []string, erro
 	// File share names can contain only uppercase and lowercase letters, numbers, and hyphens,
 	// and must begin and end with a letter or a number.
 	// however they can be nested (e.g. foo/bar)
-	if !regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]+[A-Za-z0-9]$`).MatchString(value) && !regexp.MustCompile(`^[A-Za-z0-9]{1,}/[A-Za-z0-9]{1,}$`).MatchString(value) {
+	if !regexp.MustCompile(`^[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,}(/[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,})*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%s must contain only uppercase and lowercase alphanumeric characters, numbers and hyphens. It must start and end with a letter and end only with a number or letter", k))
 	}
 

--- a/azurerm/helpers/validate/storage.go
+++ b/azurerm/helpers/validate/storage.go
@@ -11,8 +11,8 @@ func StorageShareDirectoryName(v interface{}, k string) (warnings []string, erro
 
 	// File share names can contain only uppercase and lowercase letters, numbers, and hyphens,
 	// and must begin and end with a letter or a number.
-	// however they can be nested (e.g. foo/bar)
-	if !regexp.MustCompile(`^[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,}(/[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,})*$`).MatchString(value) {
+	// However they can be nested (e.g. foo/bar) with at most one level.
+	if !regexp.MustCompile(`^[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,}(/[A-Za-z0-9]{1,}[A-Za-z0-9-]{0,1}[A-Za-z0-9]{1,})?$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%s must contain only uppercase and lowercase alphanumeric characters, numbers and hyphens. It must start and end with a letter and end only with a number or letter", k))
 	}
 

--- a/azurerm/helpers/validate/storage_test.go
+++ b/azurerm/helpers/validate/storage_test.go
@@ -49,7 +49,7 @@ func TestValidateStorageShareDirectoryName(t *testing.T) {
 		},
 		{
 			Input:    "123-abc/hello/world",
-			Expected: true,
+			Expected: false,
 		},
 		{
 			Input:    "123-abc/hello/world-",

--- a/azurerm/helpers/validate/storage_test.go
+++ b/azurerm/helpers/validate/storage_test.go
@@ -40,6 +40,22 @@ func TestValidateStorageShareDirectoryName(t *testing.T) {
 			Expected: true,
 		},
 		{
+			Input:    "123-abc/hello-world",
+			Expected: true,
+		},
+		{
+			Input:    "123-abc/hello--world",
+			Expected: false,
+		},
+		{
+			Input:    "123-abc/hello/world",
+			Expected: true,
+		},
+		{
+			Input:    "123-abc/hello/world-",
+			Expected: false,
+		},
+		{
 			Input:    "hello/",
 			Expected: false,
 		},

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
@@ -307,9 +307,9 @@ resource "azurerm_storage_share_directory" "child" {
 }
 
 resource "azurerm_storage_share_directory" "child_two" {
-	name                 = "${azurerm_storage_share_directory.parent.name}/child-two"
-	share_name           = azurerm_storage_share.test.name
-	storage_account_name = azurerm_storage_account.test.name
+  name                 = "${azurerm_storage_share_directory.parent.name}/child-two"
+  share_name           = azurerm_storage_share.test.name
+  storage_account_name = azurerm_storage_account.test.name
 }
 `, template)
 }

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
@@ -310,7 +310,7 @@ resource "azurerm_storage_share_directory" "child_two" {
 	name                 = "${azurerm_storage_share_directory.parent.name}/child-two"
 	share_name           = azurerm_storage_share.test.name
 	storage_account_name = azurerm_storage_account.test.name
-  }
+}
 `, template)
 }
 

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_share_directory_test.go
@@ -124,7 +124,7 @@ func TestAccAzureRMStorageShareDirectory_nested(t *testing.T) {
 				Config: testAccAzureRMStorageShareDirectory_nested(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageShareDirectoryExists("azurerm_storage_share_directory.parent"),
-					testCheckAzureRMStorageShareDirectoryExists("azurerm_storage_share_directory.child"),
+					testCheckAzureRMStorageShareDirectoryExists("azurerm_storage_share_directory.child_two"),
 				),
 			},
 		},
@@ -305,6 +305,12 @@ resource "azurerm_storage_share_directory" "child" {
   share_name           = azurerm_storage_share.test.name
   storage_account_name = azurerm_storage_account.test.name
 }
+
+resource "azurerm_storage_share_directory" "child_two" {
+	name                 = "${azurerm_storage_share_directory.parent.name}/child-two"
+	share_name           = azurerm_storage_share.test.name
+	storage_account_name = azurerm_storage_account.test.name
+  }
 `, template)
 }
 


### PR DESCRIPTION
This PR allows hyphens in the names of nested file share directories, for example:

`abc/hello-world`

This is noted in [this comment](https://github.com/terraform-providers/terraform-provider-azurerm/issues/5398#issuecomment-642923739) by  [JeremiahInMN](https://github.com/JeremiahInMN) as part of an issue around multi-level directory nesting.