### PR TITLE
Fix12155

### DIFF
--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -298,8 +298,10 @@ func getBasicFunctionAppAppSettings(d *pluginsdk.ResourceData, appServiceTier, e
 		connectionString = v.(string)
 	}
 
-	if storageConnection == "" && storageAccount == "" && connectionString == "" {
-		return nil, fmt.Errorf("one of `storage_connection_string` or `storage_account_name` and `storage_account_access_key` must be specified")
+	_, useIdentity := d.GetOk("identity")
+
+	if storageConnection == "" && storageAccount == "" && connectionString == ""  && !useIdentity{
+		return nil, fmt.Errorf("one of `storage_connection_string` or `storage_account_name` and `storage_account_access_key` or `identity` must be specified")
 	}
 
 	if (storageAccount == "" && connectionString != "") || (storageAccount != "" && connectionString == "") {

--- a/internal/services/web/function_app_resource.go
+++ b/internal/services/web/function_app_resource.go
@@ -170,7 +170,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 				Computed:      true, // Remove this in 3.0
 				ForceNew:      true,
 				ValidateFunc:  storageValidate.StorageAccountName,
-				ConflictsWith: []string{"storage_connection_string"},
+				ConflictsWith: []string{"storage_connection_string", "identity"},
 			},
 
 			"storage_account_access_key": {
@@ -180,7 +180,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 				// Required: true, // Uncomment this in 3.0
 				Sensitive:     true,
 				ValidateFunc:  validation.NoZeroValues,
-				ConflictsWith: []string{"storage_connection_string"},
+				ConflictsWith: []string{"storage_connection_string", "identity"},
 			},
 
 			// TODO remove this in 3.0
@@ -191,7 +191,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 				ForceNew:      true,
 				Sensitive:     true,
 				Deprecated:    "Deprecated in favour of `storage_account_name` and `storage_account_access_key`",
-				ConflictsWith: []string{"storage_account_name", "storage_account_access_key"},
+				ConflictsWith: []string{"storage_account_name", "storage_account_access_key", "identity"},
 			},
 
 			"version": {

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -168,7 +168,7 @@ The following arguments are supported:
 
 * `source_control` - (Optional) A `source_control` block, as defined below.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by this Function App (such as the dashboard, logs).
+* `storage_account_name` - (Optional) The backend storage account name which will be used by this Function App (such as the dashboard, logs).
 
 * `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Function App.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -170,7 +170,7 @@ The following arguments are supported:
 
 * `storage_account_name` - (Required) The backend storage account name which will be used by this Function App (such as the dashboard, logs).
 
-* `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Function App.
+* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Function App.
 
 ~> **Note:** When integrating a `CI/CD pipeline` and expecting to run from a deployed package in `Azure` you must seed your `app settings` as part of terraform code for function app to be successfully deployed. `Important Default key pairs`: (`"WEBSITE_RUN_FROM_PACKAGE" = ""`, `"FUNCTIONS_WORKER_RUNTIME" = "node"` (or python, etc), `"WEBSITE_NODE_DEFAULT_VERSION" = "10.14.1"`, `"APPINSIGHTS_INSTRUMENTATIONKEY" = ""`).
 


### PR DESCRIPTION
It looks like #13410 is insufficient, there's still guard remains in function_app.go that block user from using identity instead of `storage_account_access_key`.

This pr allows user use `storage_account_access_key` or `storage_connection_string` or `identity`, and mark these storage account properties conflict with `identity`.

As identity's schema is defined by `schemaAppServiceIdentity` function in app_service.go and shared by other usage, I didn't add `ConflictWith` constraint in it's schema.

And I forgot to mark `storage_account_name` as Optional in the document in #13410, fix that in this pr too.