### PR TITLE
`azurerm_application_gateway`: Support for `components` in `rewrite_rule_set.rewrite_rule.url`

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1190,6 +1190,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 												"components": {
 													Type:     pluginsdk.TypeString,
 													Optional: true,
+													Computed: true,
 													ValidateFunc: validation.StringInSlice([]string{
 														"path_only",
 														"query_string_only",
@@ -3641,9 +3642,9 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 							}
 
 							if path != queryString {
-								if path != "" {
+								if path != "" && queryString == "" {
 									components = "path_only"
-								} else {
+								} else if queryString != "" && path == "" {
 									components = "query_string_only"
 								}
 							}

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -407,6 +407,11 @@ func TestAccApplicationGateway_rewriteRuleSets_rewriteUrl(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+				check.That(data.ResourceName).Key("rewrite_rule_set.#").HasValue("2"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.url.0.components").HasValue(""),
+				check.That(data.ResourceName).Key("rewrite_rule_set.1.rewrite_rule.#").HasValue("2"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.1.rewrite_rule.0.url.0.components").HasValue("path_only"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.1.rewrite_rule.1.url.0.components").HasValue("query_string_only"),
 			),
 		},
 		data.ImportStep(),
@@ -5997,6 +6002,40 @@ resource "azurerm_application_gateway" "test" {
       url {
         path         = "/article.aspx"
         query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
+      }
+    }
+  }
+
+  rewrite_rule_set {
+    name = "${local.rewrite_rule_set_name}_1"
+
+    rewrite_rule {
+      name          = "${local.rewrite_rule_name}_1"
+      rule_sequence = 1
+
+      condition {
+        variable = "var_uri_path"
+        pattern  = ".*article/(.*)/(.*)"
+      }
+
+      url {
+        path       = "/article.aspx"
+        components = "path_only"
+      }
+    }
+
+    rewrite_rule {
+      name          = "${local.rewrite_rule_name}_2"
+      rule_sequence = 2
+
+      condition {
+        variable = "var_uri_path"
+        pattern  = ".*article2/(.*)/(.*)"
+      }
+
+      url {
+        query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
+        components   = "query_string_only"
       }
     }
   }

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -653,7 +653,9 @@ A `url` block supports the following:
 
 * `query_string` - (Optional) The query string to rewrite.
 
-~> **Note:** One or both of `path` and `query_string` must be specified.
+* `components` - (Optional) The components used to rewrite the URL. Possible values are `path_only` and `query_string_only` to limit the rewrite to the URL Path or URL Query String only.
+
+~> **Note:** One or both of `path` and `query_string` must be specified. If one of these is not specified, it means the value  will be empty. If you only want to rewrite `path` or `query_string`, use `components`.
 
 * `reroute` - (Optional) Whether the URL path map should be reevaluated after this rewrite has been applied. [More info on rewrite configutation](https://docs.microsoft.com/en-us/azure/application-gateway/rewrite-http-headers-url#rewrite-configuration)
 


### PR DESCRIPTION
Fixes #13894
Fixes #11563

Introduction of a `rewrite_rule_set.rewrite_rule.url.components` property to limit rewrite to URL Path or URL Query String only

## Acceptance Tests
```bash
❯ go install && make acctests SERVICE='network' TESTARGS='-run=TestAccApplicationGateway_rewriteRuleSets_rewriteUrl'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccApplicationGateway_rewriteRuleSets_rewriteUrl -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationGateway_rewriteRuleSets_rewriteUrl
=== PAUSE TestAccApplicationGateway_rewriteRuleSets_rewriteUrl
=== CONT  TestAccApplicationGateway_rewriteRuleSets_rewriteUrl
--- PASS: TestAccApplicationGateway_rewriteRuleSets_rewriteUrl (712.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network     714.417
```