### PR TITLE
azurerm_eventhub_namespace  - support upto 40 for maximum_throughput_units

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -110,7 +110,7 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(0, 20),
+				ValidateFunc: validation.IntBetween(0, 40),
 			},
 
 			"network_rulesets": {

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -434,7 +434,7 @@ func TestAccEventHubNamespace_maximumThroughputUnitsUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
 				check.That(data.ResourceName).Key("capacity").HasValue("2"),
-				check.That(data.ResourceName).Key("maximum_throughput_units").HasValue("20"),
+				check.That(data.ResourceName).Key("maximum_throughput_units").HasValue("25"),
 			),
 		},
 		{
@@ -854,7 +854,7 @@ resource "azurerm_eventhub_namespace" "test" {
   sku                      = "Standard"
   capacity                 = "2"
   auto_inflate_enabled     = true
-  maximum_throughput_units = 20
+  maximum_throughput_units = 25
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Azure recently increased the limit of **maximum_througput_units** for autoscaling from 20 to 40. 

You would get an error right now if you choose anything above 20. 

Fixes #13064