### PR TITLE
`azurerm_lb`: Support for adding/replacing `frontend_ip_configuration` with `availability_zone`

### DIFF
--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -216,6 +216,11 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 					if d.HasChange(fmt.Sprintf("frontend_ip_configuration.%d.availability_zone", index)) && !d.HasChange(fmt.Sprintf("frontend_ip_configuration.%d.name", index)) {
 						return fmt.Errorf("in place change of the `frontend_ip_configuration.%[1]d.availability_zone` is not allowed. It is allowed to do this while also changing `frontend_ip_configuration.%[1]d.name`", index)
 					}
+
+					// TODO - Remove in 3.0
+					if d.HasChange(fmt.Sprintf("frontend_ip_configuration.%d.zones", index)) && !d.HasChange(fmt.Sprintf("frontend_ip_configuration.%d.name", index)) {
+						return fmt.Errorf("in place change of the `frontend_ip_configuration.%[1]d.zones` is not allowed. It is allowed to do this while also changing `frontend_ip_configuration.%[1]d.name`", index)
+					}
 				}
 			}
 

--- a/internal/services/loadbalancer/loadbalancer_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_resource_test.go
@@ -165,7 +165,7 @@ func TestAccAzureRMLoadBalancer_privateIP(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone(t *testing.T) {
+func TestAccAzureRMLoadBalancer_updateFrontEndConfigsWithZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb", "test")
 	r := LoadBalancer{}
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 `frontend_ip_configuration` supports the following:
 
 * `name` - (Required) Specifies the name of the frontend ip configuration.
-* `availability_zone` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`.
+* `availability_zone` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Availability Zone can only be updated whenever the name of the front end ip configuration changes. Defaults to `Zone-Redundant`. 
  `No-Zones` - A `non-zonal` resource will be created and the resource will not be replicated or distributed to any Availability Zones.
 
  `1`, `2` or `3` (e.g. single Availability Zone) - A `zonal` resource will be created and will be replicate or distribute to a single specific Availability Zone. 


### PR DESCRIPTION
Fixes #13017

## Acceptance Tests:
```bash
❯ make acctests SERVICE='loadbalancer' TESTARGS='-run=TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/loadbalancer -run=TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone
=== PAUSE TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone
=== CONT  TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone
--- PASS: TestAccAzureRMLoadBalancer_updatefrontEndConfigsWithZone (539.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer  541.863s
```