### PR TITLE
new resource "azurerm_data_protection_backup_instance_blob_storage"

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
@@ -1,0 +1,214 @@
+package dataprotection
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection/legacysdk/dataprotection"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection/validate"
+	storageParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceDataProtectionBackupInstanceBlobStorage() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceDataProtectionBackupInstanceBlobStorageCreateUpdate,
+		Read:   resourceDataProtectionBackupInstanceBlobStorageRead,
+		Update: resourceDataProtectionBackupInstanceBlobStorageCreateUpdate,
+		Delete: resourceDataProtectionBackupInstanceBlobStorageDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BackupInstanceID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": location.Schema(),
+
+			"vault_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.BackupVaultID,
+			},
+
+			"storage_account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: storageValidate.StorageAccountID,
+			},
+
+			"backup_policy_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.BackupPolicyID,
+			},
+		},
+	}
+}
+
+func resourceDataProtectionBackupInstanceBlobStorageCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	vaultId, err := parse.BackupVaultID(d.Get("vault_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewBackupInstanceID(subscriptionId, vaultId.ResourceGroup, vaultId.Name, name)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_data_protection_backup_instance_blob_storage", id.ID())
+		}
+	}
+
+	storageAccountId, err := storageParse.StorageAccountID(d.Get("storage_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	location := location.Normalize(d.Get("location").(string))
+
+	policyId, err := parse.BackupPolicyID(d.Get("backup_policy_id").(string))
+	if err != nil {
+		return err
+	}
+
+	parameters := dataprotection.BackupInstanceResource{
+		Properties: &dataprotection.BackupInstance{
+			DataSourceInfo: &dataprotection.Datasource{
+				DatasourceType:   utils.String("Microsoft.Storage/storageAccounts/blobServices"),
+				ObjectType:       utils.String("Datasource"),
+				ResourceID:       utils.String(storageAccountId.ID()),
+				ResourceLocation: utils.String(location),
+				ResourceName:     utils.String(storageAccountId.Name),
+				ResourceType:     utils.String("Microsoft.Storage/storageAccounts"),
+			},
+			FriendlyName: utils.String(id.Name),
+			PolicyInfo: &dataprotection.PolicyInfo{
+				PolicyID: utils.String(policyId.ID()),
+			},
+		},
+	}
+	future, err := client.CreateOrUpdate(ctx, id.BackupVaultName, id.ResourceGroup, id.Name, parameters)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context had no deadline")
+	}
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(dataprotection.ConfiguringProtection), string(dataprotection.UpdatingProtection)},
+		Target:     []string{string(dataprotection.ProtectionConfigured)},
+		Refresh:    policyProtectionStateRefreshFunc(ctx, client, id),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(deadline),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s policy protection to be completed: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceDataProtectionBackupInstanceBlobStorageRead(d, meta)
+}
+
+func resourceDataProtectionBackupInstanceBlobStorageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupInstanceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] dataprotection %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	vaultId := parse.NewBackupVaultID(id.SubscriptionId, id.ResourceGroup, id.BackupVaultName)
+	d.Set("name", id.Name)
+	d.Set("vault_id", vaultId.ID())
+	if props := resp.Properties; props != nil {
+		if props.DataSourceInfo != nil {
+			d.Set("storage_account_id", props.DataSourceInfo.ResourceID)
+			d.Set("location", props.DataSourceInfo.ResourceLocation)
+		}
+		if props.PolicyInfo != nil {
+			d.Set("backup_policy_id", props.PolicyInfo.PolicyID)
+		}
+	}
+	return nil
+}
+
+func resourceDataProtectionBackupInstanceBlobStorageDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupInstanceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		if !response.WasNotFound(future.Response()) {
+			return fmt.Errorf("waiting for deletion of %s: %+v", id, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
@@ -1,0 +1,205 @@
+package dataprotection_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type DataProtectionBackupInstanceBlobStorageResource struct{}
+
+func TestAccDataProtectionBackupInstanceBlobStorage_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_blob_storage", "test")
+	r := DataProtectionBackupInstanceBlobStorageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupInstanceBlobStorage_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_blob_storage", "test")
+	r := DataProtectionBackupInstanceBlobStorageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDataProtectionBackupInstanceBlobStorage_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_blob_storage", "test")
+	r := DataProtectionBackupInstanceBlobStorageResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupInstanceBlobStorage_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_blob_storage", "test")
+	r := DataProtectionBackupInstanceBlobStorageResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.BackupInstanceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DataProtection.BackupInstanceClient.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving DataProtection BackupInstance (%q): %+v", id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-dataprotection-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "acctestdp%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_data_protection_backup_vault" "test" {
+  name                = "acctest-dataprotection-vault-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "test" {
+  name               = "acctest-dbp-%[1]d"
+  vault_id           = azurerm_data_protection_backup_vault.test.id
+  retention_duration = "P7D"
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "another" {
+  name               = "acctest-dbp2-%[1]d"
+  vault_id           = azurerm_data_protection_backup_vault.test.id
+  retention_duration = "P30D"
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Account Backup Contributor Role"
+  principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
+  name               = "acctest-dbi-%[2]d"
+  location           = azurerm_resource_group.test.location
+  vault_id           = azurerm_data_protection_backup_vault.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) requiresImport(data acceptance.TestData) string {
+	basic := r.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "import" {
+  name               = azurerm_data_protection_backup_instance_blob_storage.test.name
+  location           = azurerm_resource_group.test.location
+  vault_id           = azurerm_data_protection_backup_instance_blob_storage.test.vault_id
+  storage_account_id = azurerm_storage_account.test.id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, basic)
+}
+
+func (r DataProtectionBackupInstanceBlobStorageResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "test" {
+  name               = "acctest-dbi-%[2]d"
+  location           = azurerm_resource_group.test.location
+  vault_id           = azurerm_data_protection_backup_vault.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.another.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/dataprotection/registration.go
+++ b/internal/services/dataprotection/registration.go
@@ -24,11 +24,12 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_data_protection_backup_vault":               resourceDataProtectionBackupVault(),
-		"azurerm_data_protection_backup_policy_blob_storage": resourceDataProtectionBackupPolicyBlobStorage(),
-		"azurerm_data_protection_backup_policy_disk":         resourceDataProtectionBackupPolicyDisk(),
-		"azurerm_data_protection_backup_policy_postgresql":   resourceDataProtectionBackupPolicyPostgreSQL(),
-		"azurerm_data_protection_backup_instance_disk":       resourceDataProtectionBackupInstanceDisk(),
-		"azurerm_data_protection_backup_instance_postgresql": resourceDataProtectionBackupInstancePostgreSQL(),
+		"azurerm_data_protection_backup_vault":                 resourceDataProtectionBackupVault(),
+		"azurerm_data_protection_backup_policy_blob_storage":   resourceDataProtectionBackupPolicyBlobStorage(),
+		"azurerm_data_protection_backup_policy_disk":           resourceDataProtectionBackupPolicyDisk(),
+		"azurerm_data_protection_backup_policy_postgresql":     resourceDataProtectionBackupPolicyPostgreSQL(),
+		"azurerm_data_protection_backup_instance_blob_storage": resourceDataProtectionBackupInstanceBlobStorage(),
+		"azurerm_data_protection_backup_instance_disk":         resourceDataProtectionBackupInstanceDisk(),
+		"azurerm_data_protection_backup_instance_postgresql":   resourceDataProtectionBackupInstancePostgreSQL(),
 	}
 }

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_protection_backup_instance_blob_storage"
+description: |-
+  Manages a Backup Instance to back up a blob storage account.
+---
+
+# azurerm_data_protection_backup_instance_blob_storage
+
+Manages a Backup Instance to back up a blob storage account.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                = "examplestorageaccount"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_data_protection_backup_vault" "example" {
+  name                = "example-backup-vault"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "example" {
+  name               = "example-backup-policy"
+  vault_id           = azurerm_data_protection_backup_vault.example.id
+  retention_duration = "P30D"
+}
+
+resource "azurerm_role_assignment" "example" {
+  scope                = azurerm_storage_account.example.id
+  role_definition_name = "Storage Account Backup Contributor Role"
+  principal_id         = azurerm_data_protection_backup_vault.example.identity[0].principal_id
+}
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "example" {
+  name               = "example-backup-instance"
+  location           = azurerm_resource_group.example.location
+  vault_id           = azurerm_data_protection_backup_vault.example.id
+  storage_account_id = azurerm_storage_account.example.id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.example.id
+
+  depends_on = [azurerm_role_assignment.example]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this backup instance. Changing this forces a new backup instance to be created.
+
+* `location` - (Required) The location of the source storage account. Changing this forces a new backup instance to be created.
+
+* `vault_id` - (Required) The ID of the Backup Vault within which the storage account Backup Instance should exist. Changing this forces a new backup instance to be created.
+
+* `storage_account_id` - (Required) The ID of the source storage account. Changing this forces a new backup instance to be created.
+
+* `backup_policy_id` - (Required) The ID of the Backup Policy.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the backup instance.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Backup Instance Blob Storage.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Instance Blob Storage.
+* `update` - (Defaults to 30 minutes) Used when updating the Backup Instance Blob Storage.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Backup Instance Blob Storage.
+
+## Import
+
+Backup Instance Blob Storage can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_protection_backup_instance_blob_storage.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1
+```

--- a/website/docs/r/data_protection_backup_instance_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_disk.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_data_protection_backup_policy_disk" "example" {
 
 resource "azurerm_data_protection_backup_instance_disk" "example" {
   name                         = "example-backup-instance"
-  resource_group_name          = azurerm_resource_group.rg.name
+  location                     = azurerm_resource_group.rg.location
   vault_id                     = azurerm_data_protection_backup_vault.example.id
   disk_id                      = azurerm_managed_disk.example.id
   snapshot_resource_group_name = azurerm_resource_group.rg.name
@@ -73,8 +73,6 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Backup Instance Disk. Changing this forces a new Backup Instance Disk to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Backup Instance Disk should exist. Changing this forces a new Backup Instance Disk to be created.
-
 * `location` - (Required) The Azure Region where the Backup Instance Disk should exist. Changing this forces a new Backup Instance Disk to be created.
 
 * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Instance Disk should exist. Changing this forces a new Backup Instance Disk to be created.
@@ -87,7 +85,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported: 
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Backup Instance Disk.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request adds support for enabling operational backups on storage accounts. The implementation and the acceptance tests are largely derived from analagous implementations for PostgreSQL database backups.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: #13007

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='dataprotection' TESTARGS='-run=TestAccDataProtectionBackupInstanceBlobStorage_' TESTTIMEOUT='15m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/dataprotection -run=TestAccDataProtectionBackupInstanceBlobStorage_ -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataProtectionBackupInstanceBlobStorage_basic
=== PAUSE TestAccDataProtectionBackupInstanceBlobStorage_basic
=== RUN   TestAccDataProtectionBackupInstanceBlobStorage_requiresImport
=== PAUSE TestAccDataProtectionBackupInstanceBlobStorage_requiresImport
=== RUN   TestAccDataProtectionBackupInstanceBlobStorage_complete
=== PAUSE TestAccDataProtectionBackupInstanceBlobStorage_complete
=== RUN   TestAccDataProtectionBackupInstanceBlobStorage_update
=== PAUSE TestAccDataProtectionBackupInstanceBlobStorage_update
=== CONT  TestAccDataProtectionBackupInstanceBlobStorage_basic
=== CONT  TestAccDataProtectionBackupInstanceBlobStorage_update
=== CONT  TestAccDataProtectionBackupInstanceBlobStorage_complete
=== CONT  TestAccDataProtectionBackupInstanceBlobStorage_requiresImport
--- PASS: TestAccDataProtectionBackupInstanceBlobStorage_basic (275.75s)
--- PASS: TestAccDataProtectionBackupInstanceBlobStorage_complete (308.91s)
--- PASS: TestAccDataProtectionBackupInstanceBlobStorage_requiresImport (347.88s)
--- PASS: TestAccDataProtectionBackupInstanceBlobStorage_update (624.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection        628.362s
```
