### PR TITLE
Update charset and collation of azurerm_postgresql_flexible_server_database to optional

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_database_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_database_resource.go
@@ -49,17 +49,19 @@ func resourcePostgresqlFlexibleServerDatabase() *pluginsdk.Resource {
 
 			"charset": {
 				Type:             pluginsdk.TypeString,
-				Required:         true,
+				Optional:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validate.DatabaseCharset,
+				Default:          "UTF8",
 			},
 
 			"collation": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.DatabaseCollation,
+				Default:      "en_US.utf8",
 			},
 		},
 	}

--- a/internal/services/postgres/postgresql_flexible_server_database_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_database_resource_test.go
@@ -62,6 +62,20 @@ func TestAccPostgresqlFlexibleServerDatabase_charsetLowercase(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlFlexibleServerDatabase_withoutCharsetAndCollation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_database", "test")
+	r := PostgresqlFlexibleServerDatabaseResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withoutCharsetAndCollation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (PostgresqlFlexibleServerDatabaseResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FlexibleServerDatabaseID(state.ID)
 	if err != nil {
@@ -111,6 +125,17 @@ resource "azurerm_postgresql_flexible_server_database" "test" {
   server_id = azurerm_postgresql_flexible_server.test.id
   collation = "en_US.UTF8"
   charset   = "UTF8"
+}
+`, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
+}
+
+func (PostgresqlFlexibleServerDatabaseResource) withoutCharsetAndCollation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_database" "test" {
+  name      = "acctest-fsd-%d"
+  server_id = azurerm_postgresql_flexible_server.test.id
 }
 `, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
 }

--- a/website/docs/r/postgresql_flexible_server_database.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_database.html.markdown
@@ -45,10 +45,9 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the Azure PostgreSQL Flexible Server from which to create this PostgreSQL Flexible Server Database. Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
 
-* `charset` - (Required) Specifies the Charset for the Azure PostgreSQL Flexible Server Database, which needs [to be a valid PostgreSQL Charset](https://www.postgresql.org/docs/current/static/multibyte.html). Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
+* `charset` - (Optional) Specifies the Charset for the Azure PostgreSQL Flexible Server Database, which needs [to be a valid PostgreSQL Charset](https://www.postgresql.org/docs/current/static/multibyte.html). Defaults to `UTF8`. Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
 
-
-* `collation` - (Required) Specifies the Collation for the Azure PostgreSQL Flexible Server Database, which needs [to be a valid PostgreSQL Collation](https://www.postgresql.org/docs/current/static/collation.html). Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
+* `collation` - (Optional) Specifies the Collation for the Azure PostgreSQL Flexible Server Database, which needs [to be a valid PostgreSQL Collation](https://www.postgresql.org/docs/current/static/collation.html). Defaults to `en_US.utf8`. Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Service team confirmed there is a change in Postgresql Flexible Server Database. Now the `charset` property and the `collation` property are optional now. So it has to update them in TF accordingly.

--- PASS: TestAccPostgresqlFlexibleServerDatabase_basic (500.55s)
--- PASS: TestAccPostgresqlFlexibleServerDatabase_withoutCharsetAndCollation (515.51s)
--- PASS: TestAccPostgresqlFlexibleServerDatabase_requiresImport (539.15s)
--- PASS: TestAccPostgresqlFlexibleServerDatabase_charsetLowercase (554.46s)