### PR TITLE
Front Door: Preserve routing rules engine across updates

### DIFF
--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -588,6 +588,7 @@ func resourceFrontDoorCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		preExists = true
 		location = azure.NormalizeLocation(*exists.Location)
 
+        if exists.RoutingRules != nil {
 		for _, rule := range *exists.RoutingRules {
 			if rule.RulesEngine != nil {
 				id, err := parse.RulesEngineIDInsensitively(*rule.RulesEngine.ID)

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -590,7 +590,7 @@ func resourceFrontDoorCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 
 		if exists.RoutingRules != nil {
 			for _, rule := range *exists.RoutingRules {
-				if rule.RulesEngine != nil {
+				if rule.RulesEngine != nil && rule.RulesEngine.ID != nil && rule.Name != nil {
 					id, err := parse.RulesEngineIDInsensitively(*rule.RulesEngine.ID)
 
 					if err != nil {

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -590,7 +590,7 @@ func resourceFrontDoorCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 
 		for _, rule := range *exists.RoutingRules {
 			if rule.RulesEngine != nil {
-				id, err := parse.RulesEngineID(*rule.RulesEngine.ID)
+				id, err := parse.RulesEngineIDInsensitively(*rule.RulesEngine.ID)
 
 				if err != nil {
 					return fmt.Errorf("Error parsing rules engine id for routing rule %q (Resource Group %q): %+v", *rule.Name, resourceGroup, err)

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -588,16 +588,17 @@ func resourceFrontDoorCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		preExists = true
 		location = azure.NormalizeLocation(*exists.Location)
 
-        if exists.RoutingRules != nil {
-		for _, rule := range *exists.RoutingRules {
-			if rule.RulesEngine != nil {
-				id, err := parse.RulesEngineIDInsensitively(*rule.RulesEngine.ID)
+		if exists.RoutingRules != nil {
+			for _, rule := range *exists.RoutingRules {
+				if rule.RulesEngine != nil {
+					id, err := parse.RulesEngineIDInsensitively(*rule.RulesEngine.ID)
 
-				if err != nil {
-					return fmt.Errorf("Error parsing rules engine id for routing rule %q (Resource Group %q): %+v", *rule.Name, resourceGroup, err)
+					if err != nil {
+						return fmt.Errorf("Error parsing rules engine id for routing rule %q (Resource Group %q): %+v", *rule.Name, resourceGroup, err)
+					}
+
+					rulesEngines[*rule.Name] = id
 				}
-
-				rulesEngines[*rule.Name] = id
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes a known issue https://github.com/hashicorp/terraform-provider-azurerm/issues/7455#issuecomment-882769364 when updating any configuration in Front Door resources: any configured rules engine will simply be dropped. The current workaround isn't ideal since there will be a window of time in which the rule engine won't be active between updating the Front Door and running the `local-exec` command. This actually causes downtime in a production service of ours.

Given that https://github.com/hashicorp/terraform-provider-azurerm/pull/13803 is at [a standstill](https://github.com/hashicorp/terraform-provider-azurerm/pull/13803#issuecomment-948550725), this temporary fix will do until we figure out how to properly marry `azurerm_frontdoor` with `azurerm_frontdoor_rules_engine` resources.

I'd love to add a test case to this, but I couldn't figure out how to manually update an Azure resource in the middle of a test. The ideal test would be:

1. Create both  `azurerm_frontdoor` and `azurerm_frontdoor_rules_engine` resources
2. Manually reach out to Azure and associate them at the routing rule level
3. Test that updating a simple attribute (eg `cache_enabled`) on `azurerm_frontdoor` will preserve the association

Although I couldn't write that test case, I was able to manually test these changes using the `provider_installation` instructions. So I'm hoping we could merge this soon.

cc @heoelri

---

Additionally, I found this VS Code launch config to be **super** useful to debug a specific test, `TestAccFrontDoor_basic` in this case. I'll leave this here just in case it's useful to anyone. I'm wondering if you should document it anywhere?

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Debug TestAccFrontDoor_basic",
      "type": "go",
      "request": "launch",
      "mode": "test",
      "program": "${workspaceFolder}/internal/services/frontdoor",
      "buildFlags": "-ldflags=\"-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc\"",
      "args": [
        "-test.v",
        "-test.run=TestAccFrontDoor_basic",
        "-test.timeout",
        "60m"
      ],
      "env": {
        "TF_ACC": "1",
        "ARM_CLIENT_ID": "***",
        "ARM_CLIENT_SECRET": "***",
        "ARM_SUBSCRIPTION_ID": "***",
        "ARM_TENANT_ID": "***",
        "ARM_ENVIRONMENT": "public",
        "ARM_TEST_LOCATION": "West Europe",
        "ARM_TEST_LOCATION_ALT": "East US",
        "ARM_TEST_LOCATION_ALT2": "West US"
      }
    }
  ]
}
```