### PR TITLE
azurerm_data_factory_trigger_schedule supports schedule and description

### DIFF
--- a/internal/services/datafactory/data_factory_trigger_schedule_resource.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource.go
@@ -106,19 +106,19 @@ func resourceDataFactoryTriggerSchedule() *pluginsdk.Resource {
 							},
 						},
 
-						"monthly_occurrence": {
+						"monthly": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							MinItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"day": {
+									"weekday": {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
 										ValidateFunc: validation.IsDayOfTheWeek(false),
 									},
 
-									"occurrence": {
+									"week": {
 										Type:     pluginsdk.TypeInt,
 										Optional: true,
 										ValidateFunc: validation.Any(
@@ -375,7 +375,7 @@ func resourceDataFactoryTriggerScheduleDelete(d *pluginsdk.ResourceData, meta in
 }
 
 func expandDataFactorySchedule(input []interface{}) *datafactory.RecurrenceSchedule {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	value := input[0].(map[string]interface{})
@@ -384,11 +384,11 @@ func expandDataFactorySchedule(input []interface{}) *datafactory.RecurrenceSched
 		weekDays = append(weekDays, datafactory.DaysOfWeek(v.(string)))
 	}
 	monthlyOccurrences := make([]datafactory.RecurrenceScheduleOccurrence, 0)
-	for _, v := range value["monthly_occurrence"].([]interface{}) {
+	for _, v := range value["monthly"].([]interface{}) {
 		value := v.(map[string]interface{})
 		monthlyOccurrences = append(monthlyOccurrences, datafactory.RecurrenceScheduleOccurrence{
-			Day:        datafactory.DayOfWeek(value["day"].(string)),
-			Occurrence: utils.Int32(int32(value["occurrence"].(int))),
+			Day:        datafactory.DayOfWeek(value["weekday"].(string)),
+			Occurrence: utils.Int32(int32(value["week"].(int))),
 		})
 	}
 	return &datafactory.RecurrenceSchedule{
@@ -425,13 +425,13 @@ func flattenDataFactorySchedule(schedule *datafactory.RecurrenceSchedule) []inte
 		monthlyOccurrences := make([]interface{}, 0)
 		for _, v := range *schedule.MonthlyOccurrences {
 			occurrence := make(map[string]interface{})
-			occurrence["day"] = string(v.Day)
+			occurrence["weekday"] = string(v.Day)
 			if v.Occurrence != nil {
-				occurrence["occurrence"] = *v.Occurrence
+				occurrence["week"] = *v.Occurrence
 			}
 			monthlyOccurrences = append(monthlyOccurrences, occurrence)
 		}
-		value["monthly_occurrence"] = monthlyOccurrences
+		value["monthly"] = monthlyOccurrences
 	}
 	return []interface{}{value}
 }

--- a/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
@@ -208,9 +208,9 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
     days_of_week  = ["Monday", "Tuesday"]
     hours         = [0, 12, 24]
     minutes       = [0, 30, 60]
-    monthly_occurrence {
-      day        = "Monday"
-      occurrence = 1
+    monthly {
+      weekday = "Monday"
+      week    = 1
     }
   }
 }

--- a/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
@@ -56,6 +56,21 @@ func TestAccDataFactoryTriggerSchedule_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryTriggerSchedule_schedule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_trigger_schedule", "test")
+	r := TriggerScheduleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.schedule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t TriggerScheduleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
@@ -143,7 +158,7 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
   data_factory_name   = azurerm_data_factory.test.name
   resource_group_name = azurerm_resource_group.test.name
   pipeline_name       = azurerm_data_factory_pipeline.test.name
-
+  description         = "test"
   pipeline_parameters = azurerm_data_factory_pipeline.test.parameters
   annotations         = ["test5"]
   frequency           = "Day"
@@ -151,4 +166,53 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
   end_time            = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, endTime)
+}
+
+func (TriggerScheduleResource) schedule(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name                = "acctest%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+
+  parameters = {
+    test = "testparameter"
+  }
+}
+
+resource "azurerm_data_factory_trigger_schedule" "test" {
+  name                = "acctestdf%d"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  pipeline_name       = azurerm_data_factory_pipeline.test.name
+
+  annotations = ["test1", "test2", "test3"]
+
+  schedule {
+    days_of_month = [1, 2, 3]
+    days_of_week  = ["Monday", "Tuesday"]
+    hours         = [0, 12, 24]
+    minutes       = [0, 30, 60]
+    monthly_occurrence {
+      day        = "Monday"
+      occurrence = 1
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/data_factory_trigger_schedule.html.markdown
+++ b/website/docs/r/data_factory_trigger_schedule.html.markdown
@@ -53,17 +53,43 @@ The following arguments are supported:
 
 * `pipeline_name` - (Required) The Data Factory Pipeline name that the trigger will act on.
 
+* `description` - (Optional) The Schedule Trigger's description.
+
+* `schedule` - (Optional) The recurrence schedule for the trigger. A trigger with a specified frequency value alters its recurrence based on a recurrence schedule. The schedule property contains modifications for the recurrence that are based on minutes, hours, weekdays, month days, and week number. A `schedule` block as documented below.
+
 * `start_time` - (Optional) The time the Schedule Trigger will start. This defaults to the current time. The time will be represented in UTC.
 
 * `end_time` - (Optional) The time the Schedule Trigger should end. The time will be represented in UTC.
 
 * `interval` - (Optional) The interval for how often the trigger occurs. This defaults to 1.
 
-* `frequency` - (Optional) The trigger freqency. Valid values include `Minute`, `Hour`, `Day`, `Week`, `Month`. Defaults to `Minute`.
+* `frequency` - (Optional) The trigger frequency. Valid values include `Minute`, `Hour`, `Day`, `Week`, `Month`. Defaults to `Minute`.
 
 * `pipeline_parameters` - (Optional) The pipeline parameters that the trigger will act upon.
 
 * `annotations` - (Optional) List of tags that can be used for describing the Data Factory Schedule Trigger.
+
+---
+
+`schedule` supports the following:
+
+* `days_of_month` - (Optional) 	Day of the month on which the trigger runs. The value can be specified with a monthly frequency only.
+
+* `days_of_week` - (Optional) Days of the week the trigger runs. The value can be specified only with a weekly frequency.
+
+* `hours` - (Optional) Hours of the day at which the trigger runs.
+
+* `minutes` - (Optional) Minutes of the hour at which the trigger runs.
+
+* `monthly_occurrence` - (Optional) Days of the month on which the trigger runs. The value can be specified with a monthly frequency only. A `monthly_occurrence` block as documented below.
+
+---
+
+`monthly_occurrence` supports the following:
+
+* `day` - (Required) The day of the week on which the trigger runs. For example, a `monthly_occurrence` property with a day value of `Sunday` means every Sunday of the month.
+
+* `occurrence` - (Optional) The occurrence of the specified day during the month. For example, a `monthly_occurrence` property with day and occurrence values of `Sunday, -1` means the last Sunday of the month.
 
 ## Attributes Reference
 

--- a/website/docs/r/data_factory_trigger_schedule.html.markdown
+++ b/website/docs/r/data_factory_trigger_schedule.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The Schedule Trigger's description.
 
-* `schedule` - (Optional) The recurrence schedule for the trigger. A trigger with a specified frequency value alters its recurrence based on a recurrence schedule. The schedule property contains modifications for the recurrence that are based on minutes, hours, weekdays, month days, and week number. A `schedule` block as documented below.
+* `schedule` - (Optional) A `schedule` block as defined below, which further specifies the recurrence schedule for the trigger. A schedule is capable of limiting or increasing the number of trigger executions specified by the `frequency` and `interval` properties.
 
 * `start_time` - (Optional) The time the Schedule Trigger will start. This defaults to the current time. The time will be represented in UTC.
 
@@ -71,25 +71,25 @@ The following arguments are supported:
 
 ---
 
-`schedule` supports the following:
+A `schedule` block supports the following:
 
-* `days_of_month` - (Optional) 	Day of the month on which the trigger runs. The value can be specified with a monthly frequency only.
+* `days_of_month` - (Optional) Day(s) of the month on which the trigger is scheduled. This value can be specified with a monthly frequency only.
 
-* `days_of_week` - (Optional) Days of the week the trigger runs. The value can be specified only with a weekly frequency.
+* `days_of_week` - (Optional) Days of the week on which the trigger is scheduled. This value can be specified only with a weekly frequency.
 
-* `hours` - (Optional) Hours of the day at which the trigger runs.
+* `hours` - (Optional) Hours of the day on which the trigger is scheduled.
 
-* `minutes` - (Optional) Minutes of the hour at which the trigger runs.
+* `minutes` - (Optional) Minutes of the hour on which the trigger is scheduled.
 
-* `monthly_occurrence` - (Optional) Days of the month on which the trigger runs. The value can be specified with a monthly frequency only. A `monthly_occurrence` block as documented below.
+* `monthly` - (Optional) A `monthly` block as documented below, which specifies the days of the month on which the trigger is scheduled. The value can be specified only with a monthly frequency.
 
 ---
 
-`monthly_occurrence` supports the following:
+A `monthly` block supports the following:
 
-* `day` - (Required) The day of the week on which the trigger runs. For example, a `monthly_occurrence` property with a day value of `Sunday` means every Sunday of the month.
+* `weekday` - (Required) The day of the week on which the trigger runs. For example, a `monthly` property with a `weekday` value of `Sunday` means every Sunday of the month.
 
-* `occurrence` - (Optional) The occurrence of the specified day during the month. For example, a `monthly_occurrence` property with day and occurrence values of `Sunday, -1` means the last Sunday of the month.
+* `week` - (Optional) The occurrence of the specified day during the month. For example, a `monthly` property with `weekday` and `week` values of `Sunday, -1` means the last Sunday of the month.
 
 ## Attributes Reference
 


### PR DESCRIPTION
```
=== RUN   TestAccDataFactoryTriggerSchedule_basic
=== PAUSE TestAccDataFactoryTriggerSchedule_basic
=== CONT  TestAccDataFactoryTriggerSchedule_basic
--- PASS: TestAccDataFactoryTriggerSchedule_basic (213.63s)
=== RUN   TestAccDataFactoryTriggerSchedule_complete
=== PAUSE TestAccDataFactoryTriggerSchedule_complete
=== CONT  TestAccDataFactoryTriggerSchedule_complete
--- PASS: TestAccDataFactoryTriggerSchedule_complete (388.00s)
=== RUN   TestAccDataFactoryTriggerSchedule_schedule
=== PAUSE TestAccDataFactoryTriggerSchedule_schedule
=== CONT  TestAccDataFactoryTriggerSchedule_schedule
--- PASS: TestAccDataFactoryTriggerSchedule_schedule (213.27s)
PASS
```