### PR TITLE
Add appconfig key resource

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -141,7 +141,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		TokenFunc: func(endpoint string) (autorest.Authorizer, error) {
 			authorizer, err := builder.AuthConfig.GetAuthorizationToken(sender, oauthConfig, endpoint)
 			if err != nil {
-				return nil, fmt.Errorf("unable to get authorization token for endpoint %s: %+v", endpoint, err)
+				return nil, fmt.Errorf("getting authorization token for endpoint %s: %+v", endpoint, err)
 			}
 			return authorizer, nil
 		},

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -138,6 +138,13 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		Environment:                 *env,
 		Features:                    builder.Features,
 		StorageUseAzureAD:           builder.StorageUseAzureAD,
+		TokenFunc: func(endpoint string) (autorest.Authorizer, error) {
+			authorizer, err := builder.AuthConfig.GetAuthorizationToken(sender, oauthConfig, endpoint)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get authorization token for endpoint %s: %+v", endpoint, err)
+			}
+			return authorizer, nil
+		},
 	}
 
 	if err := client.Build(ctx, o); err != nil {

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -35,6 +35,9 @@ type ClientOptions struct {
 	Environment                 azure.Environment
 	Features                    features.UserFeatures
 	StorageUseAzureAD           bool
+
+	// Some Dataplane APIs require a token scoped for a specific endpoint
+	TokenFunc func(endpoint string) (autorest.Authorizer, error)
 }
 
 func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.Authorizer) {

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -104,6 +104,7 @@ import (
 func SupportedTypedServices() []sdk.TypedServiceRegistration {
 	return []sdk.TypedServiceRegistration{
 		apimanagement.Registration{},
+		appconfiguration.Registration{},
 		batch.Registration{},
 		eventhub.Registration{},
 		loadbalancer.Registration{},

--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -63,7 +63,6 @@ type Resource interface {
 	IDValidationFunc() pluginsdk.SchemaValidateFunc
 }
 
-// TODO: ResourceWithCustomizeDiff
 // TODO: ResourceWithStateMigration
 // TODO: a generic state migration for updating ID's
 
@@ -100,6 +99,14 @@ type ResourceWithDeprecation interface {
 	DeprecationMessage() string
 }
 
+// ResourceWithCustomizeDiff is an optional interface
+type ResourceWithCustomizeDiff interface {
+	Resource
+
+	// CustomizeDiff returns a ResourceFunc that runs the Custom Diff logic
+	CustomizeDiff() ResourceFunc
+}
+
 // ResourceRunFunc is the function which can be run
 // ctx provides a Context instance with the user-provided timeout
 // metadata is a reference to an object containing the Client, ResourceData and a Logger
@@ -109,6 +116,8 @@ type ResourceFunc struct {
 	// Func is the function which should be called for this Resource Func
 	// for example, during Read this is the Read function, during Update this is the Update function
 	Func ResourceRunFunc
+
+	DiffFunc ResourceRunFunc
 
 	// Timeout is the default timeout, which can be overridden by users
 	// for this method - in-turn used for the Azure API
@@ -126,6 +135,9 @@ type ResourceMetaData struct {
 	// This is used to be able to call operations directly should Encode/Decode be insufficient
 	// for example, to determine if a field has changes
 	ResourceData *schema.ResourceData
+
+	// ResourceDiff is a reference to the ResourceDiff object from Terraform's Plugin SDK
+	ResourceDiff *schema.ResourceDiff
 
 	// serializationDebugLogger is used for testing purposes
 	serializationDebugLogger Logger

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -5,20 +5,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
-
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
-
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyResource struct {
@@ -39,15 +37,17 @@ type KeyResourceModel struct {
 func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"configuration_store_id": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
 		},
 
 		"key": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotWhiteSpace,
 		},
 
 		"content_type": {

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -82,7 +82,7 @@ func (k KeyResource) Attributes() map[string]*schema.Schema {
 }
 
 func (k KeyResource) ModelObject() interface{} {
-	return nil
+	return KeyResourceModel{}
 }
 
 func (k KeyResource) ResourceType() string {
@@ -125,15 +125,14 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 				Tags:        tags.Expand(model.Tags),
 			}
 
-			_, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", "")
-			if err != nil {
+			if _, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", ""); err != nil {
 				return err
 			}
 
 			if model.Locked {
 				_, err = client.PutLock(ctx, model.Key, model.Label, "", "")
 				if err != nil {
-					return fmt.Errorf("while locking key/label pair %s/%s: %+v", model.Key, model.Label, err)
+					return fmt.Errorf("while locking key/label pair %q/%q: %+v", model.Key, model.Label, err)
 				}
 			}
 
@@ -220,21 +219,18 @@ func (k KeyResource) Update() sdk.ResourceFunc {
 					Tags:        tags.Expand(model.Tags),
 				}
 
-				_, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", "")
-				if err != nil {
+				if _, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", ""); err != nil {
 					return fmt.Errorf("while updating key/label pair %s/%s: %+v", model.Key, model.Label, err)
 				}
 			}
 
 			if metadata.ResourceData.HasChange("locked") {
 				if model.Locked {
-					_, err = client.PutLock(ctx, model.Key, model.Label, "", "")
-					if err != nil {
+					if _, err = client.PutLock(ctx, model.Key, model.Label, "", ""); err != nil {
 						return fmt.Errorf("while locking key/label pair %s/%s: %+v", model.Key, model.Label, err)
 					}
 				} else {
-					_, err = client.DeleteLock(ctx, model.Key, model.Label, "", "")
-					if err != nil {
+					if _, err = client.DeleteLock(ctx, model.Key, model.Label, "", ""); err != nil {
 						return fmt.Errorf("while unlocking key/label pair %s/%s: %+v", model.Key, model.Label, err)
 					}
 				}
@@ -260,7 +256,7 @@ func (k KeyResource) Delete() sdk.ResourceFunc {
 
 			_, err = client.DeleteKeyValue(ctx, resourceID.Key, resourceID.Label, "")
 			if err != nil {
-				return fmt.Errorf("while removing key %s from App Configuration store %s: %+v", resourceID.Key, resourceID.ConfigurationStoreId, err)
+				return fmt.Errorf("while removing key %q from App Configuration Store %q: %+v", resourceID.Key, resourceID.ConfigurationStoreId, err)
 			}
 
 			return nil

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -254,6 +254,10 @@ func (k KeyResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
+			if _, err = client.DeleteLock(ctx, resourceID.Key, resourceID.Label, "", ""); err != nil {
+				return fmt.Errorf("while unlocking key/label pair %s/%s: %+v", resourceID.Key, resourceID.Label, err)
+			}
+
 			_, err = client.DeleteKeyValue(ctx, resourceID.Key, resourceID.Label, "")
 			if err != nil {
 				return fmt.Errorf("while removing key %q from App Configuration Store %q: %+v", resourceID.Key, resourceID.ConfigurationStoreId, err)

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -169,10 +169,6 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 			}
 
 			kv := res.Values()[0]
-			var locked bool
-			if kv.Locked != nil {
-				locked = *kv.Locked
-			}
 
 			model := KeyResourceModel{
 				ConfigurationStoreId: resourceID.ConfigurationStoreId,
@@ -180,10 +176,12 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 				ContentType:          utils.NormalizeNilableString(kv.ContentType),
 				Label:                utils.NormalizeNilableString(kv.Label),
 				Value:                utils.NormalizeNilableString(kv.Value),
-				Locked:               locked,
 				Tags:                 tags.Flatten(kv.Tags),
 			}
 
+			if kv.Locked != nil {
+				model.Locked = *kv.Locked
+			}
 			return metadata.Encode(&model)
 		},
 		Timeout: 5 * time.Minute,

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -1,0 +1,274 @@
+package appconfiguration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KeyResource struct {
+}
+
+var _ sdk.Resource = KeyResource{}
+
+type KeyResourceModel struct {
+	ConfigurationStoreId string                 `tfschema:"configuration_store_id"`
+	Key                  string                 `tfschema:"key"`
+	ContentType          string                 `tfschema:"content_type"`
+	Label                string                 `tfschema:"label"`
+	Value                string                 `tfschema:"value"`
+	Locked               bool                   `tfschema:"locked"`
+	Tags                 map[string]interface{} `tfschema:"tags"`
+}
+
+func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"configuration_store_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"key": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"content_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+		"etag": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		"label": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"value": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+		"locked": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"tags": tags.Schema(),
+	}
+}
+
+func (k KeyResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (k KeyResource) ModelObject() interface{} {
+	return nil
+}
+
+func (k KeyResource) ResourceType() string {
+	return "azurerm_app_configuration_key"
+}
+
+func (k KeyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model KeyResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			client, err := metadata.Client.AppConfiguration.DataPlaneClient(ctx, model.ConfigurationStoreId)
+			if err != nil {
+				return err
+			}
+
+			appCfgKeyResourceID := parse.AppConfigurationKeyId{
+				ConfigurationStoreId: model.ConfigurationStoreId,
+				Key:                  model.Key,
+				Label:                model.Label,
+			}
+
+			kv, err := client.GetKeyValues(ctx, model.Key, model.Label, "", "", []string{})
+			if err != nil {
+				return fmt.Errorf("while checking for key's %q existence: %+v", model.Key, err)
+			}
+			keysFound := kv.Values()
+			if len(keysFound) > 0 {
+				return tf.ImportAsExistsError(k.ResourceType(), appCfgKeyResourceID.ID())
+			}
+
+			entity := appconfiguration.KeyValue{
+				Key:         utils.String(model.Key),
+				Label:       utils.String(model.Label),
+				ContentType: utils.String(model.ContentType),
+				Value:       utils.String(model.Value),
+				Tags:        tags.Expand(model.Tags),
+			}
+
+			_, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", "")
+			if err != nil {
+				return err
+			}
+
+			if model.Locked {
+				_, err = client.PutLock(ctx, model.Key, model.Label, "", "")
+				if err != nil {
+					return fmt.Errorf("while locking key/label pair %s/%s: %+v", model.Key, model.Label, err)
+				}
+			}
+
+			metadata.SetID(appCfgKeyResourceID)
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (k KeyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			resourceID, err := parse.AppConfigurationKeyID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			client, err := metadata.Client.AppConfiguration.DataPlaneClient(ctx, resourceID.ConfigurationStoreId)
+			if err != nil {
+				return err
+			}
+
+			res, err := client.GetKeyValues(ctx, resourceID.Key, resourceID.Label, "", "", []string{})
+			if err != nil {
+				if !utils.ResponseWasNotFound(res.Response().Response) {
+					return metadata.MarkAsGone(resourceID)
+				}
+				return fmt.Errorf("while checking for key's %q existence: %+v", resourceID.Key, err)
+			}
+
+			if len(res.Values()) > 1 {
+				return fmt.Errorf("unexpected API response. More than one value returne for Key/Label pair %s/%s", resourceID.Key, resourceID.Label)
+			}
+
+			kv := res.Values()[0]
+			var locked bool
+			if kv.Locked != nil {
+				locked = *kv.Locked
+			}
+
+			model := KeyResourceModel{
+				ConfigurationStoreId: resourceID.ConfigurationStoreId,
+				Key:                  utils.NormalizeNilableString(kv.Key),
+				ContentType:          utils.NormalizeNilableString(kv.ContentType),
+				Label:                utils.NormalizeNilableString(kv.Label),
+				Value:                utils.NormalizeNilableString(kv.Value),
+				Locked:               locked,
+				Tags:                 tags.Flatten(kv.Tags),
+			}
+
+			return metadata.Encode(&model)
+		},
+		Timeout: 5 * time.Minute,
+	}
+}
+
+func (k KeyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+
+			resourceID, err := parse.AppConfigurationKeyID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			client, err := metadata.Client.AppConfiguration.DataPlaneClient(ctx, resourceID.ConfigurationStoreId)
+			if err != nil {
+				return err
+			}
+
+			var model KeyResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			if metadata.ResourceData.HasChange("value") || metadata.ResourceData.HasChange("content_type") || metadata.ResourceData.HasChange("tags") {
+
+				entity := appconfiguration.KeyValue{
+					Key:         utils.String(model.Key),
+					Label:       utils.String(model.Label),
+					ContentType: utils.String(model.ContentType),
+					Value:       utils.String(model.Value),
+					Tags:        tags.Expand(model.Tags),
+				}
+
+				_, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", "")
+				if err != nil {
+					return fmt.Errorf("while updating key/label pair %s/%s: %+v", model.Key, model.Label, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("locked") {
+				if model.Locked {
+					_, err = client.PutLock(ctx, model.Key, model.Label, "", "")
+					if err != nil {
+						return fmt.Errorf("while locking key/label pair %s/%s: %+v", model.Key, model.Label, err)
+					}
+				} else {
+					_, err = client.DeleteLock(ctx, model.Key, model.Label, "", "")
+					if err != nil {
+						return fmt.Errorf("while unlocking key/label pair %s/%s: %+v", model.Key, model.Label, err)
+					}
+				}
+			}
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (k KeyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			resourceID, err := parse.AppConfigurationKeyID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			client, err := metadata.Client.AppConfiguration.DataPlaneClient(ctx, resourceID.ConfigurationStoreId)
+			if err != nil {
+				return err
+			}
+
+			_, err = client.DeleteKeyValue(ctx, resourceID.Key, resourceID.Label, "")
+			if err != nil {
+				return fmt.Errorf("while removing key %s from App Configuration store %s: %+v", resourceID.Key, resourceID.ConfigurationStoreId, err)
+			}
+
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (k KeyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.AppConfigurationKeyID
+}

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -166,7 +166,7 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 			}
 
 			if len(res.Values()) > 1 {
-				return fmt.Errorf("unexpected API response. More than one value returne for Key/Label pair %s/%s", resourceID.Key, resourceID.Label)
+				return fmt.Errorf("unexpected API response. More than one value returned for Key/Label pair %s/%s", resourceID.Key, resourceID.Label)
 			}
 
 			kv := res.Values()[0]

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -16,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
@@ -77,8 +75,8 @@ func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (k KeyResource) Attributes() map[string]*schema.Schema {
-	return map[string]*schema.Schema{}
+func (k KeyResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
 }
 
 func (k KeyResource) ModelObject() interface{} {

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -85,9 +85,10 @@ func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 		"type": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  "kv",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      "kv",
+			ValidateFunc: validation.StringInSlice([]string{KeyTypeVault, KeyTypeKV}, false),
 		},
 		"vault_key_reference": {
 			Type:         pluginsdk.TypeString,

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -1,0 +1,85 @@
+package appconfiguration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type AppConfigurationKeyResource struct {
+}
+
+func TestAccAppConfigurationKey_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
+	r := AppConfigurationKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t AppConfigurationKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+
+	resourceID, err := parse.AppConfigurationKeyID(state.ID)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing resource ID: %+v", err)
+	}
+
+	client, err := clients.AppConfiguration.DataPlaneClient(ctx, resourceID.ConfigurationStoreId)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.GetKeyValues(ctx, resourceID.Key, resourceID.Label, "", "", []string{})
+	if err != nil {
+		return nil, fmt.Errorf("while checking for key's %q existence: %+v", resourceID.Key, err)
+	}
+
+	return utils.Bool(res.Response().StatusCode == 200), nil
+}
+
+func (t AppConfigurationKeyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appconfig-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_configuration" "test" {
+  name                = "testacc-appconf%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "free"
+}
+
+resource "azurerm_app_configuration_key" "test" {
+   configuration_store_id = azurerm_app_configuration.test.id
+   key = "acctest-ackey-%d"
+   content_type = "test"
+   label = "acctest-ackeylabel-%d"
+   value = "a test"
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -73,11 +73,11 @@ resource "azurerm_app_configuration" "test" {
 }
 
 resource "azurerm_app_configuration_key" "test" {
-   configuration_store_id = azurerm_app_configuration.test.id
-   key = "acctest-ackey-%d"
-   content_type = "test"
-   label = "acctest-ackeylabel-%d"
-   value = "a test"
+  configuration_store_id = azurerm_app_configuration.test.id
+  key                    = "acctest-ackey-%d"
+  content_type           = "test"
+  label                  = "acctest-ackeylabel-%d"
+  value                  = "a test"
 }
 
 

--- a/internal/services/appconfiguration/client/client.go
+++ b/internal/services/appconfiguration/client/client.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/2020-06-01/configurationstores"
-
 	"github.com/Azure/go-autorest/autorest"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/2020-06-01/configurationstores"
 )
 
 type Client struct {
@@ -35,12 +34,12 @@ func (c Client) DataPlaneClient(ctx context.Context, configurationStoreId string
 		return nil, fmt.Errorf("endpoint was nil")
 	}
 
-	appConfigAuth, err := c.tokenFunc(*appConfig.Model.Properties.Endpoint)
+	endpoint := *appConfig.Model.Properties.Endpoint
+	appConfigAuth, err := c.tokenFunc(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("obtaining auth token for %q: %+v", endpoint, err)
 	}
 
-	endpoint := *appConfig.Model.Properties.Endpoint
 	client := appconfiguration.NewWithoutDefaults("", endpoint)
 	c.configureClientFunc(&client.Client, appConfigAuth)
 	return &client, nil

--- a/internal/services/appconfiguration/client/client.go
+++ b/internal/services/appconfiguration/client/client.go
@@ -37,7 +37,7 @@ func (c Client) DataPlaneClient(ctx context.Context, configurationStoreId string
 
 	appConfigAuth, err := c.tokenFunc(*appConfig.Model.Properties.Endpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("obtaining auth token for %q: %+v", endpoint, err)
 	}
 
 	endpoint := *appConfig.Model.Properties.Endpoint

--- a/internal/services/appconfiguration/client/client.go
+++ b/internal/services/appconfiguration/client/client.go
@@ -1,12 +1,49 @@
 package client
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/2020-06-01/configurationstores"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
 )
 
 type Client struct {
 	ConfigurationStoresClient *configurationstores.ConfigurationStoresClient
+	tokenFunc                 func(endpoint string) (autorest.Authorizer, error)
+	configureClientFunc       func(c *autorest.Client, authorizer autorest.Authorizer)
+}
+
+func (c Client) DataPlaneClient(ctx context.Context, configurationStoreId string) (*appconfiguration.BaseClient, error) {
+	appConfigId, err := configurationstores.ParseConfigurationStoreID(configurationStoreId)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: caching all of this
+	appConfig, err := c.ConfigurationStoresClient.Get(ctx, *appConfigId)
+	if err != nil {
+		// TODO: if not found etc
+		return nil, err
+	}
+
+	if appConfig.Model == nil || appConfig.Model.Properties == nil || appConfig.Model.Properties.Endpoint == nil {
+		return nil, fmt.Errorf("endpoint was nil")
+	}
+
+	appConfigAuth, err := c.tokenFunc(*appConfig.Model.Properties.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := *appConfig.Model.Properties.Endpoint
+	client := appconfiguration.NewWithoutDefaults("", endpoint)
+	c.configureClientFunc(&client.Client, appConfigAuth)
+	return &client, nil
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -15,5 +52,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		ConfigurationStoresClient: &configurationStores,
+		tokenFunc:                 o.TokenFunc,
+		configureClientFunc:       o.ConfigureClient,
 	}
 }

--- a/internal/services/appconfiguration/parse/app_configuration_key.go
+++ b/internal/services/appconfiguration/parse/app_configuration_key.go
@@ -1,0 +1,37 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type AppConfigurationKeyId struct {
+	ConfigurationStoreId string
+	Key                  string
+	Label                string
+}
+
+func (k AppConfigurationKeyId) ID() string {
+	return fmt.Sprintf("%s/AppConfigurationKey/%s/Label/%s", k.ConfigurationStoreId, k.Key, k.Label)
+}
+
+func AppConfigurationKeyID(input string) (*AppConfigurationKeyId, error) {
+
+	resourceID, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing resource ID: %+v", err)
+	}
+
+	keyName := resourceID.Path["AppConfigurationKey"]
+	label := resourceID.Path["Label"]
+	cfgStoreId := strings.TrimSuffix(input, fmt.Sprintf("/AppConfigurationKey/%s/Label/%s", keyName, label))
+	appcfgID := AppConfigurationKeyId{
+		ConfigurationStoreId: cfgStoreId,
+		Key:                  keyName,
+		Label:                label,
+	}
+
+	return &appcfgID, nil
+}

--- a/internal/services/appconfiguration/registration.go
+++ b/internal/services/appconfiguration/registration.go
@@ -1,10 +1,24 @@
 package appconfiguration
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 type Registration struct{}
+
+var _ sdk.TypedServiceRegistration = Registration{}
+var _ sdk.UntypedServiceRegistration = Registration{}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		KeyResource{},
+	}
+}
 
 // Name is the name of this Service
 func (r Registration) Name() string {

--- a/internal/services/appconfiguration/validate/app_configuration_key_id.go
+++ b/internal/services/appconfiguration/validate/app_configuration_key_id.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
+)
+
+func AppConfigurationKeyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.AppConfigurationKeyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an Azure App Configuration Key.
 
-## Example Usage
+## Example Usage of `kv` type
 
 ```hcl
 resource "azurerm_resource_group" "rg" {
@@ -31,6 +31,63 @@ resource "azurerm_app_configuration_key" "test" {
   label                  = "somelabel"
   value                  = "a test"
 }
+```
+
+## Example Usage of `vault` type
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_app_configuration" "appconf" {
+  name                = "appConf1"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "kv" {
+  name                       = "kv"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "create",
+      "get",
+    ]
+
+    secret_permissions = [
+      "set",
+      "get",
+      "delete",
+      "purge",
+      "recover"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "kvs" {
+  name         = "kvs"
+  value        = "szechuan"
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+resource "azurerm_app_configuration_key" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  key                    = "key1"
+  type                   = "vault"
+  label                  = "label1"
+  vault_key_reference    = azurerm_key_vault_secret.kvs.id
+}
 
 ```
 
@@ -42,13 +99,17 @@ The following arguments are supported:
 
 * `key` - (Required) The name of the App Configuration Key to create. Changing this forces a new resource to be created.
 
-* `content_type` - (Optional) The content type of the App Configuration Key.
+* `content_type` - (Optional) The content type of the App Configuration Key. This should only be set when type is set to `kv`.
 
 * `label` - (Optional) The label of the App Configuration Key.  Changing this forces a new resource to be created.
 
-* `value` - (Optional) The value of the App Configuration Key.
+* `value` - (Optional) The value of the App Configuration Key. This should only be set when type is set to `kv`.
 
 * `locked` - (Optional) Should this App Configuration Key be Locked to prevent changes?
+
+* `type` - (Optional) The type of the App Configuration Key. It can either be `kv` (simple [key/value](https://docs.microsoft.com/en-us/azure/azure-app-configuration/concept-key-value)) or `vault` (where the value is a reference to a [Key Vault Secret](https://azure.microsoft.com/en-gb/services/key-vault/). 
+
+* `vault_key_reference` - (Optional) The ID of the vault secret this App Configuration Key refers to, when `type` is set to `vault`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "App Configuration"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_configuration"
+description: |-
+  Manages an Azure App Configuration.
+
+---
+
+# azurerm_app_configuration_key
+
+Manages an Azure App Configuration Key.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_app_configuration" "appconf" {
+  name                = "appConf1"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+}
+
+resource "azurerm_app_configuration_key" "test" {
+   configuration_store_id = azurerm_app_configuration.appconf.id
+   key = "appConfKey1"
+   label = "somelabel"
+   value = "a test"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `configuration_store_id` - (Required) Specifies the id of the App Configuration. Changing this forces a new resource to be created.
+
+* `key` - (Required) The name of the key to create. Changing this forces a new resource to be created.
+
+* `content_type` - (Optional) The content type of the key.
+
+* `label` - (Optional) The label of the key.  Changing this forces a new resource to be created.
+
+* `value` - (Optional) The value of the key.
+
+* `locked` - (Optional) The lock status of the key. Can be either `true` or `false`.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The App Configuration Key ID.
+
+* `etag` - The ETag of the key.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the App Configuration.
+* `update` - (Defaults to 30 minutes) Used when updating the App Configuration.
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Configuration.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Configuration.
+
+## Import
+
+App Configuration Keys can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_configuration_key.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/appConfKey1/Label/someLabel
+```

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -26,10 +26,10 @@ resource "azurerm_app_configuration" "appconf" {
 }
 
 resource "azurerm_app_configuration_key" "test" {
-   configuration_store_id = azurerm_app_configuration.appconf.id
-   key = "appConfKey1"
-   label = "somelabel"
-   value = "a test"
+  configuration_store_id = azurerm_app_configuration.appconf.id
+  key                    = "appConfKey1"
+  label                  = "somelabel"
+  value                  = "a test"
 }
 
 ```

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `value` - (Optional) The value of the App Configuration Key.
 
-* `locked` - (Optional) The lock status of the App Configuration Key. Can be either `true` or `false`.
+* `locked` - (Optional) Should this App Configuration Key be Locked to prevent changes?
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -1,9 +1,9 @@
 ---
 subcategory: "App Configuration"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_app_configuration"
+page_title: "Azure Resource Manager: azurerm_app_configuration_key"
 description: |-
-  Manages an Azure App Configuration.
+  Manages an Azure App Configuration Key.
 
 ---
 
@@ -40,15 +40,15 @@ The following arguments are supported:
 
 * `configuration_store_id` - (Required) Specifies the id of the App Configuration. Changing this forces a new resource to be created.
 
-* `key` - (Required) The name of the key to create. Changing this forces a new resource to be created.
+* `key` - (Required) The name of the App Configuration Key to create. Changing this forces a new resource to be created.
 
-* `content_type` - (Optional) The content type of the key.
+* `content_type` - (Optional) The content type of the App Configuration Key.
 
-* `label` - (Optional) The label of the key.  Changing this forces a new resource to be created.
+* `label` - (Optional) The label of the App Configuration Key.  Changing this forces a new resource to be created.
 
-* `value` - (Optional) The value of the key.
+* `value` - (Optional) The value of the App Configuration Key.
 
-* `locked` - (Optional) The lock status of the key. Can be either `true` or `false`.
+* `locked` - (Optional) The lock status of the App Configuration Key. Can be either `true` or `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -65,7 +65,7 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the App Configuration.
+* `create` - (Defaults to 30 minutes) Used when creating the App Configuration Key.
 * `update` - (Defaults to 30 minutes) Used when updating the App Configuration.
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Configuration.
 * `delete` - (Defaults to 30 minutes) Used when deleting the App Configuration.

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -66,14 +66,14 @@ The following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Configuration Key.
-* `update` - (Defaults to 30 minutes) Used when updating the App Configuration.
-* `read` - (Defaults to 5 minutes) Used when retrieving the App Configuration.
-* `delete` - (Defaults to 30 minutes) Used when deleting the App Configuration.
+* `update` - (Defaults to 30 minutes) Used when updating the App Configuration Key.
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Configuration Key.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Configuration Key.
 
 ## Import
 
 App Configuration Keys can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_configuration_key.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/appConfKey1/Label/someLabel
+terraform import azurerm_app_configuration_key.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/appConfKey1/Label/label1
 ```


### PR DESCRIPTION
This PR introduces a new resource, azurerm_appconfiguration_key, that is used to manage key/label pairs in an Application Configuration.