### PR TITLE
`azurerm_cosmosdb_sql_container` doesn't call get throughput api when cosmos account is serverless

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -32,6 +32,26 @@ func TestAccAzureRMCosmosDbSqlContainer_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlContainer_basic_serverless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_container", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_basic_serverless(data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMCosmosDbSqlContainer_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_container", "test")
 
@@ -228,6 +248,19 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   database_name       = azurerm_cosmosdb_sql_database.test.name
 }
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)
+}
+
+func testAccAzureRMCosmosDbSqlContainer_basic_serverless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+}
+`, testAccAzureRMCosmosDbSqlDatabase_serverless(data), data.RandomInteger)
 }
 
 func testAccAzureRMCosmosDbSqlContainer_complete(data acceptance.TestData) string {


### PR DESCRIPTION
Fixes #8175, this time for real :) 

This is based on #8673 & #9187 /cc @yupwei68

Unfortunately I missed this one in 9187. This should now fix comsosdb SQL serverless.

```
make testacc TEST=./azurerm/internal/services/cosmos TESTARGS='-run=TestAccAzureRMCosmosDbSqlContainer' TESTTIMEOUT='80m'

=== RUN   TestAccAzureRMCosmosDbSqlContainer_basic
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_basic
=== RUN   TestAccAzureRMCosmosDbSqlContainer_basic_serverless
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_basic_serverless
=== RUN   TestAccAzureRMCosmosDbSqlContainer_complete
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_complete
=== RUN   TestAccAzureRMCosmosDbSqlContainer_update
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_update
=== RUN   TestAccAzureRMCosmosDbSqlContainer_autoscale
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_autoscale
=== RUN   TestAccAzureRMCosmosDbSqlContainer_indexing_policy
=== PAUSE TestAccAzureRMCosmosDbSqlContainer_indexing_policy
=== CONT  TestAccAzureRMCosmosDbSqlContainer_basic
=== CONT  TestAccAzureRMCosmosDbSqlContainer_autoscale
=== CONT  TestAccAzureRMCosmosDbSqlContainer_complete
=== CONT  TestAccAzureRMCosmosDbSqlContainer_update
=== CONT  TestAccAzureRMCosmosDbSqlContainer_indexing_policy
=== CONT  TestAccAzureRMCosmosDbSqlContainer_basic_serverless
--- PASS: TestAccAzureRMCosmosDbSqlContainer_basic (1335.18s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_complete (1336.32s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_basic_serverless (1387.55s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_indexing_policy (1550.58s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_update (1564.60s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_autoscale (1662.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos      1662.540s
```