### PR TITLE
Fix the issue of updating the maxmemory_policy property of azurerm_redis_cache

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -264,7 +264,7 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("subnet_id", props.SubnetID)
 	}
 
-	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)
+	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration, nil)
 	if err != nil {
 		return fmt.Errorf("flattening `redis_configuration`: %+v", err)
 	}

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -264,7 +264,7 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("subnet_id", props.SubnetID)
 	}
 
-	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration, nil)
+	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)
 	if err != nil {
 		return fmt.Errorf("flattening `redis_configuration`: %+v", err)
 	}

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -139,13 +139,11 @@ func resourceRedisCache() *pluginsdk.Resource {
 						"maxmemory_delta": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
-							Computed: true,
 						},
 
 						"maxmemory_reserved": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
-							Computed: true,
 						},
 
 						"maxmemory_policy": {
@@ -158,7 +156,6 @@ func resourceRedisCache() *pluginsdk.Resource {
 						"maxfragmentationmemory_reserved": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
-							Computed: true,
 						},
 
 						"rdb_backup_enabled": {
@@ -868,30 +865,8 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 		}
 		outputs["maxclients"] = i
 	}
-	if v := input["maxmemory-delta"]; v != nil {
-		i, err := strconv.Atoi(*v)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing `maxmemory-delta` %q: %+v", *v, err)
-		}
-		outputs["maxmemory_delta"] = i
-	}
-	if v := input["maxmemory-reserved"]; v != nil {
-		i, err := strconv.Atoi(*v)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing `maxmemory-reserved` %q: %+v", *v, err)
-		}
-		outputs["maxmemory_reserved"] = i
-	}
 	if v := input["maxmemory-policy"]; v != nil {
 		outputs["maxmemory_policy"] = *v
-	}
-
-	if v := input["maxfragmentationmemory-reserved"]; v != nil {
-		i, err := strconv.Atoi(*v)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing `maxfragmentationmemory-reserved` %q: %+v", *v, err)
-		}
-		outputs["maxfragmentationmemory_reserved"] = i
 	}
 
 	// delta, reserved, enabled, frequency,, count,

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -650,7 +650,7 @@ func resourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("tenant_settings", flattenTenantSettings(props.TenantSettings))
 	}
 
-	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)
+	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration, d)
 	if err != nil {
 		return fmt.Errorf("flattening `redis_configuration`: %+v", err)
 	}
@@ -855,7 +855,7 @@ func flattenTenantSettings(input map[string]*string) map[string]*string {
 	}
 	return output
 }
-func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) {
+func flattenRedisConfiguration(input map[string]*string, d *pluginsdk.ResourceData) ([]interface{}, error) {
 	outputs := make(map[string]interface{}, len(input))
 
 	if v := input["maxclients"]; v != nil {
@@ -865,8 +865,51 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 		}
 		outputs["maxclients"] = i
 	}
+
+	if d != nil {
+		if v, ok := d.GetOk("redis_configuration.0.maxmemory_delta"); ok {
+			outputs["maxmemory_delta"] = v.(int)
+		}
+	} else {
+		if v := input["maxmemory-delta"]; v != nil {
+			i, err := strconv.Atoi(*v)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing `maxmemory-delta` %q: %+v", *v, err)
+			}
+			outputs["maxmemory_delta"] = i
+		}
+	}
+
+	if d != nil {
+		if v, ok := d.GetOk("redis_configuration.0.maxmemory_reserved"); ok {
+			outputs["maxmemory_reserved"] = v.(int)
+		}
+	} else {
+		if v := input["maxmemory-reserved"]; v != nil {
+			i, err := strconv.Atoi(*v)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing `maxmemory-reserved` %q: %+v", *v, err)
+			}
+			outputs["maxmemory_reserved"] = i
+		}
+	}
+
 	if v := input["maxmemory-policy"]; v != nil {
 		outputs["maxmemory_policy"] = *v
+	}
+
+	if d != nil {
+		if v, ok := d.GetOk("redis_configuration.0.maxfragmentationmemory_reserved"); ok {
+			outputs["maxfragmentationmemory_reserved"] = v.(int)
+		}
+	} else {
+		if v := input["maxfragmentationmemory-reserved"]; v != nil {
+			i, err := strconv.Atoi(*v)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing `maxfragmentationmemory-reserved` %q: %+v", *v, err)
+			}
+			outputs["maxfragmentationmemory_reserved"] = i
+		}
 	}
 
 	// delta, reserved, enabled, frequency,, count,

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -1195,7 +1195,7 @@ resource "azurerm_redis_cache" "test" {
   resource_group_name = azurerm_resource_group.test.name
   capacity            = 2
   family              = "C"
-  sku_name            = "Standard"
+  sku_name            = "Basic"
   enable_non_ssl_port = false
   minimum_tls_version = "1.2"
 

--- a/internal/services/redis/redis_cache_resource_test.go
+++ b/internal/services/redis/redis_cache_resource_test.go
@@ -452,6 +452,28 @@ func TestAccRedisCache_TenantSettings(t *testing.T) {
 	})
 }
 
+func TestAccRedisCache_redisConfiguration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache", "test")
+	r := RedisCacheResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.redisConfiguration(data, "volatile-lru"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.redisConfiguration(data, "allkeys-lru"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t RedisCacheResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.CacheID(state.ID)
 	if err != nil {
@@ -1154,6 +1176,40 @@ resource "azurerm_redis_cache" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RedisCacheResource) redisConfiguration(data acceptance.TestData, maxMemoryPolicy string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-redis-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 2
+  family              = "C"
+  sku_name            = "Standard"
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+    maxmemory_policy = "%s"
+  }
+
+  patch_schedule {
+    day_of_week        = "Tuesday"
+    start_hour_utc     = 4
+    maintenance_window = "PT5H"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, maxMemoryPolicy)
 }
 
 func testCheckSSLInConnectionString(resourceName string, propertyName string, requireSSL bool) acceptance.TestCheckFunc {

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -156,7 +156,7 @@ redis_configuration {
 | maxmemory_delta                 | 2            | 50           | 200          |
 | maxmemory_policy                | volatile-lru | volatile-lru | volatile-lru |
 
-~> **NOTE:** The `maxmemory_reserved`, `maxmemory_delta` and `maxfragmentationmemory-reserved` settings are only available for Standard and Premium caches. More details are available in the Relevant Links section below._
+~> **NOTE:** The `maxmemory_reserved`, `maxmemory_delta` and `maxfragmentationmemory_reserved` settings are only available for Standard and Premium caches. More details are available in the Relevant Links section below.
 
 ---
 


### PR DESCRIPTION
**Symptom:**
After tested, seems updating the `maxmemory_policy` property would fail and threw below error message when `maxmemory_delta`, `maxmemory_reserved` and `maxfragmentationmemory_reserved` aren't specified and `sku_name` is `Basic`.

**Error message:**
```
redis.Client#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code='InvalidRequestBody' Message='The setting 'maxmemory-reserved' is not allowed on 'Basic' cache instances.\\r\\nRequestID=xx-xx-xxx-xx-xx'
```

**Root cause:**
Given API doesn't allow `maxmemory_delta`, `maxmemory_reserved` and `maxfragmentationmemory_reserved` when `sku_name` is `Basic` and API would return default value for `maxmemory_delta`, `maxmemory_reserved` and `maxfragmentationmemory_reserved`  when they aren't specified, so after did more investigation, I found the root cause is that `maxmemory_delta`, `maxmemory_reserved` and `maxfragmentationmemory_reserved` have `Computed: true` attribute so that TF would get the value of `maxmemory_delta`, `maxmemory_reserved` and `maxfragmentationmemory_reserved` from the last apply and set them in request body while updating this resource. Hence it failed to update `maxmemory_policy`.

**The test result after applied the fix:**
```
--- PASS: TestAccRedisCache_RedisVersion (1423.14s)
--- PASS: TestAccRedisCache_premium (1484.11s)
--- PASS: TestAccRedisCache_ReplicasPerMaster (1489.31s)
--- PASS: TestAccRedisCache_PatchScheduleUpdated (1559.25s)
--- PASS: TestAccRedisCache_TenantSettings (1606.17s)
--- PASS: TestAccRedisCache_redisConfiguration (1891.11s)
--- PASS: TestAccRedisCache_basic (1965.96s)
--- PASS: TestAccRedisCache_withoutSSL (2124.72s)
--- PASS: TestAccRedisCache_requiresImport (2129.40s)
--- PASS: TestAccRedisCache_NonStandardCasing (2165.93s)
--- PASS: TestAccRedisCache_standard (2165.99s)
--- PASS: TestAccRedisCache_ReplicasPerPrimary (1380.04s)
--- PASS: TestAccRedisCache_AOFBackupEnabled (1419.47s)
--- PASS: TestAccRedisCache_PatchSchedule (1457.70s)
--- PASS: TestAccRedisCache_BackupEnabled (1455.41s)
--- PASS: TestAccRedisCache_SubscribeAllEvents (1371.09s)
--- PASS: TestAccRedisCache_BackupEnabledDisabled (1579.14s)
--- PASS: TestAccRedisCache_AOFBackupEnabledDisabled (2099.22s)
--- PASS: TestAccRedisCache_BackupDisabled (1620.69s)
--- PASS: TestAccRedisCache_premiumShardedScaling (2628.36s)
--- PASS: TestAccRedisCache_premiumSharded (1493.10s)
--- PASS: TestAccRedisCache_PublicNetworkAccessDisabledEnabled (2132.77s)
--- PASS: TestAccRedisCache_InternalSubnet_withZone (4406.06s)
--- PASS: TestAccRedisCache_WithoutAuth (4414.01s)
--- PASS: TestAccRedisCache_InternalSubnet (3652.92s)
--- PASS: TestAccRedisCache_InternalSubnetStaticIP (3622.89s)
```