### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - `os_sku` is now computed

### DIFF
--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -176,7 +176,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ForceNew: true,
-					Default:  string(containerservice.OSSKUUbuntu),
+					Computed: true, // defaults to Ubuntu if using Linux
 					ValidateFunc: validation.StringInSlice([]string{
 						string(containerservice.OSSKUUbuntu),
 						string(containerservice.OSSKUCBLMariner),


### PR DESCRIPTION
To address issue : https://github.com/hashicorp/terraform-provider-azurerm/issues/13312

```
=== RUN   TestAccKubernetesClusterNodePool_windows
=== PAUSE TestAccKubernetesClusterNodePool_windows
=== CONT  TestAccKubernetesClusterNodePool_windows
--- PASS: TestAccKubernetesClusterNodePool_windows (1317.89s)
PASS

=== RUN   TestAccKubernetesClusterNodePool_osSku
=== PAUSE TestAccKubernetesClusterNodePool_osSku
=== CONT  TestAccKubernetesClusterNodePool_osSku
--- PASS: TestAccKubernetesClusterNodePool_osSku (918.11s)

=== RUN   TestAccKubernetesCluster_osSku
=== PAUSE TestAccKubernetesCluster_osSku
=== CONT  TestAccKubernetesCluster_osSku
--- PASS: TestAccKubernetesCluster_osSku (832.63s)
```