### PR TITLE
azurerm_synapse_workspace - support for the tenant_id property 

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -106,6 +106,27 @@ func TestAccSynapseWorkspace_azdo(t *testing.T) {
 				check.That(data.ResourceName).Key("azure_devops_repo.0.repository_name").HasValue("myrepo"),
 				check.That(data.ResourceName).Key("azure_devops_repo.0.branch_name").HasValue("dev"),
 				check.That(data.ResourceName).Key("azure_devops_repo.0.root_folder").HasValue("/"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.tenant_id").IsEmpty(),
+			),
+		},
+	})
+}
+
+func TestAccSynapseWorkspace_azdoTenant(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_workspace", "test")
+	r := SynapseWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azdoTenant(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.account_name").HasValue("myorg"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.project_name").HasValue("myproj"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.repository_name").HasValue("myrepo"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.branch_name").HasValue("dev"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.root_folder").HasValue("/"),
+				check.That(data.ResourceName).Key("azure_devops_repo.0.tenant_id").Exists(),
 			),
 		},
 	})
@@ -268,6 +289,33 @@ resource "azurerm_synapse_workspace" "test" {
     repository_name = "myrepo"
     branch_name     = "dev"
     root_folder     = "/"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r SynapseWorkspaceResource) azdoTenant(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  azure_devops_repo {
+    account_name    = "myorg"
+    project_name    = "myproj"
+    repository_name = "myrepo"
+    branch_name     = "dev"
+    root_folder     = "/"
+    tenant_id       = data.azurerm_client_config.current.tenant_id
   }
 }
 `, template, data.RandomInteger)

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -111,6 +111,8 @@ An `azure_devops_repo` block supports the following:
 
 * `root_folder` - (Required) Specifies the root folder within the repository. Set to `/` for the top level.
 
+* `tenant_id` - (Optional) the ID of the tenant for the Azure DevOps account.
+
 ---
 
 A `github_repo` block supports the following:


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request adds a new (optional) field to the `azure_devops` block of the `azurerm_synapse_workspace` schema to support cross-tenant connectivity.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #12004

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='synapse' TESTARGS='-run=TestAccSynapseWorkspace_azdo' TESTTIMEOUT='15m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/synapse -run=TestAccSynapseWorkspace_azdo -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSynapseWorkspace_azdo
=== PAUSE TestAccSynapseWorkspace_azdo
=== RUN   TestAccSynapseWorkspace_azdoTenant
=== PAUSE TestAccSynapseWorkspace_azdoTenant
=== CONT  TestAccSynapseWorkspace_azdo
=== CONT  TestAccSynapseWorkspace_azdoTenant
--- PASS: TestAccSynapseWorkspace_azdo (521.78s)
--- PASS: TestAccSynapseWorkspace_azdoTenant (764.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse       766.626s
```
