### PR TITLE
Update Log Analytics Solution to no longer enforce naming requirements

### DIFF
--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -107,7 +107,7 @@ func resourceLogAnalyticsSolutionCreateUpdate(d *pluginsdk.ResourceData, meta in
 	log.Printf("[INFO] preparing arguments for Log Analytics Solution creation.")
 
 	id := loganalyticsParse.NewLogAnalyticsSolutionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("solution_name").(string))
-	resGroup := d.Get("resource_group_name").(string)
+	//resGroup := d.Get("resource_group_name").(string)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.SolutionName)

--- a/internal/services/loganalytics/log_analytics_solution_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource_test.go
@@ -101,7 +101,6 @@ resource "azurerm_log_analytics_solution" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
 
   plan {
     publisher = "Microsoft"
@@ -124,7 +123,6 @@ resource "azurerm_log_analytics_solution" "import" {
   location              = azurerm_log_analytics_solution.test.location
   resource_group_name   = azurerm_log_analytics_solution.test.resource_group_name
   workspace_resource_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  workspace_name        = azurerm_log_analytics_solution.test.workspace_name
 
   plan {
     publisher = "Microsoft"
@@ -153,16 +151,15 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "Security"
+  solution_name         = "acctestLAW-LAS-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
 
   plan {
     publisher = "Microsoft"
     product   = "OMSGallery/Security"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "ContainerInsights"
+  solution_name         = "k8s-analytics-${random_id.workspace.hex}"
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name
   workspace_resource_id = azurerm_log_analytics_workspace.example.id
@@ -59,8 +59,6 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `workspace_resource_id` - (Required) The full resource ID of the Log Analytics workspace with which the solution will be linked. Changing this forces a new resource to be created.
-
-* `workspace_name` - (Required) The full name of the Log Analytics workspace with which the solution will be linked. Changing this forces a new resource to be created.
 
 * `plan` - (Required) A `plan` block as documented below.
 


### PR DESCRIPTION
Fixes #1775

This change no longer enforces the arbitrary naming of Log Analytic Solution resources. As per my testing with the REST API directly and this change, the resources are correctly created without seeing errors as reported in the above issue.

As the resource name is no longer constructed for the developer, the `workspace_name` value is deprecated and no longer used.

---

Potential issues with this:

- Existing resources will be renamed or destroyed/recreated. Potentially we could deprecate both `solution_name` and `workspace_name` and add `name`. If `name` is used, then use that, if the others are used then construct the current formatted name. However, I've not been able to get a combination of these to work in reality, so is this likely to be a real world occurrence?  