### PR TITLE
azurerm_kubernetes_cluster supports os_sku

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -209,6 +209,17 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"os_sku": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(containerservice.OSSKUUbuntu),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(containerservice.OSSKUUbuntu),
+					string(containerservice.OSSKUCBLMariner),
+				}, false),
+			},
+
 			"os_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -330,6 +341,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	evictionPolicy := d.Get("eviction_policy").(string)
 	mode := containerservice.AgentPoolMode(d.Get("mode").(string))
 	osType := d.Get("os_type").(string)
+	osSku := d.Get("os_sku").(string)
 	priority := d.Get("priority").(string)
 	spotMaxPrice := d.Get("spot_max_price").(float64)
 	t := d.Get("tags").(map[string]interface{})
@@ -338,6 +350,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	profile := containerservice.ManagedClusterAgentPoolProfileProperties{
 		OsType:                 containerservice.OSType(osType),
+		OsSKU:                  containerservice.OSSKU(osSku),
 		EnableAutoScaling:      utils.Bool(enableAutoScaling),
 		EnableFIPS:             utils.Bool(d.Get("fips_enabled").(bool)),
 		EnableUltraSSD:         utils.Bool(d.Get("ultra_ssd_enabled").(bool)),
@@ -760,6 +773,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		}
 		d.Set("os_disk_type", osDiskType)
 		d.Set("os_type", string(props.OsType))
+		d.Set("os_sku", string(props.OsSKU))
 		d.Set("pod_subnet_id", props.PodSubnetID)
 
 		// not returned from the API if not Spot

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -28,13 +28,16 @@ var kubernetesOtherTests = map[string]func(t *testing.T){
 	"windowsProfileLicense":             testAccKubernetesCluster_windowsProfileLicense,
 	"updateWindowsProfileLicense":       TestAccKubernetesCluster_updateWindowsProfileLicense,
 	"outboundTypeLoadBalancer":          testAccKubernetesCluster_outboundTypeLoadBalancer,
+	"osSku":                             testAccKubernetesCluster_osSku,
 	"privateClusterOn":                  testAccKubernetesCluster_privateClusterOn,
 	"privateClusterOff":                 testAccKubernetesCluster_privateClusterOff,
+	"privateClusterPublicFqdn":          testAccKubernetesCluster_privateClusterPublicFqdn,
 	"privateClusterPrivateDNS":          testAccKubernetesCluster_privateClusterOnWithPrivateDNSZone,
 	"privateClusterPrivateDNSSystem":    testAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSystem,
 	"privateClusterPrivateDNSAndSP":     testAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneAndServicePrincipal,
 	"privateClusterPrivateDNSSubDomain": testAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSubDomain,
 	"upgradeChannel":                    testAccKubernetesCluster_upgradeChannel,
+	"ultraSSD":                          testAccKubernetesCluster_ultraSSD,
 }
 
 func TestAccKubernetesCluster_basicAvailabilitySet(t *testing.T) {
@@ -745,6 +748,26 @@ func testAccKubernetesCluster_privateClusterPublicFqdn(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.privateClusterPublicFqdn(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_osSku(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_osSku(t)
+}
+
+func testAccKubernetesCluster_osSku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSku(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1966,4 +1989,31 @@ resource "azurerm_kubernetes_cluster" "test" {
   private_cluster_public_fqdn_enabled = %t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, privateClusterPublicFqdnEnabled)
+}
+
+func (KubernetesClusterResource) osSku(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    os_sku     = "Ubuntu"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -172,6 +172,17 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					}, false),
 				},
 
+				"os_sku": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  string(containerservice.OSSKUUbuntu),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(containerservice.OSSKUUbuntu),
+						string(containerservice.OSSKUCBLMariner),
+					}, false),
+				},
+
 				"ultra_ssd_enabled": {
 					Type:     pluginsdk.TypeBool,
 					ForceNew: true,
@@ -675,6 +686,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]containerservice.Manag
 		profile.OsDiskType = containerservice.OSDiskType(raw["os_disk_type"].(string))
 	}
 
+	if osSku := raw["os_sku"].(string); osSku != "" {
+		profile.OsSKU = containerservice.OSSKU(osSku)
+	}
+
 	if podSubnetID := raw["pod_subnet_id"].(string); podSubnetID != "" {
 		profile.PodSubnetID = utils.String(podSubnetID)
 	}
@@ -1070,6 +1085,7 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 			"node_taints":                  []string{},
 			"os_disk_size_gb":              osDiskSizeGB,
 			"os_disk_type":                 string(osDiskType),
+			"os_sku":                       string(agentPool.OsSKU),
 			"tags":                         tags.Flatten(agentPool.Tags),
 			"type":                         string(agentPool.Type),
 			"ultra_ssd_enabled":            enableUltraSSD,

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -343,6 +343,8 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`. Changing this forces a new resource to be created.
 
+* `os_sku` - (Optional) OsSKU to be used to specify Linux OSType. Not applicable to Windows OSType. Possible values include: `Ubuntu`, `CBLMariner`. Defaults to `Ubuntu`. Changing this forces a new resource to be created.
+
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the default Node Pool should exist. Changing this forces a new resource to be created.
 
   -> **NOTE:** This requires that the Preview Feature `Microsoft.ContainerService/PodSubnetPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#register-the-podsubnetpreview-preview-feature) for more information.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -117,6 +117,8 @@ The following arguments are supported:
 
 -> **NOTE:** This requires that the Preview Feature `Microsoft.ContainerService/PodSubnetPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#register-the-podsubnetpreview-preview-feature) for more information.
 
+* `os_sku` - (Optional) OsSKU to be used to specify Linux OSType. Not applicable to Windows OSType. Possible values include: `Ubuntu`, `CBLMariner`. Defaults to `Ubuntu`. Changing this forces a new resource to be created.
+
 * `os_type` - (Optional) The Operating System which should be used for this Node Pool. Changing this forces a new resource to be created. Possible values are `Linux` and `Windows`. Defaults to `Linux`.
 
 * `priority` - (Optional) The Priority for Virtual Machines within the Virtual Machine Scale Set that powers this Node Pool. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesCluster_osSku
=== PAUSE TestAccKubernetesCluster_osSku
=== CONT  TestAccKubernetesCluster_osSku
--- PASS: TestAccKubernetesCluster_osSku (792.93s)
=== RUN   TestAccKubernetesClusterNodePool_osSku
=== PAUSE TestAccKubernetesClusterNodePool_osSku
=== CONT  TestAccKubernetesClusterNodePool_osSku
--- PASS: TestAccKubernetesClusterNodePool_osSku(907.23s)

```