### PR TITLE
linux/windows_virtual_machine_sccale_set: define Hash function for `extension` block to ignore `protected_setting`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -523,7 +523,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -538,21 +538,21 @@ func TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostUpdate(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 		{
 			Config: r.otherEncryptionAtHost(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 		{
 			Config: r.otherEncryptionAtHost(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -567,7 +567,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostWithCMK(t *testing.
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -582,7 +582,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount(t *testing
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1579,9 +1579,9 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 		// we need to ensure the whitespace is consistent
 		settings := m["settings"].(string)
 		if settings != "" {
-			expandedSettings, err := structure.ExpandJsonFromString(settings)
+			expandedSettings, err := pluginsdk.ExpandJsonFromString(settings)
 			if err == nil {
-				serializedSettings, err := structure.FlattenJsonToString(expandedSettings)
+				serializedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 				if err == nil {
 					buf.WriteString(fmt.Sprintf("%s-", serializedSettings))
 				}
@@ -1591,9 +1591,9 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 		if v, ok := m["protected_settings"]; ok {
 			settings := v.(string)
 			if settings != "" {
-				expandedSettings, err := structure.ExpandJsonFromString(settings)
+				expandedSettings, err := pluginsdk.ExpandJsonFromString(settings)
 				if err == nil {
-					serializedSettings, err := structure.FlattenJsonToString(expandedSettings)
+					serializedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 					if err == nil {
 						buf.WriteString(fmt.Sprintf("%s-", serializedSettings))
 					}
@@ -1602,7 +1602,7 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 		}
 	}
 
-	return schema.HashString(buf.String())
+	return pluginsdk.HashString(buf.String())
 }
 
 func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *compute.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
@@ -1669,7 +1669,7 @@ func flattenVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleS
 	// since it is not returned from the API.
 	extensionsFromState := map[string]map[string]interface{}{}
 	if extSet, ok := d.GetOk("extension"); ok && extSet != nil {
-		extensions := extSet.(*schema.Set).List()
+		extensions := extSet.(*pluginsdk.Set).List()
 		for _, ext := range extensions {
 			if ext == nil {
 				continue

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1569,7 +1569,7 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%t-", m["auto_upgrade_minor_version"].(bool)))
 
 		if v, ok = m["force_update_tag"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", m["force_update_tag"].(string)))
+			buf.WriteString(fmt.Sprintf("%s-", v))
 		}
 
 		if v, ok := m["provision_after_extensions"]; ok {

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -629,7 +629,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled(t *testin
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -644,21 +644,21 @@ func TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledUpdate(t *
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 		{
 			Config: r.otherEncryptionAtHostEnabled(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 		{
 			Config: r.otherEncryptionAtHostEnabled(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -673,7 +673,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledWithCMK(t 
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -688,7 +688,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount(t *testi
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		data.ImportStep("admin_password"),
 	})
 }
 


### PR DESCRIPTION
Fixes: #11820.

The hash function is similar to the old vmss below, with some minor diffs due to schema diffs: https://github.com/terraform-providers/terraform-provider-azurerm/blob/84d710e21fca7abcf36f513f1c278c3151721fb1/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go#L774

Meanwhile, this PR removes some unnecessary ignores which are introduced in #11425. 

## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/compute -run="TestAccLinuxVirtualMachineScaleSet_extensions|TestAccWindowsVirtualMachineScaleSet_extensions"
2021/05/24 12:57:17 [DEBUG] not using binary driver name, it's no longer needed
2021/05/24 12:57:17 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsUpdate                                                                                                                                                                                               === RUN   TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension                                                                                                                                                                    === PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate                                                                                                                                                            === CONT  TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension                                                                                                                                                                  === CONT  TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
    testing.go:620: Step 1/2 error: Error running apply: exit status 1

        Error: Error creating Windows Virtual Machine Scale Set "acctvm21" (Resource Group "acctestRG-210524125717280510"): compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="windowsConfiguration.enableAutomaticUpdates cannot be set to true if upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade is already true, starting from API version 2019-03-01"

 on terraform_plugin_test.tf line 31, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          31: resource "azurerm_windows_virtual_machine_scale_set" "test" {


--- FAIL: TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension (145.64s)
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsMultiple (319.79s)
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension (332.66s)
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension (345.20s)
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension (485.79s)
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate (510.60s)
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsUpdate (774.25s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute     774.427s
FAIL
```

The only failure above is unrelated.