### PR TITLE
fix max_age_in_seconds range in storage cors settings

### DIFF
--- a/internal/services/storage/helpers.go
+++ b/internal/services/storage/helpers.go
@@ -66,7 +66,7 @@ func schemaStorageAccountCorsRule(patchEnabled bool) *pluginsdk.Schema {
 				"max_age_in_seconds": {
 					Type:         pluginsdk.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntBetween(1, 2000000000),
+					ValidateFunc: validation.IntBetween(0, 2000000000),
 				},
 			},
 		},


### PR DESCRIPTION
 Fix #8446 - add 0 to the range of max_age_in_seconds for azurerm_storage_account's CORS rules