### PR TITLE
Allow empty_dir volume shared across containers in container group

### DIFF
--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -491,6 +491,21 @@ func TestAccContainerGroup_emptyDirVolume(t *testing.T) {
 	})
 }
 
+func TestAccContainerGroup_emptyDirVolumeShared(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.emptyDirVolumeShared(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerGroup_secretVolume(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
 	r := ContainerGroupResource{}
@@ -1548,6 +1563,66 @@ resource "azurerm_container_group" "test" {
     }
 
     commands = ["/bin/bash", "-c", "ls"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (ContainerGroupResource) emptyDirVolumeShared(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroupemptyshared-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  ip_address_type     = "public"
+  dns_name_label      = "acctestcontainergroup-%d"
+  os_type             = "Linux"
+  restart_policy      = "Never"
+
+  container {
+    name   = "writer"
+    image  = "ubuntu:20.04"
+    cpu    = "1"
+    memory = "1.5"
+    commands = ["touch", "/sharedempty/file.txt"]
+
+    # Dummy port not used, workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/1697
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+
+    volume {
+      name       = "logs"
+      mount_path = "/sharedempty"
+      read_only  = false
+      empty_dir  = true
+    }
+  }
+
+  container {
+    name   = "reader"
+    image  = "ubuntu:20.04"
+    cpu    = "1"
+    memory = "1.5"
+
+    volume {
+      name       = "logs"
+      mount_path = "/sharedempty"
+      read_only  = false
+      empty_dir  = true
+    }
+
+    commands = ["/bin/bash", "-c", "timeout 30 watch --interval 1 --errexit \"! cat /sharedempty/file.txt\""]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -1589,10 +1589,10 @@ resource "azurerm_container_group" "test" {
   restart_policy      = "Never"
 
   container {
-    name   = "writer"
-    image  = "ubuntu:20.04"
-    cpu    = "1"
-    memory = "1.5"
+    name     = "writer"
+    image    = "ubuntu:20.04"
+    cpu      = "1"
+    memory   = "1.5"
     commands = ["touch", "/sharedempty/file.txt"]
 
     # Dummy port not used, workaround for https://github.com/hashicorp/terraform-provider-azurerm/issues/1697


### PR DESCRIPTION
fixes hashicorp/terraform-provider-azurerm#11444