### PR TITLE
`azurerm_databricks_workspace`: Flip logic for `public_network_access_enabled`

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -543,7 +543,7 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
 		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
-		d.Set("public_network_access_enabled", (props.PublicNetworkAccess == databricks.PublicNetworkAccessEnabled))
+		d.Set("public_network_access_enabled", (props.PublicNetworkAccess != databricks.PublicNetworkAccessDisabled))
 
 		if props.PublicNetworkAccess == databricks.PublicNetworkAccessDisabled {
 			d.Set("network_security_group_rules_required", string(props.RequiredNsgRules))

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -543,7 +543,7 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
 		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
-		d.Set("public_network_access_enabled", (props.PublicNetworkAccess != databricks.PublicNetworkAccessDisabled))
+		d.Set("public_network_access_enabled", props.PublicNetworkAccess != databricks.PublicNetworkAccessDisabled)
 
 		if props.PublicNetworkAccess == databricks.PublicNetworkAccessDisabled {
 			d.Set("network_security_group_rules_required", string(props.RequiredNsgRules))


### PR DESCRIPTION
In case databricks workspace has been created by an older API version, new API version does not return this property alltogether, resulting in SDK's internal property evaluating to an empty string `""`, rather than a value. Hence current implementation defaults to `false`, which contradicts the documentation.

This PR should fix the fact that all workspaces want to get re-created unless this property is explicitly set to `false`, however it triggers drift detection:

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.databricks_dataeng.azurerm_databricks_workspace.this has been changed
  ~ resource "azurerm_databricks_workspace" "this" {
        id                                = "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Databricks/workspaces/xxx"
        name                              = "xxx"
      ~ public_network_access_enabled     = false -> true
        tags                              = {
            "terraform-module" = "terraform-azurerm-databricks"
        }
        # (10 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.
```

In my not-so-humble opinion, it's better to trigger drift detection, rather than a workspace re-roll or making people adjust their modules to include incorrect default value.

// cc @WodansSon 