### PR TITLE
`r\purview_account_resource`: Deprecate `sku_name` property

### DIFF
--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -51,14 +51,12 @@ func resourcePurviewAccount() *pluginsdk.Resource {
 
 			"location": azure.SchemaLocation(),
 
+			// TODO 3.0 - Remove sku_name property.
+			//            https://github.com/Azure/azure-rest-api-specs/issues/15675
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Standard_1",
-					"Standard_4",
-					"Standard_16",
-				}, false),
+				Type:       pluginsdk.TypeString,
+				Optional:   true,
+				Deprecated: "This property cannot be updated by api any more, it can only be updated by creating support ticket at Azure",
 			},
 
 			"public_network_enabled": {
@@ -149,7 +147,6 @@ func resourcePurviewAccountCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			Type: purview.SystemAssigned,
 		},
 		Location: &location,
-		Sku:      expandPurviewSkuName(d),
 		Tags:     tags.Expand(t),
 	}
 
@@ -195,7 +192,6 @@ func resourcePurviewAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("sku_name", flattenPurviewSkuName(resp.Sku))
 
 	if err := d.Set("identity", flattenPurviewAccountIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("flattening `identity`: %+v", err)
@@ -241,31 +237,6 @@ func resourcePurviewAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	return nil
-}
-
-func expandPurviewSkuName(d *pluginsdk.ResourceData) *purview.AccountSku {
-	sku := d.Get("sku_name").(string)
-
-	if len(sku) == 0 {
-		return nil
-	}
-
-	name, capacity, err := azure.SplitSku(sku)
-	if err != nil {
-		return nil
-	}
-	return &purview.AccountSku{
-		Name:     purview.Name(name),
-		Capacity: utils.Int32(capacity),
-	}
-}
-
-func flattenPurviewSkuName(input *purview.AccountSku) string {
-	if input == nil || input.Capacity == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%s_%d", string(input.Name), *input.Capacity)
 }
 
 func flattenPurviewAccountIdentity(identity *purview.Identity) interface{} {

--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -56,7 +56,7 @@ func resourcePurviewAccount() *pluginsdk.Resource {
 			"sku_name": {
 				Type:       pluginsdk.TypeString,
 				Optional:   true,
-				Deprecated: "This property cannot be updated by api any more, it can only be updated by creating support ticket at Azure",
+				Deprecated: "This property can no longer be specified on create/update, it can only be updated by creating a support ticket at Azure",
 			},
 
 			"public_network_enabled": {

--- a/internal/services/purview/purview_account_resource_test.go
+++ b/internal/services/purview/purview_account_resource_test.go
@@ -71,7 +71,6 @@ resource "azurerm_purview_account" "test" {
   name                = "acctestsw%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku_name            = "Standard_1"
 }
 `, template, data.RandomInteger)
 }
@@ -85,7 +84,6 @@ resource "azurerm_purview_account" "import" {
   name                = azurerm_purview_account.test.name
   resource_group_name = azurerm_purview_account.test.resource_group_name
   location            = azurerm_purview_account.test.location
-  sku_name            = azurerm_purview_account.test.sku_name
 }
 `, template)
 }

--- a/website/docs/r/purview_account.html.markdown
+++ b/website/docs/r/purview_account.html.markdown
@@ -22,7 +22,6 @@ resource "azurerm_purview_account" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  sku_name            = "Standard_4"
 }
 ```
 
@@ -35,8 +34,6 @@ The following arguments are supported:
 * `name` - (Required) The name which should be used for this Purview Account. Changing this forces a new Purview Account to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Purview Account should exist. Changing this forces a new Purview Account to be created.
-
-* `sku_name` - (Required) The SKU's capacity for platform size and catalog capabilities. Accepted values are `Standard_1`, `Standard_4` and `Standard_16`.
 
 ---
 


### PR DESCRIPTION
- The sku property of Purview Account can only be updated through a support ticket now, and has been removed from the request body when creating the resource. Since it's no longer managed by api, and the value can only be changed outside terraform, i'm considering removing it. In order to avoid breaking change, I'm updating it from `Required` to `Optional` + `Deprecated`.

- Doc and issue:
https://docs.microsoft.com/en-us/azure/purview/concept-elastic-data-map#request-capacity
https://github.com/Azure/azure-rest-api-specs/issues/15675

- Test result:
$ make acctests SERVICE='purview' TESTARGS='-run=Test' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/purview -run=Test -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPurviewAccount_basic
=== PAUSE TestAccPurviewAccount_basic
=== RUN   TestAccPurviewAccount_requiresImport
=== PAUSE TestAccPurviewAccount_requiresImport
=== CONT  TestAccPurviewAccount_basic
=== CONT  TestAccPurviewAccount_requiresImport
--- PASS: TestAccPurviewAccount_basic (657.38s)
--- PASS: TestAccPurviewAccount_requiresImport (683.11s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/purview       683.774s