### PR TITLE
Update output to lowercase and no spaces

### DIFF
--- a/examples/cdn/outputs.tf
+++ b/examples/cdn/outputs.tf
@@ -1,3 +1,3 @@
-output "CDN Endpoint ID" {
+output "cdn_endpoint_id" {
   value = "${azurerm_cdn_endpoint.cdnendpt.name}.azureedge.net"
 }

--- a/examples/search/outputs.tf
+++ b/examples/search/outputs.tf
@@ -1,3 +1,3 @@
-output "Azure Search Service" {
-  value = "${azurerm_search_service.example.name}"
+output "azure_search_service" {
+  value = azurerm_search_service.example.name
 }

--- a/examples/servicebus/basic/outputs.tf
+++ b/examples/servicebus/basic/outputs.tf
@@ -1,7 +1,7 @@
-output "Namespace Connection String" {
-  value = "${azurerm_servicebus_namespace.example.default_primary_connection_string}"
+output "namespace_connection_string" {
+  value = azurerm_servicebus_namespace.example.default_primary_connection_string
 }
 
-output "Shared Access Policy PrimaryKey" {
-  value = "${azurerm_servicebus_namespace.example.default_primary_key}"
+output "shared_access_policy_primarykey" {
+  value = azurerm_servicebus_namespace.example.default_primary_key
 }

--- a/examples/servicebus/forwarding/outputs.tf
+++ b/examples/servicebus/forwarding/outputs.tf
@@ -1,7 +1,7 @@
-output "Namespace Connection String" {
-  value = "${azurerm_servicebus_namespace.example.default_primary_connection_string}"
+output "namespace_connection_string" {
+  value = azurerm_servicebus_namespace.example.default_primary_connection_string
 }
 
-output "Shared Access Policy PrimaryKey" {
-  value = "${azurerm_servicebus_namespace.example.default_primary_key}"
+output "shared_access_policy_primarykey" {
+  value = azurerm_servicebus_namespace.example.default_primary_key
 }


### PR DESCRIPTION
I have not run the examples, but `output` with spaces are not supported. And interpolation can be done without `"${...}"` (as of Terraform 0.12+).