### PR TITLE
New Resource: azurerm_logic_app_integration_account_certificate

### DIFF
--- a/internal/services/logic/client/client.go
+++ b/internal/services/logic/client/client.go
@@ -7,6 +7,7 @@ import (
 
 type Client struct {
 	IntegrationAccountClient            *logic.IntegrationAccountsClient
+	IntegrationAccountCertificateClient *logic.IntegrationAccountCertificatesClient
 	IntegrationServiceEnvironmentClient *logic.IntegrationServiceEnvironmentsClient
 	WorkflowClient                      *logic.WorkflowsClient
 }
@@ -14,6 +15,9 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	integrationAccountClient := logic.NewIntegrationAccountsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&integrationAccountClient.Client, o.ResourceManagerAuthorizer)
+
+	integrationAccountCertificateClient := logic.NewIntegrationAccountCertificatesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&integrationAccountCertificateClient.Client, o.ResourceManagerAuthorizer)
 
 	integrationServiceEnvironmentClient := logic.NewIntegrationServiceEnvironmentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&integrationServiceEnvironmentClient.Client, o.ResourceManagerAuthorizer)
@@ -23,6 +27,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		IntegrationAccountClient:            &integrationAccountClient,
+		IntegrationAccountCertificateClient: &integrationAccountCertificateClient,
 		IntegrationServiceEnvironmentClient: &integrationServiceEnvironmentClient,
 		WorkflowClient:                      &workflowClient,
 	}

--- a/internal/services/logic/logic_app_integration_account_certificate_resource.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource.go
@@ -1,0 +1,253 @@
+package logic
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceLogicAppIntegrationAccountCertificate() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceLogicAppIntegrationAccountCertificateCreateUpdate,
+		Read:   resourceLogicAppIntegrationAccountCertificateRead,
+		Update: resourceLogicAppIntegrationAccountCertificateCreateUpdate,
+		Delete: resourceLogicAppIntegrationAccountCertificateDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.IntegrationAccountCertificateID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.IntegrationAccountCertificateName(),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"integration_account_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.IntegrationAccountName(),
+			},
+
+			"key_vault_key": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"key_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: keyVaultValidate.NestedItemName,
+						},
+
+						"key_vault_id": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: keyVaultValidate.VaultID,
+						},
+
+						"key_version": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				AtLeastOneOf: []string{"public_certificate"},
+			},
+
+			"metadata": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+			},
+
+			"public_certificate": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				AtLeastOneOf: []string{"key_vault_key"},
+			},
+		},
+	}
+}
+
+func resourceLogicAppIntegrationAccountCertificateCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Logic.IntegrationAccountCertificateClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewIntegrationAccountCertificateID(subscriptionId, d.Get("resource_group_name").(string), d.Get("integration_account_name").(string), d.Get("name").(string))
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_logic_app_integration_account_certificate", id.ID())
+		}
+	}
+
+	parameters := logic.IntegrationAccountCertificate{
+		IntegrationAccountCertificateProperties: &logic.IntegrationAccountCertificateProperties{},
+	}
+
+	if v, ok := d.GetOk("key_vault_key"); ok {
+		parameters.IntegrationAccountCertificateProperties.Key = expandIntegrationAccountCertificateKeyVaultKey(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("metadata"); ok {
+		metadata, _ := pluginsdk.ExpandJsonFromString(v.(string))
+		parameters.IntegrationAccountCertificateProperties.Metadata = metadata
+	}
+
+	if v, ok := d.GetOk("public_certificate"); ok {
+		parameters.IntegrationAccountCertificateProperties.PublicCertificate = utils.String(v.(string))
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName, parameters); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceLogicAppIntegrationAccountCertificateRead(d, meta)
+}
+
+func resourceLogicAppIntegrationAccountCertificateRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Logic.IntegrationAccountCertificateClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.IntegrationAccountCertificateID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] %s was not found - removing from state", *id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("name", id.CertificateName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("integration_account_name", id.IntegrationAccountName)
+
+	if props := resp.IntegrationAccountCertificateProperties; props != nil {
+		if err := d.Set("key_vault_key", flattenIntegrationAccountCertificateKeyVaultKey(props.Key)); err != nil {
+			return fmt.Errorf("setting `key_vault_key`: %+v", err)
+		}
+
+		if props.Metadata != nil {
+			metadataValue := props.Metadata.(map[string]interface{})
+			metadataStr, _ := pluginsdk.FlattenJsonToString(metadataValue)
+			d.Set("metadata", metadataStr)
+		}
+
+		d.Set("public_certificate", props.PublicCertificate)
+	}
+
+	return nil
+}
+
+func resourceLogicAppIntegrationAccountCertificateDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Logic.IntegrationAccountCertificateClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.IntegrationAccountCertificateID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return nil
+}
+
+func expandIntegrationAccountCertificateKeyVaultKey(input []interface{}) *logic.KeyVaultKeyReference {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	result := logic.KeyVaultKeyReference{
+		KeyVault: &logic.KeyVaultKeyReferenceKeyVault{
+			ID: utils.String(v["key_vault_id"].(string)),
+		},
+		KeyName: utils.String(v["key_name"].(string)),
+	}
+
+	if keyVersion := v["key_version"].(string); keyVersion != "" {
+		result.KeyVersion = utils.String(keyVersion)
+	}
+
+	return &result
+}
+
+func flattenIntegrationAccountCertificateKeyVaultKey(input *logic.KeyVaultKeyReference) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	var keyName string
+	if input.KeyName != nil {
+		keyName = *input.KeyName
+	}
+
+	var keyVaultId string
+	if input.KeyVault != nil && input.KeyVault.ID != nil {
+		keyVaultId = *input.KeyVault.ID
+	}
+
+	var keyVersion string
+	if input.KeyVersion != nil {
+		keyVersion = *input.KeyVersion
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"key_name":     keyName,
+			"key_vault_id": keyVaultId,
+			"key_version":  keyVersion,
+		},
+	}
+}

--- a/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
@@ -1,0 +1,363 @@
+package logic_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type LogicAppIntegrationAccountCertificateResource struct{}
+
+func TestAccLogicAppIntegrationAccountCertificate_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_certificate", "test")
+	r := LogicAppIntegrationAccountCertificateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountCertificate_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_certificate", "test")
+	r := LogicAppIntegrationAccountCertificateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountCertificate_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_certificate", "test")
+	r := LogicAppIntegrationAccountCertificateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountCertificate_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_certificate", "test")
+	r := LogicAppIntegrationAccountCertificateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.IntegrationAccountCertificateID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Logic.IntegrationAccountCertificateClient.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %q %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azuread_service_principal" "test" {
+  display_name = "Azure Logic Apps"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-logic-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "test1" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "List",
+    "Decrypt",
+    "Sign"
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+  ]
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azuread_service_principal.test.object_id
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "List",
+    "Decrypt",
+    "Sign"
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+  ]
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey"
+  ]
+
+  depends_on = [azurerm_key_vault_access_policy.test1, azurerm_key_vault_access_policy.test2]
+}
+
+resource "azurerm_logic_app_integration_account" "test" {
+  name                = "acctestia-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_certificate" "test" {
+  name                     = "acctest-iac-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+
+  key_vault_key {
+    key_name     = azurerm_key_vault_key.test.name
+    key_vault_id = azurerm_key_vault.test.id
+    key_version  = azurerm_key_vault_key.test.version
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_certificate" "import" {
+  name                     = azurerm_logic_app_integration_account_certificate.test.name
+  resource_group_name      = azurerm_logic_app_integration_account_certificate.test.resource_group_name
+  integration_account_name = azurerm_logic_app_integration_account_certificate.test.integration_account_name
+
+  key_vault_key {
+    key_name     = azurerm_logic_app_integration_account_certificate.test.key_vault_key.0.key_name
+    key_vault_id = azurerm_logic_app_integration_account_certificate.test.key_vault_key.0.key_vault_id
+    key_version  = azurerm_logic_app_integration_account_certificate.test.key_vault_key.0.key_version
+  }
+}
+`, config)
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_certificate" "test" {
+  name                     = "acctest-iac-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+  public_certificate       = "MIICsjCCAZoCCQCMdt7DvygPtDANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBhcGkudGVycmFmb3JtLmlvMB4XDTE4MDcwNTEwMzMzMFoXDTI4MDcwMjEwMzMzMFowGzEZMBcGA1UEAwwQYXBpLnRlcnJhZm9ybS5pbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQW332Ol28CsidAheD1aL9Ul8JWnKLdaVxKZ3ssl5CXjPDOmM7IXk0SgbQnUC8lIlPFZiDGbQ1sB6OTMun6ZZ4ipLp80dtl0roCLtCnDQOBGzCNArCYAoXRurjkXEY7tpD0wwtU72+37h3HQ4g0VS6VItJCqJ9QADV+HO2ZWuZTez70MhoL6OLfZP7HGYdJDKgfEVNF5XlbVzNAGkDIJFdhjNxyGGu5Nfsm1pfQhAyunkk7JVamjUg5IojRdo63IS9wwzMOdeGSAbBcsJfYeCfVg2kupR8q0TmZ+x93RmmOlbSi66kEYxRzZ9YCQeHJmn1YfJ92BpCUiy9A6Z1iaKUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAJ7JhlecP7J48wI2QHTMbAMkkWBv/iWq1/QIF4ugH3Zb5PorOv+NfhQ0LlWiw/SzN8Ae95vUixAGYHMSa28oumM5K1OsqKEkVIo1AoBH8nBz+VcTpRD/mHXotAHPAZt9j5LqeHX+enR6RbINAf3jn+YU3MdVe0MsADdFASVDfjmQP2R7o9aJb/QqOg3bZBWsiBDEISfyaH2+pgUM7wtwEoFWmEMlgjLK1MRBs1cDZXqnHaCd/rs+NmWV9naEu7x5fyQOk4HozkpweR+Jx1sBlTRsa49/qSHt/6ULKfO01/cTs4iF71ykXPbh3Kj9cI2uo9aYtXkxkhKrGyUpA7FJqWw=="
+
+  metadata = <<METADATA
+    {
+        "foo": "bar"
+    }
+METADATA
+
+  key_vault_key {
+    key_name     = azurerm_key_vault_key.test.name
+    key_vault_id = azurerm_key_vault.test.id
+    key_version  = azurerm_key_vault_key.test.version
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountCertificateResource) update(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault" "test2" {
+  name                = "acctestkv2-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "test3" {
+  key_vault_id = azurerm_key_vault.test2.id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "List",
+    "Decrypt",
+    "Sign"
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+  ]
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azuread_service_principal.test.object_id
+}
+
+resource "azurerm_key_vault_access_policy" "test4" {
+  key_vault_id = azurerm_key_vault.test2.id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "List",
+    "Decrypt",
+    "Sign"
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+  ]
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkvkey2-%s"
+  key_vault_id = azurerm_key_vault.test2.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey"
+  ]
+
+  depends_on = [azurerm_key_vault_access_policy.test3, azurerm_key_vault_access_policy.test4]
+}
+
+resource "azurerm_logic_app_integration_account_certificate" "test" {
+  name                     = "acctest-iac-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+  public_certificate       = "MIIDbzCCAlegAwIBAgIJAIzjRD36sIbbMA0GCSqGSIb3DQEBCwUAME0xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAl0ZXJyYWZvcm0xFTATBgNVBAMMDHRlcnJhZm9ybS5pbzAgFw0xNzA0MjEyMDA1MjdaGA8yMTE3MDMyODIwMDUyN1owTTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAoMCXRlcnJhZm9ybTEVMBMGA1UEAwwMdGVycmFmb3JtLmlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3L9L5szT4+FLykTFNyyPjy/k3BQTYAfRQzP2dhnsuUKm3cdPC0NyZ+wEXIUGhoDO2YG6EYChOl8fsDqDOjloSUGKqYw++nlpHIuUgJx8IxxG2XkALCjFU7EmF+w7kn76d0ezpEIYxnLP+KG2DVornoEt1aLhv1MLmpgEZZPhDbMSLhSYWeTVRMayXLwqtfgnDumQSB+8d/1JuJqrSI4pD12JozVThzb6hsjfb6RMX4epPmrGn0PbTPEEA6awmsxBCXB0s13nNQt/O0hLM2agwvAyozilQV+s616Ckgk6DJoUkqZhDy7vPYMIRSr98fBws6zkrV6tTLjmD8xAvobePQIDAQABo1AwTjAdBgNVHQ4EFgQUXIqO421zMMmbcRRX9wctZFCQuPIwHwYDVR0jBBgwFoAUXIqO421zMMmbcRRX9wctZFCQuPIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAr82NeT3BYJOKLlUL6Om5LjUF66ewcJjG9ltdvyQwVneMcq7t5UAPxgChzqNRVk4da8PzkXpjBJyWezHupdJNX3XqeUk2kSxqQ6/gmhqvfI3y7djrwoO6jvMEY26WqtkTNORWDP3THJJVimC3zV+KMU5UBVrEzhOVhHSU709lBP75o0BBn3xGsPqSq9k8IotIFfyAc6a+XP3+ZMpvh7wqAUml7vWa5wlcXExCx39h1balfDSLGNC4swWPCp9AMnQR0p+vMay9hNP1Eh+9QYUai14d5KS3cFV+KxE1cJR5HD/iLltnnOEbpMsB0eVOZWkFvE7Y5lW0oVSAfin5TwTJMQ=="
+
+  metadata = <<METADATA
+    {
+        "foo": "bar2"
+    }
+METADATA
+
+  key_vault_key {
+    key_name     = azurerm_key_vault_key.test2.name
+    key_vault_id = azurerm_key_vault.test2.id
+    key_version  = azurerm_key_vault_key.test2.version
+  }
+}
+`, template, data.RandomString, data.RandomString, data.RandomInteger)
+}

--- a/internal/services/logic/parse/integration_account_certificate.go
+++ b/internal/services/logic/parse/integration_account_certificate.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type IntegrationAccountCertificateId struct {
+	SubscriptionId         string
+	ResourceGroup          string
+	IntegrationAccountName string
+	CertificateName        string
+}
+
+func NewIntegrationAccountCertificateID(subscriptionId, resourceGroup, integrationAccountName, certificateName string) IntegrationAccountCertificateId {
+	return IntegrationAccountCertificateId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroup:          resourceGroup,
+		IntegrationAccountName: integrationAccountName,
+		CertificateName:        certificateName,
+	}
+}
+
+func (id IntegrationAccountCertificateId) String() string {
+	segments := []string{
+		fmt.Sprintf("Certificate Name %q", id.CertificateName),
+		fmt.Sprintf("Integration Account Name %q", id.IntegrationAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Integration Account Certificate", segmentsStr)
+}
+
+func (id IntegrationAccountCertificateId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Logic/integrationAccounts/%s/certificates/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.IntegrationAccountName, id.CertificateName)
+}
+
+// IntegrationAccountCertificateID parses a IntegrationAccountCertificate ID into an IntegrationAccountCertificateId struct
+func IntegrationAccountCertificateID(input string) (*IntegrationAccountCertificateId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := IntegrationAccountCertificateId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.IntegrationAccountName, err = id.PopSegment("integrationAccounts"); err != nil {
+		return nil, err
+	}
+	if resourceId.CertificateName, err = id.PopSegment("certificates"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/logic/parse/integration_account_certificate_test.go
+++ b/internal/services/logic/parse/integration_account_certificate_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = IntegrationAccountCertificateId{}
+
+func TestIntegrationAccountCertificateIDFormatter(t *testing.T) {
+	actual := NewIntegrationAccountCertificateID("12345678-1234-9876-4563-123456789012", "group1", "account1", "certificate1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestIntegrationAccountCertificateID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *IntegrationAccountCertificateId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/",
+			Error: true,
+		},
+
+		{
+			// missing value for IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/",
+			Error: true,
+		},
+
+		{
+			// missing CertificateName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/",
+			Error: true,
+		},
+
+		{
+			// missing value for CertificateName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1",
+			Expected: &IntegrationAccountCertificateId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "group1",
+				IntegrationAccountName: "account1",
+				CertificateName:        "certificate1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.LOGIC/INTEGRATIONACCOUNTS/ACCOUNT1/CERTIFICATES/CERTIFICATE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := IntegrationAccountCertificateID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.IntegrationAccountName != v.Expected.IntegrationAccountName {
+			t.Fatalf("Expected %q but got %q for IntegrationAccountName", v.Expected.IntegrationAccountName, actual.IntegrationAccountName)
+		}
+		if actual.CertificateName != v.Expected.CertificateName {
+			t.Fatalf("Expected %q but got %q for CertificateName", v.Expected.CertificateName, actual.CertificateName)
+		}
+	}
+}

--- a/internal/services/logic/registration.go
+++ b/internal/services/logic/registration.go
@@ -29,13 +29,14 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_logic_app_action_custom":         resourceLogicAppActionCustom(),
-		"azurerm_logic_app_action_http":           resourceLogicAppActionHTTP(),
-		"azurerm_logic_app_integration_account":   resourceLogicAppIntegrationAccount(),
-		"azurerm_logic_app_trigger_custom":        resourceLogicAppTriggerCustom(),
-		"azurerm_logic_app_trigger_http_request":  resourceLogicAppTriggerHttpRequest(),
-		"azurerm_logic_app_trigger_recurrence":    resourceLogicAppTriggerRecurrence(),
-		"azurerm_logic_app_workflow":              resourceLogicAppWorkflow(),
-		"azurerm_integration_service_environment": resourceIntegrationServiceEnvironment(),
+		"azurerm_logic_app_action_custom":                   resourceLogicAppActionCustom(),
+		"azurerm_logic_app_action_http":                     resourceLogicAppActionHTTP(),
+		"azurerm_logic_app_integration_account":             resourceLogicAppIntegrationAccount(),
+		"azurerm_logic_app_integration_account_certificate": resourceLogicAppIntegrationAccountCertificate(),
+		"azurerm_logic_app_trigger_custom":                  resourceLogicAppTriggerCustom(),
+		"azurerm_logic_app_trigger_http_request":            resourceLogicAppTriggerHttpRequest(),
+		"azurerm_logic_app_trigger_recurrence":              resourceLogicAppTriggerRecurrence(),
+		"azurerm_logic_app_workflow":                        resourceLogicAppWorkflow(),
+		"azurerm_integration_service_environment":           resourceIntegrationServiceEnvironment(),
 	}
 }

--- a/internal/services/logic/resourceids.go
+++ b/internal/services/logic/resourceids.go
@@ -1,4 +1,5 @@
 package logic
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccount -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccountCertificate -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationServiceEnvironment -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationServiceEnvironments/ise1

--- a/internal/services/logic/validate/integration_account_certificate_id.go
+++ b/internal/services/logic/validate/integration_account_certificate_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+)
+
+func IntegrationAccountCertificateID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.IntegrationAccountCertificateID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/logic/validate/integration_account_certificate_id_test.go
+++ b/internal/services/logic/validate/integration_account_certificate_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestIntegrationAccountCertificateID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/",
+			Valid: false,
+		},
+
+		{
+			// missing CertificateName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CertificateName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.LOGIC/INTEGRATIONACCOUNTS/ACCOUNT1/CERTIFICATES/CERTIFICATE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := IntegrationAccountCertificateID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/logic/validate/integration_account_certificate_name.go
+++ b/internal/services/logic/validate/integration_account_certificate_name.go
@@ -1,0 +1,29 @@
+package validate
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"regexp"
+)
+
+func IntegrationAccountCertificateName() pluginsdk.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+			return
+		}
+
+		if len(v) > 80 {
+			errors = append(errors, fmt.Errorf("length should be equal to or less than %d, got %q", 80, v))
+			return
+		}
+
+		if !regexp.MustCompile(`^[A-Za-z0-9-().]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens.", k))
+			return
+		}
+
+		return
+	}
+}

--- a/internal/services/logic/validate/integration_account_certificate_name.go
+++ b/internal/services/logic/validate/integration_account_certificate_name.go
@@ -2,8 +2,9 @@ package validate
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func IntegrationAccountCertificateName() pluginsdk.SchemaValidateFunc {

--- a/internal/services/logic/validate/integration_account_certificate_name_test.go
+++ b/internal/services/logic/validate/integration_account_certificate_name_test.go
@@ -1,0 +1,54 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIntegrationAccountCertificateName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "test1",
+			valid: true,
+		},
+		{
+			input: "a2-.()b",
+			valid: true,
+		},
+		{
+			input: "a2&b",
+			valid: false,
+		},
+		{
+			input: strings.Repeat("s", 79),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 80),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 81),
+			valid: false,
+		},
+	}
+
+	validationFunction := IntegrationAccountCertificateName()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validationFunction(tt.input, "")
+			valid := err == nil
+			if valid != tt.valid {
+				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.input)
+			}
+		})
+	}
+}

--- a/website/docs/r/logic_app_integration_account_certificate.html.markdown
+++ b/website/docs/r/logic_app_integration_account_certificate.html.markdown
@@ -1,0 +1,83 @@
+---
+subcategory: "Logic App"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_logic_app_integration_account_certificate"
+description: |-
+  Manages a Logic App Integration Account Certificate.
+---
+
+# azurerm_logic_app_integration_account_certificate
+
+Manages a Logic App Integration Account Certificate.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_logic_app_integration_account" "example" {
+  name                = "example-ia"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard"
+}
+
+resource "azurerm_logic_app_integration_account_certificate" "example" {
+  name                     = "example-iac"
+  resource_group_name      = azurerm_resource_group.example.name
+  integration_account_name = azurerm_logic_app_integration_account.example.name
+  public_certificate       = "MIIDbzCCAlegAwIBAgIJAIzjRD36sIbbMA0GCSqGSIb3DQEBCwUAME0xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAl0ZXJyYWZvcm0xFTATBgNVBAMMDHRlcnJhZm9ybS5pbzAgFw0xNzA0MjEyMDA1MjdaGA8yMTE3MDMyODIwMDUyN1owTTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAoMCXRlcnJhZm9ybTEVMBMGA1UEAwwMdGVycmFmb3JtLmlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3L9L5szT4+FLykTFNyyPjy/k3BQTYAfRQzP2dhnsuUKm3cdPC0NyZ+wEXIUGhoDO2YG6EYChOl8fsDqDOjloSUGKqYw++nlpHIuUgJx8IxxG2XkALCjFU7EmF+w7kn76d0ezpEIYxnLP+KG2DVornoEt1aLhv1MLmpgEZZPhDbMSLhSYWeTVRMayXLwqtfgnDumQSB+8d/1JuJqrSI4pD12JozVThzb6hsjfb6RMX4epPmrGn0PbTPEEA6awmsxBCXB0s13nNQt/O0hLM2agwvAyozilQV+s616Ckgk6DJoUkqZhDy7vPYMIRSr98fBws6zkrV6tTLjmD8xAvobePQIDAQABo1AwTjAdBgNVHQ4EFgQUXIqO421zMMmbcRRX9wctZFCQuPIwHwYDVR0jBBgwFoAUXIqO421zMMmbcRRX9wctZFCQuPIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAr82NeT3BYJOKLlUL6Om5LjUF66ewcJjG9ltdvyQwVneMcq7t5UAPxgChzqNRVk4da8PzkXpjBJyWezHupdJNX3XqeUk2kSxqQ6/gmhqvfI3y7djrwoO6jvMEY26WqtkTNORWDP3THJJVimC3zV+KMU5UBVrEzhOVhHSU709lBP75o0BBn3xGsPqSq9k8IotIFfyAc6a+XP3+ZMpvh7wqAUml7vWa5wlcXExCx39h1balfDSLGNC4swWPCp9AMnQR0p+vMay9hNP1Eh+9QYUai14d5KS3cFV+KxE1cJR5HD/iLltnnOEbpMsB0eVOZWkFvE7Y5lW0oVSAfin5TwTJMQ=="
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Logic App Integration Account Certificate. Changing this forces a new Logic App Integration Account Certificate to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Logic App Integration Account Certificate should exist. Changing this forces a new Logic App Integration Account Certificate to be created.
+
+* `integration_account_name` - (Required) The name of the Logic App Integration Account. Changing this forces a new Logic App Integration Account Certificate to be created.
+
+* `key_vault_key` - (Optional) A `key_vault_key` block as documented below.
+
+* `metadata` - (Optional) A JSON mapping of any Metadata for this Logic App Integration Account Certificate.
+
+* `public_certificate` - (Optional) The public certificate for the Logic App Integration Account Certificate.
+
+---
+
+A `key_vault_key` block exports the following:
+
+* `key_name` - (Required) The name of Key Vault Key.
+
+* `key_vault_id` - (Required) The ID of the Key Vault.
+
+* `key_version` - (Optional) The version of Key Vault Key.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Logic App Integration Account Certificate.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Logic App Integration Account Certificate.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Logic App Integration Account Certificate.
+* `update` - (Defaults to 30 minutes) Used when updating the Logic App Integration Account Certificate.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Logic App Integration Account Certificate.
+
+## Import
+
+Logic App Integration Account Certificates can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_logic_app_integration_account_certificate.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1
+```


### PR DESCRIPTION
Currently, TF doesn't support Logic App Integration Account Certificate. So I submitted this PR to implement it.

--- PASS: TestAccLogicAppIntegrationAccountCertificate_complete (588.08s)
--- PASS: TestAccLogicAppIntegrationAccountCertificate_basic (593.28s)
--- PASS: TestAccLogicAppIntegrationAccountCertificate_requiresImport (663.53s)
--- PASS: TestAccLogicAppIntegrationAccountCertificate_update (1002.16s)

API Reference:
https://github.com/Azure/azure-rest-api-specs/blob/ceb6d11a85d834c838181a3031cd106d14a2d674/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L5226