### PR TITLE
Add `allow_shared_key_access` to `azurerm_storage_account`

### DIFF
--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -242,7 +242,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"allow_shared_key_access": {
+			"shared_key_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -105,9 +105,11 @@ The following arguments are supported:
 
 -> **NOTE:** At this time `allow_blob_public_access` is only supported in the Public Cloud, China Cloud, and US Government Cloud.
 
+* `allow_blob_public_access` - Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is `true`.
+
 * `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created.
 
--> **NOTE:** This can only be `true` when `account_tier` is `Standard` or when `account_tier` is `Premium` *and* `account_kind` is `BlockBlobStorage` 
+-> **NOTE:** This can only be `true` when `account_tier` is `Standard` or when `account_tier` is `Premium` *and* `account_kind` is `BlockBlobStorage`
 
 * `nfsv3_enabled` - (Optional) Is NFSv3 protocol enabled? Changing this forces a new resource to be created. Defaults to `false`.
 


### PR DESCRIPTION
This PR adds the `allow_shared_key_access` attribute to the `azurerm_storage_account` resource and fixes #11460.
I took the documentation from https://docs.microsoft.com/en-us/rest/api/storagerp/storage-accounts/get-properties.

When i ran the the unit test suite it errored and mentioned to move the id management over to terraform. So I did that.

Two questions regarding the id management. 
In line 1024 I dropped the ID check because the account is no longer required. Should this check be readded in another way?
And second: In line 1501 and 1758 I dropped the id parsing and now the name and resource group from the schema is used. Is this the right way?