### PR TITLE
azurerm_storage_data_lake_gen2_filesystem_resource: do not set/retrieve ACLs when HNS is not Enabled

### DIFF
--- a/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -216,7 +216,7 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error checking for existence of Storage Account %q (Resource Group %q): %+v", storageID.Name, storageID.ResourceGroup, err)
 	}
 
-	if acl != nil && (storageAccount.IsHnsEnabled == nil || *storageAccount.IsHnsEnabled == false) {
+	if acl != nil && (storageAccount.IsHnsEnabled == nil || !*storageAccount.IsHnsEnabled) {
 		return fmt.Errorf("ACL is enabled only when the Hierarchical Namespace (HNS) feature is turned ON")
 	}
 

--- a/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -57,7 +57,7 @@ func TestAccStorageDataLakeGen2FileSystem_withDefaultACL(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.RequiresImportErrorStep(r.requiresImport),
+		data.ImportStep(),
 	})
 }
 
@@ -144,15 +144,30 @@ func (r StorageDataLakeGen2FileSystemResource) Destroy(ctx context.Context, clie
 }
 
 func (r StorageDataLakeGen2FileSystemResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
-%s
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
   name               = "acctest-%d"
   storage_account_id = azurerm_storage_account.test.id
 }
-`, template, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func (r StorageDataLakeGen2FileSystemResource) requiresImport(data acceptance.TestData) string {

--- a/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -57,7 +57,7 @@ func TestAccStorageDataLakeGen2FileSystem_withDefaultACL(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.RequiresImportErrorStep(r.requiresImport),
 	})
 }
 
@@ -144,30 +144,15 @@ func (r StorageDataLakeGen2FileSystemResource) Destroy(ctx context.Context, clie
 }
 
 func (r StorageDataLakeGen2FileSystemResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_kind             = "BlobStorage"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
+%s
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
   name               = "acctest-%d"
   storage_account_id = azurerm_storage_account.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+`, template, data.RandomInteger)
 }
 
 func (r StorageDataLakeGen2FileSystemResource) requiresImport(data acceptance.TestData) string {


### PR DESCRIPTION
all synapse related test case are failed because of getting acl for storage data lake gen2 resource.

according to https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control#do-i-have-to-enable-support-for-acls

acl is enabled when Hierarchical Namespace (HNS) feature in storage account is turned ON.

After testing, when Hierarchical Namespace feature is disabled in storage account, the getAcl rest api will report error, which cause all tc in synapse fails