### PR TITLE
azurerm_policy_virtual_machine_configuration_assignment - support  assignment_type, content_uri and content_hash

### DIFF
--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -205,7 +205,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
 
   configuration {
     name            = "WhitelistedApplication"
-    version         = "1.*"
+    version         = "1.1.1.1"
     assignment_type = "ApplyAndAutoCorrect"
     content_hash    = "testcontenthash"
     content_uri     = "https://testcontenturi/package"
@@ -230,7 +230,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
 
   configuration {
     name            = "WhitelistedApplication"
-    version         = "1.*"
+    version         = "1.1.1.1"
     assignment_type = "Audit"
     content_hash    = "testcontenthash2"
     content_uri     = "https://testcontenturi/package2"

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -132,6 +132,12 @@ An `configuration` block supports the following:
 
 * `name` - (Required) The name of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
 
+* `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`.
+
+* `content_hash` - (Optional) The content hash for the Guest Configuration package.
+
+* `content_uri` - (Optional) The content URI where the Guest Configuration package is stored.
+
 * `parameter` - (Optional) One or more `parameter` blocks which define what configuration parameters and values against.
 
 * `version` - (Optional) The version of the Guest Configuration that will be assigned in this Guest Configuration Assignment.


### PR DESCRIPTION
This PR is to add support for new properties [`assignmentType`](https://github.com/Azure/azure-rest-api-specs/blob/b020247789ba2ab0065ebbcfa69050ce729493b8/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/guestconfiguration.json#L813), [`contentUri`](https://github.com/Azure/azure-rest-api-specs/blob/b020247789ba2ab0065ebbcfa69050ce729493b8/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/guestconfiguration.json#L805) and [`contentHash`](https://github.com/Azure/azure-rest-api-specs/blob/b020247789ba2ab0065ebbcfa69050ce729493b8/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/guestconfiguration.json#L809).

--- PASS: TestAccPolicyVirtualMachineConfigurationAssignment_basic (421.82s)
--- PASS: TestAccPolicyVirtualMachineConfigurationAssignment_requiresImport (468.93s)
--- PASS: TestAccPolicyVirtualMachineConfigurationAssignment_update (564.41s)