### PR TITLE
remove duplicate line on cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ You must run `Developing the Provider` commands in `bash` because `sh` scrips ar
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.16+ is **required**). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 First clone the repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-azurerm`
-First clone the repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-azurerm`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp


### PR DESCRIPTION
A line was accidentally duplicated in the README when it was updated for the org migration.