### PR TITLE
Adding comments to code that needs to be removed on v3.0

### DIFF
--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -23,7 +23,7 @@ func resourceNetAppSnapshot() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceNetAppSnapshotCreate,
 		Read:   resourceNetAppSnapshotRead,
-		// todo remove this in version 3.0 of the provider
+		// todo remove this in version 3.0 of the provider as tags was the only updatable property and they can no longer be updated and will also be removed
 		Update: resourceNetAppSnapshotUpdate,
 		Delete: resourceNetAppSnapshotDelete,
 

--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -23,6 +23,7 @@ func resourceNetAppSnapshot() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceNetAppSnapshotCreate,
 		Read:   resourceNetAppSnapshotRead,
+		// todo remove this in version 3.0 of the provider
 		Update: resourceNetAppSnapshotUpdate,
 		Delete: resourceNetAppSnapshotDelete,
 
@@ -72,6 +73,7 @@ func resourceNetAppSnapshot() *pluginsdk.Resource {
 
 			// TODO: remove this in a next breaking changes release since tags are
 			// not supported anymore on Snapshots (todo 3.0)
+			// todo remove this in version 3.0 of the provider
 			"tags": {
 				Type:     pluginsdk.TypeMap,
 				Optional: true,
@@ -169,6 +171,7 @@ func resourceNetAppSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) err
 	return nil
 }
 
+// todo remove this in version 3.0 of the provider
 func resourceNetAppSnapshotUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	// Snapshot resource in Azure changed its type to proxied resource, therefore
 	// tags are not supported anymore, ignoring any tags.

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -169,6 +169,7 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 							},
 						},
 
+						// todo remove this in version 3.0 of the provider
 						"cifs_enabled": {
 							Type:       pluginsdk.TypeBool,
 							Optional:   true,
@@ -176,6 +177,7 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 							Deprecated: "Deprecated in favour of `protocols_enabled`",
 						},
 
+						// todo remove this in version 3.0 of the provider
 						"nfsv3_enabled": {
 							Type:       pluginsdk.TypeBool,
 							Optional:   true,
@@ -183,6 +185,7 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 							Deprecated: "Deprecated in favour of `protocols_enabled`",
 						},
 
+						// todo remove this in version 3.0 of the provider
 						"nfsv4_enabled": {
 							Type:       pluginsdk.TypeBool,
 							Optional:   true,
@@ -763,9 +766,11 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 						}
 					}
 				} else {
-					// TODO: Remove in next major version
+					// todo remove this in version 3.0 of the provider
 					cifsEnabled = v["cifs_enabled"].(bool)
+					// todo remove this in version 3.0 of the provider
 					nfsv3Enabled = v["nfsv3_enabled"].(bool)
+					// todo remove this in version 3.0 of the provider
 					nfsv41Enabled = v["nfsv4_enabled"].(bool)
 				}
 			}
@@ -836,29 +841,33 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 		if v := item.AllowedClients; v != nil {
 			allowedClients = strings.Split(*v, ",")
 		}
-		// TODO: Start - Remove in next major version
+		// todo remove this in version 3.0 of the provider
 		cifsEnabled := false
+		// todo remove this in version 3.0 of the provider
 		nfsv3Enabled := false
+		// todo remove this in version 3.0 of the provider
 		nfsv4Enabled := false
-		// End - Remove in next major version
 		protocolsEnabled := []string{}
 		if v := item.Cifs; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "CIFS")
 			}
-			cifsEnabled = *v // TODO: Remove in next major version
+			// todo remove this in version 3.0 of the provider
+			cifsEnabled = *v
 		}
 		if v := item.Nfsv3; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "NFSv3")
 			}
-			nfsv3Enabled = *v // TODO: Remove in next major version
+			// todo remove this in version 3.0 of the provider
+			nfsv3Enabled = *v
 		}
 		if v := item.Nfsv41; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "NFSv4.1")
 			}
-			nfsv4Enabled = *v // TODO: Remove in next major version
+			// todo remove this in version 3.0 of the provider
+			nfsv4Enabled = *v
 		}
 		unixReadOnly := false
 		if v := item.UnixReadOnly; v != nil {
@@ -880,9 +889,11 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 			"unix_read_write":     unixReadWrite,
 			"root_access_enabled": rootAccessEnabled,
 			"protocols_enabled":   utils.FlattenStringSlice(&protocolsEnabled),
-			// TODO: Remove in next major version
-			"cifs_enabled":  cifsEnabled,
+			// todo remove this in version 3.0 of the provider
+			"cifs_enabled": cifsEnabled,
+			// todo remove this in version 3.0 of the provider
 			"nfsv3_enabled": nfsv3Enabled,
+			// todo remove this in version 3.0 of the provider
 			"nfsv4_enabled": nfsv4Enabled,
 		})
 	}

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -487,11 +487,11 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   export_policy_rule {
-    rule_index      = 3
-    allowed_clients = ["1.2.6.0/24"]
+    rule_index        = 3
+    allowed_clients   = ["1.2.6.0/24"]
     protocols_enabled = ["NFSv3"]
-    unix_read_only  = true
-    unix_read_write = false
+    unix_read_only    = true
+    unix_read_write   = false
   }
 
   tags = {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -489,9 +489,7 @@ resource "azurerm_netapp_volume" "test" {
   export_policy_rule {
     rule_index      = 3
     allowed_clients = ["1.2.6.0/24"]
-    cifs_enabled    = false
-    nfsv3_enabled   = true
-    nfsv4_enabled   = false
+    protocols_enabled = ["NFSv3"]
     unix_read_only  = true
     unix_read_write = false
   }

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -138,12 +138,6 @@ An `export_policy_rule` block supports the following:
 
 * `protocols_enabled` - (Optional) A list of allowed protocols. Valid values include `CIFS`, `NFSv3`, or `NFSv4.1`. Only one value is supported at this time. This replaces the previous arguments: `cifs_enabled`, `nfsv3_enabled` and `nfsv4_enabled`.
 
-* `cifs_enabled` - (Optional / **Deprecated in favour of `protocols_enabled`**) Is the CIFS protocol allowed?
-
-* `nfsv3_enabled` - (Optional / **Deprecated in favour of `protocols_enabled`**) Is the NFSv3 protocol allowed?
-
-* `nfsv4_enabled` - (Optional / **Deprecated in favour of `protocols_enabled`**)  Is the NFSv4 protocol allowed?
-
 * `unix_read_only` - (Optional) Is the file system on unix read only?
 
 * `unix_read_write` - (Optional) Is the file system on unix read and write?


### PR DESCRIPTION
This PR adds the following comment before code that needs to be removed due to deprecation:

```go
// todo remove this in version 3.0 of the provider
``` 