### PR TITLE
azurerm_logic_app_workflow - support for enabled & access_control

### DIFF
--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -64,6 +64,235 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 				ValidateFunc: validate.IntegrationServiceEnvironmentID,
 			},
 
+			"access_control": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"action": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"allowed_caller_ip_address_range": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+											ValidateFunc: validation.Any(
+												validation.IsCIDR,
+												validation.IsIPv4Range,
+											),
+										},
+									},
+
+									"open_authentication_policy": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"name": {
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+
+												"claim": {
+													Type:     pluginsdk.TypeSet,
+													Required: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"name": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+
+															"value": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"content": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"allowed_caller_ip_address_range": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+											ValidateFunc: validation.Any(
+												validation.IsCIDR,
+												validation.IsIPv4Range,
+											),
+										},
+									},
+
+									"open_authentication_policy": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"name": {
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+
+												"claim": {
+													Type:     pluginsdk.TypeSet,
+													Required: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"name": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+
+															"value": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"trigger": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"allowed_caller_ip_address_range": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+											ValidateFunc: validation.Any(
+												validation.IsCIDR,
+												validation.IsIPv4Range,
+											),
+										},
+									},
+
+									"open_authentication_policy": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"name": {
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+
+												"claim": {
+													Type:     pluginsdk.TypeSet,
+													Required: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"name": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+
+															"value": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"workflow_management": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"allowed_caller_ip_address_range": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+											ValidateFunc: validation.Any(
+												validation.IsCIDR,
+												validation.IsIPv4Range,
+											),
+										},
+									},
+
+									"open_authentication_policy": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"name": {
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+
+												"claim": {
+													Type:     pluginsdk.TypeSet,
+													Required: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"name": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+
+															"value": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"logic_app_integration_account_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -198,6 +427,10 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 		Tags: tags.Expand(t),
 	}
 
+	if v, ok := d.GetOk("access_control"); ok {
+		properties.WorkflowProperties.AccessControl = expandLogicAppWorkflowAccessControl(v.([]interface{}))
+	}
+
 	if iseID, ok := d.GetOk("integration_service_environment_id"); ok {
 		properties.WorkflowProperties.IntegrationServiceEnvironment = &logic.ResourceReference{
 			ID: utils.String(iseID.(string)),
@@ -283,6 +516,10 @@ func resourceLogicAppWorkflowUpdate(d *pluginsdk.ResourceData, meta interface{})
 		Tags: tags.Expand(t),
 	}
 
+	if v, ok := d.GetOk("access_control"); ok {
+		properties.WorkflowProperties.AccessControl = expandLogicAppWorkflowAccessControl(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("logic_app_integration_account_id"); ok {
 		properties.WorkflowProperties.IntegrationAccount = &logic.ResourceReference{
 			ID: utils.String(v.(string)),
@@ -327,6 +564,10 @@ func resourceLogicAppWorkflowRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if props := resp.WorkflowProperties; props != nil {
 		d.Set("access_endpoint", props.AccessEndpoint)
+
+		if err := d.Set("access_control", flattenLogicAppWorkflowFlowAccessControl(props.AccessControl)); err != nil {
+			return fmt.Errorf("setting `access_control`: %+v", err)
+		}
 
 		if props.State != "" {
 			d.Set("state", props.State)
@@ -596,6 +837,98 @@ func expandLogicAppWorkflowWorkflowParameters(input map[string]interface{}) (map
 	return output, nil
 }
 
+func expandLogicAppWorkflowAccessControl(input []interface{}) *logic.FlowAccessControlConfiguration {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+
+	result := logic.FlowAccessControlConfiguration{}
+
+	if triggers := v["trigger"].([]interface{}); len(triggers) != 0 {
+		result.Triggers = expandLogicAppWorkflowAccessControlConfigurationPolicy(triggers)
+	}
+
+	if contents := v["content"].([]interface{}); len(contents) != 0 {
+		result.Contents = expandLogicAppWorkflowAccessControlConfigurationPolicy(contents)
+	}
+
+	if actions := v["action"].([]interface{}); len(actions) != 0 {
+		result.Actions = expandLogicAppWorkflowAccessControlConfigurationPolicy(actions)
+	}
+
+	if workflowManagement := v["workflow_management"].([]interface{}); len(workflowManagement) != 0 {
+		result.WorkflowManagement = expandLogicAppWorkflowAccessControlConfigurationPolicy(workflowManagement)
+	}
+
+	return &result
+}
+
+func expandLogicAppWorkflowAccessControlConfigurationPolicy(input []interface{}) *logic.FlowAccessControlConfigurationPolicy {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+
+	result := logic.FlowAccessControlConfigurationPolicy{}
+
+	if allowedCallerIPAddressRanges := v["allowed_caller_ip_address_range"].(*pluginsdk.Set).List(); len(allowedCallerIPAddressRanges) != 0 {
+		result.AllowedCallerIPAddresses = expandLogicAppWorkflowIPAddressRanges(allowedCallerIPAddressRanges)
+	}
+
+	if openAuthenticationPolicies := v["open_authentication_policy"].(*pluginsdk.Set).List(); len(openAuthenticationPolicies) != 0 {
+		result.OpenAuthenticationPolicies = &logic.OpenAuthenticationAccessPolicies{
+			Policies: expandLogicAppWorkflowOpenAuthenticationPolicy(openAuthenticationPolicies),
+		}
+	}
+
+	return &result
+}
+
+func expandLogicAppWorkflowIPAddressRanges(input []interface{}) *[]logic.IPAddressRange {
+	results := make([]logic.IPAddressRange, 0)
+
+	for _, item := range input {
+		results = append(results, logic.IPAddressRange{
+			AddressRange: utils.String(item.(string)),
+		})
+	}
+
+	return &results
+}
+
+func expandLogicAppWorkflowOpenAuthenticationPolicy(input []interface{}) map[string]*logic.OpenAuthenticationAccessPolicy {
+	if len(input) == 0 {
+		return nil
+	}
+	results := make(map[string]*logic.OpenAuthenticationAccessPolicy)
+
+	for _, item := range input {
+		policy := item.(map[string]interface{})
+		policyName := policy["name"].(string)
+
+		results[policyName] = &logic.OpenAuthenticationAccessPolicy{
+			Claims: expandLogicAppWorkflowOpenAuthenticationPolicyClaim(policy["claim"].(*pluginsdk.Set).List()),
+		}
+	}
+
+	return results
+}
+
+func expandLogicAppWorkflowOpenAuthenticationPolicyClaim(input []interface{}) *[]logic.OpenAuthenticationPolicyClaim {
+	results := make([]logic.OpenAuthenticationPolicyClaim, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+
+		results = append(results, logic.OpenAuthenticationPolicyClaim{
+			Name:  utils.String(v["name"].(string)),
+			Value: utils.String(v["value"].(string)),
+		})
+	}
+	return &results
+}
+
 func flattenLogicAppWorkflowWorkflowParameters(input map[string]interface{}) (map[string]interface{}, error) {
 	if input == nil {
 		return nil, nil
@@ -621,4 +954,97 @@ func flattenIPAddresses(input *[]logic.IPAddress) []interface{} {
 		addresses = append(addresses, *addr.Address)
 	}
 	return addresses
+}
+
+func flattenLogicAppWorkflowFlowAccessControl(input *logic.FlowAccessControlConfiguration) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"action":              flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Actions),
+			"content":             flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Contents),
+			"trigger":             flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Triggers),
+			"workflow_management": flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.WorkflowManagement),
+		},
+	}
+}
+
+func flattenLogicAppWorkflowAccessControlConfigurationPolicy(input *logic.FlowAccessControlConfigurationPolicy) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	result := make(map[string]interface{})
+
+	if input.AllowedCallerIPAddresses != nil {
+		result["allowed_caller_ip_address_range"] = flattenLogicAppWorkflowIPAddressRanges(input.AllowedCallerIPAddresses)
+	}
+
+	if input.OpenAuthenticationPolicies != nil && input.OpenAuthenticationPolicies.Policies != nil {
+		result["open_authentication_policy"] = flattenLogicAppWorkflowOpenAuthenticationPolicy(input.OpenAuthenticationPolicies.Policies)
+	}
+
+	return append(results, result)
+}
+
+func flattenLogicAppWorkflowIPAddressRanges(input *[]logic.IPAddressRange) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		var addressRange string
+		if item.AddressRange != nil {
+			addressRange = *item.AddressRange
+		}
+		results = append(results, addressRange)
+	}
+
+	return results
+}
+
+func flattenLogicAppWorkflowOpenAuthenticationPolicy(input map[string]*logic.OpenAuthenticationAccessPolicy) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for k, v := range input {
+		results = append(results, map[string]interface{}{
+			"name":  k,
+			"claim": flattenLogicAppWorkflowOpenAuthenticationPolicyClaim(v.Claims),
+		})
+	}
+
+	return results
+}
+
+func flattenLogicAppWorkflowOpenAuthenticationPolicyClaim(input *[]logic.OpenAuthenticationPolicyClaim) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		var name string
+		if item.Name != nil {
+			name = *item.Name
+		}
+
+		var value string
+		if item.Value != nil {
+			value = *item.Value
+		}
+
+		results = append(results, map[string]interface{}{
+			"name":  name,
+			"value": value,
+		})
+	}
+
+	return results
 }

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -180,61 +180,6 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 							},
 						},
 
-						"trigger": {
-							Type:     pluginsdk.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"allowed_caller_ip_address_range": {
-										Type:     pluginsdk.TypeSet,
-										Required: true,
-										Elem: &pluginsdk.Schema{
-											Type: pluginsdk.TypeString,
-											ValidateFunc: validation.Any(
-												validation.IsCIDR,
-												validation.IsIPv4Range,
-											),
-										},
-									},
-
-									"open_authentication_policy": {
-										Type:     pluginsdk.TypeSet,
-										Optional: true,
-										Elem: &pluginsdk.Resource{
-											Schema: map[string]*pluginsdk.Schema{
-												"name": {
-													Type:         pluginsdk.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringIsNotEmpty,
-												},
-
-												"claim": {
-													Type:     pluginsdk.TypeSet,
-													Required: true,
-													Elem: &pluginsdk.Resource{
-														Schema: map[string]*pluginsdk.Schema{
-															"name": {
-																Type:         pluginsdk.TypeString,
-																Required:     true,
-																ValidateFunc: validation.StringIsNotEmpty,
-															},
-
-															"value": {
-																Type:         pluginsdk.TypeString,
-																Required:     true,
-																ValidateFunc: validation.StringIsNotEmpty,
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-
 						"workflow_management": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
@@ -843,10 +788,6 @@ func expandLogicAppWorkflowAccessControl(input []interface{}) *logic.FlowAccessC
 
 	result := logic.FlowAccessControlConfiguration{}
 
-	if triggers := v["trigger"].([]interface{}); len(triggers) != 0 {
-		result.Triggers = expandLogicAppWorkflowAccessControlConfigurationPolicy(triggers)
-	}
-
 	if contents := v["content"].([]interface{}); len(contents) != 0 {
 		result.Contents = expandLogicAppWorkflowAccessControlConfigurationPolicy(contents)
 	}
@@ -961,7 +902,6 @@ func flattenLogicAppWorkflowFlowAccessControl(input *logic.FlowAccessControlConf
 		map[string]interface{}{
 			"action":              flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Actions),
 			"content":             flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Contents),
-			"trigger":             flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.Triggers),
 			"workflow_management": flattenLogicAppWorkflowAccessControlConfigurationPolicy(input.WorkflowManagement),
 		},
 	}

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -79,6 +79,18 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 				},
 			},
 
+			"state": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(logic.WorkflowStateEnabled),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(logic.WorkflowStateEnabled),
+					string(logic.WorkflowStateDisabled),
+					string(logic.WorkflowStateDeleted),
+					string(logic.WorkflowStateSuspended),
+				}, false),
+			},
+
 			"workflow_schema": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -181,6 +193,7 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 				"parameters":     workflowParameters,
 			},
 			Parameters: parameters,
+			State:      logic.WorkflowState(d.Get("state").(string)),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -265,6 +278,7 @@ func resourceLogicAppWorkflowUpdate(d *pluginsdk.ResourceData, meta interface{})
 		WorkflowProperties: &logic.WorkflowProperties{
 			Definition: definition,
 			Parameters: parameters,
+			State:      logic.WorkflowState(d.Get("state").(string)),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -313,6 +327,10 @@ func resourceLogicAppWorkflowRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if props := resp.WorkflowProperties; props != nil {
 		d.Set("access_endpoint", props.AccessEndpoint)
+
+		if props.State != "" {
+			d.Set("state", props.State)
+		}
 
 		if props.EndpointsConfiguration == nil || props.EndpointsConfiguration.Connector == nil {
 			d.Set("connector_endpoint_ip_addresses", []interface{}{})

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -78,7 +78,7 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"allowed_caller_ip_address_range": {
 										Type:     pluginsdk.TypeSet,
-										Optional: true,
+										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.Any(
@@ -133,7 +133,7 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"allowed_caller_ip_address_range": {
 										Type:     pluginsdk.TypeSet,
-										Optional: true,
+										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.Any(
@@ -188,7 +188,7 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"allowed_caller_ip_address_range": {
 										Type:     pluginsdk.TypeSet,
-										Optional: true,
+										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.Any(
@@ -243,7 +243,7 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"allowed_caller_ip_address_range": {
 										Type:     pluginsdk.TypeSet,
-										Optional: true,
+										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.Any(
@@ -870,10 +870,8 @@ func expandLogicAppWorkflowAccessControlConfigurationPolicy(input []interface{})
 	}
 	v := input[0].(map[string]interface{})
 
-	result := logic.FlowAccessControlConfigurationPolicy{}
-
-	if allowedCallerIPAddressRanges := v["allowed_caller_ip_address_range"].(*pluginsdk.Set).List(); len(allowedCallerIPAddressRanges) != 0 {
-		result.AllowedCallerIPAddresses = expandLogicAppWorkflowIPAddressRanges(allowedCallerIPAddressRanges)
+	result := logic.FlowAccessControlConfigurationPolicy{
+		AllowedCallerIPAddresses: expandLogicAppWorkflowIPAddressRanges(v["allowed_caller_ip_address_range"].(*pluginsdk.Set).List()),
 	}
 
 	if openAuthenticationPolicies := v["open_authentication_policy"].(*pluginsdk.Set).List(); len(openAuthenticationPolicies) != 0 {

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -315,8 +315,6 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(logic.WorkflowStateEnabled),
 					string(logic.WorkflowStateDisabled),
-					string(logic.WorkflowStateDeleted),
-					string(logic.WorkflowStateSuspended),
 				}, false),
 			},
 

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -422,6 +422,42 @@ resource "azurerm_logic_app_workflow" "test" {
         }
       }
     }
+
+    action {
+      allowed_caller_ip_address_range = ["10.0.6.0-10.0.6.10"]
+
+      open_authentication_policy {
+        name = "testpolicy2"
+
+        claim {
+          name  = "iss"
+          value = "https://sts.windows.net/"
+        }
+
+        claim {
+          name  = "aud"
+          value = "https://management.core.windows.net/"
+        }
+      }
+    }
+
+    workflow_management {
+      allowed_caller_ip_address_range = ["10.0.7.0-10.0.7.10"]
+
+      open_authentication_policy {
+        name = "testpolicy3"
+
+        claim {
+          name  = "iss"
+          value = "https://sts.windows.net/"
+        }
+
+        claim {
+          name  = "aud"
+          value = "https://management.core.windows.net/"
+        }
+      }
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
@@ -449,7 +485,43 @@ resource "azurerm_logic_app_workflow" "test" {
       allowed_caller_ip_address_range = ["10.10.3.0/24"]
 
       open_authentication_policy {
-        name = "testpolicy2"
+        name = "testpolicy4"
+
+        claim {
+          name  = "iss"
+          value = "https://sts.windows.net/"
+        }
+
+        claim {
+          name  = "testclaimname"
+          value = "testclaimvalue"
+        }
+      }
+    }
+
+    action {
+      allowed_caller_ip_address_range = ["10.10.4.0/24"]
+
+      open_authentication_policy {
+        name = "testpolicy5"
+
+        claim {
+          name  = "iss"
+          value = "https://sts.windows.net/"
+        }
+
+        claim {
+          name  = "testclaimname"
+          value = "testclaimvalue"
+        }
+      }
+    }
+
+    workflow_management {
+      allowed_caller_ip_address_range = ["10.10.5.0/24"]
+
+      open_authentication_policy {
+        name = "testpolicy6"
 
         claim {
           name  = "iss"

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -398,18 +398,11 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-resource "azurerm_logic_app_integration_account" "test" {
-  name                = "acctest-IA-%[1]d"
+resource "azurerm_logic_app_workflow" "test" {
+  name                = "acctestlaw-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Standard"
-}
-
-resource "azurerm_logic_app_workflow" "test" {
-  name                             = "acctestlaw-%[1]d"
-  location                         = azurerm_resource_group.test.location
-  resource_group_name              = azurerm_resource_group.test.name
-  logic_app_integration_account_id = azurerm_logic_app_integration_account.test.id
+  state               = "Enabled"
 
   access_control {
     content {
@@ -419,12 +412,12 @@ resource "azurerm_logic_app_workflow" "test" {
         name = "testpolicy1"
 
         claim {
-          name = "iss"
+          name  = "iss"
           value = "https://sts.windows.net/"
         }
 
         claim {
-          name = "aud"
+          name  = "aud"
           value = "https://management.core.windows.net/"
         }
       }
@@ -445,18 +438,11 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-resource "azurerm_logic_app_integration_account" "test" {
-  name                = "acctest-IA-%[1]d"
+resource "azurerm_logic_app_workflow" "test" {
+  name                = "acctestlaw-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Standard"
-}
-
-resource "azurerm_logic_app_workflow" "test" {
-  name                             = "acctestlaw-%[1]d"
-  location                         = azurerm_resource_group.test.location
-  resource_group_name              = azurerm_resource_group.test.name
-  logic_app_integration_account_id = azurerm_logic_app_integration_account.test.id
+  state               = "Disabled"
 
   access_control {
     content {
@@ -466,12 +452,12 @@ resource "azurerm_logic_app_workflow" "test" {
         name = "testpolicy2"
 
         claim {
-          name = "iss"
+          name  = "iss"
           value = "https://sts.windows.net/"
         }
 
         claim {
-          name = "testclaimname"
+          name  = "testclaimname"
           value = "testclaimvalue"
         }
       }

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -402,61 +402,22 @@ resource "azurerm_logic_app_workflow" "test" {
   name                = "acctestlaw-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  state               = "Enabled"
 
   access_control {
     content {
       allowed_caller_ip_address_range = ["10.0.5.0-10.0.5.10"]
-
-      open_authentication_policy {
-        name = "testpolicy1"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "aud"
-          value = "https://management.core.windows.net/"
-        }
-      }
     }
 
     action {
       allowed_caller_ip_address_range = ["10.0.6.0-10.0.6.10"]
+    }
 
-      open_authentication_policy {
-        name = "testpolicy2"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "aud"
-          value = "https://management.core.windows.net/"
-        }
-      }
+    trigger {
+      allowed_caller_ip_address_range = ["10.0.7.0-10.0.7.10"]
     }
 
     workflow_management {
-      allowed_caller_ip_address_range = ["10.0.7.0-10.0.7.10"]
-
-      open_authentication_policy {
-        name = "testpolicy3"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "aud"
-          value = "https://management.core.windows.net/"
-        }
-      }
+      allowed_caller_ip_address_range = ["10.0.8.0-10.0.8.10"]
     }
   }
 }
@@ -478,61 +439,23 @@ resource "azurerm_logic_app_workflow" "test" {
   name                = "acctestlaw-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  state               = "Disabled"
+  enabled             = false
 
   access_control {
     content {
       allowed_caller_ip_address_range = ["10.10.3.0/24"]
-
-      open_authentication_policy {
-        name = "testpolicy4"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "testclaimname"
-          value = "testclaimvalue"
-        }
-      }
     }
 
     action {
       allowed_caller_ip_address_range = ["10.10.4.0/24"]
+    }
 
-      open_authentication_policy {
-        name = "testpolicy5"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "testclaimname"
-          value = "testclaimvalue"
-        }
-      }
+    trigger {
+      allowed_caller_ip_address_range = ["10.10.5.0/24"]
     }
 
     workflow_management {
-      allowed_caller_ip_address_range = ["10.10.5.0/24"]
-
-      open_authentication_policy {
-        name = "testpolicy6"
-
-        claim {
-          name  = "iss"
-          value = "https://sts.windows.net/"
-        }
-
-        claim {
-          name  = "testclaimname"
-          value = "testclaimvalue"
-        }
-      }
+      allowed_caller_ip_address_range = ["10.10.6.0/24"]
     }
   }
 }

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `logic_app_integration_account_id` - (Optional) The ID of the integration account linked by this Logic App Workflow.
 
-* `state` - (Optional) The state of the Logic App Workflow. Possible values are `Enabled`, `Disabled`, `Deleted` and `Suspended`. Defaults to `Enabled`.
+* `state` - (Optional) The state of the Logic App Workflow. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
 
 * `workflow_parameters` - (Optional) Specifies a map of Key-Value pairs of the Parameter Definitions to use for this Logic App Workflow. The key is the parameter name, and the value is a json encoded string of the parameter definition (see: https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-definition-language#parameters).
   

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -35,9 +35,13 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Logic App Workflow exists. Changing this forces a new resource to be created.
 
+* `access_control` - (Optional) A `access_control` block as defined below.
+
 * `integration_service_environment_id` - (Optional) The ID of the Integration Service Environment to which this Logic App Workflow belongs.  Changing this forces a new Logic App Workflow to be created.
 
 * `logic_app_integration_account_id` - (Optional) The ID of the integration account linked by this Logic App Workflow.
+
+* `state` - (Optional) The state of the Logic App Workflow. Possible values are `Enabled`, `Disabled`, `Deleted` and `Suspended`. Defaults to `Enabled`.
 
 * `workflow_parameters` - (Optional) Specifies a map of Key-Value pairs of the Parameter Definitions to use for this Logic App Workflow. The key is the parameter name, and the value is a json encoded string of the parameter definition (see: https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-definition-language#parameters).
   
@@ -50,6 +54,66 @@ The following arguments are supported:
 -> **NOTE:** Any parameters specified must exist in the Schema defined in `workflow_parameters`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `access_control` block supports the following:
+
+* `action` - (Optional) A `action` block as defined below.
+
+* `content` - (Optional) A `content` block as defined below.
+
+* `trigger` - (Optional) A `trigger` block as defined below.
+
+* `workflow_management` - (Optional) A `workflow_management` block as defined below.
+
+---
+
+A `action` block supports the following:
+
+* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
+
+* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
+
+---
+
+A `content` block supports the following:
+
+* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
+
+* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
+
+---
+
+A `trigger` block supports the following:
+
+* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
+
+* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
+
+---
+
+A `workflow_management` block supports the following:
+
+* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
+
+* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
+
+---
+
+A `open_authentication_policy` block supports the following:
+
+* `name` - (Required) The OAuth policy name for the Logic App Workflow.
+
+* `claim` - (Required) A `claim` block as defined below.
+
+---
+
+A `claim` block supports the following:
+
+* `name` - (Required) The name of the OAuth policy claim for the Logic App Workflow.
+
+* `value` - (Required) The value of the OAuth policy claim for the Logic App Workflow.
 
 ## Attributes Reference
 

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -85,14 +85,6 @@ A `content` block supports the following:
 
 ---
 
-A `trigger` block supports the following:
-
-* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
-
-* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
-
----
-
 A `workflow_management` block supports the following:
 
 * `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -63,8 +63,6 @@ A `access_control` block supports the following:
 
 * `content` - (Optional) A `content` block as defined below.
 
-* `trigger` - (Optional) A `trigger` block as defined below.
-
 * `workflow_management` - (Optional) A `workflow_management` block as defined below.
 
 ---

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `logic_app_integration_account_id` - (Optional) The ID of the integration account linked by this Logic App Workflow.
 
-* `state` - (Optional) The state of the Logic App Workflow. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+* `state` - (Optional) The state of the Logic App Workflow. Defaults to `true`.
 
 * `workflow_parameters` - (Optional) Specifies a map of Key-Value pairs of the Parameter Definitions to use for this Logic App Workflow. The key is the parameter name, and the value is a json encoded string of the parameter definition (see: https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-workflow-definition-language#parameters).
   
@@ -63,6 +63,8 @@ A `access_control` block supports the following:
 
 * `content` - (Optional) A `content` block as defined below.
 
+* `trigger` - (Optional) A `trigger` block as defined below.
+
 * `workflow_management` - (Optional) A `workflow_management` block as defined below.
 
 ---
@@ -71,39 +73,23 @@ A `action` block supports the following:
 
 * `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
 
-* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
-
 ---
 
 A `content` block supports the following:
 
 * `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
 
-* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
+---
+
+A `trigger` block supports the following:
+
+* `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
 
 ---
 
 A `workflow_management` block supports the following:
 
 * `allowed_caller_ip_address_range` - (Required) A list of the allowed caller IP address ranges.
-
-* `open_authentication_policy` - (Optional) A `open_authentication_policy` block as defined below.
-
----
-
-A `open_authentication_policy` block supports the following:
-
-* `name` - (Required) The OAuth policy name for the Logic App Workflow.
-
-* `claim` - (Required) A `claim` block as defined below.
-
----
-
-A `claim` block supports the following:
-
-* `name` - (Required) The name of the OAuth policy claim for the Logic App Workflow.
-
-* `value` - (Required) The value of the OAuth policy claim for the Logic App Workflow.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is to add support for new properties [`state`](https://github.com/Azure/azure-rest-api-specs/blob/b9f2042128fbd337c248f57d2b26af6ed2b5bb53/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L6499) and [`accessControl`](https://github.com/Azure/azure-rest-api-specs/blob/b9f2042128fbd337c248f57d2b26af6ed2b5bb53/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L6517) for azurerm_logic_app_workflow.

API failed to create Logic App Workflow with ["accessControl.triggers"](https://github.com/Azure/azure-rest-api-specs/blob/55d29f1945c8486073b981680da3ddc53d46ce07/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L8956). Per the error message, it complains "OpenAuthenticationAccessPolicy.type" should be "AAD" while creating this resource with "accessControl.triggers", which means ["OpenAuthenticationAccessPolicy.type"](https://github.com/Azure/azure-rest-api-specs/blob/55d29f1945c8486073b981680da3ddc53d46ce07/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L9019) should be writeable. But after checked swagger, I found this property is marked as [read-only](https://github.com/Azure/azure-rest-api-specs/blob/55d29f1945c8486073b981680da3ddc53d46ce07/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L9021). Service team confirmed it's a bug in swagger. So I filed an issue on [rest api spec](https://github.com/Azure/azure-rest-api-specs/issues/16018) and didn't involve it in this PR. Once the bug is fixed, I will submit another PR to add it.

--- PASS: TestAccLogicAppWorkflow_empty (261.74s)
--- PASS: TestAccLogicAppWorkflow_requiresImport (279.18s)
--- PASS: TestAccLogicAppWorkflow_tags (465.55s)
--- PASS: TestAccLogicAppWorkflow_integrationAccount (590.05s)
--- PASS: TestAccLogicAppWorkflow_parameters (240.56s)
--- PASS: TestAccLogicAppWorkflow_accessControl (374.61s)