### PR TITLE
azurerm_machine_learning_workspace - support for azurerm_machine_learning_workspace, discovery_url

### DIFF
--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -123,6 +123,19 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
+			"public_network_access": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"image_build_compute": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"description": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -147,6 +160,11 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 					// TODO -- remove Enterprise in 3.0 which has been deprecated here: https://docs.microsoft.com/en-us/azure/machine-learning/concept-workspace#what-happened-to-enterprise-edition
 					string(Enterprise),
 				}, true),
+			},
+
+			"discovery_url": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"tags": tags.Schema(),
@@ -182,9 +200,10 @@ func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta inte
 		},
 		Identity: expandMachineLearningWorkspaceIdentity(d.Get("identity").([]interface{})),
 		WorkspaceProperties: &machinelearningservices.WorkspaceProperties{
-			StorageAccount:      utils.String(d.Get("storage_account_id").(string)),
-			ApplicationInsights: utils.String(d.Get("application_insights_id").(string)),
-			KeyVault:            utils.String(d.Get("key_vault_id").(string)),
+			StorageAccount:                  utils.String(d.Get("storage_account_id").(string)),
+			ApplicationInsights:             utils.String(d.Get("application_insights_id").(string)),
+			KeyVault:                        utils.String(d.Get("key_vault_id").(string)),
+			AllowPublicAccessWhenBehindVnet: utils.Bool(d.Get("public_network_access").(bool)),
 		},
 	}
 
@@ -202,6 +221,10 @@ func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta inte
 
 	if v, ok := d.GetOk("high_business_impact"); ok {
 		workspace.HbiWorkspace = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("image_build_compute"); ok {
+		workspace.WorkspaceProperties.ImageBuildCompute = utils.String(v.(string))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, workspace)
@@ -258,6 +281,9 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("description", props.Description)
 		d.Set("friendly_name", props.FriendlyName)
 		d.Set("high_business_impact", props.HbiWorkspace)
+		d.Set("public_network_access", props.AllowPublicAccessWhenBehindVnet)
+		d.Set("image_build_compute", props.ImageBuildCompute)
+		d.Set("discovery_url", props.DiscoveryURL)
 	}
 
 	if err := d.Set("identity", flattenMachineLearningWorkspaceIdentity(resp.Identity)); err != nil {

--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -130,7 +130,7 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"image_build_compute": {
+			"image_build_compute_name": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -223,7 +223,7 @@ func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta inte
 		workspace.HbiWorkspace = utils.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("image_build_compute"); ok {
+	if v, ok := d.GetOk("image_build_compute_name"); ok {
 		workspace.WorkspaceProperties.ImageBuildCompute = utils.String(v.(string))
 	}
 
@@ -282,7 +282,7 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("friendly_name", props.FriendlyName)
 		d.Set("high_business_impact", props.HbiWorkspace)
 		d.Set("public_network_access_enabled", props.AllowPublicAccessWhenBehindVnet)
-		d.Set("image_build_compute", props.ImageBuildCompute)
+		d.Set("image_build_compute_name", props.ImageBuildCompute)
 		d.Set("discovery_url", props.DiscoveryURL)
 	}
 

--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -123,7 +123,7 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
-			"public_network_access": {
+			"public_network_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				ForceNew: true,
@@ -203,7 +203,7 @@ func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta inte
 			StorageAccount:                  utils.String(d.Get("storage_account_id").(string)),
 			ApplicationInsights:             utils.String(d.Get("application_insights_id").(string)),
 			KeyVault:                        utils.String(d.Get("key_vault_id").(string)),
-			AllowPublicAccessWhenBehindVnet: utils.Bool(d.Get("public_network_access").(bool)),
+			AllowPublicAccessWhenBehindVnet: utils.Bool(d.Get("public_network_access_enabled").(bool)),
 		},
 	}
 
@@ -281,7 +281,7 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("description", props.Description)
 		d.Set("friendly_name", props.FriendlyName)
 		d.Set("high_business_impact", props.HbiWorkspace)
-		d.Set("public_network_access", props.AllowPublicAccessWhenBehindVnet)
+		d.Set("public_network_access_enabled", props.AllowPublicAccessWhenBehindVnet)
 		d.Set("image_build_compute", props.ImageBuildCompute)
 		d.Set("discovery_url", props.DiscoveryURL)
 	}

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -221,6 +221,8 @@ resource "azurerm_machine_learning_workspace" "test" {
   container_registry_id   = azurerm_container_registry.test.id
   sku_name                = "Basic"
   high_business_impact    = true
+  public_network_access   = true
+  image_build_compute     = "terraformCompute"
 
   identity {
     type = "SystemAssigned"
@@ -259,6 +261,8 @@ resource "azurerm_machine_learning_workspace" "test" {
   container_registry_id   = azurerm_container_registry.test.id
   sku_name                = "Basic"
   high_business_impact    = true
+  public_network_access   = true
+  image_build_compute     = "terraformCompute"
 
   identity {
     type = "SystemAssigned"

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -222,12 +222,11 @@ resource "azurerm_machine_learning_workspace" "test" {
   sku_name                      = "Basic"
   high_business_impact          = true
   public_network_access_enabled = true
-  image_build_compute           = "terraformCompute"
+  image_build_compute_name      = "terraformCompute"
 
   identity {
     type = "SystemAssigned"
   }
-
 
   tags = {
     ENV = "Test"
@@ -262,7 +261,7 @@ resource "azurerm_machine_learning_workspace" "test" {
   sku_name                      = "Basic"
   high_business_impact          = true
   public_network_access_enabled = true
-  image_build_compute           = "terraformCompute"
+  image_build_compute_name      = "terraformCompute"
 
   identity {
     type = "SystemAssigned"

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -210,19 +210,19 @@ resource "azurerm_container_registry" "test" {
 }
 
 resource "azurerm_machine_learning_workspace" "test" {
-  name                    = "acctest-MLW-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  friendly_name           = "test-workspace"
-  description             = "Test machine learning workspace"
-  application_insights_id = azurerm_application_insights.test.id
-  key_vault_id            = azurerm_key_vault.test.id
-  storage_account_id      = azurerm_storage_account.test.id
-  container_registry_id   = azurerm_container_registry.test.id
-  sku_name                = "Basic"
-  high_business_impact    = true
-  public_network_access   = true
-  image_build_compute     = "terraformCompute"
+  name                          = "acctest-MLW-%[2]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  friendly_name                 = "test-workspace"
+  description                   = "Test machine learning workspace"
+  application_insights_id       = azurerm_application_insights.test.id
+  key_vault_id                  = azurerm_key_vault.test.id
+  storage_account_id            = azurerm_storage_account.test.id
+  container_registry_id         = azurerm_container_registry.test.id
+  sku_name                      = "Basic"
+  high_business_impact          = true
+  public_network_access_enabled = true
+  image_build_compute           = "terraformCompute"
 
   identity {
     type = "SystemAssigned"
@@ -250,19 +250,19 @@ resource "azurerm_container_registry" "test" {
 }
 
 resource "azurerm_machine_learning_workspace" "test" {
-  name                    = "acctest-MLW-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  friendly_name           = "test-workspace-updated"
-  description             = "Test machine learning workspace update"
-  application_insights_id = azurerm_application_insights.test.id
-  key_vault_id            = azurerm_key_vault.test.id
-  storage_account_id      = azurerm_storage_account.test.id
-  container_registry_id   = azurerm_container_registry.test.id
-  sku_name                = "Basic"
-  high_business_impact    = true
-  public_network_access   = true
-  image_build_compute     = "terraformCompute"
+  name                          = "acctest-MLW-%[2]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  friendly_name                 = "test-workspace-updated"
+  description                   = "Test machine learning workspace update"
+  application_insights_id       = azurerm_application_insights.test.id
+  key_vault_id                  = azurerm_key_vault.test.id
+  storage_account_id            = azurerm_storage_account.test.id
+  container_registry_id         = azurerm_container_registry.test.id
+  sku_name                      = "Basic"
+  high_business_impact          = true
+  public_network_access_enabled = true
+  image_build_compute           = "terraformCompute"
 
   identity {
     type = "SystemAssigned"

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Machine Learning"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_machine_learning_workspace"
 description: |-
-  Manages a Azure Machine Learning Workspace.
+Manages a Azure Machine Learning Workspace.
 ---
 # azurerm_machine_learning_workspace
 
@@ -86,6 +86,10 @@ The following arguments are supported:
 
 -> **NOTE:** The `admin_enabled` should be `true` in order to associate the Container Registry to this Machine Learning Workspace.
 
+* `public_network_access` - (Optional) Enable public access when this Machine Learning Workspace is behind VNet.
+
+* `image_build_compute` - (Optional) The compute name for image build of the Machine Learning Workspace.
+
 * `description` - (Optional) The description of this Machine Learning Workspace.
 
 * `discovery_url` - (Optional) The URL for the discovery service to identify regional endpoints for machine learning experimentation services.
@@ -109,6 +113,8 @@ An `identity` block supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the Machine Learning Workspace.
+
+* `discovery_url` - The url for the discovery service to identify regional endpoints for machine learning experimentation services.
 
 ---
 

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Enable public access when this Machine Learning Workspace is behind VNet.
 
-* `image_build_compute` - (Optional) The compute name for image build of the Machine Learning Workspace.
+* `image_build_compute_name` - (Optional) The compute name for image build of the Machine Learning Workspace.
 
 * `description` - (Optional) The description of this Machine Learning Workspace.
 

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Machine Learning"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_machine_learning_workspace"
 description: |-
-Manages a Azure Machine Learning Workspace.
+  Manages a Azure Machine Learning Workspace.
 ---
 # azurerm_machine_learning_workspace
 

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 -> **NOTE:** The `admin_enabled` should be `true` in order to associate the Container Registry to this Machine Learning Workspace.
 
-* `public_network_access` - (Optional) Enable public access when this Machine Learning Workspace is behind VNet.
+* `public_network_access_enabled` - (Optional) Enable public access when this Machine Learning Workspace is behind VNet.
 
 * `image_build_compute` - (Optional) The compute name for image build of the Machine Learning Workspace.
 


### PR DESCRIPTION
Support new machine learning workspace configuration: `public_network_access`, `image_build_compute`, `discovery_url`

acc tests:
```log
=== RUN   TestAccMachineLearningWorkspaceDataSource_basic
=== PAUSE TestAccMachineLearningWorkspaceDataSource_basic
=== CONT  TestAccMachineLearningWorkspaceDataSource_basic
--- PASS: TestAccMachineLearningWorkspaceDataSource_basic (441.06s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       450.025s


=== RUN   TestAccMachineLearningWorkspaceDataSource_basic
=== PAUSE TestAccMachineLearningWorkspaceDataSource_basic
=== RUN   TestAccMachineLearningWorkspace_basic
=== PAUSE TestAccMachineLearningWorkspace_basic
=== RUN   TestAccMachineLearningWorkspace_requiresImport
=== PAUSE TestAccMachineLearningWorkspace_requiresImport
=== RUN   TestAccMachineLearningWorkspace_basicUpdate
=== PAUSE TestAccMachineLearningWorkspace_basicUpdate
=== RUN   TestAccMachineLearningWorkspace_complete
=== PAUSE TestAccMachineLearningWorkspace_complete
=== RUN   TestAccMachineLearningWorkspace_completeUpdate
=== PAUSE TestAccMachineLearningWorkspace_completeUpdate
=== CONT  TestAccMachineLearningWorkspaceDataSource_basic
=== CONT  TestAccMachineLearningWorkspace_basicUpdate
=== CONT  TestAccMachineLearningWorkspace_requiresImport
=== CONT  TestAccMachineLearningWorkspace_complete
=== CONT  TestAccMachineLearningWorkspace_basic
=== CONT  TestAccMachineLearningWorkspace_completeUpdate
--- PASS: TestAccMachineLearningWorkspaceDataSource_basic (423.36s)
--- PASS: TestAccMachineLearningWorkspace_basic (445.04s)
--- PASS: TestAccMachineLearningWorkspace_complete (449.73s)
--- PASS: TestAccMachineLearningWorkspace_requiresImport (468.43s)
--- PASS: TestAccMachineLearningWorkspace_basicUpdate (539.36s)
--- PASS: TestAccMachineLearningWorkspace_completeUpdate (571.39s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       574.130s
```