### PR TITLE
Wait for network provisioning state when creating or updating resources

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -622,7 +622,7 @@ func SubnetProvisioningStateRefreshFunc(ctx context.Context, client *network.Sub
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
 		if err != nil {
-			return nil, "Error", err
+			return nil, "", fmt.Errorf("polling for %s: %+v", id.String(), err)
 		}
 
 		return res, string(res.ProvisioningState), nil

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -180,6 +181,7 @@ func resourceSubnet() *pluginsdk.Resource {
 // TODO: refactor the create/flatten functions
 func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.SubnetsClient
+	vnetClient := meta.(*clients.Client).Network.VnetClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -241,11 +243,36 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, subnet)
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+	}
+
+	timeout, _ := ctx.Deadline()
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(network.ProvisioningStateUpdating)},
+		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, id),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of %s: %+v", id, err)
+	}
+
+	vnetId := parse.NewVirtualNetworkID(id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkName)
+	vnetStateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(network.ProvisioningStateUpdating)},
+		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of virtual network for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -254,6 +281,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.SubnetsClient
+	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -333,6 +361,31 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for update of %s: %+v", *id, err)
+	}
+
+	timeout, _ := ctx.Deadline()
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(network.ProvisioningStateUpdating)},
+		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Refresh:    SubnetProvisioningStateRefreshFunc(ctx, client, *id),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of %s: %+v", id, err)
+	}
+
+	vnetId := parse.NewVirtualNetworkID(id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkName)
+	vnetStateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(network.ProvisioningStateUpdating)},
+		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of virtual network for %s: %+v", id, err)
 	}
 
 	return resourceSubnetRead(d, meta)
@@ -563,4 +616,15 @@ func flattenSubnetServiceEndpointPolicies(input *[]network.ServiceEndpointPolicy
 		output = append(output, id)
 	}
 	return output
+}
+
+func SubnetProvisioningStateRefreshFunc(ctx context.Context, client *network.SubnetsClient, id parse.SubnetId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
+		if err != nil {
+			return nil, "Error", err
+		}
+
+		return res, string(res.ProvisioningState), nil
+	}
 }

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -437,6 +437,21 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = [cidrsubnet("10.5.1.0/24", 4, count.index)]
+
+  enforce_private_link_endpoint_network_policies = true
+  enforce_private_link_service_network_policies  = true
+
+  service_endpoints = [
+    "Microsoft.AzureActiveDirectory",
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.ContainerRegistry",
+    "Microsoft.EventHub",
+    "Microsoft.KeyVault",
+    "Microsoft.ServiceBus",
+    "Microsoft.Sql",
+    "Microsoft.Storage",
+    "Microsoft.Web",
+  ]
 }
 
 resource "azurerm_virtual_wan" "test" {

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -527,7 +527,7 @@ func VirtualNetworkProvisioningStateRefreshFunc(ctx context.Context, client *net
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
 		if err != nil {
-			return nil, "Error", err
+			return nil, "", fmt.Errorf("polling for %s: %+v", id.String(), err)
 		}
 
 		return res, string(res.ProvisioningState), nil

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -211,6 +211,18 @@ func resourceVirtualNetworkCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		return fmt.Errorf("waiting for creation/update of %s: %+v", id, err)
 	}
 
+	timeout, _ := ctx.Deadline()
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(network.ProvisioningStateUpdating)},
+		Target:     []string{string(network.ProvisioningStateSucceeded)},
+		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, client, id),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of %s: %+v", id, err)
+	}
+
 	d.SetId(id.ID())
 	return resourceVirtualNetworkRead(d, meta)
 }
@@ -509,4 +521,15 @@ func expandAzureRmVirtualNetworkVirtualNetworkSecurityGroupNames(d *pluginsdk.Re
 	}
 
 	return nsgNames, nil
+}
+
+func VirtualNetworkProvisioningStateRefreshFunc(ctx context.Context, client *network.VirtualNetworksClient, id parse.VirtualNetworkId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+		if err != nil {
+			return nil, "Error", err
+		}
+
+		return res, string(res.ProvisioningState), nil
+	}
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request verifies the state of virtual networks and subnets returns to `Successful` after making modifications that push them in to an `Updating` state. As a result, this ensures that the associated lock held on each resource is not released until that resource is actually ready to support another operation initiated through the API (whatever that may be).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related (maybe): #3780
Related: #13105
Related (maybe): #13258

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='network' TESTARGS='-run="TestAcc(VirtualNetwork|Subnet|VirtualHubConnection)_"' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run="TestAcc(VirtualNetwork|Subnet|VirtualHubConnection)_" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSubnet_basic
=== PAUSE TestAccSubnet_basic
=== RUN   TestAccSubnet_basic_addressPrefixes
=== PAUSE TestAccSubnet_basic_addressPrefixes
=== RUN   TestAccSubnet_complete_addressPrefixes
=== PAUSE TestAccSubnet_complete_addressPrefixes
=== RUN   TestAccSubnet_update_addressPrefixes
=== PAUSE TestAccSubnet_update_addressPrefixes
=== RUN   TestAccSubnet_requiresImport
=== PAUSE TestAccSubnet_requiresImport
=== RUN   TestAccSubnet_disappears
=== PAUSE TestAccSubnet_disappears
=== RUN   TestAccSubnet_delegation
=== PAUSE TestAccSubnet_delegation
=== RUN   TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
=== PAUSE TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
=== RUN   TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== PAUSE TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== RUN   TestAccSubnet_serviceEndpoints
=== PAUSE TestAccSubnet_serviceEndpoints
=== RUN   TestAccSubnet_serviceEndpointPolicy
=== PAUSE TestAccSubnet_serviceEndpointPolicy
=== RUN   TestAccSubnet_updateAddressPrefix
=== PAUSE TestAccSubnet_updateAddressPrefix
=== RUN   TestAccVirtualHubConnection_basic
=== PAUSE TestAccVirtualHubConnection_basic
=== RUN   TestAccVirtualHubConnection_requiresImport
=== PAUSE TestAccVirtualHubConnection_requiresImport
=== RUN   TestAccVirtualHubConnection_complete
=== PAUSE TestAccVirtualHubConnection_complete
=== RUN   TestAccVirtualHubConnection_update
=== PAUSE TestAccVirtualHubConnection_update
=== RUN   TestAccVirtualHubConnection_enableInternetSecurity
=== PAUSE TestAccVirtualHubConnection_enableInternetSecurity
=== RUN   TestAccVirtualHubConnection_recreateWithSameConnectionName
=== PAUSE TestAccVirtualHubConnection_recreateWithSameConnectionName
=== RUN   TestAccVirtualHubConnection_removeRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_removeRoutingConfiguration
=== RUN   TestAccVirtualHubConnection_removePropagatedRouteTable
=== PAUSE TestAccVirtualHubConnection_removePropagatedRouteTable
=== RUN   TestAccVirtualHubConnection_removeVnetStaticRoute
=== PAUSE TestAccVirtualHubConnection_removeVnetStaticRoute
=== RUN   TestAccVirtualHubConnection_requiresLocking
=== PAUSE TestAccVirtualHubConnection_requiresLocking
=== RUN   TestAccVirtualHubConnection_updateRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_updateRoutingConfiguration
=== RUN   TestAccVirtualNetwork_basic
=== PAUSE TestAccVirtualNetwork_basic
=== RUN   TestAccVirtualNetwork_complete
=== PAUSE TestAccVirtualNetwork_complete
=== RUN   TestAccVirtualNetwork_basicUpdated
=== PAUSE TestAccVirtualNetwork_basicUpdated
=== RUN   TestAccVirtualNetwork_requiresImport
=== PAUSE TestAccVirtualNetwork_requiresImport
=== RUN   TestAccVirtualNetwork_ddosProtectionPlan
=== PAUSE TestAccVirtualNetwork_ddosProtectionPlan
=== RUN   TestAccVirtualNetwork_disappears
=== PAUSE TestAccVirtualNetwork_disappears
=== RUN   TestAccVirtualNetwork_withTags
=== PAUSE TestAccVirtualNetwork_withTags
=== RUN   TestAccVirtualNetwork_deleteSubnet
=== PAUSE TestAccVirtualNetwork_deleteSubnet
=== RUN   TestAccVirtualNetwork_bgpCommunity
=== PAUSE TestAccVirtualNetwork_bgpCommunity
=== CONT  TestAccSubnet_basic
=== CONT  TestAccVirtualHubConnection_enableInternetSecurity
=== CONT  TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== CONT  TestAccVirtualHubConnection_update
=== CONT  TestAccVirtualHubConnection_complete
=== CONT  TestAccVirtualHubConnection_requiresImport
=== CONT  TestAccVirtualHubConnection_basic
=== CONT  TestAccSubnet_updateAddressPrefix
--- PASS: TestAccSubnet_basic (155.68s)
=== CONT  TestAccSubnet_serviceEndpointPolicy
--- PASS: TestAccSubnet_updateAddressPrefix (229.75s)
=== CONT  TestAccSubnet_serviceEndpoints
--- PASS: TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies (299.07s)
=== CONT  TestAccVirtualNetwork_complete
--- PASS: TestAccVirtualNetwork_complete (122.07s)
=== CONT  TestAccVirtualNetwork_bgpCommunity
--- PASS: TestAccSubnet_serviceEndpointPolicy (271.80s)
=== CONT  TestAccVirtualNetwork_deleteSubnet
--- PASS: TestAccSubnet_serviceEndpoints (358.93s)
=== CONT  TestAccVirtualNetwork_withTags
--- PASS: TestAccVirtualNetwork_deleteSubnet (194.53s)
=== CONT  TestAccVirtualNetwork_disappears
--- PASS: TestAccVirtualNetwork_bgpCommunity (276.93s)
=== CONT  TestAccVirtualNetwork_ddosProtectionPlan
--- PASS: TestAccVirtualNetwork_disappears (108.43s)
=== CONT  TestAccVirtualNetwork_requiresImport
--- PASS: TestAccVirtualNetwork_withTags (169.14s)
=== CONT  TestAccSubnet_requiresImport
=== CONT  TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
--- PASS: TestAccVirtualNetwork_requiresImport (194.22s)
--- PASS: TestAccVirtualNetwork_ddosProtectionPlan (239.51s)
=== CONT  TestAccSubnet_delegation
--- PASS: TestAccSubnet_requiresImport (213.89s)
=== CONT  TestAccSubnet_disappears
--- PASS: TestAccSubnet_disappears (123.26s)
=== CONT  TestAccVirtualHubConnection_removeVnetStaticRoute
--- PASS: TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies (300.65s)
=== CONT  TestAccVirtualNetwork_basic
--- PASS: TestAccSubnet_delegation (444.16s)
=== CONT  TestAccVirtualHubConnection_updateRoutingConfiguration
--- PASS: TestAccVirtualNetwork_basic (182.92s)
=== CONT  TestAccVirtualHubConnection_requiresLocking
--- PASS: TestAccVirtualHubConnection_basic (2062.10s)
=== CONT  TestAccSubnet_complete_addressPrefixes
--- PASS: TestAccVirtualHubConnection_requiresImport (2146.35s)
=== CONT  TestAccSubnet_update_addressPrefixes
--- PASS: TestAccSubnet_complete_addressPrefixes (197.01s)
=== CONT  TestAccVirtualNetwork_basicUpdated
=== CONT  TestAccSubnet_basic_addressPrefixes
--- PASS: TestAccVirtualHubConnection_complete (2277.51s)
--- PASS: TestAccVirtualHubConnection_enableInternetSecurity (2363.56s)
=== CONT  TestAccVirtualHubConnection_removeRoutingConfiguration
--- PASS: TestAccSubnet_basic_addressPrefixes (141.19s)
=== CONT  TestAccVirtualHubConnection_removePropagatedRouteTable
--- PASS: TestAccVirtualNetwork_basicUpdated (204.44s)
=== CONT  TestAccVirtualHubConnection_recreateWithSameConnectionName
--- PASS: TestAccSubnet_update_addressPrefixes (356.92s)
--- PASS: TestAccVirtualHubConnection_update (2870.52s)
--- PASS: TestAccVirtualHubConnection_removeVnetStaticRoute (2221.92s)
--- PASS: TestAccVirtualHubConnection_updateRoutingConfiguration (2125.62s)
--- PASS: TestAccVirtualHubConnection_requiresLocking (2104.49s)
--- PASS: TestAccVirtualHubConnection_removePropagatedRouteTable (2248.30s)
--- PASS: TestAccVirtualHubConnection_removeRoutingConfiguration (2317.69s)
--- PASS: TestAccVirtualHubConnection_recreateWithSameConnectionName (2559.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       5025.064s
```
