### PR TITLE
docs: move local_account_disabled to correct section

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -108,6 +108,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `linux_profile` - (Optional) A `linux_profile` block as defined below.
 
+* `local_account_disabled` - (Optional) Is local account disabled for AAD integrated kubernetes cluster?
+
 * `maintenance_window` - (Optional) A `maintenance_window` block as defined below.
 
 * `network_profile` - (Optional) A `network_profile` block as defined below.
@@ -324,8 +326,6 @@ A `default_node_pool` block supports the following:
 ~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. At this time the only possible value is `OS`.
-
-* `local_account_disabled` - (Optional) Is local account disabled for AAD integrated kubernetes cluster?
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
this PR moves the `local_account_disabled` argument from the default_node_pool section to the root section to fix:  `Error: Unsupported argument - An argument named "local_account_disabled" is not expected here`