### PR TITLE
Fallback check for lowercase resourceid segments when given ResourceID doesn't match case convention

### DIFF
--- a/helpers/azure/resourceid.go
+++ b/helpers/azure/resourceid.go
@@ -156,10 +156,17 @@ func ParseAzureResourceIDWithoutSubscription(id string) (*ResourceID, error) {
 func (id *ResourceID) PopSegment(name string) (string, error) {
 	val, ok := id.Path[name]
 	if !ok {
-		return "", fmt.Errorf("ID was missing the `%s` element", name)
+		// Some Azure APIs are weird and provide things in lower case...
+		// However it's not clear whether the casing of other elements in the URI
+		// matter, so we explicitly look for that case here.
+		val, ok = id.Path[strings.ToLower(name)]
+		if !ok {
+			return "", fmt.Errorf("ID was missing the `%s` element in `%v`", name, id)
+		}
 	}
 
 	delete(id.Path, name)
+	delete(id.Path, strings.ToLower(name))
 	return val, nil
 }
 


### PR DESCRIPTION
- Precendence of this happening when checking resource group segments
  ref: https://github.com/hashicorp/terraform-provider-azurerm/blob/a64ec86a4b5ad363e1f9992529d7585e13e62ead/helpers/azure/resourceid.go#L84-L90
- Resolves #13838 if merged