### PR TITLE
azurerm_mssql_database: Attempt to work around SKU change constraints for replicating databases

### DIFF
--- a/internal/services/mssql/helper/database.go
+++ b/internal/services/mssql/helper/database.go
@@ -1,0 +1,110 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+// FindDatabaseReplicationPartners looks for partner databases having one of the specified replication roles, by
+// reading any replication links then attempting to discover and match the corresponding server/database resources for
+// the other end of the link.
+func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *sql.DatabasesClient, replicationLinksClient *sql.ReplicationLinksClient, resourcesClient *resources.Client, id parse.DatabaseId, rolesToFind []sql.ReplicationRole) ([]sql.Database, error) {
+	var partnerDatabases []sql.Database
+
+	matchesRole := func(role sql.ReplicationRole) bool {
+		for _, r := range rolesToFind {
+			if r == role {
+				return true
+			}
+		}
+		return false
+	}
+
+	resp, err := replicationLinksClient.ListByDatabase(ctx, id.ResourceGroup, id.ServerName, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("reading Replication Links for %s: %+v", id, err)
+	}
+	if resp.Value == nil {
+		return nil, fmt.Errorf("reading Replication Links for %s: response was nil", id)
+	}
+
+	for _, link := range *resp.Value {
+		linkProps := link.ReplicationLinkProperties
+
+		if linkProps == nil {
+			log.Printf("[INFO] Replication Link Properties was nil for %s", id)
+			continue
+		}
+		if linkProps.PartnerLocation == nil || linkProps.PartnerServer == nil || linkProps.PartnerDatabase == nil {
+			log.Printf("[INFO] Replication Link Properties was invalid for %s", id)
+			continue
+		}
+
+		log.Printf("[INFO] Replication Link found for %s", id)
+
+		// Look for candidate partner SQL servers
+		filter := fmt.Sprintf("(resourceType eq 'Microsoft.Sql/servers') and ((name eq '%s'))", *linkProps.PartnerServer)
+		var resourceList []resources.GenericResourceExpanded
+		for resourcesIterator, err := resourcesClient.ListComplete(ctx, filter, "", nil); resourcesIterator.NotDone(); err = resourcesIterator.NextWithContext(ctx) {
+			if err != nil {
+				return nil, fmt.Errorf("retrieving Partner SQL Servers with filter %q for %s: %+v", filter, id, err)
+			}
+			resourceList = append(resourceList, resourcesIterator.Value())
+		}
+
+		for _, server := range resourceList {
+			if server.ID == nil {
+				log.Printf("[INFO] Partner SQL Server ID was nil for %s", id)
+				continue
+			}
+
+			partnerServerId, err := parse.ServerID(*server.ID)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Partner SQL Server ID %q: %+v", *server.ID, err)
+			}
+
+			// Check if like-named server has a database named like the partner database, also with a replication link
+			linksPossiblePartner, err := replicationLinksClient.ListByDatabase(ctx, partnerServerId.ResourceGroup, partnerServerId.Name, *linkProps.PartnerDatabase)
+			if err != nil {
+				if utils.ResponseWasNotFound(linksPossiblePartner.Response) {
+					log.Printf("[INFO] no replication link found for Database %q (%s)", *linkProps.PartnerDatabase, partnerServerId)
+					continue
+				}
+				return nil, fmt.Errorf("reading Replication Links for Database %s (%s): %+v", *linkProps.PartnerDatabase, partnerServerId, err)
+			}
+			if linksPossiblePartner.Value == nil {
+				return nil, fmt.Errorf("reading Replication Links for Database %s (%s): response was nil", *linkProps.PartnerDatabase, partnerServerId)
+			}
+
+			for _, linkPossiblePartner := range *linksPossiblePartner.Value {
+				if linkPossiblePartner.ReplicationLinkProperties == nil {
+					log.Printf("[INFO] Replication Link Properties was nil for Database %s (%s)", *linkProps.PartnerDatabase, partnerServerId)
+					continue
+				}
+
+				linkPropsPossiblePartner := *linkPossiblePartner.ReplicationLinkProperties
+
+				// If the database has a replication link for the specified role and a matching partner location, we'll consider it a partner of this database
+				if matchesRole(linkPropsPossiblePartner.Role) && *linkPossiblePartner.Location == *linkProps.PartnerLocation {
+					partnerDatabaseId := parse.NewDatabaseID(partnerServerId.SubscriptionId, partnerServerId.ResourceGroup, partnerServerId.Name, *linkProps.PartnerDatabase)
+					partnerDatabase, err := databasesClient.Get(ctx, partnerDatabaseId.ResourceGroup, partnerDatabaseId.ServerName, partnerDatabaseId.Name)
+					if err != nil {
+						return nil, fmt.Errorf("retrieving Partner %s: %+v", partnerDatabaseId, err)
+					}
+					if partnerDatabase.ID != nil {
+						partnerDatabases = append(partnerDatabases, partnerDatabase)
+					}
+				}
+			}
+		}
+	}
+
+	return partnerDatabases, nil
+}

--- a/internal/services/mssql/helper/sku.go
+++ b/internal/services/mssql/helper/sku.go
@@ -1,0 +1,25 @@
+package helper
+
+import (
+	"strings"
+)
+
+// CompareDatabaseSkuServiceTiers returns true if sku1 has a higher service tier than sku2
+func CompareDatabaseSkuServiceTiers(sku1, sku2 string) bool {
+	// These are intentionally short so that both forms can be matched, e.g. "S1" or "Standard"
+	order := []string{
+		"", "B", "S", "P",
+	}
+
+	var index1, index2 int
+	for i, v := range order {
+		if strings.HasPrefix(strings.ToLower(sku1), strings.ToLower(v)) {
+			index1 = i
+		}
+		if strings.HasPrefix(strings.ToLower(sku2), strings.ToLower(v)) {
+			index2 = i
+		}
+	}
+
+	return index1 > 0 && index2 > 0 && index1 > index2
+}

--- a/internal/services/mssql/helper/sku.go
+++ b/internal/services/mssql/helper/sku.go
@@ -6,9 +6,10 @@ import (
 
 // CompareDatabaseSkuServiceTiers returns true if sku1 has a higher service tier than sku2
 func CompareDatabaseSkuServiceTiers(sku1, sku2 string) bool {
-	// These are intentionally short so that both forms can be matched, e.g. "S1" or "Standard"
+	// This order was observed to be enforced by the API. These are intentionally short so that
+	// both forms can be matched for DTU tiers, e.g. "S1" or "Standard"
 	order := []string{
-		"", "B", "S", "P",
+		"", "B", "S", "GP", "P", "BC",
 	}
 
 	var index1, index2 int

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -338,12 +338,13 @@ func resourceMsSqlDatabaseImporter(ctx context.Context, d *pluginsdk.ResourceDat
 			return nil, fmt.Errorf("parsing ID for Replication Partner Database %q: %+v", *partnerDatabase.ID, err)
 		}
 
-		d.Set("creation_source_database_id", parse.NewDatabaseID(partnerDatabaseId.SubscriptionId, partnerDatabaseId.ResourceGroup, partnerDatabaseId.ServerName, partnerDatabaseId.Name).ID())
+		d.Set("create_mode", string(sql.CreateModeSecondary))
+		d.Set("creation_source_database_id", partnerDatabaseId.ID())
 
 		return []*pluginsdk.ResourceData{d}, nil
 	}
 
-	d.Set("create_mode", "Default")
+	d.Set("create_mode", string(sql.CreateModeDefault))
 
 	return []*pluginsdk.ResourceData{d}, nil
 }

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -445,8 +445,7 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 				return fmt.Errorf("parsing ID for Replication Partner Database %q: %+v", *partnerDatabase.ID, err)
 			}
 
-			// TODO: sku limitations for replicating databases aren't yet fully understood, this can be improved
-			// We're going on this: https://docs.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview#configuring-secondary-database
+			// See: https://docs.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview#configuring-secondary-database
 			if partnerDatabase.Sku != nil && partnerDatabase.Sku.Name != nil && helper.CompareDatabaseSkuServiceTiers(skuName.(string), *partnerDatabase.Sku.Name) {
 				future, err := client.Update(ctx, partnerDatabaseId.ResourceGroup, partnerDatabaseId.ServerName, partnerDatabaseId.Name, sql.DatabaseUpdate{
 					Sku: &sql.Sku{

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -276,42 +276,56 @@ func TestAccMsSqlDatabase_scaleReplicaSet(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "P2", 200),
+			Config: r.scaleReplicaSet(data, "P2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "BC_Gen5_2", 200),
+			Config: r.scaleReplicaSet(data, "BC_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "S2", 200),
+			Config: r.scaleReplicaSet(data, "S2"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sample_name"),
+		{
+			Config: r.scaleReplicaSet(data, "Basic"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sample_name"),
+		{
+			Config: r.scaleReplicaSet(data, "S1"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -967,7 +981,7 @@ resource "azurerm_mssql_database" "secondary" {
 `, r.complete(data), data.RandomInteger, data.Locations.Secondary)
 }
 
-func (r MsSqlDatabaseResource) scaleReplicaSet(data acceptance.TestData, sku string, size int) string {
+func (r MsSqlDatabaseResource) scaleReplicaSet(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -976,7 +990,7 @@ resource "azurerm_mssql_database" "primary" {
   server_id   = azurerm_mssql_server.test.id
   sample_name = "AdventureWorksLT"
 
-  max_size_gb = %[5]d
+  max_size_gb = "2"
   sku_name    = "%[4]s"
 }
 
@@ -1002,7 +1016,7 @@ resource "azurerm_mssql_database" "secondary" {
 
   sku_name = "%[4]s"
 }
-`, r.template(data), data.RandomInteger, data.Locations.Secondary, sku, size)
+`, r.template(data), data.RandomInteger, data.Locations.Secondary, sku)
 }
 
 func (r MsSqlDatabaseResource) scaleReplicaSetWithFailovergroup(data acceptance.TestData, sku string, size int) string {

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -241,7 +241,7 @@ func TestAccMsSqlDatabase_createPITRMode(t *testing.T) {
 		data.ImportStep(),
 
 		{
-			PreConfig: func() { time.Sleep(7 * time.Minute) },
+			PreConfig: func() { time.Sleep(11 * time.Minute) },
 			Config:    r.createPITRMode(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That("azurerm_mssql_database.pitr").ExistsInAzure(r),
@@ -1064,7 +1064,7 @@ resource "azurerm_mssql_failover_group" "failover_group" {
   server_id = azurerm_mssql_server.test.id
   databases = [azurerm_mssql_database.test.id]
 
-  partner_servers {
+  partner_server {
     id = azurerm_mssql_server.second.id
   }
 

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -276,21 +276,42 @@ func TestAccMsSqlDatabase_scaleReplicaSet(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scaleReplicaSet(data, "Basic", 2),
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "S0", 250),
+			Config: r.scaleReplicaSet(data, "P2", 200),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("sample_name"),
 		{
-			Config: r.scaleReplicaSet(data, "Basic", 2),
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sample_name"),
+		{
+			Config: r.scaleReplicaSet(data, "BC_Gen5_2", 200),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sample_name"),
+		{
+			Config: r.scaleReplicaSet(data, "GP_Gen5_2", 200),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sample_name"),
+		{
+			Config: r.scaleReplicaSet(data, "S2", 200),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/mssql/validate/database_sku_name.go
+++ b/internal/services/mssql/validate/database_sku_name.go
@@ -9,26 +9,26 @@ import (
 )
 
 const (
-	free             = "(Free)"
-	basic            = "(Basic)"
-	elastic          = "(ElasticPool)"
-	standard         = "(S(0|1|2|3|4|6|7|9|12))"
-	premium          = "(P(1|2|4|6|11|15))"
-	dataWarehouse    = "(DW(1|2|3|4|5|6|7|8|9)5?000*c)"
-	stretch          = "(DS(1|2|3|4|5|6|10|12|15|20)00)"
-	businessCritical = "(BC_M_(8|10|12|14|16|18|20|24|32|64|128))"
-	gen4             = "((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))"
-	gen5             = "(GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
-	serverlessGen5   = "(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))"
-	fsv2             = "(GP_Fsv2_(8|10|12|14|16|18|20|24|32|36|72))"
-	dc               = "((GP|BC|HS)_DC_(2|4|6|8))"
-	eightIM          = "(HS_8IM_(24|48|80))"
-	serverless8IM    = "(HS_S_8IM_(24|80))"
+	Free             = "(Free)"
+	Basic            = "(Basic)"
+	Elastic          = "(ElasticPool)"
+	Standard         = "(S(0|1|2|3|4|6|7|9|12))"
+	Premium          = "(P(1|2|4|6|11|15))"
+	DataWarehouse    = "(DW(1|2|3|4|5|6|7|8|9)5?000*c)"
+	Stretch          = "(DS(1|2|3|4|5|6|10|12|15|20)00)"
+	BusinessCritical = "(BC_M_(8|10|12|14|16|18|20|24|32|64|128))"
+	Gen4             = "((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))"
+	Gen5             = "(GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
+	ServerlessGen5   = "(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))"
+	Fsv2             = "(GP_Fsv2_(8|10|12|14|16|18|20|24|32|36|72))"
+	Dc               = "((GP|BC|HS)_DC_(2|4|6|8))"
+	EightIM          = "(HS_8IM_(24|48|80))"
+	Serverless8IM    = "(HS_S_8IM_(24|80))"
 )
 
 func DatabaseSkuName() pluginsdk.SchemaValidateFunc {
 	pattern := "(?i)(^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$)"
-	return validation.StringMatch(regexp.MustCompile(fmt.Sprintf(pattern, free, basic, elastic, standard, premium, dataWarehouse, stretch, businessCritical, gen4, gen5, serverlessGen5, fsv2, dc, eightIM, serverless8IM)),
+	return validation.StringMatch(regexp.MustCompile(fmt.Sprintf(pattern, Free, Basic, Elastic, Standard, Premium, DataWarehouse, Stretch, BusinessCritical, Gen4, Gen5, ServerlessGen5, Fsv2, Dc, EightIM, Serverless8IM)),
 
 		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a MS SQL Database.
 
-~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
+~> **Note:** The Database Extended Auditing Policy can be set inline here, as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
 ## Example Usage
 
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `creation_source_database_id` - (Optional) The ID of the source database from which to create the new database. This should only be used for databases with `create_mode` values that use another database as reference. Changing this forces a new resource to be created.
 
+-> **Note:** When configuring a secondary database, please be aware of the constraints for the `sku_name` property, as noted below, for both the primary and secondary databases. The `sku_name` of the secondary database may be inadvertently changed to match that of the primary when an incompatible combination of SKUs is detected by the provider.
+
 * `collation` - (Optional) Specifies the collation of the database. Changing this forces a new resource to be created.
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
@@ -118,7 +120,7 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) Specifies the name of the SKU used by the database. For example, `GP_S_Gen5_2`,`HS_Gen4_1`,`BC_Gen5_2`, `ElasticPool`, `Basic`,`S0`, `P2` ,`DW100c`, `DS100`. Changing this from the HyperScale service tier to another service tier will force a new resource to be created.
 
-~> **Note:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. In such cases it's recommended to use the same `sku_name` for all related databases.
+~> **Note:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. When changing the `sku_name` of a database having one or more secondary databases, this resource will first update any secondary databases as necessary. In such cases it's recommended to use the same `sku_name` in your configuration for all related databases, as not doing so may cause an unresolvable diff during subsequent plans.
 
 * `storage_account_type` - (Optional) Specifies the storage account type used to store backups for this database. Changing this forces a new resource to be created.  Possible values are `GRS`, `LRS` and `ZRS`.  The default value is `GRS`.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -74,13 +74,13 @@ The following arguments are supported:
 
 * `server_id` - (Required) The id of the Ms SQL Server on which to create the database. Changing this forces a new resource to be created.
 
-~> **NOTE:** This setting is still required for "Serverless" SKU's
+~> **Note:** This setting is still required for "Serverless" SKU's
 
 * `auto_pause_delay_in_minutes` - (Optional) Time in minutes after which database is automatically paused. A value of `-1` means that automatic pause is disabled. This property is only settable for General Purpose Serverless databases.
 
 * `create_mode` - (Optional) The create mode of the database. Possible values are `Copy`, `Default`, `OnlineSecondary`, `PointInTimeRestore`, `Recovery`, `Restore`, `RestoreExternalBackup`, `RestoreExternalBackupSecondary`, `RestoreLongTermRetentionBackup` and `Secondary`. 
 
-* `creation_source_database_id` - (Optional) The id of the source database to be referred to create the new database. This should only be used for databases with `create_mode` values that use another database as reference. Changing this forces a new resource to be created.
+* `creation_source_database_id` - (Optional) The ID of the source database from which to create the new database. This should only be used for databases with `create_mode` values that use another database as reference. Changing this forces a new resource to be created.
 
 * `collation` - (Optional) Specifies the collation of the database. Changing this forces a new resource to be created.
 
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 * `geo_backup_enabled` - (Optional) A boolean that specifies if the Geo Backup Policy is enabled. 
 
-~> **NOTE** `geo_backup_enabled` is only applicable for DataWarehouse SKUs (DW*). This setting is ignored for all other SKUs.
+~> **Note:** `geo_backup_enabled` is only applicable for DataWarehouse SKUs (DW*). This setting is ignored for all other SKUs.
 
 * `license_type` - (Optional) Specifies the license type applied to this database. Possible values are `LicenseIncluded` and `BasePrice`.
 
@@ -116,9 +116,9 @@ The following arguments are supported:
 
 * `short_term_retention_policy` - (Optional) A `short_term_retention_policy` block as defined below.
 
-* `sku_name` - (Optional) Specifies the name of the sku used by the database. Only changing this from tier `Hyperscale` to another tier will force a new resource to be created. For example, `GP_S_Gen5_2`,`HS_Gen4_1`,`BC_Gen5_2`, `ElasticPool`, `Basic`,`S0`, `P2` ,`DW100c`, `DS100`.
+* `sku_name` - (Optional) Specifies the name of the SKU used by the database. For example, `GP_S_Gen5_2`,`HS_Gen4_1`,`BC_Gen5_2`, `ElasticPool`, `Basic`,`S0`, `P2` ,`DW100c`, `DS100`. Changing this from the HyperScale service tier to another service tier will force a new resource to be created.
 
-~> **NOTE** The default sku_name value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity.
+~> **Note:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. In such cases it's recommended to use the same `sku_name` for all related databases.
 
 * `storage_account_type` - (Optional) Specifies the storage account type used to store backups for this database. Changing this forces a new resource to be created.  Possible values are `GRS`, `LRS` and `ZRS`.  The default value is `GRS`.
 


### PR DESCRIPTION
When databases are replicating, the primary cannot have a SKU belonging to a higher service tier than any of its partner databases. To work around this, we'll try to identify any partner databases that are secondary to this database, and where the new SKU tier for this database is going to be higher, first upgrade those databases to the same `sku_name` as we'll be changing this database to. If that sku is different to the one configured for any of the partner databases, that discrepancy will have to be corrected by the resource for that database.

That might happen as part of the same apply, if a change was already planned for it, else it will only be picked up in a second plan/apply.

For the best experience, configurations should use the same SKU for a primary database and any secondary databases that are replicating from it.

Closes: #12235