### PR TITLE
`azurerm_app_configuration_key`: Fix nil pointer for removed key

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -212,6 +212,10 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("unexpected API response. More than one value returned for Key/Label pair %s/%s", resourceID.Key, resourceID.Label)
 			}
 
+			if len(res.Values()) < 1 {
+				return metadata.MarkAsGone(resourceID)
+			}
+
 			kv := res.Values()[0]
 
 			model := KeyResourceModel{


### PR DESCRIPTION
Fixes #13482

## Reproduction
After adding a value with a different label and removing the original label with value, the nil pointer showed up. After the fix it marked the resource gone, effectively recreating the removed original label value

## AccTests Passing:

```bash
❯ make acctests SERVICE='appconfiguration' TESTARGS='-run=TestAccAppConfigurationKey_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appconfiguration -run=TestAccAppConfigurationKey_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAppConfigurationKey_basic
=== PAUSE TestAccAppConfigurationKey_basic
=== RUN   TestAccAppConfigurationKey_basicNoLabel
=== PAUSE TestAccAppConfigurationKey_basicNoLabel
=== RUN   TestAccAppConfigurationKey_basicVault
=== PAUSE TestAccAppConfigurationKey_basicVault
=== RUN   TestAccAppConfigurationKey_KVToVault
=== PAUSE TestAccAppConfigurationKey_KVToVault
=== RUN   TestAccAppConfigurationKey_requiresImport
=== PAUSE TestAccAppConfigurationKey_requiresImport
=== RUN   TestAccAppConfigurationKey_lockUpdate
=== PAUSE TestAccAppConfigurationKey_lockUpdate
=== CONT  TestAccAppConfigurationKey_basic
=== CONT  TestAccAppConfigurationKey_requiresImport
=== CONT  TestAccAppConfigurationKey_basicVault
=== CONT  TestAccAppConfigurationKey_lockUpdate
=== CONT  TestAccAppConfigurationKey_basicNoLabel
=== CONT  TestAccAppConfigurationKey_KVToVault
--- PASS: TestAccAppConfigurationKey_basic (138.13s)
--- PASS: TestAccAppConfigurationKey_lockUpdate (178.89s)
--- PASS: TestAccAppConfigurationKey_basicNoLabel (203.42s)
--- PASS: TestAccAppConfigurationKey_requiresImport (213.47s)
--- PASS: TestAccAppConfigurationKey_basicVault (355.79s)
--- PASS: TestAccAppConfigurationKey_KVToVault (423.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfi
```