### PR TITLE
Remove  parameter when retrieving the key vault id via Resource API

### DIFF
--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -113,7 +113,7 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *res
 	}
 
 	filter := fmt.Sprintf("resourceType eq 'Microsoft.KeyVault/vaults' and name eq '%s'", *keyVaultName)
-	result, err := resourcesClient.ResourcesClient.List(ctx, filter, "", utils.Int32(5))
+	result, err := resourcesClient.ResourcesClient.List(ctx, filter, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing resources matching %q: %+v", filter, err)
 	}


### PR DESCRIPTION
The purpose of this PR:

1. When investigating [issue 11059](https://github.com/hashicorp/terraform-provider-azurerm/issues/11059), I found that using “top” parameter in Resource API will have performance issue, when retrieving key vault id. We could get the key vault directly by specifying the “resourceType” and “name” only. If it exists, since the key vault name is global unique in a sub, there will be only one match returned. To proof the theory, I did a test to set a secret for an existing key vault. Below are the results:

    - Prerequisites:
      - The number of resources under my test subscription: 183
      - The position of the existing key vault in the resource list: 91
    
    - Results:
      -  Set “top” to 5 then get the key vault after 19 requests sent by calling “Next” URI
      -  Set “top” to nil then get the key vault after one request

2. Many customers have the similar issue with 11059, but we have tried many times and have not been able to reproduce it. Per the log and information provided by customer,  I found:
    - When the secret is read again after setting it, the Key Vault cannot be found through the Resource API (but it did exist after the customer confirmed) ,which caused the error mentioned in issue 11059.
    - Retrieve the key vault ID by Resource API, the requests are hundreds and not found specified key vault finally.  

So, this PR can improve the performance a lot ,reduce the chance to meet the issue dramatically and maybe fix issue 11059(cannot verify because it cannot be reproduced).

Test Results (The failed testcases report the same error before modification):
--- PASS: TestAccKustoClusterCustomerManagedKey_userIdentity (1466.42s)
--- PASS: TestAccKustoClusterCustomerManagedKey_basic (1476.59s)
--- PASS: TestAccKustoClusterCustomerManagedKey_requiresImport (1613.76s)
--- PASS: TestAccKustoClusterCustomerManagedKey_updateKey (1665.89s)
--- PASS: TestAccDatabricksWorkspace_basic (649.91s)
--- PASS: TestAccDatabricksWorkspace_infrastructureEncryption (650.00s)
--- PASS: TestAccDatabricksWorkspace_loadBalancerSecureClusterConnectivity (807.88s)
--- PASS: TestAccDatabricksWorkspace_secureClusterConnectivity (824.62s)
--- PASS: TestAccDatabricksWorkspace_managedServicesAndDbfsCMK (840.12s)
--- PASS: TestAccDatabricksWorkspace_managedServices (852.94s)
--- PASS: TestAccDatabricksWorkspace_machineLearning (934.09s)
--- PASS: TestAccDatabricksWorkspace_complete (1041.71s)
--- PASS: TestAccDatabricksWorkspace_privateLink (1054.53s)
--- PASS: TestAccDatabricksWorkspace_updateSKU (1195.65s)
--- PASS: TestAccDatabricksWorkspace_requiresImport (614.18s)
--- PASS: TestAccDatabricksWorkspace_managedServicesDbfsCMKAndPrivateLink (1267.79s)
--- PASS: TestAccDatabricksWorkspace_sameName (615.21s)
--- PASS: TestAccDatabricksWorkspace_update (1096.10s)
--- PASS: TestAccKeyVaultCertificateIssuer_complete (336.53s)
--- PASS: TestAccKeyVaultCertificateIssuer_basic (362.05s)
--- PASS: TestAccKeyVaultCertificateIssuer_disappears (380.55s)
--- PASS: TestAccKeyVaultCertificateIssuer_requiresImport (436.91s)
--- PASS: TestAccKeyVaultCertificateIssuer_update (489.20s)
--- PASS: TestAccDataSourceKeyVaultKey_complete (433.25s)
--- PASS: TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted (313.53s)
--- PASS: TestAccKeyVaultKey_purge (351.26s)
--- PASS: TestAccKeyVaultKey_complete (354.84s)
--- PASS: TestAccKeyVaultKey_basicEC (371.14s)
--- PASS: TestAccKeyVaultKey_basicECHSM (409.62s)
--- PASS: TestAccKeyVaultKey_requiresImport (430.33s)
--- PASS: TestAccKeyVaultKey_curveEC (433.03s)
--- PASS: TestAccKeyVaultKey_curveECDeprecated (433.14s)
--- PASS: TestAccKeyVaultKey_update (489.96s)
--- PASS: TestAccKeyVaultKey_updatedExternally (558.87s)
--- PASS: TestAccKeyVaultKey_basicRSAHSM (302.16s)
--- PASS: TestAccKeyVaultKey_disappears (327.10s)
--- PASS: TestAccKeyVaultKey_basicRSA (315.10s)
--- PASS: TestAccKeyVaultKey_withExternalAccessPolicy (426.86s)
--- PASS: TestAccKeyVaultKey_softDeleteRecovery (873.31s)
--- PASS: TestAccKeyVaultSecret_basic (349.26s)
--- PASS: TestAccKeyVaultSecret_complete (355.82s)
--- PASS: TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted (364.68s)
--- PASS: TestAccKeyVaultSecret_purge (367.13s)
--- PASS: TestAccKeyVaultSecret_disappears (392.22s)
--- PASS: TestAccKeyVaultSecret_requiresImport (440.20s)
--- PASS: TestAccKeyVaultSecret_withExternalAccessPolicy (454.11s)
--- PASS: TestAccKeyVaultSecret_update (468.02s)
--- PASS: TestAccKeyVaultSecret_updatingValueChangedExternally (471.92s)
--- PASS: TestAccKeyVaultSecret_recovery (849.96s)
--- PASS: TestAccDatabricksWorkspaceCustomerManagedKey_requiresImport (717.21s)
--- PASS: TestAccDatabricksWorkspaceCustomerManagedKey_basic (724.66s)
--- PASS: TestAccDatabricksWorkspaceCustomerManagedKey_remove (756.50s)
--- PASS: TestAccDatabricksWorkspaceCustomerManagedKey_noIp (898.99s)
--- PASS: TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted (311.94s)
--- PASS: TestAccKeyVaultCertificate_basicGenerate (354.96s)
--- PASS: TestAccKeyVaultCertificate_emptyExtendedKeyUsage (366.03s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateSans (370.79s)
--- PASS: TestAccKeyVaultCertificate_basicImportPFX (379.70s)
--- PASS: TestAccKeyVaultCertificate_disappears (401.14s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateTags (412.31s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize (426.83s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateUnknownIssuer (432.10s)
--- PASS: TestAccKeyVaultCertificate_requiresImport (449.36s)
--- PASS: TestAccKeyVaultCertificate_basicExtendedKeyUsage (310.07s)
--- PASS: TestAccKeyVaultCertificate_purge (391.22s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurve (377.67s)
--- PASS: TestAccKeyVaultCertificate_withExternalAccessPolicy (511.66s)
--- PASS: TestAccKeyVaultCertificate_softDeleteRecovery (885.20s)
--- PASS: TestAccDataFactoryLinkedServiceKeyVault_basic (353.32s)
--- PASS: TestAccDataFactoryLinkedServiceKeyVault_update (362.12s)
--- PASS: TestAccPostgreSQLServerKey_basic (437.57s)
--- PASS: TestAccPostgreSQLServerKey_requiresImport (469.55s)
--- PASS: TestAccPostgreSQLServerKey_updateKey (548.71s)
--- PASS: TestAccStorageAccountCustomerManagedKey_userAssignedIdentity (363.23s)
--- PASS: TestAccStorageAccountCustomerManagedKey_requiresImport (448.50s)
--- PASS: TestAccStorageAccountCustomerManagedKey_updateKey (448.56s)
--- PASS: TestAccStorageAccountCustomerManagedKey_basic (492.95s)
--- PASS: TestAccStorageAccountCustomerManagedKey_testKeyVersion (509.63s)
--- PASS: TestAccAppServiceCertificate_PfxNoPassword (128.04s)
--- PASS: TestAccAppServiceCertificate_Pfx (181.94s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurve (332.87s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateTags (345.03s)
--- PASS: TestAccKeyVaultCertificate_emptyExtendedKeyUsage (387.03s)
--- PASS: TestAccKeyVaultCertificate_basicGenerate (392.98s)
--- PASS: TestAccKeyVaultCertificate_basicExtendedKeyUsage (398.25s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateSans (399.21s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize (411.52s)
--- PASS: TestAccKeyVaultCertificate_purge (415.09s)
--- PASS: TestAccKeyVaultCertificate_basicImportPFX (418.63s)
--- PASS: TestAccKeyVaultCertificate_withExternalAccessPolicy (539.30s)
--- PASS: TestAccKeyVaultCertificate_disappears (289.93s)
--- PASS: TestAccKeyVaultCertificate_basicGenerateUnknownIssuer (375.64s)
--- PASS: TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted (324.03s)
--- PASS: TestAccKeyVaultCertificate_requiresImport (326.79s)
--- PASS: TestAccKeyVaultCertificate_softDeleteRecovery (832.37s)
--- PASS: TestAccKeyVaultCertificateIssuer_complete (285.79s)
--- PASS: TestAccKeyVaultCertificateIssuer_disappears (340.07s)
--- PASS: TestAccKeyVaultCertificateIssuer_basic (353.33s)
--- PASS: TestAccKeyVaultCertificateIssuer_requiresImport (374.66s)
--- PASS: TestAccKeyVaultCertificateIssuer_update (376.56s)
--- PASS: TestAccMySQLServerKey_basic (425.81s)
--- PASS: TestAccMySQLServerKey_updateKey (468.78s)
--- PASS: TestAccMySQLServerKey_requiresImport (486.28s)

--- FAIL: TestAccDiskEncryptionSet_keyRotate (499.69s)
--- FAIL: TestAccAppServiceCertificate_KeyVault (20.58s)