### PR TITLE
Fix KV import with no label

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -169,6 +169,11 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			if appCfgKeyResourceID.Label == "" {
+				// We set an empty label as %00 in the resource ID
+				// Otherwise it breaks the ID parsing logic
+				appCfgKeyResourceID.Label = "%00"
+			}
 			metadata.SetID(appCfgKeyResourceID)
 			return nil
 		},
@@ -182,6 +187,12 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 			resourceID, err := parse.AppConfigurationKeyID(metadata.ResourceData.Id())
 			if err != nil {
 				return fmt.Errorf("while parsing resource ID: %+v", err)
+			}
+
+			// We set an empty label as %00 in the ID to make the ID validator happy
+			// but in reality the label is just an empty string
+			if resourceID.Label == "%00" {
+				resourceID.Label = ""
 			}
 
 			client, err := metadata.Client.AppConfiguration.DataPlaneClient(ctx, resourceID.ConfigurationStoreId)

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -32,6 +32,20 @@ func TestAccAppConfigurationKey_basic(t *testing.T) {
 	})
 }
 
+func TestAccAppConfigurationKey_basicNoLabel(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
+	r := AppConfigurationKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicNoLabel(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppConfigurationKey_basicVault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
 	r := AppConfigurationKeyResource{}
@@ -146,6 +160,33 @@ resource "azurerm_app_configuration_key" "test" {
   value                  = "a test"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (t AppConfigurationKeyResource) basicNoLabel(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appconfig-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_configuration" "test" {
+  name                = "testacc-appconf%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_app_configuration_key" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  key                    = "acctest-ackey-%d"
+  content_type           = "test"
+  value                  = "a test"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (t AppConfigurationKeyResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/appconfiguration/parse/app_configuration_key.go
+++ b/internal/services/appconfiguration/parse/app_configuration_key.go
@@ -26,12 +26,20 @@ func AppConfigurationKeyID(input string) (*AppConfigurationKeyId, error) {
 
 	keyName := resourceID.Path["AppConfigurationKey"]
 	label := resourceID.Path["Label"]
-	cfgStoreId := strings.TrimSuffix(input, fmt.Sprintf("/AppConfigurationKey/%s/Label/%s", keyName, label))
+
 	appcfgID := AppConfigurationKeyId{
-		ConfigurationStoreId: cfgStoreId,
-		Key:                  keyName,
-		Label:                label,
+		Key:   keyName,
+		Label: label,
 	}
+
+	// Golang's URL parser will translate %00 to \000 (NUL). This will only happen if we're dealing with an empty
+	// label, so we set the label to the expected value (empty string) and trim the input string, so we can properly
+	// extract the configuration store ID out of it.
+	if label == "\000" {
+		appcfgID.Label = ""
+		input = strings.TrimSuffix(input, "%00")
+	}
+	appcfgID.ConfigurationStoreId = strings.TrimSuffix(input, fmt.Sprintf("/AppConfigurationKey/%s/Label/%s", appcfgID.Key, appcfgID.Label))
 
 	return &appcfgID, nil
 }

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -138,3 +138,8 @@ App Configuration Keys can be imported using the `resource id`, e.g.
 ```shell
 terraform import azurerm_app_configuration_key.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/appConfKey1/Label/label1
 ```
+
+If you wish to import a key with an empty label then sustitute the label's name with `%00`, like this:
+```shell
+terraform import azurerm_app_configuration_key.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/appConfKey1/Label/%00
+```


### PR DESCRIPTION
Inject a default value for empty labels in order to fix the import issue.﻿

Fixes #13230
