### PR TITLE
State migration for storage account resource

### DIFF
--- a/internal/services/storage/helpers/helpers.go
+++ b/internal/services/storage/helpers/helpers.go
@@ -1,11 +1,11 @@
-package storage
+package helpers
 
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-func schemaStorageAccountCorsRule(patchEnabled bool) *pluginsdk.Schema {
+func SchemaStorageAccountCorsRule(patchEnabled bool) *pluginsdk.Schema {
 	// CorsRule "PATCH" method is only supported by blob
 	allowedMethods := []string{
 		"DELETE",

--- a/internal/services/storage/migration/account.go
+++ b/internal/services/storage/migration/account.go
@@ -204,3 +204,20 @@ func accountSchemaForV0AndV1() map[string]*pluginsdk.Schema {
 		},
 	}
 }
+
+type AccountV2ToV3 struct{}
+
+func (AccountV2ToV3) Schema() map[string]*pluginsdk.Schema {
+	return accountSchemaForV0AndV1()
+}
+
+func (AccountV2ToV3) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		x, ok := rawState["allow_blob_public_access"]
+		if ok {
+			rawState["allow_nested_items_to_be_public"] = x
+			delete(rawState, "allow_blob_public_access")
+		}
+		return rawState, nil
+	}
+}

--- a/internal/services/storage/migration/account.go
+++ b/internal/services/storage/migration/account.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	msiValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 var _ pluginsdk.StateUpgrade = AccountV0ToV1{}
@@ -205,10 +212,800 @@ func accountSchemaForV0AndV1() map[string]*pluginsdk.Schema {
 	}
 }
 
+func accountSchemaForV2() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.StorageAccountName,
+		},
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"location": azure.SchemaLocation(),
+
+		"account_kind": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(storage.Storage),
+				string(storage.BlobStorage),
+				string(storage.BlockBlobStorage),
+				string(storage.FileStorage),
+				string(storage.StorageV2),
+			}, true),
+			Default: string(storage.StorageV2),
+		},
+
+		"account_tier": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Standard",
+				"Premium",
+			}, true),
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		"account_replication_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"LRS",
+				"ZRS",
+				"GRS",
+				"RAGRS",
+				"GZRS",
+				"RAGZRS",
+			}, true),
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		// Only valid for BlobStorage & StorageV2 accounts, defaults to "Hot" in create function
+		"access_tier": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(storage.Cool),
+				string(storage.Hot),
+			}, true),
+		},
+
+		"azure_files_authentication": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"directory_type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(storage.DirectoryServiceOptionsAADDS),
+							string(storage.DirectoryServiceOptionsAD),
+						}, false),
+					},
+
+					"active_directory": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"storage_sid": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"domain_guid": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.IsUUID,
+								},
+
+								"domain_name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"domain_sid": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"forest_name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"netbios_domain_name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"custom_domain": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"use_subdomain": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
+
+		"enable_https_traffic_only": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"min_tls_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(storage.TLS10),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(storage.TLS10),
+				string(storage.TLS11),
+				string(storage.TLS12),
+			}, false),
+		},
+
+		"is_hns_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+			ForceNew: true,
+		},
+
+		"nfsv3_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+			ForceNew: true,
+		},
+
+		"allow_blob_public_access": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"shared_access_key_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"network_rules": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"bypass": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(storage.AzureServices),
+								string(storage.Logging),
+								string(storage.Metrics),
+								string(storage.None),
+							}, true),
+						},
+						Set: pluginsdk.HashString,
+					},
+
+					"ip_rules": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validate.StorageAccountIpRule,
+						},
+						Set: pluginsdk.HashString,
+					},
+
+					"virtual_network_subnet_ids": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Computed: true,
+						Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+						Set:      pluginsdk.HashString,
+					},
+
+					"default_action": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(storage.DefaultActionAllow),
+							string(storage.DefaultActionDeny),
+						}, false),
+					},
+
+					"private_link_access": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"endpoint_resource_id": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: azure.ValidateResourceID,
+								},
+
+								"endpoint_tenant_id": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									Computed:     true,
+									ValidateFunc: validation.IsUUID,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"identity": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:             pluginsdk.TypeString,
+						Required:         true,
+						DiffSuppressFunc: suppress.CaseDifference,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(storage.IdentityTypeSystemAssigned),
+							string(storage.IdentityTypeSystemAssignedUserAssigned),
+							string(storage.IdentityTypeUserAssigned),
+						}, true),
+					},
+					"principal_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"tenant_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"identity_ids": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: msiValidate.UserAssignedIdentityID,
+						},
+					},
+				},
+			},
+		},
+
+		"blob_properties": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
+					"delete_retention_policy": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									Default:      7,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+
+					"versioning_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"change_feed_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"default_service_version": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validate.BlobPropertiesDefaultServiceVersion,
+					},
+
+					"last_access_time_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"container_delete_retention_policy": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									Default:      7,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"queue_properties": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"cors_rule": helpers.SchemaStorageAccountCorsRule(false),
+					"logging": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"version": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"delete": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"read": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"write": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"retention_policy_days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+					"hour_metrics": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"version": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"include_apis": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+								},
+								"retention_policy_days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+					"minute_metrics": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"version": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"include_apis": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+								},
+								"retention_policy_days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"routing": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"publish_internet_endpoints": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"publish_microsoft_endpoints": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"choice": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(storage.MicrosoftRouting),
+							string(storage.InternetRouting),
+						}, false),
+						Default: string(storage.MicrosoftRouting),
+					},
+				},
+			},
+		},
+
+		"share_properties": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
+
+					"retention_policy": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									Default:      7,
+									ValidateFunc: validation.IntBetween(1, 365),
+								},
+							},
+						},
+					},
+
+					"smb": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"versions": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{
+											"SMB2.1",
+											"SMB3.0",
+											"SMB3.1.1",
+										}, false),
+									},
+								},
+
+								"authentication_types": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{
+											"NTLMv2",
+											"Kerberos",
+										}, false),
+									},
+								},
+
+								"kerberos_ticket_encryption_type": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{
+											"RC4-HMAC",
+											"AES-256",
+										}, false),
+									},
+								},
+
+								"channel_encryption_type": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{
+											"AES-128-CCM",
+											"AES-128-GCM",
+											"AES-256-GCM",
+										}, false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		//lintignore:XS003
+		"static_website": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"index_document": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"error_404_document": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+
+		"large_file_share_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+
+		"primary_location": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_location": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_blob_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_blob_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_blob_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_blob_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_queue_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_queue_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_queue_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_queue_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_table_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_table_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_table_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_table_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_web_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_web_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_web_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_web_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_dfs_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_dfs_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_dfs_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_dfs_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_file_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_file_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_file_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_file_host": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Sensitive: true,
+			Computed:  true,
+		},
+
+		"secondary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_blob_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_blob_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"tags": {
+			Type:         pluginsdk.TypeMap,
+			Optional:     true,
+			ValidateFunc: validate.StorageAccountTags,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
 type AccountV2ToV3 struct{}
 
 func (AccountV2ToV3) Schema() map[string]*pluginsdk.Schema {
-	return accountSchemaForV0AndV1()
+	return accountSchemaForV2()
 }
 
 func (AccountV2ToV3) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/storage/migration/account.go
+++ b/internal/services/storage/migration/account.go
@@ -218,7 +218,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validate.StorageAccountName,
 		},
 
 		"resource_group_name": azure.SchemaResourceGroupName(),
@@ -228,39 +227,17 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 		"account_kind": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(storage.Storage),
-				string(storage.BlobStorage),
-				string(storage.BlockBlobStorage),
-				string(storage.FileStorage),
-				string(storage.StorageV2),
-			}, true),
-			Default: string(storage.StorageV2),
 		},
 
 		"account_tier": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
 			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				"Standard",
-				"Premium",
-			}, true),
-			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"account_replication_type": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				"LRS",
-				"ZRS",
-				"GRS",
-				"RAGRS",
-				"GZRS",
-				"RAGZRS",
-			}, true),
-			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		// Only valid for BlobStorage & StorageV2 accounts, defaults to "Hot" in create function
@@ -268,10 +245,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Computed: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(storage.Cool),
-				string(storage.Hot),
-			}, true),
 		},
 
 		"azure_files_authentication": {
@@ -283,10 +256,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					"directory_type": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(storage.DirectoryServiceOptionsAADDS),
-							string(storage.DirectoryServiceOptionsAD),
-						}, false),
 					},
 
 					"active_directory": {
@@ -299,37 +268,31 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"storage_sid": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 
 								"domain_guid": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.IsUUID,
 								},
 
 								"domain_name": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 
 								"domain_sid": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 
 								"forest_name": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 
 								"netbios_domain_name": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 							},
 						},
@@ -367,12 +330,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 		"min_tls_version": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  string(storage.TLS10),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(storage.TLS10),
-				string(storage.TLS11),
-				string(storage.TLS12),
-			}, false),
 		},
 
 		"is_hns_enabled": {
@@ -414,12 +371,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Computed: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(storage.AzureServices),
-								string(storage.Logging),
-								string(storage.Metrics),
-								string(storage.None),
-							}, true),
 						},
 						Set: pluginsdk.HashString,
 					},
@@ -430,7 +381,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Computed: true,
 						Elem: &pluginsdk.Schema{
 							Type:         pluginsdk.TypeString,
-							ValidateFunc: validate.StorageAccountIpRule,
 						},
 						Set: pluginsdk.HashString,
 					},
@@ -446,10 +396,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					"default_action": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(storage.DefaultActionAllow),
-							string(storage.DefaultActionDeny),
-						}, false),
 					},
 
 					"private_link_access": {
@@ -460,14 +406,12 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"endpoint_resource_id": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: azure.ValidateResourceID,
 								},
 
 								"endpoint_tenant_id": {
 									Type:         pluginsdk.TypeString,
 									Optional:     true,
 									Computed:     true,
-									ValidateFunc: validation.IsUUID,
 								},
 							},
 						},
@@ -486,12 +430,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					"type": {
 						Type:             pluginsdk.TypeString,
 						Required:         true,
-						DiffSuppressFunc: suppress.CaseDifference,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(storage.IdentityTypeSystemAssigned),
-							string(storage.IdentityTypeSystemAssignedUserAssigned),
-							string(storage.IdentityTypeUserAssigned),
-						}, true),
 					},
 					"principal_id": {
 						Type:     pluginsdk.TypeString,
@@ -507,7 +445,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						MinItems: 1,
 						Elem: &pluginsdk.Schema{
 							Type:         pluginsdk.TypeString,
-							ValidateFunc: msiValidate.UserAssignedIdentityID,
 						},
 					},
 				},
@@ -532,7 +469,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
 									Default:      7,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -554,7 +490,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
 						Computed:     true,
-						ValidateFunc: validate.BlobPropertiesDefaultServiceVersion,
 					},
 
 					"last_access_time_enabled": {
@@ -573,7 +508,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
 									Default:      7,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -599,7 +533,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"version": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								"delete": {
 									Type:     pluginsdk.TypeBool,
@@ -616,7 +549,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"retention_policy_days": {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -630,7 +562,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"version": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								"enabled": {
 									Type:     pluginsdk.TypeBool,
@@ -643,7 +574,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"retention_policy_days": {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -657,7 +587,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"version": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								"enabled": {
 									Type:     pluginsdk.TypeBool,
@@ -670,7 +599,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 								"retention_policy_days": {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -701,11 +629,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					"choice": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(storage.MicrosoftRouting),
-							string(storage.InternetRouting),
-						}, false),
-						Default: string(storage.MicrosoftRouting),
 					},
 				},
 			},
@@ -730,7 +653,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Type:         pluginsdk.TypeInt,
 									Optional:     true,
 									Default:      7,
-									ValidateFunc: validation.IntBetween(1, 365),
 								},
 							},
 						},
@@ -747,11 +669,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{
-											"SMB2.1",
-											"SMB3.0",
-											"SMB3.1.1",
-										}, false),
 									},
 								},
 
@@ -760,10 +677,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{
-											"NTLMv2",
-											"Kerberos",
-										}, false),
 									},
 								},
 
@@ -772,10 +685,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{
-											"RC4-HMAC",
-											"AES-256",
-										}, false),
 									},
 								},
 
@@ -784,11 +693,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{
-											"AES-128-CCM",
-											"AES-128-GCM",
-											"AES-256-GCM",
-										}, false),
 									},
 								},
 							},
@@ -808,12 +712,10 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					"index_document": {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
 					},
 					"error_404_document": {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
 					},
 				},
 			},
@@ -994,7 +896,6 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 		"tags": {
 			Type:         pluginsdk.TypeMap,
 			Optional:     true,
-			ValidateFunc: validate.StorageAccountTags,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},

--- a/internal/services/storage/migration/account.go
+++ b/internal/services/storage/migration/account.go
@@ -4,14 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	msiValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 var _ pluginsdk.StateUpgrade = AccountV0ToV1{}
@@ -215,14 +208,22 @@ func accountSchemaForV0AndV1() map[string]*pluginsdk.Schema {
 func accountSchemaForV2() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 
-		"resource_group_name": azure.SchemaResourceGroupName(),
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-		"location": azure.SchemaLocation(),
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
 		"account_kind": {
 			Type:     pluginsdk.TypeString,
@@ -266,33 +267,33 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"storage_sid": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"domain_guid": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"domain_name": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"domain_sid": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"forest_name": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"netbios_domain_name": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 							},
 						},
@@ -380,7 +381,7 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Optional: true,
 						Computed: true,
 						Elem: &pluginsdk.Schema{
-							Type:         pluginsdk.TypeString,
+							Type: pluginsdk.TypeString,
 						},
 						Set: pluginsdk.HashString,
 					},
@@ -404,14 +405,14 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"endpoint_resource_id": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"endpoint_tenant_id": {
-									Type:         pluginsdk.TypeString,
-									Optional:     true,
-									Computed:     true,
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Computed: true,
 								},
 							},
 						},
@@ -428,8 +429,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"type": {
-						Type:             pluginsdk.TypeString,
-						Required:         true,
+						Type:     pluginsdk.TypeString,
+						Required: true,
 					},
 					"principal_id": {
 						Type:     pluginsdk.TypeString,
@@ -444,7 +445,7 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Optional: true,
 						MinItems: 1,
 						Elem: &pluginsdk.Schema{
-							Type:         pluginsdk.TypeString,
+							Type: pluginsdk.TypeString,
 						},
 					},
 				},
@@ -458,7 +459,53 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
+					"cors_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 5,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"allowed_origins": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"exposed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_methods": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"max_age_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Required: true,
+								},
+							},
+						},
+					},
 					"delete_retention_policy": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
@@ -466,9 +513,9 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
-									Default:      7,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  7,
 								},
 							},
 						},
@@ -487,9 +534,9 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 					},
 
 					"default_service_version": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
 					},
 
 					"last_access_time_enabled": {
@@ -505,9 +552,9 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
-									Default:      7,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  7,
 								},
 							},
 						},
@@ -523,7 +570,53 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"cors_rule": helpers.SchemaStorageAccountCorsRule(false),
+					"cors_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 5,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"allowed_origins": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"exposed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_methods": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"max_age_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Required: true,
+								},
+							},
+						},
+					},
 					"logging": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
@@ -531,8 +624,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"version": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 								"delete": {
 									Type:     pluginsdk.TypeBool,
@@ -547,8 +640,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Required: true,
 								},
 								"retention_policy_days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
 								},
 							},
 						},
@@ -560,8 +653,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"version": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 								"enabled": {
 									Type:     pluginsdk.TypeBool,
@@ -572,8 +665,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 								},
 								"retention_policy_days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
 								},
 							},
 						},
@@ -585,8 +678,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"version": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 								"enabled": {
 									Type:     pluginsdk.TypeBool,
@@ -597,8 +690,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 									Optional: true,
 								},
 								"retention_policy_days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
 								},
 							},
 						},
@@ -641,7 +734,53 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
+					"cors_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 5,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"allowed_origins": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"exposed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_headers": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_methods": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MaxItems: 64,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"max_age_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Required: true,
+								},
+							},
+						},
+					},
 
 					"retention_policy": {
 						Type:     pluginsdk.TypeList,
@@ -650,9 +789,9 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"days": {
-									Type:         pluginsdk.TypeInt,
-									Optional:     true,
-									Default:      7,
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  7,
 								},
 							},
 						},
@@ -710,12 +849,12 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"index_document": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
 					},
 					"error_404_document": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
 					},
 				},
 			},
@@ -894,8 +1033,8 @@ func accountSchemaForV2() map[string]*pluginsdk.Schema {
 		},
 
 		"tags": {
-			Type:         pluginsdk.TypeMap,
-			Optional:     true,
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -45,7 +45,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 	}
 	schemaVersion := 2
 
-	if features.ThreePointOhBetaResources() {
+	if features.ThreePointOh() {
 		upgraders[2] = migration.AccountV2ToV3{}
 		schemaVersion = 3
 	}
@@ -3007,11 +3007,11 @@ func setEndpointAndHost(d *pluginsdk.ResourceData, ordinalString string, endpoin
 func getDefaultAllowBlobPublicAccess() bool {
 	// The default value for the field that controls if the blobs that belong to a storage account
 	// can allow anonymous access or not will change from false to true in 3.0.
-	return features.ThreePointOhBetaResources()
+	return features.ThreePointOh()
 }
 
 func getDefaultAllowBlobPublicAccessName() string {
-	if features.ThreePointOhBetaResources() {
+	if features.ThreePointOh() {
 		return "allow_nested_items_to_be_public"
 	}
 	return "allow_blob_public_access"

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -22,6 +22,7 @@ import (
 	msiValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	vnetParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -380,7 +381,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"cors_rule": schemaStorageAccountCorsRule(true),
+						"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
 						"delete_retention_policy": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
@@ -448,7 +449,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"cors_rule": schemaStorageAccountCorsRule(false),
+						"cors_rule": helpers.SchemaStorageAccountCorsRule(false),
 						"logging": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
@@ -577,7 +578,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"cors_rule": schemaStorageAccountCorsRule(true),
+						"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
 
 						"retention_policy": {
 							Type:     pluginsdk.TypeList,

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -46,6 +46,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 	}
 	schemaVersion := 2
 
+	// TODO: (v3.0) The migration is not backwards compatible so we need to make sure it's always
+	// behind a flag that is *not* user configurable.
+
+	// TODO: (v3.0) Add the following to the migration guide:
+	// *Breaking Change* In this version the field `allow_blob_public_access` is renamed to `allow_nested_items_to_be_public`
+	// in order to make its use clearer. Please update your configuration before running terraform.
 	if features.ThreePointOh() {
 		upgraders[2] = migration.AccountV2ToV3{}
 		schemaVersion = 3

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -220,8 +220,8 @@ func TestAccStorageAccount_minTLSVersion(t *testing.T) {
 }
 
 func TestAccStorageAccount_allowBlobPublicAccess(t *testing.T) {
-	if features.ThreePointOhBetaResources() {
-		t.Skip("Skipping since ARM_THREEPOINTZERO_BETA_RESOURCES is set")
+	if features.ThreePointOh() {
+		t.Skip("Skipping since 3.0 mode is enabled")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -254,7 +254,7 @@ func TestAccStorageAccount_allowBlobPublicAccess(t *testing.T) {
 }
 
 func TestAccStorageAccount_allowNestedItemsToBePublic(t *testing.T) {
-	if !features.ThreePointOhBetaResources() {
+	if !features.ThreePointOh() {
 		return
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
@@ -2914,7 +2914,7 @@ resource "azurerm_storage_account" "test" {
 
   share_properties {
     cors_rule {
-      allowed_origins    = ["	http://www.example.com"]
+      allowed_origins    = ["http://www.example.com"]
       exposed_headers    = ["x-tempo-*"]
       allowed_headers    = ["x-tempo-*"]
       allowed_methods    = ["GET", "PUT", "PATCH"]

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -255,7 +255,7 @@ func TestAccStorageAccount_allowBlobPublicAccess(t *testing.T) {
 
 func TestAccStorageAccount_allowNestedItemsToBePublic(t *testing.T) {
 	if !features.ThreePointOh() {
-		return
+		t.Skip("Skipping since 3.0 mode is disabled")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}


### PR DESCRIPTION
In 3.0 we're renaming `allow_blob_public_access` to
`allow_nested_items_to_be_public`.

This PR adds a state migration to support this change that only takes
place when we're actually running on 3.0 or the user has opted-in.
