### PR TITLE
`azurerm_data_factory`: Support for `identity = SystemAssiged,UserAssigned`

### DIFF
--- a/internal/services/datafactory/data_factory_resource.go
+++ b/internal/services/datafactory/data_factory_resource.go
@@ -73,6 +73,7 @@ func resourceDataFactory() *pluginsdk.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								string(datafactory.FactoryIdentityTypeSystemAssigned),
 								string(datafactory.FactoryIdentityTypeUserAssigned),
+								string(datafactory.FactoryIdentityTypeSystemAssignedUserAssigned),
 							}, false),
 						},
 
@@ -273,8 +274,8 @@ func resourceDataFactoryCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		identityIdsRaw := d.Get("identity.0.identity_ids").([]interface{})
 		if len(identityIdsRaw) > 0 {
-			if identityType != string(datafactory.FactoryIdentityTypeUserAssigned) {
-				return fmt.Errorf("`identity_ids` can only be specified when `type` is `%s`", string(datafactory.FactoryIdentityTypeUserAssigned))
+			if !(identityType == string(datafactory.FactoryIdentityTypeUserAssigned) || identityType == string(datafactory.FactoryIdentityTypeSystemAssignedUserAssigned)) {
+				return fmt.Errorf("`identity_ids` can only be specified when `type` is `%s` or `%s`", string(datafactory.FactoryIdentityTypeUserAssigned), string(datafactory.FactoryIdentityTypeSystemAssignedUserAssigned))
 			}
 
 			identityIds := make(map[string]interface{})

--- a/internal/services/datafactory/data_factory_resource_test.go
+++ b/internal/services/datafactory/data_factory_resource_test.go
@@ -180,6 +180,21 @@ func TestAccDataFactory_userAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccDataFactory_systemAssignedUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
+	r := DataFactoryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataFactory_keyVaultKeyEncryption(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
 	r := DataFactoryResource{}
@@ -493,6 +508,38 @@ resource "azurerm_data_factory" "test" {
 
   identity {
     type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (DataFactoryResource) systemAssignedUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctest%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  identity {
+    type = "SystemAssigned,UserAssigned"
     identity_ids = [
       azurerm_user_assigned_identity.test.id
     ]

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -81,9 +81,9 @@ A `global_parameter` block supports the following:
 
 A `identity` block supports the following:
 
-* `type` - (Required) Specifies the identity type of the Data Factory. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) Specifies the identity type of the Data Factory. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned,UserAssigned`.
 
-* `identity_ids` - (Optional) Specifies the IDs of user assigned identities. Requiered if `UserAssigned` type is used.
+* `identity_ids` - (Optional) Specifies the IDs of user assigned identities. Required if `UserAssigned` or `SystemAssigned,UserAssigned` type is used.
 
 ---
 


### PR DESCRIPTION
Fixes #13471

## AccTest

```bash
❯ make acctests SERVICE='datafactory' TESTARGS='-run=TestAccDataFactory_systemAssignedUserAssignedIdentity'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/datafactory -run=TestAccDataFactory_doubleIdentity -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataFactory_systemAssignedUserAssignedIdentity
=== PAUSE TestAccDataFactory_systemAssignedUserAssignedIdentity
=== CONT  TestAccDataFactory_systemAssignedUserAssignedIdentity
--- PASS: TestAccDataFactory_systemAssignedUserAssignedIdentity (169.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory   170.932s
```