### PR TITLE
azurerm_synapse_workspace - mark tenant_id as computed

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -187,6 +187,7 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 						"tenant_id": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IsUUID,
 						},
 					},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request marks the `tenant_id` field as computed to avoid extraneous diff calculations if/when the field is omitted from the configuration.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related: #13290

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='synapse' TESTARGS='-run="^TestAccSynapseWorkspace_azdo"' TESTTIMEOUT='120m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/synapse -run="^TestAccSynapseWorkspace_azdo" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSynapseWorkspace_azdo
=== PAUSE TestAccSynapseWorkspace_azdo
=== RUN   TestAccSynapseWorkspace_azdoTenant
=== PAUSE TestAccSynapseWorkspace_azdoTenant
=== CONT  TestAccSynapseWorkspace_azdo
=== CONT  TestAccSynapseWorkspace_azdoTenant
--- PASS: TestAccSynapseWorkspace_azdo (678.60s)
--- PASS: TestAccSynapseWorkspace_azdoTenant (765.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse       768.730s
```
