### PR TITLE
azurerm_kubernetes_cluster  - private_cluster_public_fqdn_enabled is no longer force new

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1223,11 +1223,11 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			existing.ManagedClusterProperties.APIServerAccessProfile.PrivateDNSZone = utils.String(v.(string))
 		}
 	}
-	
+
 	if d.HasChange("private_cluster_public_fqdn_enabled") {
-                updateCluster = true
-                existing.ManagedClusterProperties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN = utils.Bool(d.Get("private_cluster_public_fqdn_enabled").(bool))
-        }
+		updateCluster = true
+		existing.ManagedClusterProperties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN = utils.Bool(d.Get("private_cluster_public_fqdn_enabled").(bool))
+	}
 
 	if d.HasChange("auto_scaler_profile") {
 		updateCluster = true

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -593,7 +593,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: false,
 			},
 
 			"private_dns_zone_id": {
@@ -1224,6 +1223,11 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			existing.ManagedClusterProperties.APIServerAccessProfile.PrivateDNSZone = utils.String(v.(string))
 		}
 	}
+	
+	if d.HasChange("private_cluster_public_fqdn_enabled") {
+                updateCluster = true
+                existing.ManagedClusterProperties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN = utils.Bool(d.Get("private_cluster_public_fqdn_enabled").(bool))
+        }
 
 	if d.HasChange("auto_scaler_profile") {
 		updateCluster = true

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -593,7 +593,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
+				ForceNew: false,
 			},
 
 			"private_dns_zone_id": {


### PR DESCRIPTION
Fix #13099, to do in place update for `private_cluster_public_fqdn_enabled`