### PR TITLE
`azurerm_private_endpoint_connection` - Export `network_interface` attributes from private endpoints

### DIFF
--- a/internal/services/network/private_endpoint_connection_data_source_test.go
+++ b/internal/services/network/private_endpoint_connection_data_source_test.go
@@ -19,6 +19,8 @@ func TestAccDataSourcePrivateEndpointConnection_complete(t *testing.T) {
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_interface.0.id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.name").Exists(),
 				check.That(data.ResourceName).Key("private_service_connection.0.status").HasValue("Approved"),
 			),
 		},

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -64,6 +64,23 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
+			"network_interface": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"private_dns_zone_group": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -418,13 +435,21 @@ func resourcePrivateEndpointRead(d *pluginsdk.ResourceData, meta interface{}) er
 			return fmt.Errorf("setting `custom_dns_configs`: %+v", err)
 		}
 
+		networkInterfaceId := ""
 		privateIpAddress := ""
 		if nics := props.NetworkInterfaces; nics != nil && len(*nics) > 0 {
 			nic := (*nics)[0]
 			if nic.ID != nil && *nic.ID != "" {
-				privateIpAddress = getPrivateIpAddress(ctx, nicsClient, *nic.ID)
+				networkInterfaceId = *nic.ID
+				privateIpAddress = getPrivateIpAddress(ctx, nicsClient, networkInterfaceId)
 			}
 		}
+
+		networkInterface := getNetworkInterface(networkInterfaceId)
+		if err := d.Set("network_interface", networkInterface); err != nil {
+			return fmt.Errorf("setting `network_interface`: %+v", err)
+		}
+
 		flattenedConnection := flattenPrivateLinkEndpointServiceConnection(props.PrivateLinkServiceConnections, props.ManualPrivateLinkServiceConnections, privateIpAddress)
 		if err := d.Set("private_service_connection", flattenedConnection); err != nil {
 			return fmt.Errorf("setting `private_service_connection`: %+v", err)

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -26,6 +26,8 @@ func TestAccPrivateEndpoint_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("subnet_id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.name").Exists(),
 				check.That(data.ResourceName).Key("private_service_connection.0.private_ip_address").Exists(),
 			),
 		},
@@ -75,6 +77,8 @@ func TestAccPrivateEndpoint_requestMessage(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("subnet_id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.name").Exists(),
 				check.That(data.ResourceName).Key("private_service_connection.0.request_message").HasValue("CATS: ALL YOUR BASE ARE BELONG TO US."),
 			),
 		},
@@ -84,6 +88,8 @@ func TestAccPrivateEndpoint_requestMessage(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("subnet_id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.name").Exists(),
 				check.That(data.ResourceName).Key("private_service_connection.0.request_message").HasValue("CAPTAIN: WHAT YOU SAY!!"),
 			),
 		},
@@ -214,6 +220,8 @@ func TestAccPrivateEndpoint_privateConnectionAlias(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("subnet_id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.id").Exists(),
+				check.That(data.ResourceName).Key("network_interface.0.name").Exists(),
 				check.That(data.ResourceName).Key("private_service_connection.0.private_connection_resource_alias").Exists(),
 			),
 		},

--- a/website/docs/d/private_endpoint_connection.html.markdown
+++ b/website/docs/d/private_endpoint_connection.html.markdown
@@ -38,6 +38,16 @@ The following attributes are exported:
 
 * `location` - The supported Azure location where the resource exists.
 
+---
+
+A `network_interface` block exports:
+
+* `id` - The ID of the network interface associated with the private endpoint.
+
+* `name` - The name of the network interface associated with the private endpoint.
+
+---
+
 A `private_service_connection` block exports the following:
 
 * `name` - The name of the private endpoint.

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -194,6 +194,14 @@ The following attributes are exported:
 
 ---
 
+A `network_interface` block exports:
+
+* `id` - The ID of the network interface associated with the `private_endpoint`.
+
+* `name` - The name of the network interface associated with the `private_endpoint`.
+
+---
+
 A `private_dns_zone_group` block exports:
 
 * `id` - The ID of the Private DNS Zone Group.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request exports the ID and name of the network interface associated with private endpoints.

* The `TestAccPrivateEndpoint_privateConnectionAlias` test seems to be a bit flaky. I haven't confirmed the root cause as to why this test intermittently fails, but I have confirmed that it's not the result of these changes.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #12283

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='network' TESTARGS='-run="TestAcc(PrivateEndpointConnection|PrivateEndpoint)_"' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run="TestAcc(PrivateEndpointConnection|PrivateEndpoint)_" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPrivateEndpoint_basic
=== PAUSE TestAccPrivateEndpoint_basic
=== RUN   TestAccPrivateEndpoint_updateTag
=== PAUSE TestAccPrivateEndpoint_updateTag
=== RUN   TestAccPrivateEndpoint_requestMessage
=== PAUSE TestAccPrivateEndpoint_requestMessage
=== RUN   TestAccPrivateEndpoint_privateDnsZoneGroup
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneGroup
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRename
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRename
=== RUN   TestAccPrivateEndpoint_privateDnsZoneUpdate
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneUpdate
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRemove
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRemove
=== RUN   TestAccPrivateEndpoint_privateConnectionAlias
=== PAUSE TestAccPrivateEndpoint_privateConnectionAlias
=== CONT  TestAccPrivateEndpoint_basic
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRename
=== CONT  TestAccPrivateEndpoint_requestMessage
=== CONT  TestAccPrivateEndpoint_privateDnsZoneGroup
=== CONT  TestAccPrivateEndpoint_updateTag
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRemove
=== CONT  TestAccPrivateEndpoint_privateConnectionAlias
=== CONT  TestAccPrivateEndpoint_privateDnsZoneUpdate
--- PASS: TestAccPrivateEndpoint_basic (301.98s)
--- PASS: TestAccPrivateEndpoint_privateConnectionAlias (329.88s)
--- PASS: TestAccPrivateEndpoint_requestMessage (379.03s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneGroup (457.55s)
--- PASS: TestAccPrivateEndpoint_updateTag (543.34s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRename (563.73s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRemove (643.23s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneUpdate (1228.28s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1230.978s
```
