### PR TITLE
Enabling advanced_filtering_on_arrays_enabled

### DIFF
--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -279,6 +279,14 @@ func eventSubscriptionSchemaIncludedEventTypes() *pluginsdk.Schema {
 	}
 }
 
+func eventSubscriptionSchemaEnableAdvancedFilteringOnArrays() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeBool,
+		Optional: true,
+		Default:  true,
+	}
+}
+
 func eventSubscriptionSchemaSubjectFilter() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -989,6 +997,13 @@ func expandEventGridEventSubscriptionFilter(d *pluginsdk.ResourceData) (*eventgr
 			}
 		}
 		filter.AdvancedFilters = &advancedFilters
+	}
+
+	if v, ok := d.GetOk("advanced_filtering_on_arrays_enabled"); ok {
+		filter.EnableAdvancedFilteringOnArrays = eventgrid.Disabled
+		if v.(bool) {
+			filter.EnableAdvancedFilteringOnArrays = eventgrid.Enabled
+		}		
 	}
 
 	return filter, nil

--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -1000,10 +1000,7 @@ func expandEventGridEventSubscriptionFilter(d *pluginsdk.ResourceData) (*eventgr
 	}
 
 	if v, ok := d.GetOk("advanced_filtering_on_arrays_enabled"); ok {
-		filter.EnableAdvancedFilteringOnArrays = &eventgrid.Disabled
-		if v.(bool) {
-			filter.EnableAdvancedFilteringOnArrays = &eventgrid.Enabled
-		}		
+		filter.EnableAdvancedFilteringOnArrays = utils.Bool(v.(bool))			
 	}
 
 	return filter, nil

--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -1000,9 +1000,9 @@ func expandEventGridEventSubscriptionFilter(d *pluginsdk.ResourceData) (*eventgr
 	}
 
 	if v, ok := d.GetOk("advanced_filtering_on_arrays_enabled"); ok {
-		filter.EnableAdvancedFilteringOnArrays = eventgrid.Disabled
+		filter.EnableAdvancedFilteringOnArrays = &eventgrid.Disabled
 		if v.(bool) {
-			filter.EnableAdvancedFilteringOnArrays = eventgrid.Enabled
+			filter.EnableAdvancedFilteringOnArrays = &eventgrid.Enabled
 		}		
 	}
 

--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -283,7 +283,7 @@ func eventSubscriptionSchemaEnableAdvancedFilteringOnArrays() *pluginsdk.Schema 
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeBool,
 		Optional: true,
-		Default:  true,
+		Default:  false,
 	}
 }
 
@@ -1000,7 +1000,7 @@ func expandEventGridEventSubscriptionFilter(d *pluginsdk.ResourceData) (*eventgr
 	}
 
 	if v, ok := d.GetOk("advanced_filtering_on_arrays_enabled"); ok {
-		filter.EnableAdvancedFilteringOnArrays = utils.Bool(v.(bool))			
+		filter.EnableAdvancedFilteringOnArrays = utils.Bool(v.(bool))
 	}
 
 	return filter, nil

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -313,7 +313,7 @@ func resourceEventGridEventSubscriptionRead(d *pluginsdk.ResourceData, meta inte
 			}
 			if err := d.Set("advanced_filter", flattenEventGridEventSubscriptionAdvancedFilter(filter)); err != nil {
 				return fmt.Errorf("Error setting `advanced_filter` for EventGrid Event Subscription %q (Scope %q): %s", id.Name, id.Scope, err)
-			}			
+			}
 		}
 
 		if props.DeadLetterDestination != nil {

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -146,6 +146,8 @@ func resourceEventGridEventSubscription() *pluginsdk.Resource {
 			"retry_policy": eventSubscriptionSchemaRetryPolicy(),
 
 			"labels": eventSubscriptionSchemaLabels(),
+
+			"advanced_filtering_on_arrays_enabled": eventSubscriptionSchemaEnableAdvancedFilteringOnArrays(),
 		},
 	}
 }
@@ -305,12 +307,13 @@ func resourceEventGridEventSubscriptionRead(d *pluginsdk.ResourceData, meta inte
 
 		if filter := props.Filter; filter != nil {
 			d.Set("included_event_types", filter.IncludedEventTypes)
+			d.Set("advanced_filtering_on_arrays_enabled", filter.EnableAdvancedFilteringOnArrays)
 			if err := d.Set("subject_filter", flattenEventGridEventSubscriptionSubjectFilter(filter)); err != nil {
 				return fmt.Errorf("Error setting `subject_filter` for EventGrid Event Subscription %q (Scope %q): %s", id.Name, id.Scope, err)
 			}
 			if err := d.Set("advanced_filter", flattenEventGridEventSubscriptionAdvancedFilter(filter)); err != nil {
 				return fmt.Errorf("Error setting `advanced_filter` for EventGrid Event Subscription %q (Scope %q): %s", id.Name, id.Scope, err)
-			}
+			}			
 		}
 
 		if props.DeadLetterDestination != nil {

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -150,6 +150,7 @@ func TestAccEventGridEventSubscription_filter(t *testing.T) {
 				check.That(data.ResourceName).Key("included_event_types.1").HasValue("Microsoft.Storage.BlobDeleted"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_ends_with").HasValue(".jpg"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_begins_with").HasValue("test/test"),
+        check.That(data.ResourceName).Key("advanced_filtering_on_arrays_enabled").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -349,6 +350,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     subject_ends_with   = ".jpg"
   }
 
+  advanced_filtering_on_arrays_enabled = false
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
   labels               = ["test4", "test5", "test6"]
 }

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -150,7 +150,7 @@ func TestAccEventGridEventSubscription_filter(t *testing.T) {
 				check.That(data.ResourceName).Key("included_event_types.1").HasValue("Microsoft.Storage.BlobDeleted"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_ends_with").HasValue(".jpg"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_begins_with").HasValue("test/test"),
-        check.That(data.ResourceName).Key("advanced_filtering_on_arrays_enabled").Exists(),
+				check.That(data.ResourceName).Key("advanced_filtering_on_arrays_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -350,7 +350,6 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     subject_ends_with   = ".jpg"
   }
 
-  advanced_filtering_on_arrays_enabled = false
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
   labels               = ["test4", "test5", "test6"]
 }
@@ -490,7 +489,9 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     storage_account_id = azurerm_storage_account.test.id
     queue_name         = azurerm_storage_queue.test.name
   }
-
+  
+  advanced_filtering_on_arrays_enabled = true
+  
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
 
   subject_filter {

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -489,9 +489,9 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     storage_account_id = azurerm_storage_account.test.id
     queue_name         = azurerm_storage_queue.test.name
   }
-  
+
   advanced_filtering_on_arrays_enabled = true
-  
+
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
 
   subject_filter {

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource.go
@@ -124,6 +124,8 @@ func resourceEventGridSystemTopicEventSubscription() *pluginsdk.Resource {
 			"retry_policy": eventSubscriptionSchemaRetryPolicy(),
 
 			"labels": eventSubscriptionSchemaLabels(),
+
+			"advanced_filtering_on_arrays_enabled": eventSubscriptionSchemaEnableAdvancedFilteringOnArrays(),
 		},
 	}
 }
@@ -277,6 +279,7 @@ func resourceEventGridSystemTopicEventSubscriptionRead(d *pluginsdk.ResourceData
 
 		if filter := props.Filter; filter != nil {
 			d.Set("included_event_types", filter.IncludedEventTypes)
+			d.Set("advanced_filtering_on_arrays_enabled", filter.EnableAdvancedFilteringOnArrays)
 			if err := d.Set("subject_filter", flattenEventGridEventSubscriptionSubjectFilter(filter)); err != nil {
 				return fmt.Errorf("Error setting `subject_filter` for EventGrid System Topic Event Subscription %q (System Topic %q): %s", id.Name, id.SystemTopic, err)
 			}

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -150,6 +150,7 @@ func TestAccEventGridSystemTopicEventSubscription_filter(t *testing.T) {
 				check.That(data.ResourceName).Key("included_event_types.1").HasValue("Microsoft.Storage.BlobDeleted"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_ends_with").HasValue(".jpg"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_begins_with").HasValue("test/test"),
+				check.That(data.ResourceName).Key("advanced_filtering_on_arrays_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -554,6 +555,8 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
     queue_name         = azurerm_storage_queue.test.name
   }
 
+  advanced_filtering_on_arrays_enabled = true
+  
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
 
   subject_filter {

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -556,7 +556,7 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
   }
 
   advanced_filtering_on_arrays_enabled = true
-  
+
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
 
   subject_filter {

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -91,6 +91,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) A list of labels to assign to the event subscription.
 
+* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag  to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `true`.
 ---
 
 A `storage_queue_endpoint` supports the following:

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) A list of labels to assign to the event subscription.
 
-* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag  to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
+* `advanced_filtering_on_arrays_enabled` - (Optional) Specifies whether advanced filters should be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
 ---
 
 A `storage_queue_endpoint` supports the following:

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) A list of labels to assign to the event subscription.
 
-* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag  to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `true`.
+* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag  to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
 ---
 
 A `storage_queue_endpoint` supports the following:

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) A list of labels to assign to the event subscription.
 
-* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
+* `advanced_filtering_on_arrays_enabled` - (Optional) Specifies whether advanced filters should be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) A list of labels to assign to the event subscription.
 
+* `advanced_filtering_on_arrays_enabled` - (Optional) Boolean flag to allows advanced filters to be evaluated against an array of values instead of expecting a singular value. Defaults to `false`.
+
 ---
 
 A `storage_queue_endpoint` supports the following:


### PR DESCRIPTION
This PR introducing a new boolean variable called `advanced_filtering_on_arrays_enabled` for the event grid subscription.
- Default to `false` 

**Test Results**

![image](https://user-images.githubusercontent.com/25414541/126042877-aff51c7b-b306-4222-afff-294b10a4ed70.png)

```
$ make acctests SERVICE=eventgrid TESTARGS='-run="TestAccEventGridEvent subscription_filter"i TESTTIMEOUT=10m
==> checking that code complies with gofmt requirements...
==> checking that Custom Timeouts are used...
==> checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid -run="TestAccEventGridEvent subscription_filter" -timeout 10m -1dflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version. Provider version=acc"
=== RUN TestAccEventGridEvent subscription_filter
=== PAUSE TestAccEventGridEvent subscription_filter
=== CONT TestAccEventGridEvent subscription_filter
--- PASS: TestAccEventGridEvent subscription_filter (250.43s)
PASS
ok github.com/terraform-providers/terraform-provider-azur erm/azurerm/internal/services/eventgrid 250.996s
```

Support for [EnableAdvancedFilteringOnArrays in version2020-10-15-preview](https://docs.microsoft.com/en-us/rest/api/eventgrid/version2020-10-15-preview/event-subscriptions/update#eventsubscriptionfilter)

- Fixing https://github.com/terraform-providers/terraform-provider-azurerm/issues/12563
