### PR TITLE
`d/azurerm_public_ips`: Deprecate `attached` for `attachment_status`

### DIFF
--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -46,7 +46,7 @@ func dataSourcePublicIPs() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"Attached",
 					"Unattached",
-					"All",
+					"All", // TODO - Remove "All" in 3.0.
 				}, false),
 				ConflictsWith: []string{
 					"attached",

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -118,10 +118,10 @@ func dataSourcePublicIPsRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		}
 
 		attachmentStatus, attachmentStatusOk := d.GetOk("attachment_status")
-		if attachmentStatus.(string) == "Attached" && !nicIsAttached {
+		if attachmentStatusOk && attachmentStatus.(string) == "Attached" && !nicIsAttached {
 			continue
 		}
-		if attachmentStatus.(string) == "Unattached" && nicIsAttached {
+		if attachmentStatusOk && attachmentStatus.(string) == "Unattached" && nicIsAttached {
 			continue
 		}
 

--- a/internal/services/network/public_ips_data_source_test.go
+++ b/internal/services/network/public_ips_data_source_test.go
@@ -34,7 +34,10 @@ func TestAccDataSourcePublicIPs_assigned(t *testing.T) {
 	r := PublicIPsResource{}
 
 	attachedDataSourceName := "data.azurerm_public_ips.attached"
+	attachedDataSourceName2 := "data.azurerm_public_ips.attached2"
 	unattachedDataSourceName := "data.azurerm_public_ips.unattached"
+	unattachedDataSourceName2 := "data.azurerm_public_ips.unattached2"
+	unattachedAndAttachedDataSourceName := "data.azurerm_public_ips.unattached_and_attached"
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -45,8 +48,14 @@ func TestAccDataSourcePublicIPs_assigned(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				acceptance.TestCheckResourceAttr(attachedDataSourceName, "public_ips.#", "3"),
 				acceptance.TestCheckResourceAttr(attachedDataSourceName, "public_ips.0.name", fmt.Sprintf("acctestpip%s-0", data.RandomString)),
+				acceptance.TestCheckResourceAttr(attachedDataSourceName2, "public_ips.#", "3"),
+				acceptance.TestCheckResourceAttr(attachedDataSourceName2, "public_ips.0.name", fmt.Sprintf("acctestpip%s-0", data.RandomString)),
 				acceptance.TestCheckResourceAttr(unattachedDataSourceName, "public_ips.#", "4"),
 				acceptance.TestCheckResourceAttr(unattachedDataSourceName, "public_ips.0.name", fmt.Sprintf("acctestpip%s-3", data.RandomString)),
+				acceptance.TestCheckResourceAttr(unattachedDataSourceName2, "public_ips.#", "4"),
+				acceptance.TestCheckResourceAttr(unattachedDataSourceName2, "public_ips.0.name", fmt.Sprintf("acctestpip%s-3", data.RandomString)),
+				acceptance.TestCheckResourceAttr(unattachedAndAttachedDataSourceName, "public_ips.#", "7"),
+				acceptance.TestCheckResourceAttr(unattachedAndAttachedDataSourceName, "public_ips.0.name", fmt.Sprintf("acctestpip%s-0", data.RandomString)),
 			),
 		},
 	})
@@ -119,10 +128,25 @@ func (r PublicIPsResource) attachedDataSource(data acceptance.TestData) string {
 
 data "azurerm_public_ips" "unattached" {
   resource_group_name = azurerm_resource_group.test.name
+  attachment_status   = "Unattached"
+}
+
+data "azurerm_public_ips" "unattached2" {
+  resource_group_name = azurerm_resource_group.test.name
   attached            = false
 }
 
+data "azurerm_public_ips" "unattached_and_attached" {
+  resource_group_name = azurerm_resource_group.test.name
+  attachment_status   = "All"
+}
+
 data "azurerm_public_ips" "attached" {
+  resource_group_name = azurerm_resource_group.test.name
+  attachment_status   = "Attached"
+}
+
+data "azurerm_public_ips" "attached2" {
   resource_group_name = azurerm_resource_group.test.name
   attached            = true
 }

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -22,7 +22,6 @@ data "azurerm_public_ips" "example" {
 ## Argument Reference
 
 * `resource_group_name` - Specifies the name of the resource group.
-* `attached` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`true`) or unattached (`false`). This option is deprecated for `attachment_status`. Default value is `false`, unless `attachment_status` is set.
 * `attachment_status` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`Attached`) or unattached (`Unattached`). To allow for both, use `All`.
 * `name_prefix` - (Optional) A prefix match used for the IP Addresses `name` field, case sensitive.
 * `allocation_type` - (Optional) The Allocation Type for the Public IP Address. Possible values include `Static` or `Dynamic`.

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -22,7 +22,8 @@ data "azurerm_public_ips" "example" {
 ## Argument Reference
 
 * `resource_group_name` - Specifies the name of the resource group.
-* `attached` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`true`) or unattached (`false`).
+* `attached` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`true`) or unattached (`false`). This option is deprecated for `attachment_status`. Default value is `false`, unless `attachment_status` is set.
+* `attachment_status` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`Attached`) or unattached (`Unattached`). To allow for both, use `All`.
 * `name_prefix` - (Optional) A prefix match used for the IP Addresses `name` field, case sensitive.
 * `allocation_type` - (Optional) The Allocation Type for the Public IP Address. Possible values include `Static` or `Dynamic`.
 


### PR DESCRIPTION
Fixes #13497

## Solution
`attachment_status` contains both the option to select based on the status (what is currently supported by `attached = true/false` -> `attachment_status = "Attached"/"Unattached"`) and to select all in one go ( `attachment_status = "All"` ).

At 3.0, default will show all IPs, attached or not