### PR TITLE
`azurerm_hpc_cache_nfs_target` - support for `access_policy_name`

### DIFF
--- a/azurerm/internal/services/hpccache/hpc_cache_blob_target_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_blob_target_resource.go
@@ -69,11 +69,9 @@ func resourceHPCCacheBlobTarget() *schema.Resource {
 			},
 
 			"access_policy_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				// TODO 3.0: Remove `Computed` and add `Default: "default"`.
-				// O+C here is for backward compatibility to make the existing tf state no need to change to make the resource created prior to API 2021-03-01 work.
-				Computed:     true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "default",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},

--- a/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
@@ -78,6 +78,13 @@ func resourceHPCCacheNFSTarget() *schema.Resource {
 							Default:      "",
 							ValidateFunc: validate.CacheNFSTargetPath,
 						},
+
+						"access_policy_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "default",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
 					},
 				},
 			},
@@ -228,9 +235,10 @@ func expandNamespaceJunctions(input []interface{}) *[]storagecache.NamespaceJunc
 	for _, v := range input {
 		b := v.(map[string]interface{})
 		result = append(result, storagecache.NamespaceJunction{
-			NamespacePath: utils.String(b["namespace_path"].(string)),
-			NfsExport:     utils.String(b["nfs_export"].(string)),
-			TargetPath:    utils.String(b["target_path"].(string)),
+			NamespacePath:   utils.String(b["namespace_path"].(string)),
+			NfsExport:       utils.String(b["nfs_export"].(string)),
+			TargetPath:      utils.String(b["target_path"].(string)),
+			NfsAccessPolicy: utils.String(b["access_policy_name"].(string)),
 		})
 	}
 
@@ -260,10 +268,16 @@ func flattenNamespaceJunctions(input *[]storagecache.NamespaceJunction) []interf
 			targetPath = *v
 		}
 
+		accessPolicy := ""
+		if v := e.NfsAccessPolicy; v != nil {
+			accessPolicy = *e.NfsAccessPolicy
+		}
+
 		output = append(output, map[string]interface{}{
-			"namespace_path": namespacePath,
-			"nfs_export":     nfsExport,
-			"target_path":    targetPath,
+			"namespace_path":     namespacePath,
+			"nfs_export":         nfsExport,
+			"target_path":        targetPath,
+			"access_policy_name": accessPolicy,
 		})
 	}
 

--- a/website/docs/r/hpc_cache_blob_target.html.markdown
+++ b/website/docs/r/hpc_cache_blob_target.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 -> **Note:** This is the Resource Manager ID of the Storage Container, rather than the regular ID - and can be accessed on the `azurerm_storage_container` Data Source/Resource as `resource_manager_id`.
 
-* `access_policy_name` - (Optional) The name of the access policy applied to this target.
+* `access_policy_name` - (Optional) The name of the access policy applied to this target. Defaults to `default`.
 
 ## Attributes Reference
 

--- a/website/docs/r/hpc_cache_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_nfs_target.html.markdown
@@ -153,6 +153,8 @@ A `namespace_junction` block supports the following:
 
 * `target_path` - (Optional) The relative subdirectory path from the `nfs_export` to map to the `namespace_path`. Defaults to `""`, in which case the whole `nfs_export` is exported.
 
+* `access_policy_name` - (Optional) The name of the access policy applied to this target. Defaults to `default`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Add `access_policy_name` to `azurerm_hpc_cache_nfs_target`. The existing resources are guaranteed to use the access policy as `default`, so making it the default value should make no breaking change or unnecessary plan diff. For the same reason, I've updated the schema for the same property for `azurerm_hpc_cache_blob_target`.

## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/hpccache TESTARGS='-run "TestAccHPCCacheNFSTarget_accessPolicy"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/hpccache -v -run "TestAccHPCCacheNFSTarget_accessPolicy" -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/04/01 11:23:27 [DEBUG] not using binary driver name, it's no longer needed
2021/04/01 11:23:27 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccHPCCacheNFSTarget_accessPolicy
=== PAUSE TestAccHPCCacheNFSTarget_accessPolicy
=== CONT  TestAccHPCCacheNFSTarget_accessPolicy
 --- PASS: TestAccHPCCacheNFSTarget_accessPolicy (2832.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hpccache    2832.392s
```