### PR TITLE
Allow UTF-8 characters in SQL pool name

### DIFF
--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -30,6 +30,21 @@ func TestAccSynapseSqlPool_basic(t *testing.T) {
 	})
 }
 
+func TestAccSynapseSqlPool_utf8(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_sql_pool", "test")
+	r := SynapseSqlPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.utf8(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSynapseSqlPool_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_synapse_sql_pool", "test")
 	r := SynapseSqlPoolResource{}
@@ -122,6 +137,24 @@ resource "azurerm_synapse_sql_pool" "test" {
   create_mode          = "Default"
 }
 `, template, data.RandomString)
+}
+
+func (r SynapseSqlPoolResource) utf8(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_synapse_sql_pool" "test" {
+  name                 = "販売管理"
+  synapse_workspace_id = azurerm_synapse_workspace.test.id
+  sku_name             = "DW100c"
+  create_mode          = "Default"
+}
+`, template)
 }
 
 func (r SynapseSqlPoolResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/synapse/validate/sql_pool_name.go
+++ b/internal/services/synapse/validate/sql_pool_name.go
@@ -13,10 +13,10 @@ func SqlPoolName(i interface{}, k string) (warnings []string, errors []error) {
 	}
 
 	// The name attribute rules are :
-	// 1. can contain only letters, numbers and underscore.
-	// 2. The value must be between 1 and 15 characters long
-
-	if !regexp.MustCompile(`^[a-zA-Z_\d]{1,15}$`).MatchString(v) {
+	// 1. can't contain '<,>,*,%,&,:,\,/,?,@,-' or control characters
+	// 2. can't end with '.' or ' '
+	// 3. The value must be between 1 and 60 characters long
+	if !regexp.MustCompile(`^[^<>*%&:\\\/?@-]{0,59}[^\s.<>*%&:\\\/?@-]$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%s can contain only letters, numbers or underscore, The value must be between 1 and 15 characters long", k))
 		return
 	}

--- a/internal/services/synapse/validate/sql_pool_name_test.go
+++ b/internal/services/synapse/validate/sql_pool_name_test.go
@@ -20,18 +20,33 @@ func TestSqlPoolName(t *testing.T) {
 			expected: true,
 		},
 		{
+			// UTF-8
+			input:    "販売管理",
+			expected: true,
+		},
+		{
 			// can't contain hyphen
 			input:    "ab-c",
 			expected: false,
 		},
 		{
-			// 15 chars
-			input:    "abcdefghijklmno",
+			// can't end with .
+			input:    "abc.",
+			expected: false,
+		},
+		{
+			// can't end with space
+			input:    "abc ",
+			expected: false,
+		},
+		{
+			// 60 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh",
 			expected: true,
 		},
 		{
-			// 16 chars
-			input:    "abcdefghijklmnop",
+			// 61 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi",
 			expected: false,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Owen Farrell <owen.farrell@gmail.com><!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request updates the validation logic associated with Synapse SQL pool names to support UTF-8 characters and other non-alphanumeric characters that are supported by Azure.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #11554

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='synapse' TESTARGS='-run=TestAccSynapseSqlPool_utf8' TESTTIMEOUT='30m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/synapse -run=TestAccSynapseSqlPool_utf8 -timeout 30m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSynapseSqlPool_utf8
=== PAUSE TestAccSynapseSqlPool_utf8
=== CONT  TestAccSynapseSqlPool_utf8
--- PASS: TestAccSynapseSqlPool_utf8 (980.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse       983.397s
```
