### PR TITLE
docs: add defaults for upgrade channel

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -80,7 +80,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 ---
 
-* `automatic_channel_upgrade` - (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are `patch`, `rapid`, `node-image` and `stable`.
+* `automatic_channel_upgrade` - (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are `patch`, `rapid`, `node-image` and `stable`. If not specified, defaults to `none`.
 
 !> **Note:** Cluster Auto-Upgrade will update the Kubernetes Cluster (and it's Node Pools) to the latest GA version of Kubernetes automatically - please [see the Azure documentation for more information](https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster#set-auto-upgrade-channel-preview).
 


### PR DESCRIPTION
This PR adds a information that the default value for the option `automatic_channel_upgrade` is now `none` if the option is not specified. Please see my comment here: https://github.com/hashicorp/terraform-provider-azurerm/issues/11396#issuecomment-932917104

This was introduces in the Release `2.79.0`with https://github.com/hashicorp/terraform-provider-azurerm/pull/13493.