### PR TITLE
New resource: azurerm_logic_app_integration_account_partner

### DIFF
--- a/internal/services/logic/client/client.go
+++ b/internal/services/logic/client/client.go
@@ -8,6 +8,7 @@ import (
 type Client struct {
 	IntegrationAccountClient            *logic.IntegrationAccountsClient
 	IntegrationAccountCertificateClient *logic.IntegrationAccountCertificatesClient
+	IntegrationAccountPartnerClient     *logic.IntegrationAccountPartnersClient
 	IntegrationAccountSchemaClient      *logic.IntegrationAccountSchemasClient
 	IntegrationAccountSessionClient     *logic.IntegrationAccountSessionsClient
 	IntegrationServiceEnvironmentClient *logic.IntegrationServiceEnvironmentsClient
@@ -21,6 +22,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	integrationAccountCertificateClient := logic.NewIntegrationAccountCertificatesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&integrationAccountCertificateClient.Client, o.ResourceManagerAuthorizer)
+
+	integrationAccountPartnerClient := logic.NewIntegrationAccountPartnersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&integrationAccountPartnerClient.Client, o.ResourceManagerAuthorizer)
 
 	integrationAccountSchemaClient := logic.NewIntegrationAccountSchemasClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&integrationAccountSchemaClient.Client, o.ResourceManagerAuthorizer)
@@ -40,6 +44,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	return &Client{
 		IntegrationAccountClient:            &integrationAccountClient,
 		IntegrationAccountCertificateClient: &integrationAccountCertificateClient,
+		IntegrationAccountPartnerClient:     &integrationAccountPartnerClient,
 		IntegrationAccountSchemaClient:      &integrationAccountSchemaClient,
 		IntegrationAccountSessionClient:     &integrationAccountSessionClient,
 		IntegrationServiceEnvironmentClient: &integrationServiceEnvironmentClient,

--- a/internal/services/logic/logic_app_integration_account_partner_resource.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource.go
@@ -59,13 +59,15 @@ func resourceLogicAppIntegrationAccountPartner() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"qualifier": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"value": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validate.IntegrationAccountPartnerBusinessIdentityValue(),
 						},
 					},
 				},

--- a/internal/services/logic/logic_app_integration_account_partner_resource.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource.go
@@ -1,0 +1,225 @@
+package logic
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceLogicAppIntegrationAccountPartner() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceLogicAppIntegrationAccountPartnerCreateUpdate,
+		Read:   resourceLogicAppIntegrationAccountPartnerRead,
+		Update: resourceLogicAppIntegrationAccountPartnerCreateUpdate,
+		Delete: resourceLogicAppIntegrationAccountPartnerDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.IntegrationAccountPartnerID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.IntegrationAccountPartnerName(),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"integration_account_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.IntegrationAccountName(),
+			},
+
+			"business_identity": {
+				Type:     pluginsdk.TypeSet,
+				Required: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"qualifier": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+						},
+
+						"value": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"metadata": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+			},
+		},
+	}
+}
+
+func resourceLogicAppIntegrationAccountPartnerCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Logic.IntegrationAccountPartnerClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewIntegrationAccountPartnerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("integration_account_name").(string), d.Get("name").(string))
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_logic_app_integration_account_partner", id.ID())
+		}
+	}
+
+	parameters := logic.IntegrationAccountPartner{
+		IntegrationAccountPartnerProperties: &logic.IntegrationAccountPartnerProperties{
+			Content: &logic.PartnerContent{
+				B2b: &logic.B2BPartnerContent{
+					BusinessIdentities: expandIntegrationAccountPartnerBusinessIdentity(d.Get("business_identity").(*pluginsdk.Set).List()),
+				},
+			},
+			PartnerType: logic.PartnerTypeB2B,
+		},
+	}
+
+	if v, ok := d.GetOk("metadata"); ok {
+		metadata, _ := pluginsdk.ExpandJsonFromString(v.(string))
+		parameters.IntegrationAccountPartnerProperties.Metadata = metadata
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName, parameters); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceLogicAppIntegrationAccountPartnerRead(d, meta)
+}
+
+func resourceLogicAppIntegrationAccountPartnerRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Logic.IntegrationAccountPartnerClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.IntegrationAccountPartnerID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] %s was not found - removing from state", *id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("name", id.PartnerName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("integration_account_name", id.IntegrationAccountName)
+
+	if props := resp.IntegrationAccountPartnerProperties; props != nil {
+		if props.Content != nil && props.Content.B2b != nil && props.Content.B2b.BusinessIdentities != nil {
+			if err := d.Set("business_identity", flattenIntegrationAccountPartnerBusinessIdentity(props.Content.B2b.BusinessIdentities)); err != nil {
+				return fmt.Errorf("setting `business_identity`: %+v", err)
+			}
+		}
+
+		if props.Metadata != nil {
+			metadataValue := props.Metadata.(map[string]interface{})
+			metadataStr, _ := pluginsdk.FlattenJsonToString(metadataValue)
+			d.Set("metadata", metadataStr)
+		}
+	}
+
+	return nil
+}
+
+func resourceLogicAppIntegrationAccountPartnerDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Logic.IntegrationAccountPartnerClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.IntegrationAccountPartnerID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return nil
+}
+
+func expandIntegrationAccountPartnerBusinessIdentity(input []interface{}) *[]logic.BusinessIdentity {
+	results := make([]logic.BusinessIdentity, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+
+		results = append(results, logic.BusinessIdentity{
+			Qualifier: utils.String(v["qualifier"].(string)),
+			Value:     utils.String(v["value"].(string)),
+		})
+	}
+
+	return &results
+}
+
+func flattenIntegrationAccountPartnerBusinessIdentity(input *[]logic.BusinessIdentity) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		var qualifier string
+		if item.Qualifier != nil {
+			qualifier = *item.Qualifier
+		}
+
+		var value string
+		if item.Value != nil {
+			value = *item.Value
+		}
+
+		results = append(results, map[string]interface{}{
+			"qualifier": qualifier,
+			"value":     value,
+		})
+	}
+
+	return results
+}

--- a/internal/services/logic/logic_app_integration_account_partner_resource.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource.go
@@ -61,7 +61,7 @@ func resourceLogicAppIntegrationAccountPartner() *pluginsdk.Resource {
 						"qualifier": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							ValidateFunc: validate.IntegrationAccountPartnerBusinessIdentityQualifier(),
 						},
 
 						"value": {

--- a/internal/services/logic/logic_app_integration_account_partner_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource_test.go
@@ -52,7 +52,7 @@ func TestAccLogicAppIntegrationAccountPartner_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.complete(data, "ZZ", "AA", "bar"),
+			Config: r.complete(data, "DUNS", "FabrikamNY", "bar"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -67,14 +67,14 @@ func TestAccLogicAppIntegrationAccountPartner_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.complete(data, "ZZ", "AA", "bar"),
+			Config: r.complete(data, "DUNS", "FabrikamNY", "bar"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data, "XX", "GG", "bar2"),
+			Config: r.complete(data, "AS2Identity", "FabrikamDC", "bar2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -130,8 +130,8 @@ resource "azurerm_logic_app_integration_account_partner" "test" {
   integration_account_name = azurerm_logic_app_integration_account.test.name
 
   business_identity {
-    qualifier = "ZZ"
-    value     = "AA"
+    qualifier = "DUNS"
+    value     = "FabrikamNY"
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -147,8 +147,8 @@ resource "azurerm_logic_app_integration_account_partner" "import" {
   integration_account_name = azurerm_logic_app_integration_account_partner.test.integration_account_name
 
   business_identity {
-    qualifier = "ZZ"
-    value     = "AA"
+    qualifier = "DUNS"
+    value     = "FabrikamNY"
   }
 }
 `, r.basic(data))

--- a/internal/services/logic/logic_app_integration_account_partner_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource_test.go
@@ -1,0 +1,178 @@
+package logic_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type LogicAppIntegrationAccountPartnerResource struct{}
+
+func TestAccLogicAppIntegrationAccountPartner_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_partner", "test")
+	r := LogicAppIntegrationAccountPartnerResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountPartner_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_partner", "test")
+	r := LogicAppIntegrationAccountPartnerResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountPartner_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_partner", "test")
+	r := LogicAppIntegrationAccountPartnerResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data, "ZZ", "AA", "bar"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppIntegrationAccountPartner_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_partner", "test")
+	r := LogicAppIntegrationAccountPartnerResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data, "ZZ", "AA", "bar"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data, "XX", "GG", "bar2"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LogicAppIntegrationAccountPartnerResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.IntegrationAccountPartnerID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Logic.IntegrationAccountPartnerClient.Get(ctx, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %q %+v", id, err)
+	}
+
+	return utils.Bool(resp.IntegrationAccountPartnerProperties != nil), nil
+}
+
+func (r LogicAppIntegrationAccountPartnerResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-logic-%d"
+  location = "%s"
+}
+
+resource "azurerm_logic_app_integration_account" "test" {
+  name                = "acctest-ia-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountPartnerResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_partner" "test" {
+  name                     = "acctest-iap-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+
+  business_identity {
+    qualifier = "ZZ"
+    value     = "AA"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountPartnerResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_partner" "import" {
+  name                     = azurerm_logic_app_integration_account_partner.test.name
+  resource_group_name      = azurerm_logic_app_integration_account_partner.test.resource_group_name
+  integration_account_name = azurerm_logic_app_integration_account_partner.test.integration_account_name
+
+  business_identity {
+    qualifier = "ZZ"
+    value     = "AA"
+  }
+}
+`, r.basic(data))
+}
+
+func (r LogicAppIntegrationAccountPartnerResource) complete(data acceptance.TestData, qualifier string, value string, metdataContent string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_partner" "test" {
+  name                     = "acctest-iap-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+
+  business_identity {
+    qualifier = "%s"
+    value     = "%s"
+  }
+
+  metadata = <<METADATA
+    {
+        "foo": "%s"
+    }
+METADATA
+}
+`, r.template(data), data.RandomInteger, qualifier, value, metdataContent)
+}

--- a/internal/services/logic/parse/integration_account_partner.go
+++ b/internal/services/logic/parse/integration_account_partner.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type IntegrationAccountPartnerId struct {
+	SubscriptionId         string
+	ResourceGroup          string
+	IntegrationAccountName string
+	PartnerName            string
+}
+
+func NewIntegrationAccountPartnerID(subscriptionId, resourceGroup, integrationAccountName, partnerName string) IntegrationAccountPartnerId {
+	return IntegrationAccountPartnerId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroup:          resourceGroup,
+		IntegrationAccountName: integrationAccountName,
+		PartnerName:            partnerName,
+	}
+}
+
+func (id IntegrationAccountPartnerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Partner Name %q", id.PartnerName),
+		fmt.Sprintf("Integration Account Name %q", id.IntegrationAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Integration Account Partner", segmentsStr)
+}
+
+func (id IntegrationAccountPartnerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Logic/integrationAccounts/%s/partners/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.IntegrationAccountName, id.PartnerName)
+}
+
+// IntegrationAccountPartnerID parses a IntegrationAccountPartner ID into an IntegrationAccountPartnerId struct
+func IntegrationAccountPartnerID(input string) (*IntegrationAccountPartnerId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := IntegrationAccountPartnerId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.IntegrationAccountName, err = id.PopSegment("integrationAccounts"); err != nil {
+		return nil, err
+	}
+	if resourceId.PartnerName, err = id.PopSegment("partners"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/logic/parse/integration_account_partner_test.go
+++ b/internal/services/logic/parse/integration_account_partner_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = IntegrationAccountPartnerId{}
+
+func TestIntegrationAccountPartnerIDFormatter(t *testing.T) {
+	actual := NewIntegrationAccountPartnerID("12345678-1234-9876-4563-123456789012", "group1", "account1", "partner1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/partner1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestIntegrationAccountPartnerID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *IntegrationAccountPartnerId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/",
+			Error: true,
+		},
+
+		{
+			// missing value for IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/",
+			Error: true,
+		},
+
+		{
+			// missing PartnerName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/",
+			Error: true,
+		},
+
+		{
+			// missing value for PartnerName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/partner1",
+			Expected: &IntegrationAccountPartnerId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "group1",
+				IntegrationAccountName: "account1",
+				PartnerName:            "partner1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.LOGIC/INTEGRATIONACCOUNTS/ACCOUNT1/PARTNERS/PARTNER1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := IntegrationAccountPartnerID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.IntegrationAccountName != v.Expected.IntegrationAccountName {
+			t.Fatalf("Expected %q but got %q for IntegrationAccountName", v.Expected.IntegrationAccountName, actual.IntegrationAccountName)
+		}
+		if actual.PartnerName != v.Expected.PartnerName {
+			t.Fatalf("Expected %q but got %q for PartnerName", v.Expected.PartnerName, actual.PartnerName)
+		}
+	}
+}

--- a/internal/services/logic/registration.go
+++ b/internal/services/logic/registration.go
@@ -33,6 +33,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_logic_app_action_http":                     resourceLogicAppActionHTTP(),
 		"azurerm_logic_app_integration_account":             resourceLogicAppIntegrationAccount(),
 		"azurerm_logic_app_integration_account_certificate": resourceLogicAppIntegrationAccountCertificate(),
+		"azurerm_logic_app_integration_account_partner":     resourceLogicAppIntegrationAccountPartner(),
 		"azurerm_logic_app_integration_account_schema":      resourceLogicAppIntegrationAccountSchema(),
 		"azurerm_logic_app_integration_account_session":     resourceLogicAppIntegrationAccountSession(),
 		"azurerm_logic_app_trigger_custom":                  resourceLogicAppTriggerCustom(),

--- a/internal/services/logic/resourceids.go
+++ b/internal/services/logic/resourceids.go
@@ -2,6 +2,7 @@ package logic
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccount -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccountCertificate -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/certificates/certificate1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccountPartner -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/partner1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccountSchema -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/integrationAccount1/schemas/schema1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationAccountSession -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/integrationAccount1/sessions/session1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=IntegrationServiceEnvironment -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationServiceEnvironments/ise1

--- a/internal/services/logic/validate/integration_account_partner_business_identity_qualifier.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_qualifier.go
@@ -1,0 +1,25 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func IntegrationAccountPartnerBusinessIdentityQualifier() pluginsdk.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+			return
+		}
+
+		if !regexp.MustCompile(`^[A-Za-z0-9]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters and numbers", k))
+			return
+		}
+
+		return
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_business_identity_qualifier_test.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_qualifier_test.go
@@ -1,0 +1,45 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestIntegrationAccountPartnerBusinessIdentityQualifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "test01",
+			valid: true,
+		},
+		{
+			input: "test",
+			valid: true,
+		},
+		{
+			input: "1",
+			valid: true,
+		},
+		{
+			input: "a@b",
+			valid: false,
+		},
+	}
+
+	validationFunction := IntegrationAccountPartnerBusinessIdentityQualifier()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validationFunction(tt.input, "")
+			valid := err == nil
+			if valid != tt.valid {
+				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.input)
+			}
+		})
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_business_identity_value.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_value.go
@@ -21,7 +21,7 @@ func IntegrationAccountPartnerBusinessIdentityValue() pluginsdk.SchemaValidateFu
 		}
 
 		if !regexp.MustCompile(`^[A-Za-z0-9-() .]+$`).MatchString(v) {
-			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens.", k))
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens", k))
 			return
 		}
 

--- a/internal/services/logic/validate/integration_account_partner_business_identity_value.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_value.go
@@ -1,0 +1,30 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func IntegrationAccountPartnerBusinessIdentityValue() pluginsdk.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+			return
+		}
+
+		if len(v) > 128 {
+			errors = append(errors, fmt.Errorf("length should be equal to or less than %d, got %q", 128, v))
+			return
+		}
+
+		if !regexp.MustCompile(`^[A-Za-z0-9-() .]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens.", k))
+			return
+		}
+
+		return
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_business_identity_value_test.go
+++ b/internal/services/logic/validate/integration_account_partner_business_identity_value_test.go
@@ -1,0 +1,58 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIntegrationAccountPartnerBusinessIdentityValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "test1",
+			valid: true,
+		},
+		{
+			input: "a2-.()b",
+			valid: true,
+		},
+		{
+			input: "a2&b",
+			valid: false,
+		},
+		{
+			input: "a b",
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 127),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 128),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 129),
+			valid: false,
+		},
+	}
+
+	validationFunction := IntegrationAccountPartnerBusinessIdentityValue()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validationFunction(tt.input, "")
+			valid := err == nil
+			if valid != tt.valid {
+				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.input)
+			}
+		})
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_id.go
+++ b/internal/services/logic/validate/integration_account_partner_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
+)
+
+func IntegrationAccountPartnerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.IntegrationAccountPartnerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/logic/validate/integration_account_partner_id_test.go
+++ b/internal/services/logic/validate/integration_account_partner_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestIntegrationAccountPartnerID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IntegrationAccountName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/",
+			Valid: false,
+		},
+
+		{
+			// missing PartnerName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PartnerName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/partner1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.LOGIC/INTEGRATIONACCOUNTS/ACCOUNT1/PARTNERS/PARTNER1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := IntegrationAccountPartnerID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_name.go
+++ b/internal/services/logic/validate/integration_account_partner_name.go
@@ -1,0 +1,30 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func IntegrationAccountPartnerName() pluginsdk.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+			return
+		}
+
+		if len(v) > 80 {
+			errors = append(errors, fmt.Errorf("length should be equal to or less than %d, got %q", 80, v))
+			return
+		}
+
+		if !regexp.MustCompile(`^[A-Za-z0-9-().]+$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("%q contains only letters, numbers, dots, parentheses and hyphens.", k))
+			return
+		}
+
+		return
+	}
+}

--- a/internal/services/logic/validate/integration_account_partner_name_test.go
+++ b/internal/services/logic/validate/integration_account_partner_name_test.go
@@ -1,0 +1,54 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIntegrationAccountPartnerName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "test1",
+			valid: true,
+		},
+		{
+			input: "a2-.()b",
+			valid: true,
+		},
+		{
+			input: "a2&b",
+			valid: false,
+		},
+		{
+			input: strings.Repeat("s", 79),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 80),
+			valid: true,
+		},
+		{
+			input: strings.Repeat("s", 81),
+			valid: false,
+		},
+	}
+
+	validationFunction := IntegrationAccountPartnerName()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validationFunction(tt.input, "")
+			valid := err == nil
+			if valid != tt.valid {
+				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.input)
+			}
+		})
+	}
+}

--- a/website/docs/r/logic_app_integration_account_partner.html.markdown
+++ b/website/docs/r/logic_app_integration_account_partner.html.markdown
@@ -1,0 +1,83 @@
+---
+subcategory: "Logic App"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_logic_app_integration_account_partner"
+description: |-
+  Manages a Logic App Integration Account Partner.
+---
+
+# azurerm_logic_app_integration_account_partner
+
+Manages a Logic App Integration Account Partner.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_logic_app_integration_account" "example" {
+  name                = "example-ia"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard"
+}
+
+resource "azurerm_logic_app_integration_account_partner" "example" {
+  name                     = "example-iap"
+  resource_group_name      = azurerm_resource_group.example.name
+  integration_account_name = azurerm_logic_app_integration_account.example.name
+
+  business_identity {
+    qualifier = "ZZ"
+    value     = "AA"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Logic App Integration Account Partner. Changing this forces a new Logic App Integration Account Partner to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Logic App Integration Account Partner should exist. Changing this forces a new Logic App Integration Account Partner to be created.
+
+* `integration_account_name` - (Required) The name of the Logic App Integration Account. Changing this forces a new Logic App Integration Account Partner to be created.
+
+* `business_identity` - (Optional) A `business_identity` block as documented below.
+
+* `metadata` - (Optional) A JSON mapping of any Metadata for this Logic App Integration Account Partner.
+
+---
+
+A `business_identity` block exports the following:
+
+* `qualifier` - (Required) The business identity qualifier for the Logic App Integration Account Partner.
+
+* `value` - (Required) The user defined business identity value for the Logic App Integration Account Partner.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Logic App Integration Account Partner.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Logic App Integration Account Partner.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Logic App Integration Account Partner.
+* `update` - (Defaults to 30 minutes) Used when updating the Logic App Integration Account Partner.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Logic App Integration Account Partner.
+
+## Import
+
+Logic App Integration Account Partners can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_logic_app_integration_account_partner.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Logic/integrationAccounts/account1/partners/partner1
+```

--- a/website/docs/r/logic_app_integration_account_partner.html.markdown
+++ b/website/docs/r/logic_app_integration_account_partner.html.markdown
@@ -55,9 +55,9 @@ The following arguments are supported:
 
 A `business_identity` block exports the following:
 
-* `qualifier` - (Required) The business identity qualifier for the Logic App Integration Account Partner.
+* `qualifier` - (Required) The authenticating body that provides unique business identities to organizations.
 
-* `value` - (Required) The user defined business identity value for the Logic App Integration Account Partner.
+* `value` - (Required) The value that identifies the documents that your logic apps receive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Currently, TF doesn't support Logic App Integration Account Partner. So submitted this PR to implement it.

--- PASS: TestAccLogicAppIntegrationAccountPartner_basic (277.01s)
--- PASS: TestAccLogicAppIntegrationAccountPartner_complete (279.23s)
--- PASS: TestAccLogicAppIntegrationAccountPartner_requiresImport (296.33s)
--- PASS: TestAccLogicAppIntegrationAccountPartner_update (389.14s)

API Reference:
https://github.com/Azure/azure-rest-api-specs/blob/ceb6d11a85d834c838181a3031cd106d14a2d674/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L4602