### PR TITLE
`azurerm_storage_account_network_rules ` - Deprecate `storage_account_name` and `resource_group_name` in favor of `storage_account_id`

### DIFF
--- a/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -29,6 +29,21 @@ func TestAccStorageAccountNetworkRules_basic(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccountNetworkRules_id(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rules", "test")
+	r := StorageAccountNetworkRulesResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.id(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_storage_account.test").ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccountNetworkRules_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rules", "test")
 	r := StorageAccountNetworkRulesResource{}
@@ -186,6 +201,55 @@ resource "azurerm_storage_account" "test" {
 resource "azurerm_storage_account_network_rules" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Deny"
+  ip_rules                   = ["127.0.0.1"]
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}
+
+// TODO: Remove in 3.0
+func (r StorageAccountNetworkRulesResource) id(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "azurerm_storage_account_network_rules" "test" {
+  storage_account_id = azurerm_storage_account.test.id
 
   default_action             = "Deny"
   ip_rules                   = ["127.0.0.1"]

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -66,9 +66,15 @@ resource "azurerm_storage_account_network_rules" "test" {
 
 The following arguments are supported:
 
-* `storage_account_name` - (Required) Specifies the name of the storage account. Changing this forces a new resource to be created. This must be unique across the entire Azure service, not just within the resource group.
+* `storage_account_name` - (Optional) Specifies the name of the storage account. Changing this forces a new resource to be created. This must be unique across the entire Azure service, not just within the resource group.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the storage account. Changing this forces a new resource to be created.
+-> **NOTE:** This property has been deprecated in favour of the `storage_account_id` property and will be removed in version 3.0 of the provider.
+
+* `resource_group_name` - (Optional) The name of the resource group in which to create the storage account. Changing this forces a new resource to be created.
+
+-> **NOTE:** This property has been deprecated in favour of the `storage_account_id` property and will be removed in version 3.0 of the provider.
+
+* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created.
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request establishes a migration path from the current use resource group name and storage account name towards storage account IDs instead.

* The resouce group name and storage account name fields have been marked as deprecated in favor of the storage account ID
* Existing acceptance tests have **_not_** been modified to confirm backwards compatibility with the current implementation 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #9899
Related: #13106

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccountNetworkRules_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageAccountNetworkRules_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccountNetworkRules_basic
=== PAUSE TestAccStorageAccountNetworkRules_basic
=== RUN   TestAccStorageAccountNetworkRules_id
=== PAUSE TestAccStorageAccountNetworkRules_id
=== RUN   TestAccStorageAccountNetworkRules_update
=== PAUSE TestAccStorageAccountNetworkRules_update
=== RUN   TestAccStorageAccountNetworkRules_privateLinkAccess
=== PAUSE TestAccStorageAccountNetworkRules_privateLinkAccess
=== RUN   TestAccStorageAccountNetworkRules_SynapseAccess
=== PAUSE TestAccStorageAccountNetworkRules_SynapseAccess
=== RUN   TestAccStorageAccountNetworkRules_empty
=== PAUSE TestAccStorageAccountNetworkRules_empty
=== CONT  TestAccStorageAccountNetworkRules_basic
=== CONT  TestAccStorageAccountNetworkRules_privateLinkAccess
=== CONT  TestAccStorageAccountNetworkRules_update
=== CONT  TestAccStorageAccountNetworkRules_id
=== CONT  TestAccStorageAccountNetworkRules_empty
=== CONT  TestAccStorageAccountNetworkRules_SynapseAccess
--- PASS: TestAccStorageAccountNetworkRules_empty (183.93s)
--- PASS: TestAccStorageAccountNetworkRules_basic (251.22s)
--- PASS: TestAccStorageAccountNetworkRules_id (289.08s)
--- PASS: TestAccStorageAccountNetworkRules_privateLinkAccess (512.75s)
--- PASS: TestAccStorageAccountNetworkRules_update (529.76s)
--- PASS: TestAccStorageAccountNetworkRules_SynapseAccess (880.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       883.124s
```
