### PR TITLE
`azurerm_linux_virtual_machine_scale_set` - fix potential crash in update to rolling_upgrade_policy

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -610,7 +610,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			}
 		} else {
 			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
-			existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -603,8 +603,14 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	if d.HasChange("automatic_os_upgrade_policy") || d.HasChange("rolling_upgrade_policy") {
-		upgradePolicy := compute.UpgradePolicy{
-			Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+		upgradePolicy := compute.UpgradePolicy{}
+		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
+			upgradePolicy = compute.UpgradePolicy{
+				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+			}
+		} else {
+			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
+			existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -631,8 +631,14 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		}
 	}
 	if d.HasChange("automatic_os_upgrade_policy") || d.HasChange("rolling_upgrade_policy") {
-		upgradePolicy := compute.UpgradePolicy{
-			Mode: upgradeMode,
+		upgradePolicy := compute.UpgradePolicy{}
+		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
+			upgradePolicy = compute.UpgradePolicy{
+				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+			}
+		} else {
+			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
+			existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -638,7 +638,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 			}
 		} else {
 			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
-			existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
 		}
 
 		if d.HasChange("automatic_os_upgrade_policy") {


### PR DESCRIPTION
`azurerm_windows_virtual_machine_scale_set` - fix potential crash in update to rolling_upgrade_policy

Fixes #13004