### PR TITLE
azurerm_communication_service - export primary_connection_string, secondary_connection_string, primary_key, secondary_key

### DIFF
--- a/internal/services/communication/communication_service_resource.go
+++ b/internal/services/communication/communication_service_resource.go
@@ -141,6 +141,23 @@ func resourceArmCommunicationServiceRead(d *pluginsdk.ResourceData, meta interfa
 		d.Set("data_location", props.DataLocation)
 	}
 
+	keysResp, err := client.ListKeys(ctx, id.ResourceGroup, id.Name)
+
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] %s was not found - removing from state", *id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("primary_connection_string", keysResp.PrimaryConnectionString)
+	d.Set("secondary_connection_string", keysResp.SecondaryConnectionString)
+	d.Set("primary_key", keysResp.PrimaryKey)
+	d.Set("secondary_key", keysResp.SecondaryKey)
+
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 

--- a/internal/services/communication/communication_service_resource.go
+++ b/internal/services/communication/communication_service_resource.go
@@ -62,6 +62,26 @@ func resourceArmCommunicationService() *pluginsdk.Resource {
 			},
 
 			"tags": tags.Schema(),
+
+			"primary_connection_string": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"secondary_connection_string": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"primary_key": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"secondary_key": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/services/communication/communication_service_resource_test.go
+++ b/internal/services/communication/communication_service_resource_test.go
@@ -54,6 +54,10 @@ func TestAccCommunicationService_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+				check.That(data.ResourceName).Key("primary_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_key").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/communication_service.html.markdown
+++ b/website/docs/r/communication_service.html.markdown
@@ -44,6 +44,10 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Communication Service.
+* `primary_connection_string` - The primary connection string of the Communication Service.
+* `secondary_connection_string` - The secondary connection string of the Communication Service.
+* `primary_key` - The primary key of the Communication Service.
+* `secondary_key` - The secondary key of the Communication Service.
 
 ## Timeouts
 


### PR DESCRIPTION
Currently the azure communication services has no way to retrieve the connection strings from the created resource this PR now returns the following attributes upon resource read: 

* primary_connection_string
* secondary_connection_string
* primary_key
* secondary_key