### PR TITLE
`azurerm_search_service` - Add support for `allowed_ips`

### DIFF
--- a/azurerm/internal/services/search/resource_arm_search_service.go
+++ b/azurerm/internal/services/search/resource_arm_search_service.go
@@ -109,7 +109,7 @@ func resourceArmSearchService() *schema.Resource {
 				Default:  true,
 			},
 
-			"ip_rules": {
+			"allowed_ips": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
@@ -161,7 +161,7 @@ func resourceArmSearchServiceCreateUpdate(d *schema.ResourceData, meta interface
 		ServiceProperties: &search.ServiceProperties{
 			PublicNetworkAccess: publicNetworkAccess,
 			NetworkRuleSet: &search.NetworkRuleSet{
-				IPRules: expandSearchServiceIPRules(d.Get("ip_rules").([]interface{})),
+				IPRules: expandSearchServiceIPRules(d.Get("allowed_ips").([]interface{})),
 			},
 		},
 		Tags: tags.Expand(t),
@@ -238,7 +238,7 @@ func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) erro
 
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess != "Disabled")
 
-		d.Set("ip_rules", flattenSearchServiceIPRules(props.NetworkRuleSet))
+		d.Set("allowed_ips", flattenSearchServiceIPRules(props.NetworkRuleSet))
 	}
 
 	adminKeysClient := meta.(*clients.Client).Search.AdminKeysClient

--- a/azurerm/internal/services/search/resource_arm_search_service.go
+++ b/azurerm/internal/services/search/resource_arm_search_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/search/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -108,6 +109,15 @@ func resourceArmSearchService() *schema.Resource {
 				Default:  true,
 			},
 
+			"ip_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validate.IPv4Address,
+				},
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -150,6 +160,9 @@ func resourceArmSearchServiceCreateUpdate(d *schema.ResourceData, meta interface
 		},
 		ServiceProperties: &search.ServiceProperties{
 			PublicNetworkAccess: publicNetworkAccess,
+			NetworkRuleSet: &search.NetworkRuleSet{
+				IPRules: expandSearchServiceIPRules(d.Get("ip_rules").([]interface{})),
+			},
 		},
 		Tags: tags.Expand(t),
 	}
@@ -164,8 +177,13 @@ func resourceArmSearchServiceCreateUpdate(d *schema.ResourceData, meta interface
 		properties.ServiceProperties.PartitionCount = utils.Int32(partitionCount)
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, properties, nil); err != nil {
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, properties, nil)
+	if err != nil {
 		return fmt.Errorf("Error issuing create/update request for Search Service %q (ResourceGroup %q): %s", name, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("error waiting for the completion of the creating/updating of Search Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	resp, err := client.Get(ctx, resourceGroup, name, nil)
@@ -219,6 +237,8 @@ func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess != "Disabled")
+
+		d.Set("ip_rules", flattenSearchServiceIPRules(props.NetworkRuleSet))
 	}
 
 	adminKeysClient := meta.(*clients.Client).Search.AdminKeysClient
@@ -275,4 +295,32 @@ func flattenSearchQueryKeys(input []search.QueryKey) []interface{} {
 	}
 
 	return results
+}
+
+func expandSearchServiceIPRules(input []interface{}) *[]search.IPRule {
+	output := make([]search.IPRule, 0)
+	if input == nil {
+		return &output
+	}
+
+	for _, rule := range input {
+		if rule != nil {
+			output = append(output, search.IPRule{
+				Value: utils.String(rule.(string)),
+			})
+		}
+	}
+
+	return &output
+}
+
+func flattenSearchServiceIPRules(input *search.NetworkRuleSet) []interface{} {
+	if input == nil || *input.IPRules == nil || len(*input.IPRules) == 0 {
+		return nil
+	}
+	result := make([]interface{}, 0)
+	for _, rule := range *input.IPRules {
+		result = append(result, rule.Value)
+	}
+	return result
 }

--- a/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
+++ b/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
@@ -276,7 +276,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-search-%d"
   location = "%s"
 }
 

--- a/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
+++ b/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
@@ -106,6 +106,42 @@ func TestAccAzureRMSearchService_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSearchService_ipRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_search_service", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSearchService_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMSearchService_ipRules(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMSearchService_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMSearchServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Search.ServicesClient
@@ -228,6 +264,32 @@ resource "azurerm_search_service" "test" {
   tags = {
     environment = "Production"
     residential = "Area"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMSearchService_ipRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_search_service" "test" {
+  name                = "acctestsearchservice%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+
+  ip_rules = ["168.1.5.65"]
+
+  tags = {
+    environment = "staging"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
+++ b/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
@@ -286,7 +286,7 @@ resource "azurerm_search_service" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
 
-  ip_rules = ["168.1.5.65"]
+  allowed_ips = ["168.1.5.65"]
 
   tags = {
     environment = "staging"

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 -> **Note:** `partition_count` and `replica_count` can only be configured when using a `standard` sku.
 
+* `ip_rules` - (Optional) A list of IP addresses that are allowed access to the search service endpoint. 
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Search Service.
 
 ## Attributes Reference

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 -> **Note:** `partition_count` and `replica_count` can only be configured when using a `standard` sku.
 
-* `ip_rules` - (Optional) A list of IP addresses that are allowed access to the search service endpoint. 
+* `allowed_ips` - (Optional) A list of IPv4 addresses that are allowed access to the search service endpoint. 
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Search Service.
 


### PR DESCRIPTION
```
--- PASS: TestAccAzureRMSearchService_basic (84.53s)
--- PASS: TestAccAzureRMSearchService_requiresImport (89.07s)
--- PASS: TestAccAzureRMSearchService_update (1621.21s)
--- PASS: TestAccAzureRMSearchService_ipRules (1168.95s)
```