### PR TITLE
`azurerm_frontdoor_rules_engine` `negate_condition` defaults to `false`

### DIFF
--- a/internal/services/frontdoor/frontdoor_rules_engine_rule.go
+++ b/internal/services/frontdoor/frontdoor_rules_engine_rule.go
@@ -148,7 +148,7 @@ func resourceFrontDoorRulesEngine() *pluginsdk.Resource {
 									"negate_condition": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
-										Default:  true,
+										Default:  false,
 									},
 
 									"value": {

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -124,6 +124,6 @@ The `match_condition` block supports the following:
 
 * `transform` can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
 
-* `negate_condition` can be set to `true` or `false` to negate the given condition.
+* `negate_condition` can be set to `true` or `false` to negate the given condition. (Defaults to `false`)
 
 * `value` (array) can contain one or more strings.


### PR DESCRIPTION
This PR contains a small fix to change the default behavior of `match_condition` > `negate_condition` in `azurerm_frontdoor_rules_engine` from `true` to `false`. 

This was brought up by @aidapsibr in https://github.com/hashicorp/terraform-provider-azurerm/issues/7455#issuecomment-928465852