### PR TITLE
Revert 13379

### DIFF
--- a/internal/services/web/app_service_certificate_binding_resource.go
+++ b/internal/services/web/app_service_certificate_binding_resource.go
@@ -111,6 +111,11 @@ func resourceAppServiceCertificateBindingCreate(d *pluginsdk.ResourceData, meta 
 		return fmt.Errorf("failed reading App Service Certificate %q (Resource Group %q): %+v", id.CertificateId.Name, id.CertificateId.ResourceGroup, err)
 	}
 
+	if certDetails.Thumbprint == nil {
+		return fmt.Errorf("could not read thumbprint from certificate %q (resource group %q): %+v", id.CertificateId.Name, id.CertificateId.ResourceGroup, err)
+	}
+	thumbprint := certDetails.Thumbprint
+
 	binding, err := client.GetHostNameBinding(ctx, id.HostnameBindingId.ResourceGroup, id.HostnameBindingId.SiteName, id.HostnameBindingId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(binding.Response) {
@@ -121,7 +126,7 @@ func resourceAppServiceCertificateBindingCreate(d *pluginsdk.ResourceData, meta 
 
 	props := binding.HostNameBindingProperties
 	if props != nil {
-		if props.SslState != "" || props.VirtualIP != nil {
+		if props.Thumbprint != nil && *props.Thumbprint == *thumbprint {
 			return tf.ImportAsExistsError("azurerm_app_service_certificate_binding", id.ID())
 		}
 	}
@@ -130,6 +135,7 @@ func resourceAppServiceCertificateBindingCreate(d *pluginsdk.ResourceData, meta 
 	defer locks.UnlockByName(id.HostnameBindingId.SiteName, appServiceHostnameBindingResourceName)
 
 	binding.HostNameBindingProperties.SslState = web.SslState(d.Get("ssl_state").(string))
+	binding.HostNameBindingProperties.Thumbprint = thumbprint
 
 	if _, err := client.CreateOrUpdateHostNameBinding(ctx, id.HostnameBindingId.ResourceGroup, id.HostnameBindingId.SiteName, id.HostnameBindingId.Name, binding); err != nil {
 		return fmt.Errorf("creating/updating Custom Hostname Certificate Binding %q with certificate name %q (App Service %q / Resource Group %q): %+v", id.HostnameBindingId.Name, id.CertificateId.Name, id.HostnameBindingId.SiteName, id.HostnameBindingId.ResourceGroup, err)


### PR DESCRIPTION
Reverts #13379 

fixes #13425 

Changes in thumbprint return values were limited to Azure Managed Certs only, not globally as believed, resulting in a bug in the use of other custom certs.