### PR TITLE
Support for `local_authentication_disabled` in `azurerm_application_insights`

### DIFF
--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -130,6 +130,12 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"disable_local_auth": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -163,6 +169,7 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 	applicationType := d.Get("application_type").(string)
 	samplingPercentage := utils.Float(d.Get("sampling_percentage").(float64))
 	disableIpMasking := d.Get("disable_ip_masking").(bool)
+	disableLocalAuth := d.Get("disable_local_auth").(bool)
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
@@ -171,6 +178,7 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 		ApplicationType:    insights.ApplicationType(applicationType),
 		SamplingPercentage: samplingPercentage,
 		DisableIPMasking:   utils.Bool(disableIpMasking),
+		DisableLocalAuth:   utils.Bool(disableLocalAuth),
 	}
 
 	if workspaceRaw, hasWorkspaceId := d.GetOk("workspace_id"); hasWorkspaceId {
@@ -269,6 +277,7 @@ func resourceApplicationInsightsRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("sampling_percentage", props.SamplingPercentage)
 		d.Set("disable_ip_masking", props.DisableIPMasking)
 		d.Set("connection_string", props.ConnectionString)
+		d.Set("disable_local_auth", props.DisableLocalAuth)
 
 		if v := props.WorkspaceResourceID; v != nil {
 			d.Set("workspace_id", v)

--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -131,7 +131,7 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
-			"disable_local_auth": {
+			"local_authentication_disabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -169,7 +169,7 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 	applicationType := d.Get("application_type").(string)
 	samplingPercentage := utils.Float(d.Get("sampling_percentage").(float64))
 	disableIpMasking := d.Get("disable_ip_masking").(bool)
-	disableLocalAuth := d.Get("disable_local_auth").(bool)
+	localAuthenticationDisabled := d.Get("local_authentication_disabled").(bool)
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
@@ -178,7 +178,7 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 		ApplicationType:    insights.ApplicationType(applicationType),
 		SamplingPercentage: samplingPercentage,
 		DisableIPMasking:   utils.Bool(disableIpMasking),
-		DisableLocalAuth:   utils.Bool(disableLocalAuth),
+		DisableLocalAuth:   utils.Bool(localAuthenticationDisabled),
 	}
 
 	if workspaceRaw, hasWorkspaceId := d.GetOk("workspace_id"); hasWorkspaceId {
@@ -277,7 +277,7 @@ func resourceApplicationInsightsRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("sampling_percentage", props.SamplingPercentage)
 		d.Set("disable_ip_masking", props.DisableIPMasking)
 		d.Set("connection_string", props.ConnectionString)
-		d.Set("disable_local_auth", props.DisableLocalAuth)
+		d.Set("local_authentication_disabled", props.DisableLocalAuth)
 
 		if v := props.WorkspaceResourceID; v != nil {
 			d.Set("workspace_id", v)

--- a/internal/services/applicationinsights/application_insights_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_resource_test.go
@@ -191,6 +191,7 @@ func TestAccApplicationInsights_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("sampling_percentage").HasValue("50"),
 				check.That(data.ResourceName).Key("daily_data_cap_in_gb").HasValue("50"),
 				check.That(data.ResourceName).Key("daily_data_cap_notifications_disabled").HasValue("true"),
+				check.That(data.ResourceName).Key("disable_local_auth").HasValue("true"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.Hello").HasValue("World"),
 			),
@@ -283,6 +284,7 @@ resource "azurerm_application_insights" "test" {
   daily_data_cap_in_gb                  = 50
   daily_data_cap_notifications_disabled = true
   disable_ip_masking                    = true
+  disable_local_auth                    = true
 
   tags = {
     Hello = "World"

--- a/internal/services/applicationinsights/application_insights_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_resource_test.go
@@ -191,7 +191,7 @@ func TestAccApplicationInsights_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("sampling_percentage").HasValue("50"),
 				check.That(data.ResourceName).Key("daily_data_cap_in_gb").HasValue("50"),
 				check.That(data.ResourceName).Key("daily_data_cap_notifications_disabled").HasValue("true"),
-				check.That(data.ResourceName).Key("disable_local_auth").HasValue("true"),
+				check.That(data.ResourceName).Key("local_authentication_disabled").HasValue("true"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.Hello").HasValue("World"),
 			),
@@ -284,7 +284,7 @@ resource "azurerm_application_insights" "test" {
   daily_data_cap_in_gb                  = 50
   daily_data_cap_notifications_disabled = true
   disable_ip_masking                    = true
-  disable_local_auth                    = true
+  local_authentication_disabled         = true
 
   tags = {
     Hello = "World"

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -96,6 +96,8 @@ The following arguments are supported:
 
 * `workspace_id` - (Optional) Specifies the id of a log analytics workspace resource
 
+* `disable_local_auth` - (Optional) Disable Non-Azure AD based Auth. Defaults to `false`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `workspace_id` - (Optional) Specifies the id of a log analytics workspace resource
 
-* `disable_local_auth` - (Optional) Disable Non-Azure AD based Auth. Defaults to `false`.
+* `local_authentication_disabled` - (Optional) Disable Non-Azure AD based Auth. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Close #13173

### Acctests result

```
TF_ACC=1 go test -v ./internal/services/applicationinsights -run=TestAccApplicationInsights_complete -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationInsights_complete
=== PAUSE TestAccApplicationInsights_complete
=== CONT  TestAccApplicationInsights_complete
--- PASS: TestAccApplicationInsights_complete (171.48s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights   171.489s
```