### PR TITLE
Updated the `allowed_methods` description

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -167,7 +167,7 @@ A `cors_rule` block supports the following:
 
 * `allowed_headers` - (Required) A list of headers that are allowed to be a part of the cross-origin request.
 
-* `allowed_methods` - (Required) A list of http headers that are allowed to be executed by the origin. Valid options are
+* `allowed_methods` - (Required) A list of http methods that are allowed to be executed by the origin. Valid options are
 `DELETE`, `GET`, `HEAD`, `MERGE`, `POST`, `OPTIONS`, `PUT` or `PATCH`.
 
 * `allowed_origins` - (Required) A list of origin domains that will be allowed by CORS.


### PR DESCRIPTION
Changed the [allowed_methods](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#allowed_methods) description.