### PR TITLE
Update `azurerm_synapse_spark_pool` to support spark 3.1 instead of 3.0

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -150,6 +150,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 				Default:  "2.4",
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
+					"3.0", // TODO: remove in 3.0 as support for this value has been dropped
 					"3.1",
 				}, false),
 			},

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -150,7 +150,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 				Default:  "2.4",
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
-					"3.0",
+					"3.1",
 				}, false),
 			},
 

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -97,7 +97,7 @@ func TestAccSynapseSpark3Pool_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, "3.0"),
+			Config: r.complete(data, "3.1"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -120,7 +120,7 @@ func TestAccSynapseSpark3Pool_update(t *testing.T) {
 		},
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
-			Config: r.complete(data, "3.0"),
+			Config: r.complete(data, "3.1"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.0`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.1`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
Azure Synapse now support [Apache Spark 3.1 (preview) ](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-3-runtime)and support for Spark 3.0 is dropped.

```
❯ make acctests SERVICE='synapse' TESTARGS='-run=TestAccSynapseSpark3Pool_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/synapse -run=TestAccSynapseSpark3Pool_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSynapseSpark3Pool_complete
=== PAUSE TestAccSynapseSpark3Pool_complete
=== RUN   TestAccSynapseSpark3Pool_update
=== PAUSE TestAccSynapseSpark3Pool_update
=== CONT  TestAccSynapseSpark3Pool_complete
=== CONT  TestAccSynapseSpark3Pool_update
--- PASS: TestAccSynapseSpark3Pool_complete (1517.20s)
--- PASS: TestAccSynapseSpark3Pool_update (1574.70s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse       1576.160s
```