### PR TITLE
datasource `azurerm_app_service_environment_v3` fix missing inbound ip-addresses

### DIFF
--- a/internal/services/web/app_service_environment_v3_data_source.go
+++ b/internal/services/web/app_service_environment_v3_data_source.go
@@ -219,6 +219,8 @@ func (r AppServiceEnvironmentV3DataSource) Read() sdk.ResourceFunc {
 			if props := existingNetwork.AseV3NetworkingConfigurationProperties; props != nil {
 				model.WindowsOutboundIPAddresses = *props.WindowsOutboundIPAddresses
 				model.LinuxOutboundIPAddresses = *props.LinuxOutboundIPAddresses
+				model.InternalInboundIPAddresses = *props.InternalInboundIPAddresses
+				model.ExternalInboundIPAddresses = *props.ExternalInboundIPAddresses
 				model.AllowNewPrivateEndpointConnections = *props.AllowNewPrivateEndpointConnections
 			}
 


### PR DESCRIPTION
This PR fixes the missing attributes `internal_inbound_ip_addresses` and `external_inbound_ip_addresses` on the datasource for `azurerm_app_service_environment_v3`.

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/12450