### PR TITLE
`azurerm_*.*.zone` - can no longer be passed in as empty

### DIFF
--- a/azurerm/helpers/azure/zones.go
+++ b/azurerm/helpers/azure/zones.go
@@ -1,6 +1,9 @@
 package azure
 
-import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
+)
 
 func SchemaZones() *schema.Schema {
 	return &schema.Schema{
@@ -9,6 +12,7 @@ func SchemaZones() *schema.Schema {
 		ForceNew: true,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
+			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
 }
@@ -21,6 +25,7 @@ func SchemaSingleZone() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
+			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
 }
@@ -33,6 +38,7 @@ func SchemaMultipleZones() *schema.Schema {
 		MinItems: 1,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
+			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
 }
@@ -44,6 +50,7 @@ func SchemaZonesComputed() *schema.Schema {
 		Computed: true,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
+			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
 }

--- a/azurerm/helpers/azure/zones.go
+++ b/azurerm/helpers/azure/zones.go
@@ -11,7 +11,7 @@ func SchemaZones() *schema.Schema {
 		Optional: true,
 		ForceNew: true,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
@@ -24,7 +24,7 @@ func SchemaSingleZone() *schema.Schema {
 		ForceNew: true,
 		MaxItems: 1,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
@@ -37,7 +37,7 @@ func SchemaMultipleZones() *schema.Schema {
 		ForceNew: true,
 		MinItems: 1,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
@@ -49,7 +49,7 @@ func SchemaZonesComputed() *schema.Schema {
 		Optional: true,
 		Computed: true,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
 			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}

--- a/azurerm/helpers/azure/zones.go
+++ b/azurerm/helpers/azure/zones.go
@@ -2,7 +2,7 @@ package azure
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func SchemaZones() *schema.Schema {
@@ -12,7 +12,7 @@ func SchemaZones() *schema.Schema {
 		ForceNew: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }
@@ -25,7 +25,7 @@ func SchemaSingleZone() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }
@@ -38,7 +38,7 @@ func SchemaMultipleZones() *schema.Schema {
 		MinItems: 1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }
@@ -50,7 +50,7 @@ func SchemaZonesComputed() *schema.Schema {
 		Computed: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }


### PR DESCRIPTION
Fixes #8232