### PR TITLE
Support for `local_authentication_disabled` in `azurerm_cosmosdb_account`

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -282,6 +282,12 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			"local_authentication_disabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"mongo_server_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -493,6 +499,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 	enableMultipleWriteLocations := d.Get("enable_multiple_write_locations").(bool)
 	enableAnalyticalStorage := d.Get("analytical_storage_enabled").(bool)
+	localAuthenticationDisabled := d.Get("local_authentication_disabled").(bool)
 
 	r, err := client.CheckNameExists(ctx, name)
 	if err != nil {
@@ -541,6 +548,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("access_key_metadata_writes_enabled").(bool)),
 			NetworkACLBypass:                   networkByPass,
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
+			DisableLocalAuth:                   utils.Bool(localAuthenticationDisabled),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -613,6 +621,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 	enableMultipleWriteLocations := d.Get("enable_multiple_write_locations").(bool)
 	enableAnalyticalStorage := d.Get("analytical_storage_enabled").(bool)
+	localAuthenticationDisabled := d.Get("local_authentication_disabled").(bool)
 
 	newLocations, err := expandAzureRmCosmosDBAccountGeoLocations(d)
 	if err != nil {
@@ -673,6 +682,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("access_key_metadata_writes_enabled").(bool)),
 			NetworkACLBypass:                   networkByPass,
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
+			DisableLocalAuth:                   utils.Bool(localAuthenticationDisabled),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -828,6 +838,7 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		}
 		d.Set("network_acl_bypass_for_azure_services", props.NetworkACLBypass == documentdb.NetworkACLBypassAzureServices)
 		d.Set("network_acl_bypass_ids", utils.FlattenStringSlice(props.NetworkACLBypassResourceIds))
+		d.Set("local_authentication_disabled", props.DisableLocalAuth)
 
 		policy, err := flattenCosmosdbAccountBackup(props.BackupPolicy)
 		if err != nil {

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -499,7 +499,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 	enableMultipleWriteLocations := d.Get("enable_multiple_write_locations").(bool)
 	enableAnalyticalStorage := d.Get("analytical_storage_enabled").(bool)
-	localAuthenticationDisabled := d.Get("local_authentication_disabled").(bool)
+	disableLocalAuthentication := d.Get("local_authentication_disabled").(bool)
 
 	r, err := client.CheckNameExists(ctx, name)
 	if err != nil {
@@ -548,7 +548,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("access_key_metadata_writes_enabled").(bool)),
 			NetworkACLBypass:                   networkByPass,
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
-			DisableLocalAuth:                   utils.Bool(localAuthenticationDisabled),
+			DisableLocalAuth:                   utils.Bool(disableLocalAuthentication),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -621,7 +621,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 	enableMultipleWriteLocations := d.Get("enable_multiple_write_locations").(bool)
 	enableAnalyticalStorage := d.Get("analytical_storage_enabled").(bool)
-	localAuthenticationDisabled := d.Get("local_authentication_disabled").(bool)
+	disableLocalAuthentication := d.Get("local_authentication_disabled").(bool)
 
 	newLocations, err := expandAzureRmCosmosDBAccountGeoLocations(d)
 	if err != nil {
@@ -682,7 +682,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("access_key_metadata_writes_enabled").(bool)),
 			NetworkACLBypass:                   networkByPass,
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
-			DisableLocalAuth:                   utils.Bool(localAuthenticationDisabled),
+			DisableLocalAuth:                   utils.Bool(disableLocalAuthentication),
 		},
 		Tags: tags.Expand(t),
 	}

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -114,6 +114,8 @@ The following arguments are supported:
 
 * `network_acl_bypass_ids` - (Optional) The list of resource Ids for Network Acl Bypass for this Cosmos DB account.
 
+* `local_authentication_disabled` - (Optional) Disable local authentication and ensure only MSI and AAD can be used exclusively for authentication. Defaults to `false`. Can be set only when using the SQL API.
+
 * `backup` - (Optional) A `backup` block as defined below.
 
 * `cors_rule` - (Optional) A `cors_rule` block as defined below.


### PR DESCRIPTION
Close #13184

### Acctests result

```
TF_ACC=1 go test -v ./internal/services/cosmos -run=TestAccCosmosDBAccount_localAuthenticationDisabled -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccCosmosDBAccount_localAuthenticationDisabled
=== PAUSE TestAccCosmosDBAccount_localAuthenticationDisabled
=== CONT  TestAccCosmosDBAccount_localAuthenticationDisabled
--- PASS: TestAccCosmosDBAccount_localAuthenticationDisabled (1133.39s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos        (cached)
```