### PR TITLE
docs: azurerm_resource_group_template_deployment - restructure provider features block sentence

### DIFF
--- a/website/docs/r/resource_group_template_deployment.html.markdown
+++ b/website/docs/r/resource_group_template_deployment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Resource Group Template Deployment.
 
-~> **Note:** This resource will automatically attempt to delete resources deployed by the ARM Template when it is deleted. You can opt-out of this by setting the `delete_nested_items_during_deletion` field within the `template_deployment` block of the `features` block to `false`.
+~> **Note:** This resource will automatically attempt to delete resources deployed by the ARM Template when it is deleted. This behavior can be disabled in the provider `features` block by setting the `delete_nested_items_during_deletion` field to `false` within the `template_deployment` block.
 
 ## Example Usage
 


### PR DESCRIPTION
Restructured a sentence in the note about resource deletion opt-out in an attempt to be more descriptive.

related to #13052 