### PR TITLE
azurerm_storage_account: set default for `min_tls_version`

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1103,7 +1103,12 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		if meta.(*clients.Client).Account.Environment.Name != autorestAzure.PublicCloud.Name {
 			d.Set("min_tls_version", string(storage.TLS10))
 		} else {
-			d.Set("min_tls_version", string(props.MinimumTLSVersion))
+			// For storage account created using old API, the response of GET call will not return "min_tls_version", either.
+			minTlsVersion := string(storage.TLS10)
+			if props.MinimumTLSVersion != "" {
+				minTlsVersion = string(props.MinimumTLSVersion)
+			}
+			d.Set("min_tls_version", minTlsVersion)
 		}
 
 		if customDomain := props.CustomDomain; customDomain != nil {


### PR DESCRIPTION
For those storage account created using old API version (at least
2018-02-01, before provider v1.29.0), the GET call of new API version
will not return the `minimumTLSVersion` in response body. So those users
will get a diff.

This PR sets the default value for `min_tls_version` in case it is
missing in response, using the same value as the default value defined
in schema.

At least fixes the issue encountered by [this user comment](https://github.com/terraform-providers/terraform-provider-azurerm/pull/7879#issuecomment-671984119).