### PR TITLE
`azurerm_virtual_hub_connection` - Optimized state change refresh function

### DIFF
--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -24,15 +25,17 @@ func resourceVirtualHubConnection() *pluginsdk.Resource {
 		Update: resourceVirtualHubConnectionCreateOrUpdate,
 		Delete: resourceVirtualHubConnectionDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
-
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.HubVirtualNetworkConnectionID(id)
+			return err
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -164,17 +167,18 @@ func resourceVirtualHubConnection() *pluginsdk.Resource {
 
 func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.HubVirtualNetworkConnectionClient
-	vnetClient := meta.(*clients.Client).Network.VnetClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
+	virtualHubId, err := parse.VirtualHubID(d.Get("virtual_hub_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, virtualHubResourceName)
-	defer locks.UnlockByName(id.Name, virtualHubResourceName)
+	id := parse.NewHubVirtualNetworkConnectionID(virtualHubId.SubscriptionId, virtualHubId.ResourceGroup, virtualHubId.Name, d.Get("name").(string))
+
+	locks.ByName(virtualHubId.Name, virtualHubResourceName)
+	defer locks.UnlockByName(virtualHubId.Name, virtualHubResourceName)
 
 	remoteVirtualNetworkId, err := parse.VirtualNetworkID(d.Get("remote_virtual_network_id").(string))
 	if err != nil {
@@ -184,13 +188,11 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	locks.ByName(remoteVirtualNetworkId.Name, VirtualNetworkResourceName)
 	defer locks.UnlockByName(remoteVirtualNetworkId.Name, VirtualNetworkResourceName)
 
-	name := d.Get("name").(string)
-
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name, name)
+		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Connection %q (Virtual Hub %q / Resource Group %q): %+v", name, id.Name, id.ResourceGroup, err)
+				return fmt.Errorf("checking for presence of %s: %+v", id, err)
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
@@ -199,7 +201,7 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	}
 
 	connection := network.HubVirtualNetworkConnection{
-		Name: utils.String(name),
+		Name: utils.String(id.Name),
 		HubVirtualNetworkConnectionProperties: &network.HubVirtualNetworkConnectionProperties{
 			RemoteVirtualNetwork: &network.SubResource{
 				ID: utils.String(remoteVirtualNetworkId.ID()),
@@ -212,13 +214,13 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 		connection.HubVirtualNetworkConnectionProperties.RoutingConfiguration = expandVirtualHubConnectionRouting(v.([]interface{}))
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, name, connection)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualHubName, id.Name, connection)
 	if err != nil {
-		return fmt.Errorf("creating Connection %q (Virtual Hub %q / Resource Group %q): %+v", name, id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Connection %q (Virtual Hub %q / Resource Group %q): %+v", name, id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	timeout, _ := ctx.Deadline()
@@ -226,22 +228,15 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 	vnetStateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(network.ProvisioningStateUpdating)},
 		Target:     []string{string(network.ProvisioningStateSucceeded)},
-		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, vnetClient, *remoteVirtualNetworkId),
+		Refresh:    virtualHubConnectionProvisioningStateRefreshFunc(ctx, client, id),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
 	if _, err = vnetStateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for provisioning state of virtual network for Connection %q (Virtual Hub %q / Resource Group %q): %+v", name, id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for provisioning state of %s: %+v", id, err)
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, name)
-	if err != nil {
-		return fmt.Errorf("retrieving Connection %q (Virtual Hub %q / Resource Group %q): %+v", name, id.Name, id.ResourceGroup, err)
-	}
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("cannot read Connection %q (Virtual Hub %q / Resource Group %q) ID", name, id.Name, id.ResourceGroup)
-	}
-	d.SetId(*resp.ID)
+	d.SetId(id.ID())
 
 	return resourceVirtualHubConnectionRead(d, meta)
 }
@@ -259,11 +254,11 @@ func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{
 	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Connection %q (Virtual Hub %q / Resource Group %q) does not exist - removing from state", id.Name, id.VirtualHubName, id.ResourceGroup)
+			log.Printf("[INFO] %s does not exist - removing from state", *id)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("reading Connection %q (Virtual Hub %q / Resource Group %q): %+v", id.Name, id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
 	d.Set("name", id.Name)
@@ -306,11 +301,11 @@ func resourceVirtualHubConnectionDelete(d *pluginsdk.ResourceData, meta interfac
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
 	if err != nil {
-		return fmt.Errorf("deleting Connection %q (Virtual Hub %q / Resource Group %q): %+v", id.Name, id.VirtualHubName, id.ResourceGroup, err)
+		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deleting Connection %q (Virtual Hub %q / Resource Group %q): %+v", id.Name, id.VirtualHubName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 	}
 
 	return nil
@@ -500,4 +495,15 @@ func flattenSubResourcesToIDs(input *[]network.SubResource) []interface{} {
 	}
 
 	return ids
+}
+
+func virtualHubConnectionProvisioningStateRefreshFunc(ctx context.Context, client *network.HubVirtualNetworkConnectionsClient, id parse.HubVirtualNetworkConnectionId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroup, id.VirtualHubName, id.Name)
+		if err != nil {
+			return nil, "", fmt.Errorf("polling for %s: %+v", id, err)
+		}
+
+		return res, string(res.ProvisioningState), nil
+	}
 }

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_virtual_network" "example" {
   resource_group_name = azurerm_resource_group.example.name
 }
 
-resource "azurerm_virtual_wan" "test" {
+resource "azurerm_virtual_wan" "example" {
   name                = "example-vwan"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request changes the state changes refresh function when provisioning/updating virtual hub connections to the virtual hub connection itself instead of the remote virtual network.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/11497#issuecomment-928622693

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='network' TESTARGS='-run="^TestAccVirtualHubConnection_"' TESTTIMEOUT='120m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run="^TestAccVirtualHubConnection_" -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualHubConnection_basic
=== PAUSE TestAccVirtualHubConnection_basic
=== RUN   TestAccVirtualHubConnection_requiresImport
=== PAUSE TestAccVirtualHubConnection_requiresImport
=== RUN   TestAccVirtualHubConnection_complete
=== PAUSE TestAccVirtualHubConnection_complete
=== RUN   TestAccVirtualHubConnection_update
=== PAUSE TestAccVirtualHubConnection_update
=== RUN   TestAccVirtualHubConnection_enableInternetSecurity
=== PAUSE TestAccVirtualHubConnection_enableInternetSecurity
=== RUN   TestAccVirtualHubConnection_recreateWithSameConnectionName
=== PAUSE TestAccVirtualHubConnection_recreateWithSameConnectionName
=== RUN   TestAccVirtualHubConnection_removeRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_removeRoutingConfiguration
=== RUN   TestAccVirtualHubConnection_removePropagatedRouteTable
=== PAUSE TestAccVirtualHubConnection_removePropagatedRouteTable
=== RUN   TestAccVirtualHubConnection_removeVnetStaticRoute
=== PAUSE TestAccVirtualHubConnection_removeVnetStaticRoute
=== RUN   TestAccVirtualHubConnection_requiresLocking
=== PAUSE TestAccVirtualHubConnection_requiresLocking
=== RUN   TestAccVirtualHubConnection_updateRoutingConfiguration
=== PAUSE TestAccVirtualHubConnection_updateRoutingConfiguration
=== CONT  TestAccVirtualHubConnection_basic
=== CONT  TestAccVirtualHubConnection_removeRoutingConfiguration
=== CONT  TestAccVirtualHubConnection_requiresLocking
=== CONT  TestAccVirtualHubConnection_enableInternetSecurity
=== CONT  TestAccVirtualHubConnection_update
=== CONT  TestAccVirtualHubConnection_recreateWithSameConnectionName
=== CONT  TestAccVirtualHubConnection_complete
=== CONT  TestAccVirtualHubConnection_removeVnetStaticRoute
--- PASS: TestAccVirtualHubConnection_removeVnetStaticRoute (2155.81s)
=== CONT  TestAccVirtualHubConnection_removePropagatedRouteTable
--- PASS: TestAccVirtualHubConnection_requiresLocking (2199.25s)
=== CONT  TestAccVirtualHubConnection_requiresImport
--- PASS: TestAccVirtualHubConnection_basic (2214.99s)
=== CONT  TestAccVirtualHubConnection_updateRoutingConfiguration
--- PASS: TestAccVirtualHubConnection_removeRoutingConfiguration (2439.80s)
--- PASS: TestAccVirtualHubConnection_enableInternetSecurity (2441.31s)
--- PASS: TestAccVirtualHubConnection_recreateWithSameConnectionName (2556.45s)
--- PASS: TestAccVirtualHubConnection_complete (2796.03s)
--- PASS: TestAccVirtualHubConnection_update (3222.31s)
--- PASS: TestAccVirtualHubConnection_requiresImport (2318.08s)
--- PASS: TestAccVirtualHubConnection_removePropagatedRouteTable (2488.58s)
--- PASS: TestAccVirtualHubConnection_updateRoutingConfiguration (2429.84s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       4647.404s
```

### Important Factoids

The report provided in the issue linked above specifically calls out a cross-subscription use case. I've locally tested a cross-subscription configuration with a configuration documented in the same issue. But I don't see a precedent for cross-subscription acceptance tests.

So while the above acceptance tests are all successful, they don't specifically demonstrate that the report in the linked issue is really "fixed".