### PR TITLE
Add support for new property of azurerm_network_connection_monitor

### DIFF
--- a/internal/services/network/network_connection_monitor_resource.go
+++ b/internal/services/network/network_connection_monitor_resource.go
@@ -424,6 +424,15 @@ func resourceNetworkConnectionMonitor() *pluginsdk.Resource {
 										Optional: true,
 										Default:  true,
 									},
+
+									"destination_port_behavior": {
+										Type:     pluginsdk.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(network.DestinationPortBehaviorNone),
+											string(network.DestinationPortBehaviorListenIfAvailable),
+										}, false),
+									},
 								},
 							},
 						},
@@ -821,10 +830,16 @@ func expandNetworkConnectionMonitorTCPConfiguration(input []interface{}) *networ
 
 	v := input[0].(map[string]interface{})
 
-	return &network.ConnectionMonitorTCPConfiguration{
+	result := &network.ConnectionMonitorTCPConfiguration{
 		Port:              utils.Int32(int32(v["port"].(int))),
 		DisableTraceRoute: utils.Bool(!v["trace_route_enabled"].(bool)),
 	}
+
+	if destinationPortBehavior := v["destination_port_behavior"].(string); destinationPortBehavior != "" {
+		result.DestinationPortBehavior = network.DestinationPortBehavior(destinationPortBehavior)
+	}
+
+	return result
 }
 
 func expandNetworkConnectionMonitorIcmpConfiguration(input []interface{}) *network.ConnectionMonitorIcmpConfiguration {
@@ -1163,10 +1178,16 @@ func flattenNetworkConnectionMonitorTCPConfiguration(input *network.ConnectionMo
 		port = *input.Port
 	}
 
+	var destinationPortBehavior network.DestinationPortBehavior
+	if input.DestinationPortBehavior != "" {
+		destinationPortBehavior = input.DestinationPortBehavior
+	}
+
 	return []interface{}{
 		map[string]interface{}{
-			"trace_route_enabled": enableTraceRoute,
-			"port":                port,
+			"trace_route_enabled":       enableTraceRoute,
+			"port":                      port,
+			"destination_port_behavior": string(destinationPortBehavior),
 		},
 	}
 }

--- a/internal/services/network/network_connection_monitor_resource_test.go
+++ b/internal/services/network/network_connection_monitor_resource_test.go
@@ -458,7 +458,8 @@ resource "azurerm_network_connection_monitor" "test" {
     protocol = "Tcp"
 
     tcp_configuration {
-      port = 80
+      port                      = 80
+      destination_port_behavior = "None"
     }
   }
 
@@ -516,7 +517,8 @@ resource "azurerm_network_connection_monitor" "test" {
     preferred_ip_version      = "IPv4"
 
     tcp_configuration {
-      port = 80
+      port                      = 80
+      destination_port_behavior = "ListenIfAvailable"
     }
 
     success_threshold {

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -279,6 +279,8 @@ A `tcp_configuration` block supports the following:
 
 * `trace_route_enabled` - (Optional) Should path evaluation with trace route be enabled? Defaults to `true`.
 
+* `destination_port_behavior` - (Optional) The destination port behavior for the Tcp connection. Possible values are `None` and `ListenIfAvailable`.
+
 ---
 
 A `test_group` block supports the following:


### PR DESCRIPTION
This PR is to add support for new property [`destinationPortBehavior`](https://github.com/Azure/azure-rest-api-specs/blob/7a1bad6e4e724077b0dfa9d3c2f4072554418601/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/networkWatcher.json#L4474) of azurerm_network_connection_monitor.

--- PASS: TestAccNetworkWatcher
--- PASS: TestAccNetworkWatcher/ConnectionMonitor
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/updateEndpoint
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/vmUpdate
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/endpointType
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/addressComplete
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/missingDestinationInvalid
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/bothDestinationsInvalid
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/bothAddressAndVirtualMachineId
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/addressBasic
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/addressUpdate
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/vmBasic
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/vmComplete
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/destinationUpdate
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/requiresImport
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/httpConfiguration
--- PASS: TestAccNetworkWatcher/ConnectionMonitor/icmpConfiguration

