### PR TITLE
azurerm_key_vault_certificate_data: fix PEM private key block header

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -214,6 +214,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	}
 
 	var keyX509 []byte
+	var pemType string = "PRIVATE KEY"
 	if privateKey != nil {
 		switch v := privateKey.(type) {
 		case *ecdsa.PrivateKey:
@@ -223,6 +224,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 			}
 		case *rsa.PrivateKey:
 			keyX509 = x509.MarshalPKCS1PrivateKey(privateKey.(*rsa.PrivateKey))
+			pemType = "RSA PRIVATE KEY"
 		default:
 			return fmt.Errorf("marshalling private key type %+v (%q): key type is not supported", v, id.Name)
 		}
@@ -230,7 +232,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 
 	// Encode Key and PEM
 	keyBlock := &pem.Block{
-		Type:  "PRIVATE KEY",
+		Type:  pemType,
 		Bytes: keyX509,
 	}
 

--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -214,7 +214,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	}
 
 	var keyX509 []byte
-	var pemType string = "PRIVATE KEY"
+	var pemKeyHeader string = "PRIVATE KEY"
 	if privateKey != nil {
 		switch v := privateKey.(type) {
 		case *ecdsa.PrivateKey:
@@ -224,7 +224,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 			}
 		case *rsa.PrivateKey:
 			keyX509 = x509.MarshalPKCS1PrivateKey(privateKey.(*rsa.PrivateKey))
-			pemType = "RSA PRIVATE KEY"
+			pemKeyHeader = "RSA PRIVATE KEY"
 		default:
 			return fmt.Errorf("marshalling private key type %+v (%q): key type is not supported", v, id.Name)
 		}
@@ -232,7 +232,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 
 	// Encode Key and PEM
 	keyBlock := &pem.Block{
-		Type:  pemType,
+		Type:  pemKeyHeader,
 		Bytes: keyX509,
 	}
 


### PR DESCRIPTION
Currently, azurerm_key_vault_certificate_data returns RSA private key as a PEM block encoded in PKCS 1 with a header “PRIVATE KEY”. According to [rfc7468](https://datatracker.ietf.org/doc/html/rfc7468) the PRIVATE KEY block should be encoded in PKCS8. 

Some tools (most notably openssl) fail to parse PEM block with PRIVATE KEY header and PKCS1 encoding.

AFAIK, a header for PKCS1 encoding is not standardized but usually RSA PRIVATE KEY is used.

The proposed PR changes the header for PKCS1 encoding to RSA PRIVATE KEY. 

--- PASS: TestAccDataSourceKeyVaultCertificateData_ecdsa_PFX (273.93s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_ecdsa_PEM (274.94s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_basic (280.79s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_single_PEM (281.36s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PFX (281.67s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PEM (283.03s)