### PR TITLE
`azurerm_app_service_managed_certificate`: Fix for empty `issue_date`

### DIFF
--- a/internal/services/web/app_service_managed_certificate_resource.go
+++ b/internal/services/web/app_service_managed_certificate_resource.go
@@ -218,7 +218,11 @@ func resourceAppServiceManagedCertificateRead(d *pluginsdk.ResourceData, meta in
 		d.Set("subject_name", props.SubjectName)
 		d.Set("host_names", props.HostNames)
 		d.Set("issuer", props.Issuer)
-		d.Set("issue_date", props.IssueDate.Format(time.RFC3339))
+		issueDate := ""
+		if props.IssueDate != nil {
+			issueDate = props.IssueDate.Format(time.RFC3339)
+		}
+		d.Set("issue_date", issueDate)
 		expirationDate := ""
 		if props.ExpirationDate != nil {
 			expirationDate = props.ExpirationDate.Format(time.RFC3339)


### PR DESCRIPTION
Fixes #13353
Fixes #13352 

## Reason
According to Microsoft Azure Support,  the following values will be null/empty going forward via API:

- `Thumbprint`
- `Issuer`
- `IssueDate`
- `ExpirationDate`