### PR TITLE
`service/keyvault`: Fix some acceptance tests

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -30,7 +30,7 @@ func TestAccKeyVaultKey_basicEC(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 
@@ -77,7 +77,7 @@ func TestAccKeyVaultKey_curveEC(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("key_vault_id"),
 	})
 }
 
@@ -92,7 +92,7 @@ func TestAccKeyVaultKey_curveECDeprecated(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("key_vault_id"),
 	})
 }
 
@@ -107,7 +107,7 @@ func TestAccKeyVaultKey_basicRSA(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 
@@ -122,7 +122,7 @@ func TestAccKeyVaultKey_basicRSAHSM(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 
@@ -142,7 +142,7 @@ func TestAccKeyVaultKey_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkv-%s.vault.azure.net/keys/key-%s", data.RandomString, data.RandomString)),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 
@@ -161,7 +161,7 @@ func TestAccKeyVaultKey_softDeleteRecovery(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 		{
 			Config:  r.softDeleteRecovery(data, false),
 			Destroy: true,
@@ -226,7 +226,7 @@ func TestAccKeyVaultKey_updatedExternally(t *testing.T) {
 			Config:   r.basicECUpdatedExternally(data),
 			PlanOnly: true,
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 
@@ -268,14 +268,14 @@ func TestAccKeyVaultKey_withExternalAccessPolicy(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 		{
 			Config: r.withExternalAccessPolicyUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("key_size"),
+		data.ImportStep("key_size", "key_vault_id"),
 	})
 }
 


### PR DESCRIPTION
```
--- PASS: TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted (209.63s)
--- PASS: TestAccKeyVaultKey_disappears (220.07s)
--- PASS: TestAccKeyVaultKey_basicRSA (251.84s)
--- PASS: TestAccKeyVaultKey_basicEC (251.84s)
--- PASS: TestAccKeyVaultKey_basicRSAHSM (252.40s)
--- PASS: TestAccKeyVaultKey_curveECDeprecated (252.51s)
--- PASS: TestAccKeyVaultKey_purge (261.37s)
--- PASS: TestAccKeyVaultKey_complete (268.08s)
--- PASS: TestAccKeyVaultKey_requiresImport (268.77s)
--- PASS: TestAccKeyVaultKey_basicECHSM (320.70s)
--- PASS: TestAccKeyVaultKey_withExternalAccessPolicy (322.56s)
--- PASS: TestAccKeyVaultKey_curveEC (330.62s)
--- PASS: TestAccKeyVaultKey_update (343.38s)
--- PASS: TestAccKeyVaultKey_updatedExternally (398.22s)
--- PASS: TestAccKeyVaultKey_softDeleteRecovery (661.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault	662.880s
```