### PR TITLE
Dash shell compliant check-test-package.sh

### DIFF
--- a/scripts/check-test-package.sh
+++ b/scripts/check-test-package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 files=$(find . | egrep "/azurerm/internal/services/[a-z]+/[a-z_]+(resource|data_source)[a-z_]+\.go$" | egrep "test.go")
 error=false
@@ -7,8 +7,7 @@ echo "==> Checking that acceptance test packages are used..."
 
 for f in $files; do
   line=$(head -n 1 $f)
-  regex="_test$"
-  if [[ ! $line =~ $regex ]]; then
+  if [ "$line" = "${line%%_test}" ]; then
     echo $f
     error=true
   fi


### PR DESCRIPTION
Dash is the default SHELL for the Travis-CI jobs. 

Many make commands run fmtcheck that runs ./scripts/check-test-package.sh. This had a Bash/POSIX style `[[ textexpr ]]` that caused the following errors.

```text
==> Checking that acceptance test packages are used...
./scripts/check-test-package.sh: 11: [[: not found
./scripts/check-test-package.sh: 11: [[: not found
./scripts/check-test-package.sh: 11: [[: not found
./scripts/check-test-package.sh: 11: [[: not found
 <repeated>
```

The script was therefore not successfully checking for acceptance test files using the same package and could have missed circular dependencies.

New version is Dash shell compliant.