### PR TITLE
azurerm_app_service_certificate - introduce argument app_service_plan_id for usage with ASE

### DIFF
--- a/azurerm/internal/services/web/app_service_certificate_resource.go
+++ b/azurerm/internal/services/web/app_service_certificate_resource.go
@@ -74,10 +74,15 @@ func resourceAppServiceCertificate() *pluginsdk.Resource {
 				ConflictsWith: []string{"pfx_blob", "password"},
 			},
 
-			"hosting_environment_profile_id": {
+			"app_service_plan_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+
+			"hosting_environment_profile_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"friendly_name": {
@@ -138,7 +143,7 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 	pfxBlob := d.Get("pfx_blob").(string)
 	password := d.Get("password").(string)
 	keyVaultSecretId := d.Get("key_vault_secret_id").(string)
-	hostingEnvironmentProfileId := d.Get("hosting_environment_profile_id").(string)
+	appServicePlanId := d.Get("app_service_plan_id").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	if pfxBlob == "" && keyVaultSecretId == "" {
@@ -166,10 +171,8 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 		Tags:     tags.Expand(t),
 	}
 
-	if len(hostingEnvironmentProfileId) > 0 {
-		certificate.CertificateProperties.HostingEnvironmentProfile = &web.HostingEnvironmentProfile{
-			ID: &hostingEnvironmentProfileId,
-		}
+	if appServicePlanId != "" {
+		certificate.CertificateProperties.ServerFarmID = &appServicePlanId
 	}
 
 	if pfxBlob != "" {

--- a/azurerm/internal/services/web/app_service_environment_resource_test.go
+++ b/azurerm/internal/services/web/app_service_environment_resource_test.go
@@ -333,7 +333,7 @@ resource "azurerm_app_service_environment" "test" {
 }
 
 func (r AppServiceEnvironmentResource) withCertificatePfx(data acceptance.TestData) string {
-	template := r.basic(data)
+	template := r.withAppServicePlan(data)
 	return fmt.Sprintf(`
 %s
 
@@ -343,7 +343,7 @@ resource "azurerm_app_service_certificate" "test" {
   location                       = azurerm_resource_group.test.location
   pfx_blob                       = filebase64("testdata/app_service_certificate.pfx")
   password                       = "terraform"
-  hosting_environment_profile_id = azurerm_app_service_environment.test.id
+  app_service_plan_id            = azurerm_app_service_plan.test.id
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `password` - (Optional) The password to access the certificate's private key. Changing this forces a new resource to be created.
 
-* `hosting_environment_profile_id` - (Optional) Must be specified when the certificate is for an App Service Environment hosted App Service. Changing this forces a new resource to be created.
+* `app_service_plan_id` - (Optional) Resource ID of the associated App Service plan. Must be specified when the certificate is used inside an App Service Environment hosted App Service. Changing this forces a new resource to be created.
 
 * `key_vault_secret_id` - (Optional) The ID of the Key Vault secret. Changing this forces a new resource to be created.
 
@@ -78,6 +78,8 @@ The following attributes are exported:
 * `expiration_date` - The expiration date for the certificate.
 
 * `thumbprint` - The thumbprint for the certificate.
+
+* `hosting_environment_profile_id` - The ID of the the App Service Environment to use for the certificate.
 
 ## Timeouts
 


### PR DESCRIPTION
This PR introduces the argument `app_service_plan_id` to the resource `azurerm_app_service_certificate ` and changes the attribute `hosting_environment_profile_id` to be computed.

The Azure SDK attribute `hostingEnvironmentProfile` is read-only and was never part of the REST API call for create or update a app_service_certificate. 
**Azure SDK for go:** https://github.com/Azure/azure-sdk-for-go/blob/main/services/web/mgmt/2020-06-01/web/models.go#L7124
**Azure REST API:** https://github.com/Azure/azure-rest-api-specs/blob/master/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/Certificates.json#L395

The new argument `app_service_plan_id` maps to the Azure SDK attribute `serverFarmId` which is required if an app-service-environment is in place.
**Azure REST API:** https://github.com/Azure/azure-rest-api-specs/blob/master/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/Certificates.json#L430

fixes #11771