### PR TITLE
`azurerm_storage_share` - add supports for `enabled_protocol`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9
 	github.com/sergi/go-diff v1.2.0
 	github.com/shopspring/decimal v1.2.0
-	github.com/tombuildsstuff/giovanni v0.16.0
+	github.com/tombuildsstuff/giovanni v0.17.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tombuildsstuff/giovanni v0.16.0 h1:Q8QKgsr4Fmhf+z6Mf1UPQKeovkCdudkiMaAZmq9CIjg=
-github.com/tombuildsstuff/giovanni v0.16.0/go.mod h1:66KVLYma2whJhEdxPSPL3GQHkulhK+C5CluKfHGfPF4=
+github.com/tombuildsstuff/giovanni v0.17.0 h1:Flq608eARmHuTkFfvT5vD0rLcEMRqDFPq0khVRrxAIk=
+github.com/tombuildsstuff/giovanni v0.17.0/go.mod h1:66KVLYma2whJhEdxPSPL3GQHkulhK+C5CluKfHGfPF4=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/internal/services/storage/shim/shares.go
+++ b/internal/services/storage/shim/shares.go
@@ -17,7 +17,8 @@ type StorageShareWrapper interface {
 }
 
 type StorageShareProperties struct {
-	ACLs     []shares.SignedIdentifier
-	MetaData map[string]string
-	QuotaGB  int
+	ACLs            []shares.SignedIdentifier
+	MetaData        map[string]string
+	QuotaGB         int
+	EnabledProtocol shares.ShareProtocol
 }

--- a/internal/services/storage/shim/shares_data_plane.go
+++ b/internal/services/storage/shim/shares_data_plane.go
@@ -87,9 +87,10 @@ func (w DataPlaneStorageShareWrapper) Get(ctx context.Context, _, accountName, s
 	}
 
 	return &StorageShareProperties{
-		MetaData: props.MetaData,
-		QuotaGB:  props.ShareQuota,
-		ACLs:     acls.SignedIdentifiers,
+		MetaData:        props.MetaData,
+		QuotaGB:         props.ShareQuota,
+		ACLs:            acls.SignedIdentifiers,
+		EnabledProtocol: props.EnabledProtocol,
 	}, nil
 }
 

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -100,12 +100,12 @@ func resourceStorageShare() *pluginsdk.Resource {
 			"enabled_protocol": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(shares.SMB),
 					string(shares.NFS),
 				}, false),
+				Default: string(shares.SMB),
 			},
 
 			"resource_manager_id": {

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -97,6 +97,17 @@ func resourceStorageShare() *pluginsdk.Resource {
 				},
 			},
 
+			"enabled_protocol": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(shares.SMB),
+					string(shares.NFS),
+				}, false),
+			},
+
 			"resource_manager_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -150,8 +161,9 @@ func resourceStorageShareCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Share %q in Storage Account %q", shareName, accountName)
 	input := shares.CreateInput{
-		QuotaInGB: quota,
-		MetaData:  metaData,
+		QuotaInGB:       quota,
+		MetaData:        metaData,
+		EnabledProtocol: shares.ShareProtocol(d.Get("enabled_protocol").(string)),
 	}
 
 	if err := client.Create(ctx, account.ResourceGroup, accountName, shareName, input); err != nil {
@@ -205,6 +217,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.Set("storage_account_name", id.AccountName)
 	d.Set("quota", props.QuotaGB)
 	d.Set("url", id.ID())
+	d.Set("enabled_protocol", string(props.EnabledProtocol))
 
 	if err := d.Set("acl", flattenStorageShareACLs(props.ACLs)); err != nil {
 		return fmt.Errorf("flattening `acl`: %+v", err)

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -471,6 +471,7 @@ resource "azurerm_storage_account" "test" {
   name                     = "acctestacc%s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
+  account_kind             = "FileStorage"
   account_tier             = "Premium"
   account_replication_type = "LRS"
 }

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -24,6 +24,7 @@ func TestAccStorageShare_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enabled_protocol").HasValue("SMB"),
 			),
 		},
 		data.ImportStep(),
@@ -176,6 +177,21 @@ func TestAccStorageShare_largeQuota(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.largeQuotaUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShare_nfsProtocol(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
+	r := StorageShareResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nfsProtocol(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -436,6 +452,33 @@ resource "azurerm_storage_share" "test" {
   name                 = "testshare%s"
   storage_account_name = azurerm_storage_account.test.name
   quota                = 10000
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (r StorageShareResource) nfsProtocol(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  enabled_protocol     = "NFS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/create.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/create.go
@@ -18,6 +18,9 @@ type CreateInput struct {
 	// Must be greater than 0, and less than or equal to 5TB (5120).
 	QuotaInGB int
 
+	// Specifies the enabled protocols on the share. If not specified, the default is SMB.
+	EnabledProtocol ShareProtocol
+
 	MetaData map[string]string
 }
 
@@ -75,6 +78,12 @@ func (client Client) CreatePreparer(ctx context.Context, accountName, shareName 
 		"x-ms-version":     APIVersion,
 		"x-ms-share-quota": input.QuotaInGB,
 	}
+
+	protocol := SMB
+	if input.EnabledProtocol != "" {
+		protocol = input.EnabledProtocol
+	}
+	headers["x-ms-enabled-protocols"] = protocol
 
 	headers = metadata.SetIntoHeaders(headers, input.MetaData)
 

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/models.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/models.go
@@ -10,3 +10,13 @@ type AccessPolicy struct {
 	Expiry     string `xml:"Expiry"`
 	Permission string `xml:"Permission"`
 }
+
+type ShareProtocol string
+
+const (
+	// SMB indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST.
+	SMB ShareProtocol = "SMB"
+
+	// NFS indicates the share can be accessed by NFSv4.1. A premium account is required for this option.
+	NFS ShareProtocol = "NFS"
+)

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/properties_get.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares/properties_get.go
@@ -17,8 +17,9 @@ import (
 type GetPropertiesResult struct {
 	autorest.Response
 
-	MetaData   map[string]string
-	ShareQuota int
+	MetaData        map[string]string
+	ShareQuota      int
+	EnabledProtocol ShareProtocol
 }
 
 // GetProperties returns the properties about the specified Storage Share
@@ -100,6 +101,12 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetProp
 			}
 			result.ShareQuota = quota
 		}
+
+		protocol := SMB
+		if protocolRaw := resp.Header.Get("x-ms-enabled-protocols"); protocolRaw != "" {
+			protocol = ShareProtocol(protocolRaw)
+		}
+		result.EnabledProtocol = protocol
 	}
 
 	err = autorest.Respond(

--- a/vendor/github.com/tombuildsstuff/giovanni/version/version.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Number = "v0.16.0"
+const Number = "v0.17.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -393,7 +393,7 @@ github.com/sergi/go-diff/diffmatchpatch
 # github.com/shopspring/decimal v1.2.0
 ## explicit
 github.com/shopspring/decimal
-# github.com/tombuildsstuff/giovanni v0.16.0
+# github.com/tombuildsstuff/giovanni v0.17.0
 ## explicit
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/accounts
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/blobs

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -56,7 +56,9 @@ The following arguments are supported:
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
-* `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. Defaults to `SMB`. Changing this forces a new resource to be created.
+* `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. The `SBM` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. The `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `SMB`. Changing this forces a new resource to be created.
+
+~>**NOTE:** The `Premium` sku of the `azurerm_storage_account` is required for the `NFS` protocol.
 
 * `quota` - (Optional) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be greater than 0 and less than 5120 GB (5 TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and less than 102400 GB (100 TB). Default is 5120.
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
+* `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. Defaults to `SMB`. Changing this forces a new resource to be created.
+
 * `quota` - (Optional) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be greater than 0 and less than 5120 GB (5 TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and less than 102400 GB (100 TB). Default is 5120.
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.


### PR DESCRIPTION
`azurerm_storage_share` - add supports for `enabled_protocol`.

Fixes #8711 

## Test

```bash
terraform-provider-azurerm on  storage_share_protocol via 🐹 v1.17.2
💤 TF_ACC=1 go test -timeout=3h -v ./internal/services/storage -run='TestAccStorageShare_basic|TestAccStorageShare_nfsProtocol'
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== RUN   TestAccStorageShare_nfsProtocol
=== PAUSE TestAccStorageShare_nfsProtocol
=== CONT  TestAccStorageShare_basic
=== CONT  TestAccStorageShare_nfsProtocol
--- PASS: TestAccStorageShare_nfsProtocol (98.22s)
--- PASS: TestAccStorageShare_basic (160.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       160.777s
```