### PR TITLE
`data.kubernetes_cluster.html.markdown`: add missing docs for `identity` block

### DIFF
--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -312,6 +312,8 @@ The `identity` block exports the following:
 
 * `tenant_id` - The tenant id of the system assigned identity which is used by primary components.
 
+* `user_assigned_identity_id` - The ID of the User Assigned Identity which is used by primary components. This value will be empty when using system assigned identity.
+
 ---
 
 The `kubelet_identity` block exports the following:


### PR DESCRIPTION
It looks like the docs for `identity` block for `data.kubernetes_cluster` is missing the statement that it also has `user_assigned_identity_id` field.

This PR fixes that.

I have tested that `user_assigned_identity_id` is indeed present when using user assigned identity.

```hcl
data "azurerm_kubernetes_cluster" "cluster_user_assigned" {
  name                = "REDACTED"
  resource_group_name = "REDACTED"
}

output "cluster_user_assigned" {
  value = {
    identity = data.azurerm_kubernetes_cluster.cluster_user_assigned.identity
  }
}

Changes to Outputs:
  + cluster_user_assigned   = {
      + identity = [
          + {
              + principal_id              = ""
              + tenant_id                 = ""
              + type                      = "UserAssigned"
              + user_assigned_identity_id = "/subscriptions/REDACTED/resourceGroups/REDACTED/providers/Microsoft.ManagedIdentity/userAssignedIdentities/REDACTED"
            },
        ]
    }

```

I have tested that the value of `user_assigned_identity_id` is indeed empty when using system assigned identity.

```hcl
data "azurerm_kubernetes_cluster" "cluster_system_assigned" {
  name                = "REDACTED"
  resource_group_name = "REDACTED"
}

output "cluster_system_assigned" {
  value = {
    identity = data.azurerm_kubernetes_cluster.cluster_system_assigned.identity
  }
}

Changes to Outputs:
  + cluster_system_assigned = {
      + identity = [
          + {
              + principal_id              = "REDACTED"
              + tenant_id                 = "REDACTED"
              + type                      = "SystemAssigned"
              + user_assigned_identity_id = ""
            },
        ]
    }
```


