### PR TITLE
Fixing typo in servicebus_namespace_disaster_recovery_config docs

### DIFF
--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -39,7 +39,7 @@ resource "azurerm_servicebus_namespace" "secondary" {
 resource "azurerm_servicebus_namespace_disaster_recovery_config" "example" {
   name                 = "servicebus-alias-name"
   primary_namespace_id = azurerm_servicebus_namespace.primary.id
-  partner_namespace_id = azurerm_resource_group.secondary.id
+  partner_namespace_id = azurerm_servicebus_namespace.secondary.id
 }
 
 ```


### PR DESCRIPTION
This PR is fixing a typo in the example for [`servicebus_namespace_disaster_recovery_config`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_disaster_recovery_config) where a wrong reference is used. This typo was probably introduced by copy&pasting lines when the original documentation was created.