### PR TITLE
`d/azurerm_kubernetes_cluster`: Support `local_account_disabled` setup in data source

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -692,7 +692,7 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		// adminProfile is only available for RBAC enabled clusters with AAD and without local accounts disabled
-		if props.AadProfile != nil && !*props.DisableLocalAccounts {
+		if props.AadProfile != nil && (props.DisableLocalAccounts == nil || !*props.DisableLocalAccounts) {
 			adminProfile, err := client.GetAccessProfile(ctx, resourceGroup, name, "clusterAdmin")
 			if err != nil {
 				return fmt.Errorf("retrieving Admin Access Profile for Managed Kubernetes Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -691,8 +691,8 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			return fmt.Errorf("setting `service_principal`: %+v", err)
 		}
 
-		// adminProfile is only available for RBAC enabled clusters with AAD
-		if props.AadProfile != nil {
+		// adminProfile is only available for RBAC enabled clusters with AAD and without local accounts disabled
+		if props.AadProfile != nil && !*props.DisableLocalAccounts {
 			adminProfile, err := client.GetAccessProfile(ctx, resourceGroup, name, "clusterAdmin")
 			if err != nil {
 				return fmt.Errorf("retrieving Admin Access Profile for Managed Kubernetes Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -167,7 +167,7 @@ func testAccDataSourceKubernetesCluster_localAccountDisabled(t *testing.T) {
 				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
 				check.That(data.ResourceName).Key("kube_config_raw").Exists(),
 				check.That(data.ResourceName).Key("kube_admin_config.#").HasValue("0"),
-				check.That(data.ResourceName).Key("kube_admin_config_raw").DoesNotExist(),
+				check.That(data.ResourceName).Key("kube_admin_config_raw").HasValue(""),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -16,6 +16,7 @@ var kubernetesDataSourceTests = map[string]func(t *testing.T){
 	"basic":                                            testAccDataSourceKubernetesCluster_basic,
 	"roleBasedAccessControl":                           testAccDataSourceKubernetesCluster_roleBasedAccessControl,
 	"roleBasedAccessControlAAD":                        testAccDataSourceKubernetesCluster_roleBasedAccessControlAAD,
+	"localAccountDisabled":                             testAccDataSourceKubernetesCluster_localAccountDisabled,
 	"internalNetwork":                                  testAccDataSourceKubernetesCluster_internalNetwork,
 	"advancedNetworkingAzure":                          testAccDataSourceKubernetesCluster_advancedNetworkingAzure,
 	"advancedNetworkingAzureCalicoPolicy":              testAccDataSourceKubernetesCluster_advancedNetworkingAzureCalicoPolicy,
@@ -140,6 +141,33 @@ func testAccDataSourceKubernetesCluster_roleBasedAccessControlAAD(t *testing.T) 
 				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.tenant_id").Exists(),
 				check.That(data.ResourceName).Key("kube_admin_config.#").HasValue("1"),
 				check.That(data.ResourceName).Key("kube_admin_config_raw").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKubernetesCluster_localAccountDisabled(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccDataSourceKubernetesCluster_localAccountDisabled(t)
+}
+
+func testAccDataSourceKubernetesCluster_localAccountDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+	clientData := data.Client()
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.localAccountDisabled(data, clientData.TenantID),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("role_based_access_control.#").HasValue("1"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.#").HasValue("1"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.managed").HasValue("true"),
+				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
+				check.That(data.ResourceName).Key("kube_config_raw").Exists(),
+				check.That(data.ResourceName).Key("kube_admin_config.#").HasValue("0"),
+				check.That(data.ResourceName).Key("kube_admin_config_raw").DoesNotExist(),
 			),
 		},
 	})
@@ -636,6 +664,17 @@ data "azurerm_kubernetes_cluster" "test" {
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
 `, KubernetesClusterResource{}.roleBasedAccessControlConfig(data))
+}
+
+func (KubernetesClusterDataSource) localAccountDisabled(data acceptance.TestData, tenantId string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.roleBasedAccessControlAADManagedConfigWithLocalAccountDisabled(data, tenantId))
 }
 
 func (KubernetesClusterDataSource) roleBasedAccessControlAADConfig(data acceptance.TestData, clientId, clientSecret, tenantId string) string {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -52,9 +52,9 @@ The following attributes are exported:
 
 -> **NOTE:**  At this time Private Link is in Public Preview.
 
-* `kube_admin_config` - A `kube_admin_config` block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts not disabled.
+* `kube_admin_config` - A `kube_admin_config` block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts are not disabled.
 
-* `kube_admin_config_raw` - Raw Kubernetes config for the admin account to be used by [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts not disabled.
+* `kube_admin_config_raw` - Raw Kubernetes config for the admin account to be used by [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts are not disabled.
 
 * `kube_config` - A `kube_config` block as defined below.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -52,9 +52,9 @@ The following attributes are exported:
 
 -> **NOTE:**  At this time Private Link is in Public Preview.
 
-* `kube_admin_config` - A `kube_admin_config` block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled.
+* `kube_admin_config` - A `kube_admin_config` block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts not disabled.
 
-* `kube_admin_config_raw` - Raw Kubernetes config for the admin account to be used by [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled.
+* `kube_admin_config_raw` - Raw Kubernetes config for the admin account to be used by [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts not disabled.
 
 * `kube_config` - A `kube_config` block as defined below.
 


### PR DESCRIPTION
Fixes #13248

## Acceptance Test
- [x] Test added for fixed/new functionality: TestAccDataSourceKubernetesCluster_localAccountDisabled
- [x] New test run:
```bash
❯ make acctests SERVICE='containers' TESTARGS='-run=TestAccDataSourceKubernetesCluster_localAccountDisabled'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccDataSourceKubernetesCluster_localAccountDisabled -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceKubernetesCluster_localAccountDisabled
=== PAUSE TestAccDataSourceKubernetesCluster_localAccountDisabled
=== CONT  TestAccDataSourceKubernetesCluster_localAccountDisabled
--- PASS: TestAccDataSourceKubernetesCluster_localAccountDisabled (473.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    474.821s
```  