### PR TITLE
Backwards compatible fix for Cluster Variable

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -592,7 +592,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"private_cluster_public_fqdn_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
 				ForceNew: true,
 			},
 


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/issues/13099

This default value causes clusters to be rebuilt on existing
deployments. Simply removing the default value should be sufficient for
preventing the rebuilds from occuring.

If someone needs to explicitly set this to false for some reason, they
can still do that manually. This is a preferable situation to existing
users not being able to upgrade without a complete cluster rebuild.