### PR TITLE
New Attribute: Front Door `rules_engine_id`

### DIFF
--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -201,6 +201,8 @@ The `routing_rule` block supports the following:
 
 * `redirect_configuration`   - (Optional) A `redirect_configuration` block as defined below.
 
+* `rules_engine_id` - (Optional) Defines the Rules Engine configuration `ID` for the Backend Routing Rule.
+
 ---
 
 The `forwarding_configuration` block supports the following:


### PR DESCRIPTION
This PR introduces a new resource attribute called `rules_engine_id` for the `azurerm_frontdoor` resource. This resource attribute is meant to associate Rules Engine configurations with Routing Rules in Azure Front Door Service.

From https://github.com/hashicorp/terraform-provider-azurerm/issues/7455.

@heoelri Did a great job on https://github.com/hashicorp/terraform-provider-azurerm/pull/13249, but there's more work to do, most importantly connecting the rules engine with the rules themselves.

I've added the attribute, it should be used as such:

```tf
resource "azurerm_frontdoor" "sample_frontdoor" {
  name                = "test"
  resource_group_name = azurerm_resource_group.test.name

  frontend_endpoint {
    name      = "test-default-FE"
    host_name = "test.azurefd.net"
  }

  routing_rule {
    name            = "test"
    rules_engine_id = azurerm_frontdoor_rules_engine.sample_engine_config
  }
}

resource "azurerm_frontdoor_rules_engine" "sample_engine_config" {
  name                = "test"
  frontdoor_name      = azurerm_frontdoor.sample_frontdoor.name
  resource_group_name = azurerm_resource_group.test.name
}
```

Immediately you can see where I'm having trouble: there's a circular dependency here. I couldn't find precedence in the source code of how to untangle this, I need help from someone who knows the codebase well. I'm not even sure if TerraForm supports untangling circular dependencies.

If the proposed format isn't going to work out, let me know if you have any thoughts on how we could implement this alternatively, I'd love to help out any way I can.

Additionally, it would be great if the implicit dependency between these two resources got resolved explicity. The [`azurerm_frontdoor_rules_engine` tests](https://github.com/joaomoreno/terraform-provider-azurerm/blob/0af3e88cce33f81ef17e2d9c0fe73fdf16ae8780/internal/services/frontdoor/frontdoor_resource_test.go/#L1017-L1019) highlight this implicit dependency. Shouldn't this dependency be built into the declarative language? IMO that `depends_on` should never be neccessary. Shouldn't `azurerm_frontdoor_rules_engine` have a `frontdoor_id` attribute instead of a `frontdoor_name` one? That would make the dependency explicit. Maybe @heoelri can elaborate on the `frontdoor_name` choice, and whether it was driven by some restriction I am not aware of.

Thanks for all your help! I'm new to both the codebase as well as golang, so thanks for being patient with me.