### PR TITLE
azurerm_lb_nat_rule: use the inbound nat rule dedicated endpoint instead of load balancer endpoint to make the code easier to maintain

### DIFF
--- a/internal/services/loadbalancer/client/client.go
+++ b/internal/services/loadbalancer/client/client.go
@@ -8,6 +8,7 @@ import (
 type Client struct {
 	LoadBalancersClient                   *network.LoadBalancersClient
 	LoadBalancerBackendAddressPoolsClient *network.LoadBalancerBackendAddressPoolsClient
+	LoadBalancerInboundNatRulesClient     *network.InboundNatRulesClient
 	LoadBalancingRulesClient              *network.LoadBalancerLoadBalancingRulesClient
 }
 
@@ -18,12 +19,16 @@ func NewClient(o *common.ClientOptions) *Client {
 	loadBalancerBackendAddressPoolsClient := network.NewLoadBalancerBackendAddressPoolsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loadBalancerBackendAddressPoolsClient.Client, o.ResourceManagerAuthorizer)
 
+	loadBalancerInboundNatRulesClient := network.NewInboundNatRulesClient(o.SubscriptionId)
+	o.ConfigureClient(&loadBalancerInboundNatRulesClient.Client, o.ResourceManagerAuthorizer)
+
 	loadBalancingRulesClient := network.NewLoadBalancerLoadBalancingRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loadBalancingRulesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
 		LoadBalancersClient:                   &loadBalancersClient,
 		LoadBalancerBackendAddressPoolsClient: &loadBalancerBackendAddressPoolsClient,
+		LoadBalancerInboundNatRulesClient:     &loadBalancerInboundNatRulesClient,
 		LoadBalancingRulesClient:              &loadBalancingRulesClient,
 	}
 }

--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -139,7 +139,7 @@ func resourceArmLoadBalancerNatRuleCreateUpdate(d *pluginsdk.ResourceData, meta 
 		existing, err := client.Get(ctx, id.ResourceGroup, id.LoadBalancerName, id.InboundNatRuleName, "")
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Load Balancer Inbound Nat Rule %q: %+v", id, err)
+				return fmt.Errorf("checking for presence of existing %q: %+v", id, err)
 			}
 		}
 
@@ -165,7 +165,7 @@ func resourceArmLoadBalancerNatRuleCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, id.InboundNatRuleName, *newNatRule)
 	if err != nil {
-		return fmt.Errorf("updating Load Balancer %q (Resource Group %q) for Nat Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.InboundNatRuleName, err)
+		return fmt.Errorf("creating/updating %q: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
@@ -191,7 +191,7 @@ func resourceArmLoadBalancerNatRuleRead(d *pluginsdk.ResourceData, meta interfac
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
-			log.Printf("[INFO] Load Balancer Inbound Nat Rule %q not found. Removing from state", id)
+			log.Printf("[INFO] %q not found. Removing from state", id)
 			return nil
 		}
 		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Nat Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.InboundNatRuleName, err)
@@ -258,11 +258,11 @@ func resourceArmLoadBalancerNatRuleDelete(d *pluginsdk.ResourceData, meta interf
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.LoadBalancerName, id.InboundNatRuleName)
 	if err != nil {
-		return fmt.Errorf("deleting Load Balancer Nat Rule %q: %+v", id, err)
+		return fmt.Errorf("deleting %q: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for the completion of deleting Load Balancer Nat Rule %q: %+v", id, err)
+		return fmt.Errorf("waiting for the completion of deleting %q: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -253,27 +253,12 @@ func resourceArmLoadBalancerNatRuleRead(d *pluginsdk.ResourceData, meta interfac
 
 func resourceArmLoadBalancerNatRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).LoadBalancers.LoadBalancerInboundNatRulesClient
-	lbClient := meta.(*clients.Client).LoadBalancers.LoadBalancersClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.LoadBalancerInboundNatRuleID(d.Id())
 	if err != nil {
 		return err
-	}
-
-	loadBalancerId := parse.NewLoadBalancerID(id.SubscriptionId, id.ResourceGroup, id.LoadBalancerName)
-	loadBalancerID := loadBalancerId.ID()
-	locks.ByID(loadBalancerID)
-	defer locks.UnlockByID(loadBalancerID)
-
-	loadBalancer, err := lbClient.Get(ctx, loadBalancerId.ResourceGroup, loadBalancerId.Name, "")
-	if err != nil {
-		if utils.ResponseWasNotFound(loadBalancer.Response) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Nat Rule %q: %+v", loadBalancerId.Name, loadBalancerId.ResourceGroup, id.InboundNatRuleName, err)
 	}
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.LoadBalancerName, id.InboundNatRuleName)

--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/parse"
 	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -149,10 +148,6 @@ func resourceArmLoadBalancerNatRuleCreateUpdate(d *pluginsdk.ResourceData, meta 
 		}
 	}
 
-	loadBalancerIdRaw := loadBalancerId.ID()
-	locks.ByID(loadBalancerIdRaw)
-	defer locks.UnlockByID(loadBalancerIdRaw)
-
 	loadBalancer, err := lbClient.Get(ctx, loadBalancerId.ResourceGroup, loadBalancerId.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(loadBalancer.Response) {
@@ -196,7 +191,7 @@ func resourceArmLoadBalancerNatRuleRead(d *pluginsdk.ResourceData, meta interfac
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
-			log.Printf("[INFO] Load Balancer %q not found. Removing from state", id.LoadBalancerName)
+			log.Printf("[INFO] Load Balancer Inbound Nat Rule %q not found. Removing from state", id)
 			return nil
 		}
 		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Nat Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.InboundNatRuleName, err)

--- a/website/docs/r/lb_nat_rule.html.markdown
+++ b/website/docs/r/lb_nat_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Load Balancer NAT Rule.
 
--> **NOTE:** This resource cannot be used with with virtual machine scale sets, instead use the `azurerm_lb_nat_pool` resource.
+-> **NOTE:** This resource cannot be used with virtual machine scale sets, instead use the `azurerm_lb_nat_pool` resource.
 
 ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 


### PR DESCRIPTION
The purpose of this PR:

Use the inbound nat rule dedicated endpoint instead of load balancer endpoint would make code easier, since it will directly create, read, delete the nat rules instead of updating load balancer to implement.

Test Results:

TF_ACC=1 go test ./internal/services/loadbalancer/ -v -parallel 11 -test.run=TestAccAzureRMLoadBalancerNatRule_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN TestAccAzureRMLoadBalancerNatRule_basic
=== PAUSE TestAccAzureRMLoadBalancerNatRule_basic
=== RUN TestAccAzureRMLoadBalancerNatRule_complete
=== PAUSE TestAccAzureRMLoadBalancerNatRule_complete
=== RUN TestAccAzureRMLoadBalancerNatRule_update
=== PAUSE TestAccAzureRMLoadBalancerNatRule_update
=== RUN TestAccAzureRMLoadBalancerNatRule_requiresImport
=== PAUSE TestAccAzureRMLoadBalancerNatRule_requiresImport
=== RUN TestAccAzureRMLoadBalancerNatRule_disappears
=== PAUSE TestAccAzureRMLoadBalancerNatRule_disappears
=== RUN TestAccAzureRMLoadBalancerNatRule_updateMultipleRules
=== PAUSE TestAccAzureRMLoadBalancerNatRule_updateMultipleRules
=== CONT TestAccAzureRMLoadBalancerNatRule_basic
=== CONT TestAccAzureRMLoadBalancerNatRule_disappears
=== CONT TestAccAzureRMLoadBalancerNatRule_requiresImport
=== CONT TestAccAzureRMLoadBalancerNatRule_complete
=== CONT TestAccAzureRMLoadBalancerNatRule_update
=== CONT TestAccAzureRMLoadBalancerNatRule_updateMultipleRules
--- PASS: TestAccAzureRMLoadBalancerNatRule_basic (291.64s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_updateMultipleRules (319.19s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_requiresImport (324.26s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_update (335.34s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_disappears (421.75s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_complete (423.10s)
PASS
ok github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer 423.473s