### PR TITLE
`azurerm_cosmosdb_mongo_collection`: ignore throughput if Cosmos DB provisioned in 'serverless' capacity mode

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1009,6 +1009,17 @@ func findZoneRedundant(locations *[]documentdb.Location, id string) bool {
 	return false
 }
 
+func isServerlessCapacityMode(accResp documentdb.DatabaseAccountGetResults) bool {
+	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
+		for _, v := range *props.Capabilities {
+			if *v.Name == "EnableServerless" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func flattenAzureRmCosmosDBAccountCapabilities(capabilities *[]documentdb.Capability) *schema.Set {
 	s := schema.Set{
 		F: resourceAzureRMCosmosDBAccountCapabilitiesHash,

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -136,7 +136,7 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: diffSuppressIgnoreKeyVaultKeyVersion,
-				ValidateFunc:     keyVaultValidate.NestedItemIdWithOptionalVersion,
+				ValidateFunc:     keyVaultValidate.VersionlessNestedItemId,
 			},
 
 			"consistency_policy": {
@@ -768,11 +768,7 @@ func resourceCosmosDbAccountDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
-	if err != nil {
-		if future.Response().StatusCode == http.StatusNoContent {
-			return nil
-		}
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.Name); err != nil {
 		return fmt.Errorf("deleting CosmosDB Account %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
@@ -1012,7 +1008,7 @@ func findZoneRedundant(locations *[]documentdb.Location, id string) bool {
 func isServerlessCapacityMode(accResp documentdb.DatabaseAccountGetResults) bool {
 	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
 		for _, v := range *props.Capabilities {
-			if *v.Name == "EnableServerless" {
+			if v.Name != nil && *v.Name == "EnableServerless" {
 				return true
 			}
 		}

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_database_resource.go
@@ -234,27 +234,18 @@ func resourceCosmosDbMongoDatabaseRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("cosmosDB Account %q (Resource Group %q) ID is empty or nil", id.DatabaseAccountName, id.ResourceGroup)
 	}
 
-	// if the cosmos Account is serverless, it could not call the get throughput api
-	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
-		serverless := false
-		for _, v := range *props.Capabilities {
-			if *v.Name == "EnableServerless" {
-				serverless = true
-			}
-		}
-
-		if !serverless {
-			throughputResp, err := client.GetMongoDBDatabaseThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
-			if err != nil {
-				if !utils.ResponseWasNotFound(throughputResp.Response) {
-					return fmt.Errorf("Error reading Throughput on Cosmos Mongo Database %q (Account: %q): %+v", id.Name, id.DatabaseAccountName, err)
-				} else {
-					d.Set("throughput", nil)
-					d.Set("autoscale_settings", nil)
-				}
+	// if the cosmos account is serverless calling the get throughput api would yield an error
+	if !isServerlessCapacityMode(accResp) {
+		throughputResp, err := client.GetMongoDBDatabaseThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(throughputResp.Response) {
+				return fmt.Errorf("Error reading Throughput on Cosmos Mongo Database %q (Account: %q): %+v", id.Name, id.DatabaseAccountName, err)
 			} else {
-				common.SetResourceDataThroughputFromResponse(throughputResp, d)
+				d.Set("throughput", nil)
+				d.Set("autoscale_settings", nil)
 			}
+		} else {
+			common.SetResourceDataThroughputFromResponse(throughputResp, d)
 		}
 	}
 

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -229,26 +229,18 @@ func resourceCosmosDbSQLDatabaseRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("cosmosDB Account %q (Resource Group %q) ID is empty or nil", id.DatabaseAccountName, id.ResourceGroup)
 	}
 
-	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
-		serverless := false
-		for _, v := range *props.Capabilities {
-			if *v.Name == "EnableServerless" {
-				serverless = true
-			}
-		}
-
-		if !serverless {
-			throughputResp, err := client.GetSQLDatabaseThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
-			if err != nil {
-				if !utils.ResponseWasNotFound(throughputResp.Response) {
-					return fmt.Errorf("Error reading Throughput on Cosmos SQL Database %q (Account: %q) ID: %v", id.Name, id.DatabaseAccountName, err)
-				} else {
-					d.Set("throughput", nil)
-					d.Set("autoscale_settings", nil)
-				}
+	// if the cosmos account is serverless calling the get throughput api would yield an error
+	if !isServerlessCapacityMode(accResp) {
+		throughputResp, err := client.GetSQLDatabaseThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(throughputResp.Response) {
+				return fmt.Errorf("Error reading Throughput on Cosmos SQL Database %q (Account: %q) ID: %v", id.Name, id.DatabaseAccountName, err)
 			} else {
-				common.SetResourceDataThroughputFromResponse(throughputResp, d)
+				d.Set("throughput", nil)
+				d.Set("autoscale_settings", nil)
 			}
+		} else {
+			common.SetResourceDataThroughputFromResponse(throughputResp, d)
 		}
 	}
 

--- a/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
@@ -229,26 +229,18 @@ func resourceCosmosDbTableRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("cosmosDB Account %q (Resource Group %q) ID is empty or nil", id.DatabaseAccountName, id.ResourceGroup)
 	}
 
-	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
-		serverless := false
-		for _, v := range *props.Capabilities {
-			if *v.Name == "EnableServerless" {
-				serverless = true
-			}
-		}
-
-		if !serverless {
-			throughputResp, err := client.GetTableThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
-			if err != nil {
-				if !utils.ResponseWasNotFound(throughputResp.Response) {
-					return fmt.Errorf("Error reading Throughput on Cosmos Table %q (Account: %q) ID: %v", id.Name, id.DatabaseAccountName, err)
-				} else {
-					d.Set("throughput", nil)
-					d.Set("autoscale_settings", nil)
-				}
+	// if the cosmos account is serverless calling the get throughput api would yield an error
+	if !isServerlessCapacityMode(accResp) {
+		throughputResp, err := client.GetTableThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(throughputResp.Response) {
+				return fmt.Errorf("Error reading Throughput on Cosmos Table %q (Account: %q) ID: %v", id.Name, id.DatabaseAccountName, err)
 			} else {
-				common.SetResourceDataThroughputFromResponse(throughputResp, d)
+				d.Set("throughput", nil)
+				d.Set("autoscale_settings", nil)
 			}
+		} else {
+			common.SetResourceDataThroughputFromResponse(throughputResp, d)
 		}
 	}
 


### PR DESCRIPTION
This should fix #9697. I stumbled upon the same "Error reading Throughput on Cosmos Mongo Collection" when I provisioned a "serverless" Cosmos DB in Mongo mode.

There was already some code in other places (obviously missing from `cosmosdb_mongo_collection_resource.go`) that handles throughput if and only if...

1. ...the database account contains _any_ `Capabilities`
2. ...these `Capabilities` _do not contain_ `EnableServerless`

However I think that throughput should _also_ be handled if there are _no_ `Capabilities` since "Provisioned throughput" is the default, so I fixed that as well.

I moved the code into a central function `isServerlessCapacityMode` (DRY!) which I put into file `cosmosdb_account_resource.go`. Not sure if this is the right place though.

Feedback very welcome!