### PR TITLE
Remove forceNew for `zone` and `standby_availability_zone` of azurerm_postgresql_flexible_server

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -515,7 +515,6 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("waiting for the update of the Postgresql Flexible Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	// Once `zone` and `standby_availability_zone` is exchanged, it has to fail over
 	if requireFailover {
 		restartParameters := &postgresqlflexibleservers.RestartParameter{
 			RestartWithFailover: utils.Bool(true),

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -450,14 +450,13 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 			standbyZone := d.Get("high_availability.0.standby_availability_zone").(string)
 
 			if props.AvailabilityZone != nil && props.HighAvailability != nil && props.HighAvailability.StandbyAvailabilityZone != nil {
-				if zone == *props.AvailabilityZone && standbyZone == *props.HighAvailability.StandbyAvailabilityZone {
-					log.Printf("[INFO] `zone` and `standby_availability_zone` have already been failed over")
-					requireFailover = false
-				} else if zone == *props.HighAvailability.StandbyAvailabilityZone && standbyZone == *props.AvailabilityZone {
+				if zone == *props.HighAvailability.StandbyAvailabilityZone && standbyZone == *props.AvailabilityZone {
 					requireFailover = true
 				} else {
 					return fmt.Errorf("failover only supports exchange between `zone` and `standby_availability_zone`")
 				}
+			} else {
+				return fmt.Errorf("`standby_availability_zone` cannot be added after creation")
 			}
 		}
 	} else if !d.HasChange("zone") && !d.HasChange("high_availability.0.standby_availability_zone") {

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -101,10 +101,14 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 			},
 
 			"zone": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"1",
+					"2",
+					"3",
+				}, false),
 			},
 
 			"create_mode": {
@@ -201,10 +205,14 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 						},
 
 						"standby_availability_zone": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"1",
+								"2",
+								"3",
+							}, false),
 						},
 					},
 				},

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -208,14 +208,14 @@ func TestAccPostgresqlflexibleServer_failover(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.failover(data, "1", "3"),
+			Config: r.failover(data, "1", "2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
 		{
-			Config: r.failover(data, "3", "1"),
+			Config: r.failover(data, "1", "3"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -61,7 +61,7 @@ func TestAccPostgresqlflexibleServer_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
+		data.ImportStep("administrator_password", "create_mode"),
 	})
 }
 
@@ -77,7 +77,7 @@ func TestAccPostgresqlflexibleServer_completeUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
+		data.ImportStep("administrator_password", "create_mode"),
 		{
 			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -86,7 +86,7 @@ func TestAccPostgresqlflexibleServer_completeUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "zone"),
+		data.ImportStep("administrator_password", "create_mode"),
 	})
 }
 
@@ -213,14 +213,14 @@ func TestAccPostgresqlflexibleServer_failover(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
+		data.ImportStep("administrator_password", "create_mode"),
 		{
-			Config: r.failover(data, "1", "3"),
+			Config: r.failover(data, "2", "1"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
+		data.ImportStep("administrator_password", "create_mode"),
 	})
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -61,7 +61,7 @@ func TestAccPostgresqlflexibleServer_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
 	})
 }
 
@@ -77,7 +77,7 @@ func TestAccPostgresqlflexibleServer_completeUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
 		{
 			Config: r.completeUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -86,7 +86,7 @@ func TestAccPostgresqlflexibleServer_completeUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "zone"),
 	})
 }
 
@@ -199,6 +199,28 @@ func TestAccPostgresqlflexibleServer_pitr(t *testing.T) {
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode", "point_in_time_restore_time_in_utc"),
+	})
+}
+
+func TestAccPostgresqlflexibleServer_failover(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
+	r := PostgresqlFlexibleServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.failover(data, "1", "3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
+		{
+			Config: r.failover(data, "3", "1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode", "zone", "high_availability.0.standby_availability_zone"),
 	})
 }
 
@@ -319,7 +341,7 @@ resource "azurerm_postgresql_flexible_server" "test" {
 
   high_availability {
     mode                      = "ZoneRedundant"
-    standby_availability_zone = "1"
+    standby_availability_zone = "2"
   }
 
   maintenance_window {
@@ -482,4 +504,34 @@ resource "azurerm_postgresql_flexible_server" "pitr" {
   point_in_time_restore_time_in_utc = "%s"
 }
 `, r.basic(data), data.RandomInteger, time.Now().Add(time.Duration(15)*time.Minute).UTC().Format(time.RFC3339))
+}
+
+func (r PostgresqlFlexibleServerResource) failover(data acceptance.TestData, parimaryZone string, standbyZone string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  version                = "12"
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  zone                   = "%s"
+  backup_retention_days  = 10
+  storage_mb             = 131072
+  sku_name               = "GP_Standard_D2s_v3"
+
+  maintenance_window {
+    day_of_week  = 0
+    start_hour   = 0
+    start_minute = 0
+  }
+
+  high_availability {
+    mode                      = "ZoneRedundant"
+    standby_availability_zone = "%s"
+  }
+}
+`, r.template(data), data.RandomInteger, parimaryZone, standbyZone)
 }

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `administrator_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Flexible Server. Required when `create_mode` is `Default`.
 
-* `zone` - (Optional) The availability zone of the PostgreSQL Flexible Server. Possible values are `1`, `2` and `3`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `zone` - (Optional) The availability zone of the PostgreSQL Flexible Server. Possible values are `1`, `2` and `3`.
 
 * `backup_retention_days` - (Optional) The backup retention days for the PostgreSQL Flexible Server. Possible values are between `7` and `35` days.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/13443

Symptom:
   Currently, TF would recreate this resource when `zone` and `standby_availability_zone` is changed.

Expected behavior:
   After confirmed with service team, TF shouldn't recreate this resource when `zone` and `standby_availability_zone` is changed and failover between `zone` and `standby_availability_zone` is only supported when their values are exchanged.

--- PASS: TestAccPostgresqlflexibleServer_basic (564.91s)
--- PASS: TestAccPostgresqlflexibleServer_requiresImport (598.20s)
--- PASS: TestAccPostgresqlflexibleServer_updateMaintenanceWindow (1090.05s)
--- PASS: TestAccPostgresqlflexibleServer_complete (1170.18s)
--- PASS: TestAccPostgresqlflexibleServer_updateSku (1490.18s)
--- PASS: TestAccPostgresqlflexibleServer_failover (1582.92s)
--- PASS: TestAccPostgresqlflexibleServer_pitr (1954.23s)
--- PASS: TestAccPostgresqlflexibleServer_completeUpdate (2148.29s)