### PR TITLE
`azurerm_policy_virtual_machine_configuration_assignment`: Updated example HCL, add datasource

### DIFF
--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source.go
@@ -97,7 +97,7 @@ func dataSourcePolicyVirtualMachineConfigurationAssignmentRead(d *pluginsdk.Reso
 
 	if props := resp.Properties; props != nil {
 		if v := props.AssignmentHash; v != nil {
-			d.Set("assignment_hash", *v)
+			d.Set("assignment_hash", v)
 		}
 
 		if v := string(props.ComplianceStatus); v != "" {
@@ -105,7 +105,7 @@ func dataSourcePolicyVirtualMachineConfigurationAssignmentRead(d *pluginsdk.Reso
 		}
 
 		if v := props.LatestReportID; v != nil {
-			d.Set("latest_report_id", *v)
+			d.Set("latest_report_id", v)
 		}
 
 		if v := props.LastComplianceStatusChecked; v != nil {

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source.go
@@ -1,0 +1,143 @@
+package policy
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/guestconfiguration/mgmt/2020-06-25/guestconfiguration"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourcePolicyVirtualMachineConfigurationAssignmentRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"virtual_machine_name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"content_hash": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"content_uri": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"assignment_hash": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"compliance_status": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"latest_report_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"last_compliance_status_checked": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePolicyVirtualMachineConfigurationAssignmentRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Policy.GuestConfigurationAssignmentsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	vmName := d.Get("virtual_machine_name").(string)
+	name := d.Get("name").(string)
+
+	id := parse.NewVirtualMachineConfigurationAssignmentID(subscriptionId, resourceGroup, vmName, name)
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.GuestConfigurationAssignmentName, id.VirtualMachineName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] guestConfiguration %q was not found", id.GuestConfigurationAssignmentName)
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	d.Set("name", id.GuestConfigurationAssignmentName)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("virtual_machine_name", vmName)
+
+	if props := resp.Properties; props != nil {
+		if v := props.AssignmentHash; v != nil {
+			d.Set("assignment_hash", *v)
+		}
+
+		if v := string(props.ComplianceStatus); v != "" {
+			d.Set("compliance_status", v)
+		}
+
+		if v := props.LatestReportID; v != nil {
+			d.Set("latest_report_id", *v)
+		}
+
+		if v := props.LastComplianceStatusChecked; v != nil {
+			d.Set("last_compliance_status_checked", v.Format(time.RFC3339))
+		}
+
+		contentHash, contentUri := dataSourceFlattenGuestConfigurationAssignment(props.GuestConfiguration)
+
+		if contentHash != nil {
+			d.Set("content_hash", contentHash)
+		}
+
+		if contentUri != nil {
+			d.Set("content_uri", contentUri)
+		}
+	}
+	return nil
+}
+
+func dataSourceFlattenGuestConfigurationAssignment(input *guestconfiguration.Navigation) (*string, *string) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var contentHash *string
+	if input.ContentHash != nil {
+		contentHash = input.ContentHash
+	}
+	var contentUri *string
+	if input.ContentURI != nil {
+		contentUri = input.ContentURI
+	}
+
+	return contentHash, contentUri
+}

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
@@ -1,0 +1,150 @@
+package policy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type PolicyVirtualMachineConfigurationAssignmentDataSource struct {
+}
+
+func TestAccPolicyVirtualMachineConfigurationAssignmentDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_policy_virtual_machine_configuration_assignment", "test")
+	r := PolicyVirtualMachineConfigurationAssignmentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("compliance_status").Exists(),
+			),
+		},
+	})
+}
+
+func (r PolicyVirtualMachineConfigurationAssignmentDataSource) templateBase(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  vm_name = "acctestvm%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r PolicyVirtualMachineConfigurationAssignmentDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                       = "AzurePolicyforWindows"
+  virtual_machine_id         = azurerm_windows_virtual_machine.test.id
+  publisher                  = "Microsoft.GuestConfiguration"
+  type                       = "ConfigurationforWindows"
+  type_handler_version       = "1.0"
+  auto_upgrade_minor_version = "true"
+}
+`, r.templateBase(data))
+}
+
+func (r PolicyVirtualMachineConfigurationAssignmentDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
+  name               = "AzureWindowsBaseline"
+  location           = azurerm_windows_virtual_machine.test.location
+  virtual_machine_id = azurerm_windows_virtual_machine.test.id
+  configuration {
+    assignment_type = "ApplyAndMonitor"
+    version         = "1.*"
+    parameter {
+      name  = "Minimum Password Length;ExpectedValue"
+      value = "16"
+    }
+    parameter {
+      name  = "Minimum Password Age;ExpectedValue"
+      value = "0"
+    }
+    parameter {
+      name  = "Maximum Password Age;ExpectedValue"
+      value = "30,45"
+    }
+    parameter {
+      name  = "Enforce Password History;ExpectedValue"
+      value = "10"
+    }
+    parameter {
+      name  = "Password Must Meet Complexity Requirements;ExpectedValue"
+      value = "1"
+    }
+  }
+}
+
+data "azurerm_policy_virtual_machine_configuration_assignment" "test" {
+  name                 = azurerm_policy_virtual_machine_configuration_assignment.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_machine_name = azurerm_windows_virtual_machine.test.name
+}
+`, r.template(data))
+}

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
@@ -106,9 +106,11 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
   name               = "AzureWindowsBaseline"
   location           = azurerm_windows_virtual_machine.test.location
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
+
   configuration {
     assignment_type = "ApplyAndMonitor"
     version         = "1.*"
+
     parameter {
       name  = "Minimum Password Length;ExpectedValue"
       value = "16"

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_data_source_test.go
@@ -95,15 +95,6 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-
-resource "azurerm_virtual_machine_extension" "test" {
-  name                       = "AzurePolicyforWindows"
-  virtual_machine_id         = azurerm_windows_virtual_machine.test.id
-  publisher                  = "Microsoft.GuestConfiguration"
-  type                       = "ConfigurationforWindows"
-  type_handler_version       = "1.0"
-  auto_upgrade_minor_version = "true"
-}
 `, r.templateBase(data))
 }
 

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -80,12 +80,14 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						"content_hash": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"content_uri": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
 						},
 
@@ -114,6 +116,27 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						},
 					},
 				},
+			},
+
+			// Computed
+			"assignment_hash": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"compliance_status": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"latest_report_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"last_compliance_status_checked": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -187,6 +210,22 @@ func resourcePolicyVirtualMachineConfigurationAssignmentRead(d *pluginsdk.Resour
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if props := resp.Properties; props != nil {
+		if v := props.AssignmentHash; v != nil {
+			d.Set("assignment_hash", *v)
+		}
+
+		if v := string(props.ComplianceStatus); v != "" {
+			d.Set("compliance_status", v)
+		}
+
+		if v := props.LatestReportID; v != nil {
+			d.Set("latest_report_id", *v)
+		}
+
+		if v := props.LastComplianceStatusChecked; v != nil {
+			d.Set("last_compliance_status_checked", v.Format(time.RFC3339))
+		}
+
 		if err := d.Set("configuration", flattenGuestConfigurationAssignment(props.GuestConfiguration)); err != nil {
 			return fmt.Errorf("setting `configuration`: %+v", err)
 		}

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -69,8 +69,6 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						"assignment_type": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							ForceNew: true,
-							Default:  string(guestconfiguration.AssignmentTypeAudit),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(guestconfiguration.AssignmentTypeAudit),
 								string(guestconfiguration.AssignmentTypeDeployAndAutoCorrect),
@@ -90,6 +88,18 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
+									"content_hash": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"content_uri": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
+									},
+
 									"value": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
@@ -101,16 +111,6 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						"version": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-						},
-
-						"content_hash": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"content_uri": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
 						},
 					},
 				},

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -69,24 +69,14 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						"assignment_type": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
+							ForceNew: true,
+							Default:  string(guestconfiguration.AssignmentTypeAudit),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(guestconfiguration.AssignmentTypeAudit),
 								string(guestconfiguration.AssignmentTypeDeployAndAutoCorrect),
 								string(guestconfiguration.AssignmentTypeApplyAndAutoCorrect),
 								string(guestconfiguration.AssignmentTypeApplyAndMonitor),
 							}, false),
-						},
-
-						"content_hash": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"content_uri": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
 						},
 
 						"parameter": {
@@ -111,6 +101,16 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 						"version": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
+						},
+
+						"content_hash": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"content_uri": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
 						},
 					},
 				},

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -77,6 +77,18 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 							}, false),
 						},
 
+						"content_hash": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"content_uri": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
+						},
+
 						"parameter": {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
@@ -86,18 +98,6 @@ func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"content_hash": {
-										Type:         pluginsdk.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"content_uri": {
-										Type:         pluginsdk.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.IsURLWithScheme([]string{"http", "https"}),
 									},
 
 									"value": {

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -156,9 +156,11 @@ func (r PolicyVirtualMachineConfigurationAssignmentResource) basic(data acceptan
 %s
 
 resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
-  name               = "WhitelistedApplication"
-  location           = azurerm_windows_virtual_machine.test.location
+  name     = "WhitelistedApplication"
+  location = azurerm_windows_virtual_machine.test.location
+
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
+
   configuration {
     name    = "WhitelistedApplication"
     version = "1.*"

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -162,7 +162,6 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
 
   configuration {
-    name    = "WhitelistedApplication"
     version = "1.*"
 
     parameter {

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -156,7 +156,7 @@ func (r PolicyVirtualMachineConfigurationAssignmentResource) basic(data acceptan
 %s
 
 resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
-  name               = "acctest-gca-%d"
+  name               = "WhitelistedApplication"
   location           = azurerm_windows_virtual_machine.test.location
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
   configuration {
@@ -169,7 +169,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r PolicyVirtualMachineConfigurationAssignmentResource) requiresImport(data acceptance.TestData) string {
@@ -182,7 +182,6 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "import" {
   virtual_machine_id = azurerm_policy_virtual_machine_configuration_assignment.test.virtual_machine_id
 
   configuration {
-    name    = "WhitelistedApplication"
     version = "1.*"
 
     parameter {
@@ -199,12 +198,11 @@ func (r PolicyVirtualMachineConfigurationAssignmentResource) complete(data accep
 %s
 
 resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
-  name               = "acctest-gca-%d"
+  name               = "WhitelistedApplication"
   location           = azurerm_windows_virtual_machine.test.location
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
 
   configuration {
-    name            = "WhitelistedApplication"
     version         = "1.1.1.1"
     assignment_type = "ApplyAndAutoCorrect"
     content_hash    = "testcontenthash"
@@ -216,7 +214,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r PolicyVirtualMachineConfigurationAssignmentResource) updateGuestConfiguration(data acceptance.TestData) string {
@@ -224,12 +222,11 @@ func (r PolicyVirtualMachineConfigurationAssignmentResource) updateGuestConfigur
 %s
 
 resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
-  name               = "acctest-gca-%d"
+  name               = "WhitelistedApplication"
   location           = azurerm_windows_virtual_machine.test.location
   virtual_machine_id = azurerm_windows_virtual_machine.test.id
 
   configuration {
-    name            = "WhitelistedApplication"
     version         = "1.1.1.1"
     assignment_type = "Audit"
     content_hash    = "testcontenthash2"
@@ -241,5 +238,5 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }

--- a/internal/services/policy/registration.go
+++ b/internal/services/policy/registration.go
@@ -39,8 +39,9 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_policy_definition":     dataSourceArmPolicyDefinition(),
-		"azurerm_policy_set_definition": dataSourceArmPolicySetDefinition(),
+		"azurerm_policy_definition":                               dataSourceArmPolicyDefinition(),
+		"azurerm_policy_set_definition":                           dataSourceArmPolicySetDefinition(),
+		"azurerm_policy_virtual_machine_configuration_assignment": dataSourcePolicyVirtualMachineConfigurationAssignment(),
 	}
 }
 

--- a/website/docs/d/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/d/policy_virtual_machine_configuration_assignment.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Policy"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_policy_virtual_machine_configuration_assignment"
+description: |-
+  Get information about a Guest Configuration Policy.
+---
+
+# Data Source: azurerm_policy_virtual_machine_configuration_assignment
+
+Use this data source to access information about an existing Guest Configuration Policy.
+
+## Example Usage
+
+```hcl
+data "azurerm_policy_virtual_machine_configuration_assignment" "example" {
+  name                 = "AzureWindowsBaseline"
+  resource_group_name  = "example-RG"
+  virtual_machine_name = "example-vm"
+}
+
+output "compliance_status" {
+  value = data.azurerm_policy_virtual_machine_configuration_assignment.example.compliance_status
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the Guest Configuration Assignment.
+
+* `resource_group_name` - (Required) Specifies the Name of the Resource Group where the Guest Configuration Assignment exists.
+
+* `virtual_machine_name` - (Required) Only retrieve Policy Set Definitions from this Management Group.
+
+## Attributes Reference
+
+* `id` - The ID of the Guest Configuration Assignment.
+
+* `content_hash` - The content hash for the Guest Configuration package.
+
+* `content_uri` - The content URI where the Guest Configuration package is stored.
+
+* `assignment_hash` - Combined hash of the configuration package and parameters.
+
+* `compliance_status` - A value indicating compliance status of the machine for the assigned guest configuration. Possible return values are `Compliant`, `NonCompliant` and `Pending`. 
+
+* `last_compliance_status_checked` - Date and time, in RFC3339 format, when the machines compliance status was last checked.
+
+* `latest_report_id` - The ID of the latest report for the guest configuration assignment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Guest Configuration Assignment.

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -133,7 +133,11 @@ A `configuration` block supports the following:
 
 * `name` - (Required) The name of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
 
-* `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`. Defaults to `Audit`. Changing this forces a new resource to be created.
+* `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`.
+
+* `content_hash` - (Optional) The content hash for the Guest Configuration package.
+
+* `content_uri` - (Optional) The content URI where the Guest Configuration package is stored.
 
 * `parameter` - (Optional) One or more `parameter` blocks which define what configuration parameters and values against.
 
@@ -152,13 +156,6 @@ A `parameter` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Policy Virtual Machine Configuration Assignment.
-
-A `configuration` block exports the following:
-
-* `content_hash` - The content hash for the Guest Configuration package.
-
-* `content_uri` - The content URI where the Guest Configuration package is stored.
-
 
 ## Timeouts
 

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -86,8 +86,9 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "example" {
   location           = azurerm_windows_virtual_machine.example.location
   virtual_machine_id = azurerm_windows_virtual_machine.example.id
   configuration {
-    name    = "AzureWindowsBaseline"
-    version = "1.*"
+    assignment_type = "ApplyAndMonitor"
+    name            = "AzureWindowsBaseline"
+    version         = "1.*"
     parameter {
       name  = "Minimum Password Length;ExpectedValue"
       value = "16"

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -129,15 +129,11 @@ The following arguments are supported:
 
 ---
 
-An `configuration` block supports the following:
+A `configuration` block supports the following:
 
 * `name` - (Required) The name of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
 
-* `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`.
-
-* `content_hash` - (Optional) The content hash for the Guest Configuration package.
-
-* `content_uri` - (Optional) The content URI where the Guest Configuration package is stored.
+* `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`. Defaults to `Audit`. Changing this forces a new resource to be created.
 
 * `parameter` - (Optional) One or more `parameter` blocks which define what configuration parameters and values against.
 
@@ -145,7 +141,7 @@ An `configuration` block supports the following:
 
 ---
 
-An `parameter` block supports the following:
+A `parameter` block supports the following:
 
 * `name` - (Required) The name of the configuration parameter to check.
 
@@ -156,6 +152,13 @@ An `parameter` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Policy Virtual Machine Configuration Assignment.
+
+A `configuration` block exports the following:
+
+* `content_hash` - The content hash for the Guest Configuration package.
+
+* `content_uri` - The content URI where the Guest Configuration package is stored.
+
 
 ## Timeouts
 

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -139,6 +139,8 @@ A `configuration` block supports the following:
 
 * `content_uri` - (Optional) The content URI where the Guest Configuration package is stored.
 
+~> **NOTE:** When deploying a Custom Guest Configuration package the `content_hash` and `content_uri` fields must be defined. For Built-in Guest Configuration packages, such as the `AzureWindowsBaseline` package, the `content_hash` and `content_uri` should not be defined, rather these fields will be returned after the Built-in Guest Configuration package has been provisioned. For more information on guest configuration assignments please see the [product documentation](https://docs.microsoft.com/azure/governance/policy/concepts/guest-configuration-assignments).
+
 * `parameter` - (Optional) One or more `parameter` blocks which define what configuration parameters and values against.
 
 * `version` - (Optional) The version of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
@@ -156,6 +158,15 @@ A `parameter` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Policy Virtual Machine Configuration Assignment.
+
+* `assignment_hash` - Combined hash of the configuration package and parameters.
+
+* `compliance_status` - A value indicating compliance status of the machine for the assigned guest configuration. Possible return values are `Compliant`, `NonCompliant` and `Pending`. 
+
+* `last_compliance_status_checked` - Date and time, in RFC3339 format, when the machines compliance status was last checked.
+
+* `latest_report_id` - The ID of the latest report for the guest configuration assignment.
+
 
 ## Timeouts
 

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_virtual_machine_configuration_assignment"
 description: |-
-  Applies a Configuration Policy to a Virtual Machine.
+  Applies a Guest Configuration Policy to a Virtual Machine.
 ---
 
 # azurerm_policy_virtual_machine_configuration_assignment
 
-Applies a Configuration Policy to a Virtual Machine.
+Applies a Guest Configuration Policy to a Virtual Machine.
 
 ## Example Usage
 
@@ -87,7 +87,6 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "example" {
   virtual_machine_id = azurerm_windows_virtual_machine.example.id
   configuration {
     assignment_type = "ApplyAndMonitor"
-    name            = "AzureWindowsBaseline"
     version         = "1.*"
     parameter {
       name  = "Minimum Password Length;ExpectedValue"
@@ -117,7 +116,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Policy Virtual Machine Configuration Assignment. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Guest Configuration that will be assigned in this Guest Configuration Assignment. Changing this forces a new resource to be created.
 
 * `location` - (Required) The Azure location where the Policy Virtual Machine Configuration Assignment should exist. Changing this forces a new resource to be created.
 
@@ -131,7 +130,8 @@ The following arguments are supported:
 
 A `configuration` block supports the following:
 
-* `name` - (Required) The name of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
+[comment]: # (TODO: Remove in 3.0)
+* `name` - (Deprecated) This field is no longer used and will be removed in the next major version of the Azure Provider.
 
 * `assignment_type` - (Optional) The assignment type for the Guest Configuration Assignment. Possible values are `Audit`, `ApplyAndAutoCorrect`, `ApplyAndMonitor` and `DeployAndAutoCorrect`.
 

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Applies a Guest Configuration Policy to a Virtual Machine.
 
+~> **NOTE:** You can create Guest Configuration Policies without defining a `azurerm_virtual_machine_extension` resource, however the policies will not be executed until a `azurerm_virtual_machine_extension` has been provisioned to the virtual machine.
+
 ## Example Usage
 
 ```hcl
@@ -85,9 +87,11 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "example" {
   name               = "AzureWindowsBaseline"
   location           = azurerm_windows_virtual_machine.example.location
   virtual_machine_id = azurerm_windows_virtual_machine.example.id
+
   configuration {
     assignment_type = "ApplyAndMonitor"
     version         = "1.*"
+
     parameter {
       name  = "Minimum Password Length;ExpectedValue"
       value = "16"
@@ -158,14 +162,6 @@ A `parameter` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Policy Virtual Machine Configuration Assignment.
-
-* `assignment_hash` - Combined hash of the configuration package and parameters.
-
-* `compliance_status` - A value indicating compliance status of the machine for the assigned guest configuration. Possible return values are `Compliant`, `NonCompliant` and `Pending`. 
-
-* `last_compliance_status_checked` - Date and time, in RFC3339 format, when the machines compliance status was last checked.
-
-* `latest_report_id` - The ID of the latest report for the guest configuration assignment.
 
 
 ## Timeouts


### PR DESCRIPTION
Service team requested that we add the assignment_type = "ApplyAndMonitor" to the example usage.

### Added Datasource:

* azurerm_policy_virtual_machine_configuration_assignment