### PR TITLE
Support for `dotnet_framework_version` in `azurerm_function_app`

### DIFF
--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -151,6 +152,18 @@ func schemaAppServiceFunctionAppSiteConfig() *pluginsdk.Schema {
 					Optional: true,
 					Default:  false,
 				},
+
+				"dotnet_framework_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "v4.0",
+					ValidateFunc: validation.StringInSlice([]string{
+						"v4.0",
+						"v5.0",
+						"v6.0",
+					}, true),
+					DiffSuppressFunc: suppress.CaseDifference,
+				},
 			},
 		},
 	}
@@ -246,6 +259,11 @@ func schemaFunctionAppDataSourceSiteConfig() *pluginsdk.Schema {
 
 				"runtime_scale_monitoring_enabled": {
 					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+
+				"dotnet_framework_version": {
+					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
 			},
@@ -456,6 +474,10 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 		siteConfig.FunctionsRuntimeScaleMonitoringEnabled = utils.Bool(v.(bool))
 	}
 
+	if v, ok := config["dotnet_framework_version"]; ok {
+		siteConfig.NetFrameworkVersion = utils.String(v.(string))
+	}
+
 	return siteConfig, nil
 }
 
@@ -528,6 +550,10 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		result["runtime_scale_monitoring_enabled"] = *input.FunctionsRuntimeScaleMonitoringEnabled
+	}
+
+	if input.NetFrameworkVersion != nil {
+		result["dotnet_framework_version"] = *input.NetFrameworkVersion
 	}
 
 	results = append(results, result)

--- a/internal/services/web/function_app_resource_test.go
+++ b/internal/services/web/function_app_resource_test.go
@@ -1000,6 +1000,54 @@ func TestAccFunctionApp_runtimeScaleMonitoringEnabled(t *testing.T) {
 	})
 }
 
+func TestAccFunctionApp_dotnetVersion4(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dotnetVersion(data, "~1", "v4.0"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v4.0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFunctionApp_dotnetVersion5(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dotnetVersion(data, "~3", "v5.0"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v5.0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFunctionApp_dotnetVersion6(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dotnetVersion(data, "~4", "v6.0"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v6.0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r FunctionAppResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FunctionAppID(state.ID)
 	if err != nil {
@@ -3268,4 +3316,51 @@ resource "azurerm_function_app" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r FunctionAppResource) dotnetVersion(data acceptance.TestData, functionVersion string, version string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  version = "%s"
+
+  site_config {
+    dotnet_framework_version = "%s"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, functionVersion, version)
 }

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -118,6 +118,8 @@ A `site_config` block exports the following:
 
 * `cors` - A `cors` block as defined above.
 
+* `dotnet_framework_version` - The version of the .net framework's CLR used in this App Service.
+
 * `elastic_instance_minimum` - The number of minimum instances for this function app. Only applicable to apps on the Premium plan.
 
 * `http2_enabled` - Is HTTP2 Enabled on this App Service?

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -200,6 +200,8 @@ The following arguments are supported:
 
 * `cors` - (Optional) A `cors` block as defined below.
 
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this function app. Possible values are `v4.0` (including .NET Core 2.1 and 3.1), `v5.0` and `v6.0`. [For more information on which .net Framework version to use based on the runtime version you're targeting - please see this table](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library#supported-versions). Defaults to `v4.0`.
+
 * `elastic_instance_minimum` - (Optional) The number of minimum instances for this function app. Only affects apps on the Premium plan.
 
 * `ftps_state` - (Optional) State of FTP / FTPS service for this function app. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`. Defaults to `AllAllowed`.

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -146,6 +146,8 @@ The following arguments are supported:
 
 * `pre_warmed_instance_count` - (Optional) The number of pre-warmed instances for this function app. Only affects apps on the Premium plan.
 
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this function app. Possible values are `v4.0` (including .NET Core 2.1 and 3.1), `v5.0` and `v6.0`. [For more information on which .net Framework version to use based on the runtime version you're targeting - please see this table](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library#supported-versions). Defaults to `v4.0`.
+
 * `cors` - (Optional) A `cors` block as defined below.
 
 * `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.


### PR DESCRIPTION
.NET Framework v4.0 / v5.0 / v6.0 can be selected for Azure Functions for C# class library, so add `dotnet_framework_version`. .NET Framework v2.0 is not supported by Azure Functions and will not be allowed.

.NET version and Functions Runtime version support table
https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library#supported-versions

Close #11988

### Acctests result

```
--- PASS: TestAccFunctionApp_dotnetVersion4 (209.85s)
--- PASS: TestAccFunctionApp_dotnetVersion5 (210.01s)
--- PASS: TestAccFunctionApp_dotnetVersion6 (212.45s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/web   212.467s

--- PASS: TestAccFunctionAppSlot_dotnetVersion4 (255.22s)
--- PASS: TestAccFunctionAppSlot_dotnetVersion6 (256.68s)
--- PASS: TestAccFunctionAppSlot_dotnetVersion5 (266.53s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/web   266.550s
```