### PR TITLE
Add support for data.azurerm_key_vault_certificate and data.azurerm_key_vault_certificate_data attributes not before and expires

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -73,6 +73,11 @@ func dataSourceKeyVaultCertificateData() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"not_before": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"certificates_count": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -133,17 +138,29 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	}
 	d.Set("hex", certificateData)
 
-	timeString, err := cert.Attributes.Expires.MarshalText()
+	expireString, err := cert.Attributes.Expires.MarshalText()
 	if err != nil {
 		return fmt.Errorf("parsing expiry time of certificate: %+v", err)
 	}
 
-	t, err := time.Parse(time.RFC3339, string(timeString))
+	e, err := time.Parse(time.RFC3339, string(expireString))
 	if err != nil {
 		return fmt.Errorf("converting text to Time struct: %+v", err)
 	}
 
-	d.Set("expires", t.Format(time.RFC3339))
+	d.Set("expires", e.Format(time.RFC3339))
+
+	notBeforeString, err := cert.Attributes.NotBefore.MarshalText()
+	if err != nil {
+		return fmt.Errorf("parsing not-before time of certificate: %+v", err)
+	}
+
+	n, err := time.Parse(time.RFC3339, string(notBeforeString))
+	if err != nil {
+		return fmt.Errorf("converting text to Time struct: %+v", err)
+	}
+
+	d.Set("not_before", n.Format(time.RFC3339))
 
 	// Get PFX
 	pfx, err := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, id.Version)

--- a/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
@@ -22,6 +22,7 @@ func TestAccDataSourceKeyVaultCertificateData_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("hex").Exists(),
 				check.That(data.ResourceName).Key("pem").Exists(),
 				check.That(data.ResourceName).Key("key").Exists(),
+				check.That(data.ResourceName).Key("not_before").HasValue("2017-10-10T08:27:55Z"),
 				check.That(data.ResourceName).Key("expires").HasValue("2027-10-08T08:27:55Z"),
 			),
 		},

--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -225,6 +225,16 @@ func dataSourceKeyVaultCertificate() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"expires": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"not_before": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -302,6 +312,30 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 		thumbprint = strings.ToUpper(hex.EncodeToString(x509Thumbprint))
 	}
 	d.Set("thumbprint", thumbprint)
+
+	expireString, err := cert.Attributes.Expires.MarshalText()
+	if err != nil {
+		return fmt.Errorf("parsing expiry time of certificate: %+v", err)
+	}
+
+	e, err := time.Parse(time.RFC3339, string(expireString))
+	if err != nil {
+		return fmt.Errorf("converting text to Time struct: %+v", err)
+	}
+
+	d.Set("expires", e.Format(time.RFC3339))
+
+	notBeforeString, err := cert.Attributes.NotBefore.MarshalText()
+	if err != nil {
+		return fmt.Errorf("parsing not-before time of certificate: %+v", err)
+	}
+
+	n, err := time.Parse(time.RFC3339, string(notBeforeString))
+	if err != nil {
+		return fmt.Errorf("converting text to Time struct: %+v", err)
+	}
+
+	d.Set("not_before", n.Format(time.RFC3339))
 
 	return tags.FlattenAndSet(d, cert.Tags)
 }

--- a/internal/services/keyvault/key_vault_certificate_data_source_test.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source_test.go
@@ -23,6 +23,8 @@ func TestAccDataSourceKeyVaultCertificate_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
 				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("2048"),
 				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("RSA"),
+				check.That(data.ResourceName).Key("not_before").HasValue("2017-10-10T08:27:55Z"),
+				check.That(data.ResourceName).Key("expires").HasValue("2027-10-08T08:27:55Z"),
 			),
 		},
 	})

--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -64,6 +64,10 @@ The following attributes are exported:
 
 * `certificate_policy` - A `certificate_policy` block as defined below.
 
+* `expires` - Expiry date of certificate in RFC3339 format.
+
+* `not_before` - Not Before date of certificate in RFC3339 format.
+
 * `tags` - A mapping of tags to assign to the resource.
 
 ---

--- a/website/docs/d/key_vault_certificate_data.html.markdown
+++ b/website/docs/d/key_vault_certificate_data.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
 
-* `version` - (Optional) Specifies the version of the certificate to look up.  (Defaults to latest) 
+* `version` - (Optional) Specifies the version of the certificate to look up.  (Defaults to latest)
 
 ~> **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
@@ -51,13 +51,15 @@ The following attributes are exported:
 
 * `certificates_count` - Amount of certificates in the chain in case Key Vault Certificate is a bundle (e.g. has an intermediate certificate).
 
-* `hex` - The raw Key Vault Certificate data represented as a hexadecimal string. 
+* `hex` - The raw Key Vault Certificate data represented as a hexadecimal string.
 
-* `pem` - The Key Vault Certificate in PEM format. 
+* `pem` - The Key Vault Certificate in PEM format.
 
-* `key` - The Key Vault Certificate Key. 
+* `key` - The Key Vault Certificate Key.
 
-* `expires` - Expiry date of certificate in RFC3339 format. 
+* `expires` - Expiry date of certificate in RFC3339 format.
+
+* `not_before` - Not Before date of certificate in RFC3339 format.
 
 * `tags` - A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Data - azurerm_key_vault_certificate, adds attributes `expires` and `not_before` dates  in RFC3339 format
Data - azurerm_key_vault_certificate_data, adds attribute `not_before` dates  in RFC3339 format

Resolves: #13275