### PR TITLE
teamcity: increasing the vmware parallelism to 3

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -70,5 +70,5 @@ var serviceTestConfigurationOverrides = mapOf(
         "springcloud" to testConfiguration(parallelism = 5),
 
         // Currently have a quota of 10 nodes, 3 nodes required per test
-        "vmware" to testConfiguration(parallelism = 1)
+        "vmware" to testConfiguration(parallelism = 3)
 )


### PR DESCRIPTION
This was temporarily reduced to 1 but that's extended the runtime
sufficiently that this needs to be bumped back up