### PR TITLE
azurerm_cosmosdb_sql_container - support for `indexing_policy`

### DIFF
--- a/azurerm/internal/services/cosmos/common/indexing_policy.go
+++ b/azurerm/internal/services/cosmos/common/indexing_policy.go
@@ -47,12 +47,6 @@ func ExpandAzureRmCosmosDbIndexingPolicy(d *schema.ResourceData) *documentdb.Ind
 	policy := &documentdb.IndexingPolicy{}
 
 	if len(i) == 0 || i[0] == nil {
-		policy.IndexingMode = documentdb.Consistent
-		policy.IncludedPaths = &[]documentdb.IncludedPath{
-			{Path: utils.String("/*")},
-		}
-		policy.ExcludedPaths = &[]documentdb.ExcludedPath{}
-
 		return policy
 	}
 

--- a/azurerm/internal/services/cosmos/common/indexing_policy.go
+++ b/azurerm/internal/services/cosmos/common/indexing_policy.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func expandAzureRmCosmosDBIndexingPolicyIncludedPaths(input []interface{}) *[]documentdb.IncludedPath {
+	if len(input) == 0 {
+		return nil
+	}
+
+	var includedPaths []documentdb.IncludedPath
+
+	for _, v := range input {
+		includedPath := v.(map[string]interface{})
+		path := documentdb.IncludedPath{
+			Path: utils.String(includedPath["path"].(string)),
+		}
+
+		includedPaths = append(includedPaths, path)
+	}
+
+	return &includedPaths
+}
+
+func expandAzureRmCosmosDBIndexingPolicyExcludedPaths(input []interface{}) *[]documentdb.ExcludedPath {
+	if len(input) == 0 {
+		return nil
+	}
+
+	var paths []documentdb.ExcludedPath
+
+	for _, v := range input {
+		block := v.(map[string]interface{})
+		paths = append(paths, documentdb.ExcludedPath{
+			Path: utils.String(block["path"].(string)),
+		})
+	}
+
+	return &paths
+}
+
+func ExpandAzureRmCosmosDbIndexingPolicy(d *schema.ResourceData) *documentdb.IndexingPolicy {
+	i := d.Get("indexing_policy").([]interface{})
+	policy := &documentdb.IndexingPolicy{}
+
+	if len(i) == 0 || i[0] == nil {
+		policy.IndexingMode = documentdb.Consistent
+		policy.IncludedPaths = &[]documentdb.IncludedPath{
+			{Path: utils.String("/*")},
+		}
+		policy.ExcludedPaths = &[]documentdb.ExcludedPath{}
+
+		return policy
+	}
+
+	input := i[0].(map[string]interface{})
+	policy.IndexingMode = documentdb.IndexingMode(input["indexing_mode"].(string))
+	if v, ok := input["included_path"].([]interface{}); ok {
+		policy.IncludedPaths = expandAzureRmCosmosDBIndexingPolicyIncludedPaths(v)
+	}
+	if v, ok := input["excluded_path"].([]interface{}); ok {
+		policy.ExcludedPaths = expandAzureRmCosmosDBIndexingPolicyExcludedPaths(v)
+	}
+
+	return policy
+}
+
+func flattenCosmosDBIndexingPolicyExcludedPaths(input *[]documentdb.ExcludedPath) []interface{} {
+	if input == nil {
+		return nil
+	}
+
+	excludedPaths := make([]interface{}, 0)
+
+	for _, v := range *input {
+		// _etag is automatically added by the server and should be excluded on flattening
+		// as the user isn't setting it and it will show changes in state.
+		if *v.Path == "/\"_etag\"/?" {
+			continue
+		}
+
+		block := make(map[string]interface{})
+		block["path"] = v.Path
+		excludedPaths = append(excludedPaths, block)
+	}
+
+	return excludedPaths
+}
+
+func flattenCosmosDBIndexingPolicyIncludedPaths(input *[]documentdb.IncludedPath) []interface{} {
+	if input == nil {
+		return nil
+	}
+
+	includedPaths := make([]interface{}, 0)
+
+	for _, v := range *input {
+		block := make(map[string]interface{})
+		block["path"] = v.Path
+		includedPaths = append(includedPaths, block)
+	}
+
+	return includedPaths
+}
+
+func FlattenAzureRmCosmosDbIndexingPolicy(indexingPolicy *documentdb.IndexingPolicy) []interface{} {
+	results := make([]interface{}, 0)
+	if indexingPolicy == nil {
+		return results
+	}
+
+	result := make(map[string]interface{})
+	result["indexing_mode"] = string(indexingPolicy.IndexingMode)
+	result["included_path"] = flattenCosmosDBIndexingPolicyIncludedPaths(indexingPolicy.IncludedPaths)
+	result["excluded_path"] = flattenCosmosDBIndexingPolicyExcludedPaths(indexingPolicy.ExcludedPaths)
+
+	results = append(results, result)
+	return results
+}

--- a/azurerm/internal/services/cosmos/common/indexing_policy_test.go
+++ b/azurerm/internal/services/cosmos/common/indexing_policy_test.go
@@ -1,0 +1,205 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
+	cases := []struct {
+		Name        string
+		Value       *documentdb.IndexingPolicy
+		ExpectError bool
+	}{
+		{
+			Name:        "nil",
+			Value:       nil,
+			ExpectError: false,
+		},
+		{
+			Name: "no included_path or excluded_path with Consistent indexing_mode",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+			},
+			ExpectError: false,
+		},
+		{
+			Name: "no included_path or excluded_path with None indexing_mode",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.None,
+			},
+			ExpectError: false,
+		},
+		{
+			Name: "included_path with /*",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Name: "excluded_path with /*",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Name: "included_path with /* and excluded_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/testing/?"),
+					},
+					{
+						Path: utils.String("/bar/?"),
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Name: "included_path and excluded_path with /*",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+					{
+						Path: utils.String("/testing/?"),
+					},
+					{
+						Path: utils.String("/bar/?"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Name: "missing /* from included_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/testing/?"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Name: "missing /* with included_path and excluded_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.Consistent,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/foo/?"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/bar/?"),
+					},
+					{
+						Path: utils.String("/foo/?"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Name: "indexing_mode None with included_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.None,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Name: "indexing_mode None with excluded_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.None,
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Name: "indexing_mode None with included_path and excluded_path",
+			Value: &documentdb.IndexingPolicy{
+				IndexingMode: documentdb.None,
+				IncludedPaths: &[]documentdb.IncludedPath{
+					{
+						Path: utils.String("/*"),
+					},
+				},
+				ExcludedPaths: &[]documentdb.ExcludedPath{
+					{
+						Path: utils.String("/testing/?"),
+					},
+				},
+			},
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		err := ValidateAzureRmCosmosDbIndexingPolicy(tc.Value)
+		if tc.ExpectError && err == nil {
+			t.Fatalf("Expected an error but didn't get one for %q", tc.Name)
+		}
+
+		if !tc.ExpectError && err != nil {
+			t.Fatalf("Expected to get no errors for %q but got error: %+v", tc.Name, err)
+		}
+	}
+}

--- a/azurerm/internal/services/cosmos/common/schema.go
+++ b/azurerm/internal/services/cosmos/common/schema.go
@@ -1,7 +1,10 @@
 package common
 
 import (
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 )
 
@@ -36,4 +39,57 @@ func MongoCollectionAutoscaleSettingsSchema() *schema.Schema {
 	autoscaleSettingsDatabaseSchema.RequiredWith = []string{"shard_key"}
 
 	return autoscaleSettingsDatabaseSchema
+}
+
+func CosmosDbIndexingPolicySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// `automatic` is excluded as it is deprecated; see https://stackoverflow.com/a/58721386
+				"indexing_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          documentdb.Consistent,
+					DiffSuppressFunc: suppress.CaseDifference, // Open issue https://github.com/Azure/azure-sdk-for-go/issues/6603
+					ValidateFunc: validation.StringInSlice([]string{
+						string(documentdb.Consistent),
+						string(documentdb.None),
+					}, false),
+				},
+
+				"included_path": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"path": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+					},
+				},
+				"excluded_path": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"path": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -112,6 +112,7 @@ func resourceArmCosmosDbSQLContainer() *schema.Resource {
 					},
 				},
 			},
+			"indexing_policy": common.CosmosDbIndexingPolicySchema(),
 		},
 	}
 }
@@ -143,7 +144,8 @@ func resourceArmCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interfac
 	db := documentdb.SQLContainerCreateUpdateParameters{
 		SQLContainerCreateUpdateProperties: &documentdb.SQLContainerCreateUpdateProperties{
 			Resource: &documentdb.SQLContainerResource{
-				ID: &name,
+				ID:             &name,
+				IndexingPolicy: common.ExpandAzureRmCosmosDbIndexingPolicy(d),
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},
@@ -219,7 +221,8 @@ func resourceArmCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interfac
 	db := documentdb.SQLContainerCreateUpdateParameters{
 		SQLContainerCreateUpdateProperties: &documentdb.SQLContainerCreateUpdateProperties{
 			Resource: &documentdb.SQLContainerResource{
-				ID: &id.Name,
+				ID:             &id.Name,
+				IndexingPolicy: common.ExpandAzureRmCosmosDbIndexingPolicy(d),
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},
@@ -315,6 +318,10 @@ func resourceArmCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{
 
 			if defaultTTL := res.DefaultTTL; defaultTTL != nil {
 				d.Set("default_ttl", defaultTTL)
+			}
+
+			if indexingPolicy := res.IndexingPolicy; indexingPolicy != nil {
+				d.Set("indexing_policy", common.FlattenAzureRmCosmosDbIndexingPolicy(indexingPolicy))
 			}
 		}
 	}

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -141,11 +141,17 @@ func resourceArmCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interfac
 		return tf.ImportAsExistsError("azurerm_cosmosdb_sql_container", *existing.ID)
 	}
 
+	indexingPolicy := common.ExpandAzureRmCosmosDbIndexingPolicy(d)
+	err = common.ValidateAzureRmCosmosDbIndexingPolicy(indexingPolicy)
+	if err != nil {
+		return fmt.Errorf("Error generating indexing policy for Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
+	}
+
 	db := documentdb.SQLContainerCreateUpdateParameters{
 		SQLContainerCreateUpdateProperties: &documentdb.SQLContainerCreateUpdateProperties{
 			Resource: &documentdb.SQLContainerResource{
 				ID:             &name,
-				IndexingPolicy: common.ExpandAzureRmCosmosDbIndexingPolicy(d),
+				IndexingPolicy: indexingPolicy,
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},
@@ -218,11 +224,17 @@ func resourceArmCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interfac
 
 	partitionkeypaths := d.Get("partition_key_path").(string)
 
+	indexingPolicy := common.ExpandAzureRmCosmosDbIndexingPolicy(d)
+	err = common.ValidateAzureRmCosmosDbIndexingPolicy(indexingPolicy)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
+	}
+
 	db := documentdb.SQLContainerCreateUpdateParameters{
 		SQLContainerCreateUpdateProperties: &documentdb.SQLContainerCreateUpdateProperties{
 			Resource: &documentdb.SQLContainerResource{
 				ID:             &id.Name,
-				IndexingPolicy: common.ExpandAzureRmCosmosDbIndexingPolicy(d),
+				IndexingPolicy: indexingPolicy,
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_sql_container_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_sql_container_resource_test.go
@@ -123,6 +123,42 @@ func TestAccAzureRMCosmosDbSqlContainer_autoscale(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlContainer_indexing_policy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_container", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_basic(data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_indexing_policy(data, "/includedPath01/*", "/excludedPath01/?"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_indexing_policy(data, "/includedPath02/*", "/excludedPath02/?"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbSqlContainerDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.SqlClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -209,6 +245,21 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   }
   default_ttl = 500
   throughput  = 600
+  indexing_policy {
+    indexing_mode = "Consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    included_path {
+      path = "/testing/id1/*"
+    }
+
+    excluded_path {
+      path = "/testing/id2/*"
+    }
+  }
 }
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)
 }
@@ -228,11 +279,42 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   }
   default_ttl = 1000
   throughput  = 400
+  indexing_policy {
+    indexing_mode = "Consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    included_path {
+      path = "/testing/id2/*"
+    }
+
+    excluded_path {
+      path = "/testing/id1/*"
+    }
+  }
 }
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)
 }
 
 func testAccAzureRMCosmosDbSqlContainer_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/definition/id"
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger, maxThroughput)
+}
+
+func testAccAzureRMCosmosDbSqlContainer_indexing_policy(data acceptance.TestData, includedPath, excludedPath string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -241,11 +323,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
   account_name        = azurerm_cosmosdb_account.test.name
   database_name       = azurerm_cosmosdb_sql_database.test.name
-  partition_key_path  = "/definition/id"
 
-  autoscale_settings {
-    max_throughput = %[3]d
+  indexing_policy {
+    indexing_mode = "Consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    included_path {
+      path = "%s"
+    }
+
+    excluded_path {
+      path = "%s"
+    }
   }
 }
-`, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger, maxThroughput)
+`, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger, includedPath, excludedPath)
 }

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -20,9 +20,9 @@ resource "azurerm_cosmosdb_sql_container" "example" {
   database_name       = azurerm_cosmosdb_sql_database.example.name
   partition_key_path  = "/definition/id"
   throughput          = 400
-  
+
   indexing_policy {
-    indexing_mode  = "Consistent"
+    indexing_mode = "Consistent"
 
     included_path {
       path = "/*"

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -20,6 +20,22 @@ resource "azurerm_cosmosdb_sql_container" "example" {
   database_name       = azurerm_cosmosdb_sql_database.example.name
   partition_key_path  = "/definition/id"
   throughput          = 400
+  
+  indexing_policy {
+    indexing_mode  = "Consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    included_path {
+      path = "/included/?"
+    }
+
+    excluded_path {
+      path = "/excluded/?"
+    }
+  }
 
   unique_key {
     paths = ["/definition/idlong", "/definition/idshort"]
@@ -49,6 +65,8 @@ The following arguments are supported:
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
+* `indexing_policy` - (Optional) An `indexing_policy` block as defined below.
+
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
 ---
@@ -61,6 +79,22 @@ An `autoscale_settings` block supports the following:
 A `unique_key` block supports the following:
 
 * `paths` - (Required) A list of paths to use for this unique key.
+
+An `indexing_policy` block supports the following:
+
+* `indexing_mode` - (Optional) Indicates the indexing mode. Possible values include: `Consistent` and `None`. Defaults to `Consistent`.
+
+* `included_path` - (Optional) One or more `included_path` blocks as defined below. Either `included_path` or `excluded_path` must contain the `path` `/*`
+
+* `excluded_path` - (Optional) One or more `excluded_path` blocks as defined below. Either `included_path` or `excluded_path` must contain the `path` `/*`
+
+An `included_path` block supports the following:
+
+* `path` - Path for which the indexing behavior applies to.
+
+An `excluded_path` block supports the following:
+
+* `path` - Path that is excluded from indexing.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Allows for the setting of indexing policies on Cosmos DB SQL Containers. Completes the work from https://github.com/terraform-providers/terraform-provider-azurerm/pull/5546.

Test status as of https://github.com/terraform-providers/terraform-provider-azurerm/pull/8461/commits/e06ca000a8fbd115b3e057e57956b7fb5fee1f16

```
--- PASS: TestAccAzureRMCosmosDbSqlContainer_basic (1600.44s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_complete (1713.66s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_update (1775.82s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_indexing_policy (1821.13s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_autoscale (1940.55s)
```