### PR TITLE
Wait for network provisioning state when creating or updating resource

### DIFF
--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	azureNetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
-	subnetParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/validate"
@@ -58,6 +59,8 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 
 func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Web.AppServicesClient
+	subnetClient := meta.(*clients.Client).Network.SubnetsClient
+	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -65,7 +68,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 	if err != nil {
 		return fmt.Errorf("parsing app service ID %+v", err)
 	}
-	subnetID, err := subnetParse.SubnetID(d.Get("subnet_id").(string))
+	subnetID, err := networkParse.SubnetID(d.Get("subnet_id").(string))
 	if err != nil {
 		return fmt.Errorf("parsing subnet ID %+v", err)
 	}
@@ -118,6 +121,31 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 	}
 	if _, err = client.CreateOrUpdateSwiftVirtualNetworkConnectionWithCheckSlot(ctx, resourceGroup, name, connectionEnvelope, slotName); err != nil {
 		return fmt.Errorf("creating/updating App Service Slot VNet association between %q (App Service %q / Resource Group %q) and Virtual Network %q: %s", slotName, name, resourceGroup, virtualNetworkName, err)
+	}
+
+	timeout, _ := ctx.Deadline()
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
+		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Refresh:    network.SubnetProvisioningStateRefreshFunc(ctx, subnetClient, *subnetID),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of subnet for App Service Slot VNet association between %q (App Service %q / Resource Group %q) and Virtual Network %q: %s", slotName, name, resourceGroup, virtualNetworkName, err)
+	}
+
+	vnetId := networkParse.NewVirtualNetworkID(subnetID.SubscriptionId, subnetID.ResourceGroup, subnetID.VirtualNetworkName)
+	vnetStateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{string(azureNetwork.ProvisioningStateUpdating)},
+		Target:     []string{string(azureNetwork.ProvisioningStateSucceeded)},
+		Refresh:    network.VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, vnetId),
+		MinTimeout: 1 * time.Minute,
+		Timeout:    time.Until(timeout),
+	}
+	if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for provisioning state of virtual network for App Service Slot VNet association between %q (App Service %q / Resource Group %q) and Virtual Network %q: %s", slotName, name, resourceGroup, virtualNetworkName, err)
 	}
 
 	read, err := client.GetSwiftVirtualNetworkConnectionSlot(ctx, resourceGroup, name, slotName)
@@ -189,7 +217,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionDelete(d *pluginsdk.Reso
 		return err
 	}
 
-	subnetID, err := subnetParse.SubnetID(d.Get("subnet_id").(string))
+	subnetID, err := networkParse.SubnetID(d.Get("subnet_id").(string))
 	if err != nil {
 		return fmt.Errorf("parsing Subnet Resource ID %q", subnetID)
 	}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request verifies the state of virtual networks and subnets returns to `Successful` after making modifications that push them in to an `Updating` state. As a result, this ensures that the associated lock held on each resource is not released until that resource is actually ready to support another operation initiated through the API (whatever that may be).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related: #13105

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='web' TESTARGS='-run="^TestAccAppService(Slot)?VirtualNetworkSwiftConnection_"' TESTTIMEOUT='120m'    
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/web -run="^TestAccAppService(Slot)?VirtualNetworkSwiftConnection_" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_basic
=== PAUSE TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_basic
=== RUN   TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_requiresImport
=== PAUSE TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_requiresImport
=== RUN   TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_update
=== PAUSE TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_update
=== RUN   TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_disappears
=== PAUSE TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_disappears
=== RUN   TestAccAppServiceVirtualNetworkSwiftConnection_basic
=== PAUSE TestAccAppServiceVirtualNetworkSwiftConnection_basic
=== RUN   TestAccAppServiceVirtualNetworkSwiftConnection_requiresImport
=== PAUSE TestAccAppServiceVirtualNetworkSwiftConnection_requiresImport
=== RUN   TestAccAppServiceVirtualNetworkSwiftConnection_update
=== PAUSE TestAccAppServiceVirtualNetworkSwiftConnection_update
=== RUN   TestAccAppServiceVirtualNetworkSwiftConnection_disappears
=== PAUSE TestAccAppServiceVirtualNetworkSwiftConnection_disappears
=== RUN   TestAccAppServiceVirtualNetworkSwiftConnection_functionAppBasic
=== PAUSE TestAccAppServiceVirtualNetworkSwiftConnection_functionAppBasic
=== CONT  TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_basic
=== CONT  TestAccAppServiceVirtualNetworkSwiftConnection_requiresImport
=== CONT  TestAccAppServiceVirtualNetworkSwiftConnection_disappears
=== CONT  TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_update
=== CONT  TestAccAppServiceVirtualNetworkSwiftConnection_update
=== CONT  TestAccAppServiceVirtualNetworkSwiftConnection_functionAppBasic
=== CONT  TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_disappears
=== CONT  TestAccAppServiceVirtualNetworkSwiftConnection_basic
--- PASS: TestAccAppServiceVirtualNetworkSwiftConnection_functionAppBasic (246.41s)
=== CONT  TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_requiresImport
--- PASS: TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_basic (275.31s)
--- PASS: TestAccAppServiceVirtualNetworkSwiftConnection_requiresImport (285.26s)
--- PASS: TestAccAppServiceVirtualNetworkSwiftConnection_disappears (300.35s)
--- PASS: TestAccAppServiceVirtualNetworkSwiftConnection_basic (339.87s)
--- PASS: TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_disappears (356.30s)
--- PASS: TestAccAppServiceVirtualNetworkSwiftConnection_update (362.50s)
--- PASS: TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_update (372.72s)
--- PASS: TestAccAppServiceSlotVirtualNetworkSwiftConnection_app_requiresImport (326.56s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/web   580.261s
```
