### PR TITLE
azurerm_cosmosdb_cassandra_table - correctly update `throughput`

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -179,7 +179,7 @@ func resourceCosmosDbCassandraTableUpdate(d *pluginsdk.ResourceData, meta interf
 		table.CassandraTableCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
 	}
 
-	future, err := client.CreateUpdateCassandraTable(ctx, id.ResourceGroup, id.DatabaseAccountName, id.DatabaseAccountName, id.TableName, table)
+	future, err := client.CreateUpdateCassandraTable(ctx, id.ResourceGroup, id.DatabaseAccountName, id.CassandraKeyspaceName, id.TableName, table)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}


### PR DESCRIPTION

References the issue here:
https://github.com/hashicorp/terraform-provider-azurerm/issues/12630

The parameters in the CreateUpdateCassandraTable method should be id.CassandraKeyspaceName instead of id.DatabaseAccountName.

Else, the module fails when trying to update with the following status message:

```
{"status":"Failed","error":{"code":"NotFound","message":"
Message: {\"code\":\"NotFound\",\"message\":\"Message: 
{\\\"Errors\\\":[\\\"Resource Not Found. Learn more: https:\\\\/\\\\/aka.ms\\\\/cosmosdb-tsg-not-found\\\"]}\\r\\n
```