### PR TITLE
`azurerm_synapse_workspace_key`: deprecate `cusomter_managed_key_name` in favour of the correctly spelled `customer_managed_key_name`

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -36,6 +36,7 @@ func (td TestData) DataSourceTestInSequence(t *testing.T, steps []TestStep) {
 	td.runAcceptanceSequentialTest(t, testCase)
 }
 
+// lintignore:AT001
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -46,6 +46,7 @@ func resourceSynapseWorkspaceKey() *pluginsdk.Resource {
 			"cusomter_managed_key_name": {
 				Type:       pluginsdk.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "As this property name contained a typo originally, please switch to using 'customer_managed_key_name' instead.",
 				AtLeastOneOf: []string{
 					"cusomter_managed_key_name",
@@ -57,6 +58,7 @@ func resourceSynapseWorkspaceKey() *pluginsdk.Resource {
 			"customer_managed_key_name": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
+				Computed:   true,
 				ConflictsWith: []string{"cusomter_managed_key_name"},
 				AtLeastOneOf: []string{
 					"cusomter_managed_key_name",

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -58,7 +58,7 @@ func resourceSynapseWorkspaceKey() *pluginsdk.Resource {
 			"customer_managed_key_name": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
-				Computed:   true,
+				Computed:      true,
 				ConflictsWith: []string{"cusomter_managed_key_name"},
 				AtLeastOneOf: []string{
 					"cusomter_managed_key_name",

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -124,14 +124,14 @@ func resourceSynapseWorkspaceKeysCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	// If the state of the key in the response (from Azure) is not equal to the desired target state (from plan/config), we'll wait until that change is complete
 	if isActiveCMK != *keyresult.KeyProperties.IsActiveCMK {
-		updateWait := synapseKeysWaitForStateChange(ctx, meta, d.Timeout(pluginsdk.TimeoutUpdate), workspaceId.ResourceGroup, workspaceId.Name, keyName, strconv.FormatBool(*keyresult.KeyProperties.IsActiveCMK), strconv.FormatBool(isActiveCMK))
+		updateWait := synapseKeysWaitForStateChange(ctx, meta, d.Timeout(pluginsdk.TimeoutUpdate), workspaceId.ResourceGroup, workspaceId.Name, actualKeyName, strconv.FormatBool(*keyresult.KeyProperties.IsActiveCMK), strconv.FormatBool(isActiveCMK))
 
 		if _, err := updateWait.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for Synapse Keys to finish updating '%q' (Workspace Group %q): %v", keyName, workspaceId.Name, err)
+			return fmt.Errorf("waiting for Synapse Keys to finish updating '%q' (Workspace Group %q): %v", actualKeyName, workspaceId.Name, err)
 		}
 	}
 
-	id := parse.NewWorkspaceKeysID(workspaceId.SubscriptionId, workspaceId.ResourceGroup, workspaceId.Name, keyName)
+	id := parse.NewWorkspaceKeysID(workspaceId.SubscriptionId, workspaceId.ResourceGroup, workspaceId.Name, actualKeyName)
 	d.SetId(id.ID())
 
 	return resourceSynapseWorkspaceKeyRead(d, meta)

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -43,7 +43,7 @@ func resourceSynapseWorkspaceKey() *pluginsdk.Resource {
 				ValidateFunc: validate.WorkspaceID,
 			},
 
-			"cusomter_managed_key_name": {
+			"customer_managed_key_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 			},
@@ -75,7 +75,7 @@ func resourceSynapseWorkspaceKeysCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	key := d.Get("customer_managed_key_versionless_id")
-	keyName := d.Get("cusomter_managed_key_name").(string)
+	keyName := d.Get("customer_managed_key_name").(string)
 	isActiveCMK := d.Get("active").(bool)
 
 	log.Printf("[INFO] Is active CMK: %t", isActiveCMK)
@@ -134,7 +134,7 @@ func resourceSynapseWorkspaceKeyRead(d *pluginsdk.ResourceData, meta interface{}
 	// Set the properties
 	d.Set("synapse_workspace_id", workspaceID.ID())
 	d.Set("active", resp.KeyProperties.IsActiveCMK)
-	d.Set("cusomter_managed_key_name", id.KeyName)
+	d.Set("customer_managed_key_name", id.KeyName)
 	d.Set("customer_managed_key_versionless_id", resp.KeyProperties.KeyVaultURL)
 
 	return nil

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -43,9 +43,17 @@ func resourceSynapseWorkspaceKey() *pluginsdk.Resource {
 				ValidateFunc: validate.WorkspaceID,
 			},
 
+			"cusomter_managed_key_name": {
+				Type:       pluginsdk.TypeString,
+				Required:   true,
+				Deprecated: "As this property name contained a typo originally, please switch to using 'customer_managed_key_name' instead.",
+				ConflictsWith: []string{"customer_managed_key_name"},
+			},
+
 			"customer_managed_key_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
+				ConflictsWith: []string{"cusomter_managed_key_name"},
 			},
 
 			"customer_managed_key_versionless_id": {
@@ -76,6 +84,7 @@ func resourceSynapseWorkspaceKeysCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	key := d.Get("customer_managed_key_versionless_id")
 	keyName := d.Get("customer_managed_key_name").(string)
+	keyNameTypoed := d.Get("cusomter_managed_key_name").(string)
 	isActiveCMK := d.Get("active").(bool)
 
 	log.Printf("[INFO] Is active CMK: %t", isActiveCMK)
@@ -89,7 +98,7 @@ func resourceSynapseWorkspaceKeysCreateUpdate(d *pluginsdk.ResourceData, meta in
 		KeyProperties: &keyProperties,
 	}
 
-	keyresult, err := client.CreateOrUpdate(ctx, workspaceId.ResourceGroup, workspaceId.Name, keyName, synapseKey)
+	keyresult, err := client.CreateOrUpdate(ctx, workspaceId.ResourceGroup, workspaceId.Name, (keyName, synapseKey)
 	if err != nil {
 		return fmt.Errorf("creating Synapse Workspace Key %q (Workspace %q): %+v", workspaceId.Name, workspaceId.Name, err)
 	}

--- a/website/docs/r/synapse_workspace_keys.html.markdown
+++ b/website/docs/r/synapse_workspace_keys.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Synapse"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_synapse_workspace_keys"
+page_title: "Azure Resource Manager: azurerm_synapse_workspace_key"
 description: |-
   Manages Synapse Workspace Keys
 ---
@@ -116,7 +116,7 @@ resource "azurerm_synapse_workspace_key" "example" {
 
 The following arguments are supported:
 
-* `key_name` - (Required) Specifies the name of the workspace key. Should match the name of the key in the synapse workspace.
+* `customer_managed_key_name` - (Required) Specifies the name of the workspace key. Should match the name of the key in the synapse workspace.
 
 * `customer_managed_key_versionless_id` - (Required) The Azure Key Vault Key Versionless ID to be used as the Customer Managed Key (CMK) for double encryption 
 


### PR DESCRIPTION
Fixes #13864