### PR TITLE
docs(azurerm_eventhub): remove tags arg from docs

### DIFF
--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -24,10 +24,6 @@ resource "azurerm_eventhub_namespace" "example" {
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
   capacity            = 1
-
-  tags = {
-    environment = "Production"
-  }
 }
 
 resource "azurerm_eventhub" "example" {


### PR DESCRIPTION
In Azure, you cannot have tags on event hub resources.
Therefore, remove tags from documentation on deployment.