### PR TITLE
Virtual hub connection lock

### DIFF
--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -175,6 +175,14 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	locks.ByName(id.Name, virtualHubResourceName)
 	defer locks.UnlockByName(id.Name, virtualHubResourceName)
 
+	remoteVirtualNetworkId, err := parse.VirtualNetworkID(d.Get("remote_virtual_network_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(remoteVirtualNetworkId.Name, VirtualNetworkResourceName)
+	defer locks.UnlockByName(remoteVirtualNetworkId.Name, VirtualNetworkResourceName)
+
 	name := d.Get("name").(string)
 
 	if d.IsNewResource() {
@@ -193,7 +201,7 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 		Name: utils.String(name),
 		HubVirtualNetworkConnectionProperties: &network.HubVirtualNetworkConnectionProperties{
 			RemoteVirtualNetwork: &network.SubResource{
-				ID: utils.String(d.Get("remote_virtual_network_id").(string)),
+				ID: utils.String(remoteVirtualNetworkId.ID()),
 			},
 			EnableInternetSecurity: utils.Bool(d.Get("internet_security_enabled").(bool)),
 		},

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -262,10 +262,10 @@ func checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConn
 
 func (r VirtualHubConnectionResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctestbasicvhubconn-%d"
+  name                      = "acctestbasicvhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
 }
@@ -274,7 +274,7 @@ resource "azurerm_virtual_hub_connection" "test" {
 
 func (r VirtualHubConnectionResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "import" {
   name                      = azurerm_virtual_hub_connection.test.name
@@ -286,23 +286,23 @@ resource "azurerm_virtual_hub_connection" "import" {
 
 func (r VirtualHubConnectionResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_network" "test2" {
-  name                = "acctestvirtnet2%d"
+  name                = "acctestvirtnet2%[2]d"
   address_space       = ["10.6.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_network_security_group" "test2" {
-  name                = "acctestnsg2%d"
+  name                = "acctestnsg2%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test2" {
-  name                 = "acctestsubnet2%d"
+  name                 = "acctestsubnet2%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test2.name
   address_prefixes     = ["10.6.1.0/24"]
@@ -314,27 +314,27 @@ resource "azurerm_subnet_network_security_group_association" "test2" {
 }
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctestvhubconn-%d"
+  name                      = "acctestvhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
   internet_security_enabled = false
 }
 
 resource "azurerm_virtual_hub_connection" "test2" {
-  name                      = "acctestvhubconn2-%d"
+  name                      = "acctestvhubconn2-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test2.id
   internet_security_enabled = true
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r VirtualHubConnectionResource) enableInternetSecurity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctestbasicvhubconn-%d"
+  name                      = "acctestbasicvhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
   internet_security_enabled = true
@@ -349,25 +349,25 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-vhub-%d"
-  location = "%s"
+  name     = "acctestRG-vhub-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
+  name                = "acctestvirtnet%[1]d"
   address_space       = ["10.5.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_network_security_group" "test" {
-  name                = "acctestnsg%d"
+  name                = "acctestnsg%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
+  name                 = "acctestsubnet%[1]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.5.1.0/24"]
@@ -379,27 +379,27 @@ resource "azurerm_subnet_network_security_group_association" "test" {
 }
 
 resource "azurerm_virtual_wan" "test" {
-  name                = "acctestvwan-%d"
+  name                = "acctestvwan-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_virtual_hub" "test" {
-  name                = "acctest-VHUB-%d"
+  name                = "acctest-VHUB-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   virtual_wan_id      = azurerm_virtual_wan.test.id
   address_prefix      = "10.0.2.0/24"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r VirtualHubConnectionResource) withRoutingConfiguration(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctest-vhubconn-%d"
+  name                      = "acctest-vhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
 
@@ -426,10 +426,10 @@ resource "azurerm_virtual_hub_connection" "test" {
 
 func (r VirtualHubConnectionResource) withoutPropagatedRouteTable(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctest-vhubconn-%d"
+  name                      = "acctest-vhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
 
@@ -446,10 +446,10 @@ resource "azurerm_virtual_hub_connection" "test" {
 
 func (r VirtualHubConnectionResource) withoutVnetStaticRoute(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctest-vhubconn-%d"
+  name                      = "acctest-vhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
 
@@ -464,10 +464,10 @@ resource "azurerm_virtual_hub_connection" "test" {
 
 func (r VirtualHubConnectionResource) updateRoutingConfiguration(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                      = "acctest-vhubconn-%d"
+  name                      = "acctest-vhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave "+1" or "me too" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Affected Resource(s)

<!--- Please list the affected resources and data sources. --->

* `azurerm_virtual_hub_connection`

### Acceptance Test Output

```
make acctests SERVICE='network' TESTARGS='-run=TestAccVirtualHubConnection_' TESTTIMEOUT='120m'              
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccVirtualHubConnection_ -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualHubConnection_basic
=== PAUSE TestAccVirtualHubConnection_basic
=== RUN   TestAccVirtualHubConnection_requiresImport
=== PAUSE TestAccVirtualHubConnection_requiresImport
=== RUN   TestAccVirtualHubConnection_complete
=== PAUSE TestAccVirtualHubConnection_complete
=== RUN   TestAccVirtualHubConnection_update
=== PAUSE TestAccVirtualHubConnection_update
=== RUN   TestAccVirtualHubConnection_enableInternetSecurity
=== PAUSE TestAccVirtualHubConnection_enableInternetSecurity
=== RUN   TestAccVirtualHubConnection_recreateWithSameConnectionName
=== PAUSE TestAccVirtualHubConnection_recreateWithSameConnectionName
=== RUN   TestAccVirtualHubConnection_removeRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_removeRoutingConfiguration
=== RUN   TestAccVirtualHubConnection_removePropagatedRouteTable
=== PAUSE TestAccVirtualHubConnection_removePropagatedRouteTable
=== RUN   TestAccVirtualHubConnection_removeVnetStaticRoute
=== PAUSE TestAccVirtualHubConnection_removeVnetStaticRoute
=== RUN   TestAccVirtualHubConnection_requiresLocking
=== PAUSE TestAccVirtualHubConnection_requiresLocking
=== RUN   TestAccVirtualHubConnection_updateRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_updateRoutingConfiguration
=== CONT  TestAccVirtualHubConnection_basic
=== CONT  TestAccVirtualHubConnection_removeRoutingConfiguration
=== CONT  TestAccVirtualHubConnection_update
=== CONT  TestAccVirtualHubConnection_updateRoutingConfiguration
=== CONT  TestAccVirtualHubConnection_recreateWithSameConnectionName
=== CONT  TestAccVirtualHubConnection_removeVnetStaticRoute
=== CONT  TestAccVirtualHubConnection_requiresLocking
=== CONT  TestAccVirtualHubConnection_removePropagatedRouteTable
--- PASS: TestAccVirtualHubConnection_basic (1953.89s)
=== CONT  TestAccVirtualHubConnection_complete
--- PASS: TestAccVirtualHubConnection_requiresLocking (2080.20s)
=== CONT  TestAccVirtualHubConnection_requiresImport
--- PASS: TestAccVirtualHubConnection_removePropagatedRouteTable (2082.63s)
=== CONT  TestAccVirtualHubConnection_enableInternetSecurity
--- PASS: TestAccVirtualHubConnection_removeVnetStaticRoute (2233.35s)
--- PASS: TestAccVirtualHubConnection_updateRoutingConfiguration (2267.52s)
--- PASS: TestAccVirtualHubConnection_recreateWithSameConnectionName (2508.23s)
--- PASS: TestAccVirtualHubConnection_removeRoutingConfiguration (2528.75s)
--- PASS: TestAccVirtualHubConnection_update (3228.00s)
--- PASS: TestAccVirtualHubConnection_requiresImport (2117.31s)
--- PASS: TestAccVirtualHubConnection_complete (2332.01s)
--- PASS: TestAccVirtualHubConnection_enableInternetSecurity (2631.95s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       4717.111s
```

### References

* Fixes: #12998