### PR TITLE
Test Fix: Additional compute package test fixes

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1265,6 +1265,15 @@ func (r LinuxVirtualMachineResource) otherSecretTemplate(data acceptance.TestDat
 	return fmt.Sprintf(`
 %s
 
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "test" {

--- a/internal/services/compute/virtual_machine_managed_disks_resource_test.go
+++ b/internal/services/compute/virtual_machine_managed_disks_resource_test.go
@@ -177,7 +177,7 @@ func TestAccVirtualMachine_osDiskTypeConflict(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.osDiskTypeConflict(data),
-			ExpectError: regexp.MustCompile("conflicts with storage_os_disk.0.managed_disk_type"),
+			ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
 		},
 	})
 }

--- a/internal/services/compute/virtual_machine_resource.go
+++ b/internal/services/compute/virtual_machine_resource.go
@@ -1071,18 +1071,18 @@ func resourceVirtualMachineDeleteManagedDisk(d *pluginsdk.ResourceData, disk *co
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.VirtualMachineID(managedDiskID)
+	id, err := parse.ManagedDiskID(managedDiskID)
 	if err != nil {
-		return err
+		return fmt.Errorf("ID: %+v\n%+v", managedDiskID, err)
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.DiskName)
 	if err != nil {
-		return fmt.Errorf("deleting Managed Disk %q (Resource Group %q) %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("deleting Managed Disk %q (Resource Group %q) %+v", id.DiskName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of Managed Disk %q (Resource Group %q) %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for deletion of Managed Disk %q (Resource Group %q) %+v", id.DiskName, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/internal/services/compute/virtual_machine_resource.go
+++ b/internal/services/compute/virtual_machine_resource.go
@@ -1073,7 +1073,7 @@ func resourceVirtualMachineDeleteManagedDisk(d *pluginsdk.ResourceData, disk *co
 
 	id, err := parse.ManagedDiskID(managedDiskID)
 	if err != nil {
-		return fmt.Errorf("ID: %+v\n%+v", managedDiskID, err)
+		return err
 	}
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.DiskName)

--- a/internal/services/compute/virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_resource_test.go
@@ -191,14 +191,14 @@ func TestAccVirtualMachineScaleSet_verify_key_data_changed(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.admin_password"),
+		data.ImportStep("os_profile.0.admin_password", "os_profile.0.custom_data"),
 		{
 			Config: r.linuxKeyDataUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("os_profile.0.admin_password"),
+		data.ImportStep("os_profile.0.admin_password", "os_profile.0.custom_data"),
 	})
 }
 


### PR DESCRIPTION
```
--- PASS: TestAccLinuxVirtualMachine_otherSecret (1364.24s)
--- PASS: TestAccVirtualMachine_osDiskTypeConflict (3.02s)
--- PASS: TestAccVirtualMachine_deleteManagedDiskOptIn (324.24s)
```

Additionally, all tests that are failing with `Error: deleting OS Managed Disk: ID was missing the virtualMachines element` should be fixed