### PR TITLE
Test Fix: Various Compute tests

### DIFF
--- a/internal/acceptance/steps.go
+++ b/internal/acceptance/steps.go
@@ -76,6 +76,20 @@ func (td TestData) CheckWithClientForResource(check ClientCheckFunc, resourceNam
 	)
 }
 
+// CheckWithClientWithoutResource returns a TestCheckFunc which will call a ClientCheckFunc
+// with the provider context and clients to find if a resource exists when the resource that created it is destroyed.
+func (td TestData) CheckWithClientWithoutResource(check ClientCheckFunc) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		func(state *terraform.State) error {
+			client, err := testclient.Build()
+			if err != nil {
+				return fmt.Errorf("building client: %+v", err)
+			}
+			return check(client.StopContext, client, nil)
+		},
+	)
+}
+
 // ImportStep returns a Test Step which Imports the Resource, optionally
 // ignoring any fields which may not be imported (for example, as they're
 // not returned from the API)

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -217,7 +217,7 @@ func TestAccLinuxVirtualMachineScaleSet_networkIPv6(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
-			ExpectError: regexp.MustCompile("Error expanding `network_interface`: An IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary"),
+			ExpectError: regexp.MustCompile("Error: expanding `network_interface`: An IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary"),
 		},
 	})
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -921,7 +921,8 @@ func (r LinuxVirtualMachineScaleSetResource) otherForceDelete(data acceptance.Te
 provider "azurerm" {
   features {
     virtual_machine_scale_set {
-      force_delete = true
+      force_delete                 = true
+      roll_instances_when_required = true
     }
   }
 }

--- a/internal/services/compute/virtual_machine_managed_disks_resource_test.go
+++ b/internal/services/compute/virtual_machine_managed_disks_resource_test.go
@@ -136,8 +136,8 @@ func TestAccVirtualMachine_deleteManagedDiskOptOut(t *testing.T) {
 		{
 			Config: r.basicLinuxMachineDeleteVM_managedDisk(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClient(r.managedDiskExists(osDiskId, true)),
-				data.CheckWithClient(r.managedDiskExists(dataDiskId, true)),
+				data.CheckWithClientWithoutResource(r.managedDiskExists(&osDiskId, true)),
+				data.CheckWithClientWithoutResource(r.managedDiskExists(&dataDiskId, true)),
 			),
 		},
 	})
@@ -163,8 +163,8 @@ func TestAccVirtualMachine_deleteManagedDiskOptIn(t *testing.T) {
 		{
 			Config: r.basicLinuxMachine_managedDisk_DestroyDisksAfter(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClient(r.managedDiskExists(osDiskId, false)),
-				data.CheckWithClient(r.managedDiskExists(dataDiskId, false)),
+				data.CheckWithClientWithoutResource(r.managedDiskExists(&osDiskId, false)),
+				data.CheckWithClientWithoutResource(r.managedDiskExists(&dataDiskId, false)),
 			),
 		},
 	})

--- a/internal/services/compute/virtual_machine_resource_test.go
+++ b/internal/services/compute/virtual_machine_resource_test.go
@@ -115,9 +115,9 @@ func (VirtualMachineResource) Exists(ctx context.Context, clients *clients.Clien
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func (VirtualMachineResource) managedDiskExists(diskId string, shouldExist bool) acceptance.ClientCheckFunc {
+func (VirtualMachineResource) managedDiskExists(diskId *string, shouldExist bool) acceptance.ClientCheckFunc {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-		id, err := parse.ManagedDiskID(diskId)
+		id, err := parse.ManagedDiskID(*diskId)
 		if err != nil {
 			return err
 		}

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -1098,7 +1098,8 @@ func (r WindowsVirtualMachineScaleSetResource) otherForceDelete(data acceptance.
 provider "azurerm" {
   features {
     virtual_machine_scale_set {
-      force_delete = true
+      force_delete                 = true
+      roll_instances_when_required = true
     }
   }
 }


### PR DESCRIPTION
```
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherForceDelete (759.33s)
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherForceDelete (884.05s)
--- PASS: TestAccVirtualMachine_osDiskTypeConflict (2.64s)
--- PASS: TestAccVirtualMachine_deleteManagedDiskOptIn (382.91s)
--- PASS: TestAccVirtualMachine_deleteManagedDiskOptOut (386.43s)
```