### PR TITLE
`azurerm_kusto_eventhub_data_connection` supports `identity_id`

### DIFF
--- a/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -76,6 +76,36 @@ func TestAccKustoEventHubDataConnection_unboundMapping2(t *testing.T) {
 	})
 }
 
+func TestAccKustoEventHubDataConnection_systemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoEventHubDataConnection_userAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KustoEventHubDataConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.DataConnectionID(state.ID)
 	if err != nil {
@@ -174,6 +204,60 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
+func (r KustoEventHubDataConnectionResource) systemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_eventhub.test.id
+  role_definition_name = "Azure Event Hubs Data Receiver"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  identity_id = azurerm_user_assigned_identity.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) userAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_eventhub.test.id
+  role_definition_name = "Azure Event Hubs Data Receiver"
+  principal_id         = azurerm_kusto_cluster.test.identity.0.principal_id
+}
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  identity_id = azurerm_kusto_cluster.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (KustoEventHubDataConnectionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -185,6 +269,12 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
 resource "azurerm_kusto_cluster" "test" {
   name                = "acctestkc%s"
   location            = azurerm_resource_group.test.location
@@ -193,6 +283,11 @@ resource "azurerm_kusto_cluster" "test" {
   sku {
     name     = "Dev(No SLA)_Standard_D11_v2"
     capacity = 1
+  }
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
 
@@ -224,5 +319,5 @@ resource "azurerm_eventhub_consumer_group" "test" {
   eventhub_name       = azurerm_eventhub.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `table_name` - (Optional) Specifies the target table name used for the message ingestion. Table must exist before resource is created.
 
+* `identity_id` - (Optional) The resource ID of a managed identity (system or user assigned) to be used to authenticate with event hub.
+
 * `mapping_rule_name` - (Optional) Specifies the mapping rule used for the message ingestion. Mapping rule must exist before resource is created.
 
 * `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSVE`, `TSV`, `TXT`, and `W3CLOGFILE`.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79895375/134621252-e97e6f83-786e-4ad6-9886-52eb41889720.png)
