### PR TITLE
Typed SDK model object validation fix

### DIFF
--- a/internal/provider/services_test.go
+++ b/internal/provider/services_test.go
@@ -12,7 +12,7 @@ func TestTypedDataSourcesContainValidModelObjects(t *testing.T) {
 		for _, resource := range service.DataSources() {
 			t.Logf("- DataSources %q..", resource.ResourceType())
 			obj := resource.ModelObject()
-			if err := sdk.ValidateModelObject(&obj); err != nil {
+			if err := sdk.ValidateModelObject(obj); err != nil {
 				t.Fatalf("validating model: %+v", err)
 			}
 		}
@@ -25,7 +25,7 @@ func TestTypedResourcesContainValidModelObjects(t *testing.T) {
 		for _, resource := range service.Resources() {
 			t.Logf("- Resource %q..", resource.ResourceType())
 			obj := resource.ModelObject()
-			if err := sdk.ValidateModelObject(&obj); err != nil {
+			if err := sdk.ValidateModelObject(obj); err != nil {
 				t.Fatalf("validating model: %+v", err)
 			}
 		}

--- a/internal/sdk/wrapper_data_source.go
+++ b/internal/sdk/wrapper_data_source.go
@@ -32,7 +32,7 @@ func (dw *DataSourceWrapper) DataSource() (*schema.Resource, error) {
 
 	modelObj := dw.dataSource.ModelObject()
 	if modelObj != nil {
-		if err := ValidateModelObject(&modelObj); err != nil {
+		if err := ValidateModelObject(modelObj); err != nil {
 			return nil, fmt.Errorf("validating model for %q: %+v", dw.dataSource.ResourceType(), err)
 		}
 	}

--- a/internal/sdk/wrapper_resource.go
+++ b/internal/sdk/wrapper_resource.go
@@ -35,7 +35,7 @@ func (rw *ResourceWrapper) Resource() (*schema.Resource, error) {
 
 	modelObj := rw.resource.ModelObject()
 	if modelObj != nil {
-		if err := ValidateModelObject(&modelObj); err != nil {
+		if err := ValidateModelObject(modelObj); err != nil {
 			return nil, fmt.Errorf("validating model for %q: %+v", rw.resource.ResourceType(), err)
 		}
 	}

--- a/internal/sdk/wrapper_validate.go
+++ b/internal/sdk/wrapper_validate.go
@@ -10,13 +10,18 @@ import (
 // required to be used with the Encode and Decode functions
 func ValidateModelObject(input interface{}) error {
 	if reflect.TypeOf(input).Kind() != reflect.Ptr {
-		return fmt.Errorf("need a pointer")
+		return fmt.Errorf("need a pointer to the model object")
 	}
 
 	// TODO: could we also validate that each `tfschema` tag exists in the schema?
 
 	objType := reflect.TypeOf(input).Elem()
 	objVal := reflect.ValueOf(input).Elem()
+
+	if objVal.Kind() == reflect.Interface {
+		return fmt.Errorf("cannot resolve pointer to interface")
+	}
+
 	return validateModelObjectRecursively("", objType, objVal)
 }
 

--- a/internal/sdk/wrapper_validate.go
+++ b/internal/sdk/wrapper_validate.go
@@ -9,6 +9,11 @@ import (
 // ValidateModelObject validates that the object contains the specified `tfschema` tags
 // required to be used with the Encode and Decode functions
 func ValidateModelObject(input interface{}) error {
+	if input == nil {
+		// model not used for this resource
+		return nil
+	}
+
 	if reflect.TypeOf(input).Kind() != reflect.Ptr {
 		return fmt.Errorf("need a pointer to the model object")
 	}

--- a/internal/sdk/wrapper_validate_test.go
+++ b/internal/sdk/wrapper_validate_test.go
@@ -34,8 +34,7 @@ func TestValidateTopLevelObjectInvalidInterface(t *testing.T) {
 	type Person struct {
 		Name string `tfschema:"name"`
 	}
-	var p interface{}
-	p = Person{}
+	var p interface{} = Person{}
 	if err := ValidateModelObject(&p); err == nil {
 		t.Fatalf("expected an error but didn't get one")
 	}

--- a/internal/sdk/wrapper_validate_test.go
+++ b/internal/sdk/wrapper_validate_test.go
@@ -30,6 +30,17 @@ func TestValidateTopLevelObjectInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateTopLevelObjectInvalidInterface(t *testing.T) {
+	type Person struct {
+		Name string `tfschema:"name"`
+	}
+	var p interface{}
+	p = Person{}
+	if err := ValidateModelObject(&p); err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+}
+
 func TestValidateNestedObjectValid(t *testing.T) {
 	type Pet struct {
 		Name string `tfschema:"name"`

--- a/internal/services/apimanagement/api_management_notification_recipient_email.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_email.go
@@ -63,7 +63,7 @@ func (r ApiManagementNotificationRecipientEmailResource) Attributes() map[string
 }
 
 func (r ApiManagementNotificationRecipientEmailResource) ModelObject() interface{} {
-	return ApiManagementNotificationRecipientEmailModel{}
+	return &ApiManagementNotificationRecipientEmailModel{}
 }
 
 func (r ApiManagementNotificationRecipientEmailResource) ResourceType() string {

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -104,7 +104,7 @@ func (k KeyResource) Attributes() map[string]*pluginsdk.Schema {
 }
 
 func (k KeyResource) ModelObject() interface{} {
-	return KeyResourceModel{}
+	return &KeyResourceModel{}
 }
 
 func (k KeyResource) ResourceType() string {

--- a/internal/services/batch/batch_job_resource.go
+++ b/internal/services/batch/batch_job_resource.go
@@ -79,7 +79,7 @@ func (r BatchJobResource) ResourceType() string {
 }
 
 func (r BatchJobResource) ModelObject() interface{} {
-	return BatchJobModel{}
+	return &BatchJobModel{}
 }
 
 func (r BatchJobResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {

--- a/internal/services/eventhub/eventhub_consumer_group_resource.go
+++ b/internal/services/eventhub/eventhub_consumer_group_resource.go
@@ -202,7 +202,7 @@ func (r ConsumerGroupResource) Delete() sdk.ResourceFunc {
 }
 
 func (r ConsumerGroupResource) ModelObject() interface{} {
-	return ConsumerGroupObject{}
+	return &ConsumerGroupObject{}
 }
 
 func (r ConsumerGroupResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {

--- a/internal/services/loadbalancer/backend_address_pool_address_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_address_resource.go
@@ -63,7 +63,7 @@ func (r BackendAddressPoolAddressResource) Attributes() map[string]*pluginsdk.Sc
 }
 
 func (r BackendAddressPoolAddressResource) ModelObject() interface{} {
-	return BackendAddressPoolAddressModel{}
+	return &BackendAddressPoolAddressModel{}
 }
 
 func (r BackendAddressPoolAddressResource) ResourceType() string {

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -42,7 +42,7 @@ func (r ResourceProviderRegistrationResource) Attributes() map[string]*pluginsdk
 }
 
 func (r ResourceProviderRegistrationResource) ModelObject() interface{} {
-	return ResourceProviderRegistrationModel{}
+	return &ResourceProviderRegistrationModel{}
 }
 
 func (r ResourceProviderRegistrationResource) ResourceType() string {

--- a/internal/services/web/app_service_environment_v3_data_source.go
+++ b/internal/services/web/app_service_environment_v3_data_source.go
@@ -162,7 +162,7 @@ func (r AppServiceEnvironmentV3DataSource) Attributes() map[string]*pluginsdk.Sc
 }
 
 func (r AppServiceEnvironmentV3DataSource) ModelObject() interface{} {
-	return AppServiceEnvironmentV3Model{}
+	return &AppServiceEnvironmentV3Model{}
 }
 
 func (r AppServiceEnvironmentV3DataSource) ResourceType() string {

--- a/internal/services/web/app_service_environment_v3_resource.go
+++ b/internal/services/web/app_service_environment_v3_resource.go
@@ -226,7 +226,7 @@ func (r AppServiceEnvironmentV3Resource) Attributes() map[string]*pluginsdk.Sche
 }
 
 func (r AppServiceEnvironmentV3Resource) ModelObject() interface{} {
-	return AppServiceEnvironmentV3Model{}
+	return &AppServiceEnvironmentV3Model{}
 }
 
 func (r AppServiceEnvironmentV3Resource) ResourceType() string {


### PR DESCRIPTION
- Return a pointer to the model object from `Resource.ModelObject()` / `DataSource.ModelObject()`
- Pass pointer as value in `ResourceWrapper.Resource()` / `DataSourceWrapper.DataSource()`
- Check to see if a `*interface` received in `ValidateModelObject()`
- Skip validation for `nil` model objects