### PR TITLE
`azurerm_data_lake_store`: Add `identity` parameter

### DIFF
--- a/website/docs/r/data_lake_store.html.markdown
+++ b/website/docs/r/data_lake_store.html.markdown
@@ -45,11 +45,20 @@ The following arguments are supported:
 
 -> **NOTE:** Support for User Managed encryption will be supported in the future once a bug in the API is fixed.
 
+* `identity` - (Required) An `identity` block defined below.
+
 * `firewall_allow_azure_ips` - are Azure Service IP's allowed through the firewall? Possible values are `Enabled` and `Disabled`. Defaults to `Enabled.`
 
 * `firewall_state` - the state of the Firewall. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled.`
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The Type of Identity which should be used for this Data Lake Store Account. At this time the only possible value is `SystemAssigned`.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #2473

```
$ TF_ACC=1 go test -v ./internal/services/datalake -timeout=1000m -run='TestAccDataLakeStore_withIdentity'
=== RUN   TestAccDataLakeStore_withIdentity
=== PAUSE TestAccDataLakeStore_withIdentity
=== CONT  TestAccDataLakeStore_withIdentity
--- PASS: TestAccDataLakeStore_withIdentity (188.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/datalake	189.714s
```