### PR TITLE
maps|msi|signalr|vmware: updating to use the latest Embedded SDK's

### DIFF
--- a/internal/services/maps/sdk/2021-02-01/accounts/id_subscription.go
+++ b/internal/services/maps/sdk/2021-02-01/accounts/id_subscription.go
@@ -1,0 +1,75 @@
+package accounts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SubscriptionId struct {
+	SubscriptionId string
+}
+
+func NewSubscriptionID(subscriptionId string) SubscriptionId {
+	return SubscriptionId{
+		SubscriptionId: subscriptionId,
+	}
+}
+
+func (id SubscriptionId) String() string {
+	segments := []string{}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription", segmentsStr)
+}
+
+func (id SubscriptionId) ID() string {
+	fmtString := "/subscriptions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId)
+}
+
+// ParseSubscriptionID parses a Subscription ID into an SubscriptionId struct
+func ParseSubscriptionID(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ParseSubscriptionIDInsensitively parses an Subscription ID into an SubscriptionId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ParseSubscriptionID method should be used instead for validation etc.
+func ParseSubscriptionIDInsensitively(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/maps/sdk/2021-02-01/accounts/id_subscription_test.go
+++ b/internal/services/maps/sdk/2021-02-01/accounts/id_subscription_test.go
@@ -1,0 +1,157 @@
+package accounts
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = SubscriptionId{}
+
+func TestSubscriptionIDFormatter(t *testing.T) {
+	actual := NewSubscriptionID("{subscriptionId}").ID()
+	expected := "/subscriptions/{subscriptionId}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestParseSubscriptionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}
+
+func TestParseSubscriptionIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}

--- a/internal/services/maps/sdk/2021-02-01/accounts/method_listbyresourcegroup_autorest.go
+++ b/internal/services/maps/sdk/2021-02-01/accounts/method_listbyresourcegroup_autorest.go
@@ -34,19 +34,6 @@ func (r ListByResourceGroupResponse) LoadMore(ctx context.Context) (resp ListByR
 	return r.nextPageFunc(ctx, *r.nextLink)
 }
 
-type MapsAccountPredicate struct {
-	// TODO: implement me
-}
-
-func (p MapsAccountPredicate) Matches(input MapsAccount) bool {
-	// TODO: implement me
-	// if p.Name != nil && input.Name != *p.Name {
-	// 	return false
-	// }
-
-	return true
-}
-
 // ListByResourceGroup ...
 func (c AccountsClient) ListByResourceGroup(ctx context.Context, id ResourceGroupId) (resp ListByResourceGroupResponse, err error) {
 	req, err := c.preparerForListByResourceGroup(ctx, id)
@@ -69,7 +56,7 @@ func (c AccountsClient) ListByResourceGroup(ctx context.Context, id ResourceGrou
 	return
 }
 
-// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results into a single object
+// ListByResourceGroupComplete retrieves all of the results into a single object
 func (c AccountsClient) ListByResourceGroupComplete(ctx context.Context, id ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
 	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, MapsAccountPredicate{})
 }

--- a/internal/services/maps/sdk/2021-02-01/accounts/method_listbysubscription_autorest.go
+++ b/internal/services/maps/sdk/2021-02-01/accounts/method_listbysubscription_autorest.go
@@ -1,0 +1,183 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListBySubscriptionResponse struct {
+	HttpResponse *http.Response
+	Model        *[]MapsAccount
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListBySubscriptionResponse, error)
+}
+
+type ListBySubscriptionCompleteResult struct {
+	Items []MapsAccount
+}
+
+func (r ListBySubscriptionResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListBySubscriptionResponse) LoadMore(ctx context.Context) (resp ListBySubscriptionResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListBySubscription ...
+func (c AccountsClient) ListBySubscription(ctx context.Context, id SubscriptionId) (resp ListBySubscriptionResponse, err error) {
+	req, err := c.preparerForListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListBySubscriptionComplete retrieves all of the results into a single object
+func (c AccountsClient) ListBySubscriptionComplete(ctx context.Context, id SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, MapsAccountPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AccountsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id SubscriptionId, predicate MapsAccountPredicate) (resp ListBySubscriptionCompleteResult, err error) {
+	items := make([]MapsAccount, 0)
+
+	page, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListBySubscription prepares the ListBySubscription request.
+func (c AccountsClient) preparerForListBySubscription(ctx context.Context, id SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Maps/accounts", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListBySubscriptionWithNextLink prepares the ListBySubscription request with the given nextLink token.
+func (c AccountsClient) preparerForListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListBySubscription handles the response to the ListBySubscription request. The method always
+// closes the http.Response Body.
+func (c AccountsClient) responderForListBySubscription(resp *http.Response) (result ListBySubscriptionResponse, err error) {
+	type page struct {
+		Values   []MapsAccount `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListBySubscriptionResponse, err error) {
+			req, err := c.preparerForListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "accounts.AccountsClient", "ListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/maps/sdk/2021-02-01/accounts/predicates.go
+++ b/internal/services/maps/sdk/2021-02-01/accounts/predicates.go
@@ -1,0 +1,29 @@
+package accounts
+
+type MapsAccountPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p MapsAccountPredicate) Matches(input MapsAccount) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/msi/sdk/2018-11-30/managedidentity/id_subscription.go
+++ b/internal/services/msi/sdk/2018-11-30/managedidentity/id_subscription.go
@@ -1,0 +1,75 @@
+package managedidentity
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SubscriptionId struct {
+	SubscriptionId string
+}
+
+func NewSubscriptionID(subscriptionId string) SubscriptionId {
+	return SubscriptionId{
+		SubscriptionId: subscriptionId,
+	}
+}
+
+func (id SubscriptionId) String() string {
+	segments := []string{}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription", segmentsStr)
+}
+
+func (id SubscriptionId) ID() string {
+	fmtString := "/subscriptions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId)
+}
+
+// ParseSubscriptionID parses a Subscription ID into an SubscriptionId struct
+func ParseSubscriptionID(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ParseSubscriptionIDInsensitively parses an Subscription ID into an SubscriptionId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ParseSubscriptionID method should be used instead for validation etc.
+func ParseSubscriptionIDInsensitively(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/msi/sdk/2018-11-30/managedidentity/id_subscription_test.go
+++ b/internal/services/msi/sdk/2018-11-30/managedidentity/id_subscription_test.go
@@ -1,0 +1,157 @@
+package managedidentity
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = SubscriptionId{}
+
+func TestSubscriptionIDFormatter(t *testing.T) {
+	actual := NewSubscriptionID("{subscriptionId}").ID()
+	expected := "/subscriptions/{subscriptionId}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestParseSubscriptionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}
+
+func TestParseSubscriptionIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}

--- a/internal/services/msi/sdk/2018-11-30/managedidentity/method_userassignedidentitieslistbyresourcegroup_autorest.go
+++ b/internal/services/msi/sdk/2018-11-30/managedidentity/method_userassignedidentitieslistbyresourcegroup_autorest.go
@@ -34,19 +34,6 @@ func (r UserAssignedIdentitiesListByResourceGroupResponse) LoadMore(ctx context.
 	return r.nextPageFunc(ctx, *r.nextLink)
 }
 
-type IdentityPredicate struct {
-	// TODO: implement me
-}
-
-func (p IdentityPredicate) Matches(input Identity) bool {
-	// TODO: implement me
-	// if p.Name != nil && input.Name != *p.Name {
-	// 	return false
-	// }
-
-	return true
-}
-
 // UserAssignedIdentitiesListByResourceGroup ...
 func (c ManagedIdentityClient) UserAssignedIdentitiesListByResourceGroup(ctx context.Context, id ResourceGroupId) (resp UserAssignedIdentitiesListByResourceGroupResponse, err error) {
 	req, err := c.preparerForUserAssignedIdentitiesListByResourceGroup(ctx, id)
@@ -69,7 +56,7 @@ func (c ManagedIdentityClient) UserAssignedIdentitiesListByResourceGroup(ctx con
 	return
 }
 
-// UserAssignedIdentitiesListByResourceGroupCompleteMatchingPredicate retrieves all of the results into a single object
+// UserAssignedIdentitiesListByResourceGroupComplete retrieves all of the results into a single object
 func (c ManagedIdentityClient) UserAssignedIdentitiesListByResourceGroupComplete(ctx context.Context, id ResourceGroupId) (UserAssignedIdentitiesListByResourceGroupCompleteResult, error) {
 	return c.UserAssignedIdentitiesListByResourceGroupCompleteMatchingPredicate(ctx, id, IdentityPredicate{})
 }

--- a/internal/services/msi/sdk/2018-11-30/managedidentity/method_userassignedidentitieslistbysubscription_autorest.go
+++ b/internal/services/msi/sdk/2018-11-30/managedidentity/method_userassignedidentitieslistbysubscription_autorest.go
@@ -1,0 +1,183 @@
+package managedidentity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type UserAssignedIdentitiesListBySubscriptionResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Identity
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (UserAssignedIdentitiesListBySubscriptionResponse, error)
+}
+
+type UserAssignedIdentitiesListBySubscriptionCompleteResult struct {
+	Items []Identity
+}
+
+func (r UserAssignedIdentitiesListBySubscriptionResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r UserAssignedIdentitiesListBySubscriptionResponse) LoadMore(ctx context.Context) (resp UserAssignedIdentitiesListBySubscriptionResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// UserAssignedIdentitiesListBySubscription ...
+func (c ManagedIdentityClient) UserAssignedIdentitiesListBySubscription(ctx context.Context, id SubscriptionId) (resp UserAssignedIdentitiesListBySubscriptionResponse, err error) {
+	req, err := c.preparerForUserAssignedIdentitiesListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForUserAssignedIdentitiesListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// UserAssignedIdentitiesListBySubscriptionComplete retrieves all of the results into a single object
+func (c ManagedIdentityClient) UserAssignedIdentitiesListBySubscriptionComplete(ctx context.Context, id SubscriptionId) (UserAssignedIdentitiesListBySubscriptionCompleteResult, error) {
+	return c.UserAssignedIdentitiesListBySubscriptionCompleteMatchingPredicate(ctx, id, IdentityPredicate{})
+}
+
+// UserAssignedIdentitiesListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ManagedIdentityClient) UserAssignedIdentitiesListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id SubscriptionId, predicate IdentityPredicate) (resp UserAssignedIdentitiesListBySubscriptionCompleteResult, err error) {
+	items := make([]Identity, 0)
+
+	page, err := c.UserAssignedIdentitiesListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := UserAssignedIdentitiesListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForUserAssignedIdentitiesListBySubscription prepares the UserAssignedIdentitiesListBySubscription request.
+func (c ManagedIdentityClient) preparerForUserAssignedIdentitiesListBySubscription(ctx context.Context, id SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForUserAssignedIdentitiesListBySubscriptionWithNextLink prepares the UserAssignedIdentitiesListBySubscription request with the given nextLink token.
+func (c ManagedIdentityClient) preparerForUserAssignedIdentitiesListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUserAssignedIdentitiesListBySubscription handles the response to the UserAssignedIdentitiesListBySubscription request. The method always
+// closes the http.Response Body.
+func (c ManagedIdentityClient) responderForUserAssignedIdentitiesListBySubscription(resp *http.Response) (result UserAssignedIdentitiesListBySubscriptionResponse, err error) {
+	type page struct {
+		Values   []Identity `json:"value"`
+		NextLink *string    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result UserAssignedIdentitiesListBySubscriptionResponse, err error) {
+			req, err := c.preparerForUserAssignedIdentitiesListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForUserAssignedIdentitiesListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedidentity.ManagedIdentityClient", "UserAssignedIdentitiesListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/msi/sdk/2018-11-30/managedidentity/predicates.go
+++ b/internal/services/msi/sdk/2018-11-30/managedidentity/predicates.go
@@ -1,0 +1,29 @@
+package managedidentity
+
+type IdentityPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p IdentityPredicate) Matches(input Identity) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/signalr/sdk/2020-05-01/signalr/constants.go
+++ b/internal/services/signalr/sdk/2020-05-01/signalr/constants.go
@@ -58,6 +58,7 @@ const (
 	SignalRRequestTypeClientConnection SignalRRequestType = "ClientConnection"
 	SignalRRequestTypeRESTAPI          SignalRRequestType = "RESTAPI"
 	SignalRRequestTypeServerConnection SignalRRequestType = "ServerConnection"
+	SignalRRequestTypeTrace            SignalRRequestType = "Trace"
 )
 
 type SignalRSkuTier string

--- a/internal/services/signalr/signalr_service_network_acl_resource.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource.go
@@ -55,8 +55,6 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						// API response includes the `Trace` type but it isn't in rest api client.
-						// https://github.com/Azure/azure-rest-api-specs/issues/14923
 						"allowed_request_types": {
 							Type:          pluginsdk.TypeSet,
 							Optional:      true,
@@ -67,7 +65,7 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 									string(signalr.SignalRRequestTypeClientConnection),
 									string(signalr.SignalRRequestTypeRESTAPI),
 									string(signalr.SignalRRequestTypeServerConnection),
-									"Trace",
+									string(signalr.SignalRRequestTypeTrace),
 								}, false),
 							},
 						},
@@ -82,7 +80,7 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 									string(signalr.SignalRRequestTypeClientConnection),
 									string(signalr.SignalRRequestTypeRESTAPI),
 									string(signalr.SignalRRequestTypeServerConnection),
-									"Trace",
+									string(signalr.SignalRRequestTypeTrace),
 								}, false),
 							},
 						},
@@ -101,8 +99,6 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 							ValidateFunc: networkValidate.PrivateEndpointID,
 						},
 
-						// API response includes the `Trace` type but it isn't in rest api client.
-						// https://github.com/Azure/azure-rest-api-specs/issues/14923
 						"allowed_request_types": {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
@@ -112,7 +108,7 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 									string(signalr.SignalRRequestTypeClientConnection),
 									string(signalr.SignalRRequestTypeRESTAPI),
 									string(signalr.SignalRRequestTypeServerConnection),
-									"Trace",
+									string(signalr.SignalRRequestTypeTrace),
 								}, false),
 							},
 						},
@@ -126,7 +122,7 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 									string(signalr.SignalRRequestTypeClientConnection),
 									string(signalr.SignalRRequestTypeRESTAPI),
 									string(signalr.SignalRRequestTypeServerConnection),
-									"Trace",
+									string(signalr.SignalRRequestTypeTrace),
 								}, false),
 							},
 						},
@@ -271,7 +267,7 @@ func resourceSignalRServiceNetworkACLDelete(d *pluginsdk.ResourceData, meta inte
 		signalr.SignalRRequestTypeClientConnection,
 		signalr.SignalRRequestTypeRESTAPI,
 		signalr.SignalRRequestTypeServerConnection,
-		"Trace",
+		signalr.SignalRRequestTypeTrace,
 	}
 	networkACL := &signalr.SignalRNetworkACLs{
 		DefaultAction: &defaultAction,

--- a/internal/services/vmware/sdk/2020-03-20/authorizations/method_list_autorest.go
+++ b/internal/services/vmware/sdk/2020-03-20/authorizations/method_list_autorest.go
@@ -34,19 +34,6 @@ func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err erro
 	return r.nextPageFunc(ctx, *r.nextLink)
 }
 
-type ExpressRouteAuthorizationPredicate struct {
-	// TODO: implement me
-}
-
-func (p ExpressRouteAuthorizationPredicate) Matches(input ExpressRouteAuthorization) bool {
-	// TODO: implement me
-	// if p.Name != nil && input.Name != *p.Name {
-	// 	return false
-	// }
-
-	return true
-}
-
 // List ...
 func (c AuthorizationsClient) List(ctx context.Context, id PrivateCloudId) (resp ListResponse, err error) {
 	req, err := c.preparerForList(ctx, id)
@@ -69,7 +56,7 @@ func (c AuthorizationsClient) List(ctx context.Context, id PrivateCloudId) (resp
 	return
 }
 
-// ListCompleteMatchingPredicate retrieves all of the results into a single object
+// ListComplete retrieves all of the results into a single object
 func (c AuthorizationsClient) ListComplete(ctx context.Context, id PrivateCloudId) (ListCompleteResult, error) {
 	return c.ListCompleteMatchingPredicate(ctx, id, ExpressRouteAuthorizationPredicate{})
 }

--- a/internal/services/vmware/sdk/2020-03-20/authorizations/predicates.go
+++ b/internal/services/vmware/sdk/2020-03-20/authorizations/predicates.go
@@ -1,0 +1,24 @@
+package authorizations
+
+type ExpressRouteAuthorizationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ExpressRouteAuthorizationPredicate) Matches(input ExpressRouteAuthorization) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/vmware/sdk/2020-03-20/clusters/method_list_autorest.go
+++ b/internal/services/vmware/sdk/2020-03-20/clusters/method_list_autorest.go
@@ -34,19 +34,6 @@ func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err erro
 	return r.nextPageFunc(ctx, *r.nextLink)
 }
 
-type ClusterPredicate struct {
-	// TODO: implement me
-}
-
-func (p ClusterPredicate) Matches(input Cluster) bool {
-	// TODO: implement me
-	// if p.Name != nil && input.Name != *p.Name {
-	// 	return false
-	// }
-
-	return true
-}
-
 // List ...
 func (c ClustersClient) List(ctx context.Context, id PrivateCloudId) (resp ListResponse, err error) {
 	req, err := c.preparerForList(ctx, id)
@@ -69,7 +56,7 @@ func (c ClustersClient) List(ctx context.Context, id PrivateCloudId) (resp ListR
 	return
 }
 
-// ListCompleteMatchingPredicate retrieves all of the results into a single object
+// ListComplete retrieves all of the results into a single object
 func (c ClustersClient) ListComplete(ctx context.Context, id PrivateCloudId) (ListCompleteResult, error) {
 	return c.ListCompleteMatchingPredicate(ctx, id, ClusterPredicate{})
 }

--- a/internal/services/vmware/sdk/2020-03-20/clusters/predicates.go
+++ b/internal/services/vmware/sdk/2020-03-20/clusters/predicates.go
@@ -1,0 +1,24 @@
+package clusters
+
+type ClusterPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ClusterPredicate) Matches(input Cluster) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/vmware/sdk/2020-03-20/privateclouds/id_subscription.go
+++ b/internal/services/vmware/sdk/2020-03-20/privateclouds/id_subscription.go
@@ -1,0 +1,75 @@
+package privateclouds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SubscriptionId struct {
+	SubscriptionId string
+}
+
+func NewSubscriptionID(subscriptionId string) SubscriptionId {
+	return SubscriptionId{
+		SubscriptionId: subscriptionId,
+	}
+}
+
+func (id SubscriptionId) String() string {
+	segments := []string{}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription", segmentsStr)
+}
+
+func (id SubscriptionId) ID() string {
+	fmtString := "/subscriptions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId)
+}
+
+// ParseSubscriptionID parses a Subscription ID into an SubscriptionId struct
+func ParseSubscriptionID(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ParseSubscriptionIDInsensitively parses an Subscription ID into an SubscriptionId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ParseSubscriptionID method should be used instead for validation etc.
+func ParseSubscriptionIDInsensitively(input string) (*SubscriptionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SubscriptionId{
+		SubscriptionId: id.SubscriptionID,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/vmware/sdk/2020-03-20/privateclouds/id_subscription_test.go
+++ b/internal/services/vmware/sdk/2020-03-20/privateclouds/id_subscription_test.go
@@ -1,0 +1,157 @@
+package privateclouds
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = SubscriptionId{}
+
+func TestSubscriptionIDFormatter(t *testing.T) {
+	actual := NewSubscriptionID("{subscriptionId}").ID()
+	expected := "/subscriptions/{subscriptionId}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestParseSubscriptionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}
+
+func TestParseSubscriptionIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}",
+			Expected: &SubscriptionId{
+				SubscriptionId: "{subscriptionId}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}

--- a/internal/services/vmware/sdk/2020-03-20/privateclouds/method_list_autorest.go
+++ b/internal/services/vmware/sdk/2020-03-20/privateclouds/method_list_autorest.go
@@ -34,19 +34,6 @@ func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err erro
 	return r.nextPageFunc(ctx, *r.nextLink)
 }
 
-type PrivateCloudPredicate struct {
-	// TODO: implement me
-}
-
-func (p PrivateCloudPredicate) Matches(input PrivateCloud) bool {
-	// TODO: implement me
-	// if p.Name != nil && input.Name != *p.Name {
-	// 	return false
-	// }
-
-	return true
-}
-
 // List ...
 func (c PrivateCloudsClient) List(ctx context.Context, id ResourceGroupId) (resp ListResponse, err error) {
 	req, err := c.preparerForList(ctx, id)
@@ -69,7 +56,7 @@ func (c PrivateCloudsClient) List(ctx context.Context, id ResourceGroupId) (resp
 	return
 }
 
-// ListCompleteMatchingPredicate retrieves all of the results into a single object
+// ListComplete retrieves all of the results into a single object
 func (c PrivateCloudsClient) ListComplete(ctx context.Context, id ResourceGroupId) (ListCompleteResult, error) {
 	return c.ListCompleteMatchingPredicate(ctx, id, PrivateCloudPredicate{})
 }

--- a/internal/services/vmware/sdk/2020-03-20/privateclouds/method_listinsubscription_autorest.go
+++ b/internal/services/vmware/sdk/2020-03-20/privateclouds/method_listinsubscription_autorest.go
@@ -1,0 +1,183 @@
+package privateclouds
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListInSubscriptionResponse struct {
+	HttpResponse *http.Response
+	Model        *[]PrivateCloud
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListInSubscriptionResponse, error)
+}
+
+type ListInSubscriptionCompleteResult struct {
+	Items []PrivateCloud
+}
+
+func (r ListInSubscriptionResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListInSubscriptionResponse) LoadMore(ctx context.Context) (resp ListInSubscriptionResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListInSubscription ...
+func (c PrivateCloudsClient) ListInSubscription(ctx context.Context, id SubscriptionId) (resp ListInSubscriptionResponse, err error) {
+	req, err := c.preparerForListInSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListInSubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListInSubscriptionComplete retrieves all of the results into a single object
+func (c PrivateCloudsClient) ListInSubscriptionComplete(ctx context.Context, id SubscriptionId) (ListInSubscriptionCompleteResult, error) {
+	return c.ListInSubscriptionCompleteMatchingPredicate(ctx, id, PrivateCloudPredicate{})
+}
+
+// ListInSubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PrivateCloudsClient) ListInSubscriptionCompleteMatchingPredicate(ctx context.Context, id SubscriptionId, predicate PrivateCloudPredicate) (resp ListInSubscriptionCompleteResult, err error) {
+	items := make([]PrivateCloud, 0)
+
+	page, err := c.ListInSubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListInSubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListInSubscription prepares the ListInSubscription request.
+func (c PrivateCloudsClient) preparerForListInSubscription(ctx context.Context, id SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.AVS/privateClouds", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListInSubscriptionWithNextLink prepares the ListInSubscription request with the given nextLink token.
+func (c PrivateCloudsClient) preparerForListInSubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListInSubscription handles the response to the ListInSubscription request. The method always
+// closes the http.Response Body.
+func (c PrivateCloudsClient) responderForListInSubscription(resp *http.Response) (result ListInSubscriptionResponse, err error) {
+	type page struct {
+		Values   []PrivateCloud `json:"value"`
+		NextLink *string        `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListInSubscriptionResponse, err error) {
+			req, err := c.preparerForListInSubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListInSubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privateclouds.PrivateCloudsClient", "ListInSubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/vmware/sdk/2020-03-20/privateclouds/predicates.go
+++ b/internal/services/vmware/sdk/2020-03-20/privateclouds/predicates.go
@@ -1,0 +1,29 @@
+package privateclouds
+
+type PrivateCloudPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p PrivateCloudPredicate) Matches(input PrivateCloud) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This PR updates the Vmware, SignalR, Maps and Managed Identity packages - for SignalR this also switches to using the Trace constant now that the upstream PR has been merged.