### PR TITLE
Tags of Redis Enterprise ressources can be updated

### DIFF
--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -103,7 +103,7 @@ func resourceRedisEnterpriseCluster() *pluginsdk.Resource {
 				Deprecated: "This field currently is not yet being returned from the service API, please see https://github.com/Azure/azure-sdk-for-go/issues/14420 for more information",
 			},
 
-			"tags": tags.ForceNewSchema(),
+			"tags": tags.SchemaDataSource(),
 		},
 	}
 }

--- a/website/docs/r/redis_enterprise_cluster.html.markdown
+++ b/website/docs/r/redis_enterprise_cluster.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `zones` - (Optional) A list of a one or more Availability Zones, where the Redis Cache should be allocated. Possible values are: `1`, `2` and `3`. Changing this forces a new Redis Enterprise Cluster to be created.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Redis Enterprise Cluster. Changing this forces a new Redis Enterprise Cluster to be created.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Redis Enterprise Cluster.
 
 ## Attributes Reference
 


### PR DESCRIPTION
I noticed my terraform plan wanted to recreate my redis enterprise when I changed the tags. I tried via the portal and I confirmed I could change them without recreating anything. 

I am not sure if this kind of PR requires unit tests also. 