### PR TITLE
Documentation examples: Fix `unsupported block type` error for App Service Environment V3

### DIFF
--- a/website/docs/r/app_service_environment_v3.html.markdown
+++ b/website/docs/r/app_service_environment_v3.html.markdown
@@ -37,7 +37,7 @@ resource "azurerm_subnet" "example" {
   delegation {
     name = "delegation"
 
-      service_delegation {
+    service_delegation {
       name    = "Microsoft.Web/hostingEnvironments"
       actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
     }

--- a/website/docs/r/app_service_environment_v3.html.markdown
+++ b/website/docs/r/app_service_environment_v3.html.markdown
@@ -34,9 +34,13 @@ resource "azurerm_subnet" "example" {
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 
-  service_delegation {
-    name    = "Microsoft.Web/hostingEnvironments"
-    actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+  delegation {
+    name = "delegation"
+
+      service_delegation {
+      name    = "Microsoft.Web/hostingEnvironments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
   }
 }
 


### PR DESCRIPTION
Move azurerm_subnet.service_delegation to azurerm_subnet.delegation.service_delegation

## Issue

Using the example from the website causes syntax errors on `terraform apply`.

```log
Error: Unsupported block type
│ 
│   on main.tf line xx, in resource "azurerm_subnet" "subnet":
│   xx:   service_delegation {
│ 
│ Blocks of type "service_delegation" are not expected here.
```

## My Approach

Adapt subnet delegation to [subnet#example-usage documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#example-usage)

