### PR TITLE
key_vault_key - add the cureve, x, y, public_key_pem, public_key_openssh

### DIFF
--- a/internal/services/keyvault/key_vault_key_data_source.go
+++ b/internal/services/keyvault/key_vault_key_data_source.go
@@ -62,12 +62,27 @@ func dataSourceKeyVaultKey() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"curve": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"n": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
 			"e": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"x": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"y": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -123,6 +138,9 @@ func dataSourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 		d.Set("n", key.N)
 		d.Set("e", key.E)
+		d.Set("x", key.X)
+		d.Set("y", key.Y)
+		d.Set("curve", key.Crv)
 	}
 
 	d.Set("version", parsedId.Version)

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -55,6 +55,10 @@ The following attributes are exported:
 
 * `n` - The RSA modulus of this Key Vault Key.
 
+* `public_key_pem` - The PEM encoded public key of this Key Vault Key.
+
+* `public_key_openssh` - The OpenSSH encoded public key of this Key Vault Key.
+
 * `tags` - A mapping of tags assigned to this Key Vault Key.
 
 * `version` - The current version of the Key Vault Key.

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -43,6 +43,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Key Vault Key.
 
+* `curve` - The EC Curve name of this Key Vault Key.
+
 * `e` - The RSA public exponent of this Key Vault Key.
 
 * `key_type` - Specifies the Key Type of this Key Vault Key
@@ -58,6 +60,10 @@ The following attributes are exported:
 * `version` - The current version of the Key Vault Key.
 
 * `versionless_id` - The Base ID of the Key Vault Key.
+
+* `x` - The EC X component of this Key Vault Key.
+
+* `y` - The EC Y component of this Key Vault Key.
 
 
 ## Timeouts

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -96,6 +96,8 @@ The following attributes are exported:
 * `e` - The RSA public exponent of this Key Vault Key.
 * `x` - The EC X component of this Key Vault Key.
 * `y` - The EC Y component of this Key Vault Key.
+* `public_key_pem` - The PEM encoded public key of this Key Vault Key.
+* `public_key_openssh` - The OpenSSH encoded public key of this Key Vault Key.
 
 ## Timeouts
 


### PR DESCRIPTION
This attempts to close match the attributes that the terraform `tls_private_key` provides. Specifically the OpenSSH and PEM format for the public keys.

At the moment the only access to the public keys are in the form of key type, key curve and then base 64 encoded N/E/X/Y values. However these aren't too helpful at runtime for terraform as you can't meaningfully manipulate these in a way that may be necessary.

For my particular case I need the OpenSSH format public key so that I can use the key vault backed key with SSH authentication. The OpenSSH format key is added to a VM as an authorized_key and the key vault key is then used for SSH authentication (yes this works and is implemented).

At the moment there's no built-in support for P256 Curves, so those keys will not be formatted but should silently fail.

Todo:
 - [x] DRY code
 - [x] Clean up commits
 - [x] Add docs
 - [ ] Tests?

---

I noticed that the data source element was missing parity with the resource in terms of attributes (no EC support) so I've added that to this PR as well.