### PR TITLE
`azurerm_kubernetes_cluster`: Allow for auto upgrade channel `none` and default to it

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -776,7 +776,9 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 					string(containerservice.UpgradeChannelRapid),
 					string(containerservice.UpgradeChannelStable),
 					string(containerservice.UpgradeChannelNodeImage),
+					string(containerservice.UpgradeChannelNone),
 				}, false),
+				Default: string(containerservice.UpgradeChannelNone),
 			},
 
 			// Computed

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -80,7 +80,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 ---
 
-* `automatic_channel_upgrade` - (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are `patch`, `rapid`, `node-image` and `stable`.
+* `automatic_channel_upgrade` - (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are `patch`, `rapid`, `node-image`, `stable` and `none`. Defaults to `none`.
 
 !> **Note:** Cluster Auto-Upgrade will update the Kubernetes Cluster (and it's Node Pools) to the latest GA version of Kubernetes automatically - please [see the Azure documentation for more information](https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster#set-auto-upgrade-channel-preview).
 


### PR DESCRIPTION
As stated in https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster#set-auto-upgrade-channel, default setting is `none`, but we don't allow for it, making use of this parameter in a module a tad complicated, requiring a dynamic. This should allow modules to set default value to none.