### PR TITLE
Test Fix: Compute tests that used key vault

### DIFF
--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -131,7 +131,12 @@ func (DiskEncryptionSetResource) Exists(ctx context.Context, clients *clients.Cl
 func (DiskEncryptionSetResource) dependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -433,7 +433,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "standard"
-  soft_delete_enabled         = true
+  soft_delete_enabled         = false
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -411,7 +411,12 @@ resource "azurerm_linux_virtual_machine" "test" {
 func (LinuxVirtualMachineResource) diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 # note: whilst these aren't used in all tests, it saves us redefining these everywhere
@@ -433,7 +438,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "standard"
-  soft_delete_enabled         = false
+  soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -456,6 +456,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "get",
     "delete",
     "set",
+	"purge",
   ]
 }
 

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -414,7 +414,7 @@ provider "azurerm" {
   features {
     key_vault {
       recover_soft_deleted_key_vaults = false
-      purge_soft_delete_on_destroy = false
+      purge_soft_delete_on_destroy    = false
     }
   }
 }
@@ -461,7 +461,6 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "get",
     "delete",
     "set",
-	"purge",
   ]
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -435,7 +435,12 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (LinuxVirtualMachineScaleSetResource) disksDataDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -268,7 +268,12 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 func (LinuxVirtualMachineScaleSetResource) disksOSDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -709,7 +709,12 @@ resource "azurerm_managed_disk" "test" {
 func (ManagedDiskResource) encryption(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -888,7 +893,12 @@ func (ManagedDiskResource) diskEncryptionSetDependencies(data acceptance.TestDat
 
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/compute/snapshot_resource_test.go
+++ b/internal/services/compute/snapshot_resource_test.go
@@ -224,7 +224,12 @@ resource "azurerm_snapshot" "test" {
 func (SnapshotResource) encryption(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -433,7 +433,12 @@ resource "azurerm_windows_virtual_machine" "test" {
 func (WindowsVirtualMachineResource) diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 # note: whilst these aren't used in all tests, it saves us redefining these everywhere

--- a/internal/services/compute/windows_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_disk_data_resource_test.go
@@ -476,6 +476,15 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 
 func (WindowsVirtualMachineScaleSetResource) disksDataDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
+}
+
 locals {
   vm_name = "acctestVM-%d"
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
@@ -263,6 +263,15 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 
 func (WindowsVirtualMachineScaleSetResource) disksOSDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
+}
+
 locals {
   vm_name = "accVM-%d"
 }


### PR DESCRIPTION
This PR fixes about 20 compute tests that were failing due to not being able to purge keyvault keys