### PR TITLE
Update target_resource_id

### DIFF
--- a/examples/sql-azure/sql_auditing_log_analytics/main.tf
+++ b/examples/sql-azure/sql_auditing_log_analytics/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_log_analytics_workspace" "example" {
 
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "${var.prefix}-DS"
-  target_resource_id         = azurerm_mssql_database.example.id
+  target_resource_id         = "${azurerm_mssql_server.example.id}/databases/master"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
 
   log {
@@ -57,7 +57,7 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
 }
 
 resource "azurerm_mssql_database_extended_auditing_policy" "example" {
-  database_id     = azurerm_mssql_database.example.id
+  database_id     = ${azurerm_mssql_server.example.id}/databases/master"
   log_monitoring_enabled = true
 }
 


### PR DESCRIPTION
Update target_resource_id  for azurerm_monitor_diagnostic_setting and azurerm_mssql_database_extended_auditing_policy as to enable auditing at logical SQLserver level it is required to only enable for master database. All other databases inherits logical server properties.