### PR TITLE
`azurerm_batch_account` - add supports for `identity`

### DIFF
--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/_meta.json
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/_meta.json
@@ -1,10 +1,10 @@
 {
-  "commit": "4e6cea592e12915061beb893134e1a70d7e5c495",
+  "commit": "e9a6009d8f1a98656cf5b6f1fe5809251bfa0085",
   "readme": "/_/azure-rest-api-specs/specification/mysql/resource-manager/readme.md",
   "tag": "package-flexibleserver-2021-05-01-preview",
-  "use": "@microsoft.azure/autorest.go@2.1.183",
+  "use": "@microsoft.azure/autorest.go@2.1.187",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
-  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.183 --tag=package-flexibleserver-2021-05-01-preview --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix /_/azure-rest-api-specs/specification/mysql/resource-manager/readme.md",
+  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.187 --tag=package-flexibleserver-2021-05-01-preview --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix /_/azure-rest-api-specs/specification/mysql/resource-manager/readme.md",
   "additional_properties": {
     "additional_options": "--go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix"
   }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/configurations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/configurations.go
@@ -66,7 +66,7 @@ func (client ConfigurationsClient) BatchUpdate(ctx context.Context, resourceGrou
 
 	result, err = client.BatchUpdateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ConfigurationsClient", "BatchUpdate", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ConfigurationsClient", "BatchUpdate", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -100,6 +100,7 @@ func (client ConfigurationsClient) BatchUpdatePreparer(ctx context.Context, reso
 // http.Response Body if it receives an error.
 func (client ConfigurationsClient) BatchUpdateSender(req *http.Request) (future ConfigurationsBatchUpdateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -371,7 +372,7 @@ func (client ConfigurationsClient) Update(ctx context.Context, resourceGroupName
 
 	result, err = client.UpdateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ConfigurationsClient", "Update", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ConfigurationsClient", "Update", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -407,6 +408,7 @@ func (client ConfigurationsClient) UpdatePreparer(ctx context.Context, resourceG
 // http.Response Body if it receives an error.
 func (client ConfigurationsClient) UpdateSender(req *http.Request) (future ConfigurationsUpdateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/databases.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/databases.go
@@ -67,7 +67,7 @@ func (client DatabasesClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 
 	result, err = client.CreateOrUpdateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.DatabasesClient", "CreateOrUpdate", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.DatabasesClient", "CreateOrUpdate", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -103,6 +103,7 @@ func (client DatabasesClient) CreateOrUpdatePreparer(ctx context.Context, resour
 // http.Response Body if it receives an error.
 func (client DatabasesClient) CreateOrUpdateSender(req *http.Request) (future DatabasesCreateOrUpdateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -159,7 +160,7 @@ func (client DatabasesClient) Delete(ctx context.Context, resourceGroupName stri
 
 	result, err = client.DeleteSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.DatabasesClient", "Delete", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.DatabasesClient", "Delete", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -192,6 +193,7 @@ func (client DatabasesClient) DeletePreparer(ctx context.Context, resourceGroupN
 // http.Response Body if it receives an error.
 func (client DatabasesClient) DeleteSender(req *http.Request) (future DatabasesDeleteFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/firewallrules.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/firewallrules.go
@@ -74,7 +74,7 @@ func (client FirewallRulesClient) CreateOrUpdate(ctx context.Context, resourceGr
 
 	result, err = client.CreateOrUpdateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.FirewallRulesClient", "CreateOrUpdate", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.FirewallRulesClient", "CreateOrUpdate", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -110,6 +110,7 @@ func (client FirewallRulesClient) CreateOrUpdatePreparer(ctx context.Context, re
 // http.Response Body if it receives an error.
 func (client FirewallRulesClient) CreateOrUpdateSender(req *http.Request) (future FirewallRulesCreateOrUpdateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -166,7 +167,7 @@ func (client FirewallRulesClient) Delete(ctx context.Context, resourceGroupName 
 
 	result, err = client.DeleteSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.FirewallRulesClient", "Delete", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.FirewallRulesClient", "Delete", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -199,6 +200,7 @@ func (client FirewallRulesClient) DeletePreparer(ctx context.Context, resourceGr
 // http.Response Body if it receives an error.
 func (client FirewallRulesClient) DeleteSender(req *http.Request) (future FirewallRulesDeleteFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/servers.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers/servers.go
@@ -73,7 +73,7 @@ func (client ServersClient) Create(ctx context.Context, resourceGroupName string
 
 	result, err = client.CreateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Create", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Create", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -108,6 +108,7 @@ func (client ServersClient) CreatePreparer(ctx context.Context, resourceGroupNam
 // http.Response Body if it receives an error.
 func (client ServersClient) CreateSender(req *http.Request) (future ServersCreateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -163,7 +164,7 @@ func (client ServersClient) Delete(ctx context.Context, resourceGroupName string
 
 	result, err = client.DeleteSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Delete", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Delete", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -195,6 +196,7 @@ func (client ServersClient) DeletePreparer(ctx context.Context, resourceGroupNam
 // http.Response Body if it receives an error.
 func (client ServersClient) DeleteSender(req *http.Request) (future ServersDeleteFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -249,7 +251,7 @@ func (client ServersClient) Failover(ctx context.Context, resourceGroupName stri
 
 	result, err = client.FailoverSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Failover", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Failover", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -281,6 +283,7 @@ func (client ServersClient) FailoverPreparer(ctx context.Context, resourceGroupN
 // http.Response Body if it receives an error.
 func (client ServersClient) FailoverSender(req *http.Request) (future ServersFailoverFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -665,7 +668,7 @@ func (client ServersClient) Restart(ctx context.Context, resourceGroupName strin
 
 	result, err = client.RestartSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Restart", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Restart", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -699,6 +702,7 @@ func (client ServersClient) RestartPreparer(ctx context.Context, resourceGroupNa
 // http.Response Body if it receives an error.
 func (client ServersClient) RestartSender(req *http.Request) (future ServersRestartFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -753,7 +757,7 @@ func (client ServersClient) Start(ctx context.Context, resourceGroupName string,
 
 	result, err = client.StartSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Start", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Start", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -785,6 +789,7 @@ func (client ServersClient) StartPreparer(ctx context.Context, resourceGroupName
 // http.Response Body if it receives an error.
 func (client ServersClient) StartSender(req *http.Request) (future ServersStartFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -839,7 +844,7 @@ func (client ServersClient) Stop(ctx context.Context, resourceGroupName string, 
 
 	result, err = client.StopSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Stop", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Stop", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -871,6 +876,7 @@ func (client ServersClient) StopPreparer(ctx context.Context, resourceGroupName 
 // http.Response Body if it receives an error.
 func (client ServersClient) StopSender(req *http.Request) (future ServersStopFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return
@@ -927,7 +933,7 @@ func (client ServersClient) Update(ctx context.Context, resourceGroupName string
 
 	result, err = client.UpdateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Update", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "mysqlflexibleservers.ServersClient", "Update", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -961,6 +967,7 @@ func (client ServersClient) UpdatePreparer(ctx context.Context, resourceGroupNam
 // http.Response Body if it receives an error.
 func (client ServersClient) UpdateSender(req *http.Request) (future ServersUpdateFuture, err error) {
 	var resp *http.Response
+	future.FutureAPI = &azure.Future{}
 	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
 	if err != nil {
 		return

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `pool_allocation_mode` - (Optional) Specifies the mode to use for pool allocation. Possible values are `BatchService` or `UserSubscription`. Defaults to `BatchService`.
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
@@ -68,6 +70,14 @@ The following arguments are supported:
 
 ---
 
+An `identity` block exports the following:
+
+* `type` - The identity type of the Batch Account. Possible values are `SystemAssigned` and `UserAssigned`.
+
+* `identity_ids` - (Optional) Specifies a list of user assigned identity ids. Required if `type` is `UserAssigned`.
+
+---
+
 A `key_vault_reference` block supports the following:
 
 * `id` - (Required) The Azure identifier of the Azure KeyVault to use.
@@ -80,6 +90,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Batch Account.
 
+* `identity` - An `identity` block as defined below.
+
 * `primary_access_key` - The Batch account primary access key.
 
 * `secondary_access_key` - The Batch account secondary access key.
@@ -87,6 +99,14 @@ The following attributes are exported:
 * `account_endpoint` - The account endpoint used to interact with the Batch service.
 
 ~> **NOTE:** Primary and secondary access keys are only available when `pool_allocation_mode` is set to `BatchService`. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.
+
+---
+
+A `identity` block exports the following:
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the system assigned identity of this Batch Account.
+
+* `principal_id` - The Principal ID for the Service Principal associated with the system assigned identity of this Batch Account.
 
 ## Timeouts
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - The identity type of the Batch Account. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The identity type of the Batch Account. Possible values are `SystemAssigned` and `UserAssigned`.
 
 * `identity_ids` - (Optional) Specifies a list of user assigned identity ids. Required if `type` is `UserAssigned`.
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 ---
 
-An `identity` block exports the following:
+An `identity` block supports the following:
 
 * `type` - The identity type of the Batch Account. Possible values are `SystemAssigned` and `UserAssigned`.
 


### PR DESCRIPTION
Fixes #8532 

## Test Result

```bash
💢 TF_ACC=1 go test -timeout=3h -v ./internal/services/batch -run='TestAccBatchAccount_identity'
=== RUN   TestAccBatchAccount_identity
=== PAUSE TestAccBatchAccount_identity
=== CONT  TestAccBatchAccount_identity
--- PASS: TestAccBatchAccount_identity (276.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/batch 276.890s
```