### PR TITLE
`policy_virtual_machine_configuration_assignment` - Remove erroneous horizontal rule in Arguments Reference

### DIFF
--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -126,8 +126,6 @@ The following arguments are supported:
 
 * `virtual_machine_id` - (Required) The resource ID of the Policy Virtual Machine which this Guest Configuration Assignment should apply to. Changing this forces a new resource to be created.
 
----
-
 * `configuration` - (Required)  A `configuration` block as defined below.
 
 ---


### PR DESCRIPTION
Documentation fix only.