### PR TITLE
`azurerm_logic_app_trigger_http_request` add `callback_url` as attribute

### DIFF
--- a/internal/services/logic/client/client.go
+++ b/internal/services/logic/client/client.go
@@ -11,6 +11,7 @@ type Client struct {
 	IntegrationAccountSessionClient     *logic.IntegrationAccountSessionsClient
 	IntegrationServiceEnvironmentClient *logic.IntegrationServiceEnvironmentsClient
 	WorkflowClient                      *logic.WorkflowsClient
+	TriggersClient                      *logic.WorkflowTriggersClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -29,11 +30,15 @@ func NewClient(o *common.ClientOptions) *Client {
 	workflowClient := logic.NewWorkflowsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&workflowClient.Client, o.ResourceManagerAuthorizer)
 
+	triggersClient := logic.NewWorkflowTriggersClient(o.SubscriptionId)
+	o.ConfigureClient(&triggersClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		IntegrationAccountClient:            &integrationAccountClient,
 		IntegrationAccountCertificateClient: &integrationAccountCertificateClient,
 		IntegrationAccountSessionClient:     &integrationAccountSessionClient,
 		IntegrationServiceEnvironmentClient: &integrationServiceEnvironmentClient,
 		WorkflowClient:                      &workflowClient,
+		TriggersClient:                      &triggersClient,
 	}
 }

--- a/internal/services/logic/logic_app_trigger_http_request_resource.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource.go
@@ -80,6 +80,11 @@ func resourceLogicAppTriggerHttpRequest() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: validate.TriggerHttpRequestRelativePath,
 			},
+
+			"callback_url": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -128,7 +133,7 @@ func resourceLogicAppTriggerHttpRequestRead(d *pluginsdk.ResourceData, meta inte
 	logicAppName := id.Path["workflows"]
 	name := id.Path["triggers"]
 
-	t, app, err := retrieveLogicAppTrigger(d, meta, resourceGroup, logicAppName, name)
+	t, app, url, err := retrieveLogicAppHttpTrigger(d, meta, resourceGroup, logicAppName, name)
 	if err != nil {
 		return err
 	}
@@ -143,6 +148,7 @@ func resourceLogicAppTriggerHttpRequestRead(d *pluginsdk.ResourceData, meta inte
 
 	d.Set("name", name)
 	d.Set("logic_app_id", app.ID)
+	d.Set("callback_url", url)
 
 	v := trigger["inputs"]
 	if v == nil {

--- a/internal/services/logic/logic_app_trigger_http_request_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource_test.go
@@ -80,6 +80,22 @@ func TestAccLogicAppTriggerHttpRequest_method(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppTriggerHttpRequest_callbackUrl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_trigger_http_request", "test")
+	r := LogicAppTriggerHttpRequestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.method(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("callback_url").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppTriggerHttpRequest_relativePath(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_trigger_http_request", "test")
 	r := LogicAppTriggerHttpRequestResource{}

--- a/website/docs/r/logic_app_trigger_http_request.html.markdown
+++ b/website/docs/r/logic_app_trigger_http_request.html.markdown
@@ -68,6 +68,8 @@ The following attributes are exported:
 
 * `id` - The ID of the HTTP Request Trigger within the Logic App Workflow.
 
+* `callback_url` - The URL for the workflow trigger
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Expose the `callback_url` of a logic app http trigger such that it can be used to pass to other resources. e.g. in a `azurerm_monitor_action_group` where it needs the `callback_url` in the `logic_app_receiver` block