### PR TITLE
Updated documentation for `azurerm_frontdoor_rules_engine`

### DIFF
--- a/internal/services/frontdoor/frontdoor_rules_engine_rule.go
+++ b/internal/services/frontdoor/frontdoor_rules_engine_rule.go
@@ -148,7 +148,7 @@ func resourceFrontDoorRulesEngine() *pluginsdk.Resource {
 									"negate_condition": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
-										Default:  true, // TODO - needs to change https://github.com/hashicorp/terraform-provider-azurerm/pull/13605
+										Default:  true, // TODO 3,0 change to false- needs to change https://github.com/hashicorp/terraform-provider-azurerm/pull/13605
 									},
 
 									"value": {

--- a/internal/services/frontdoor/frontdoor_rules_engine_rule.go
+++ b/internal/services/frontdoor/frontdoor_rules_engine_rule.go
@@ -148,7 +148,7 @@ func resourceFrontDoorRulesEngine() *pluginsdk.Resource {
 									"negate_condition": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
-										Default:  true,
+										Default:  true, // TODO - needs to change https://github.com/hashicorp/terraform-provider-azurerm/pull/13605
 									},
 
 									"value": {

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -118,12 +118,12 @@ The `match_condition` block supports the following:
 
 * `variable` can be set to `IsMobile`, `RemoteAddr`, `RequestMethod`, `QueryString`, `PostArgs`, `RequestURI`, `RequestPath`, `RequestFilename`, `RequestFilenameExtension`,`RequestHeader`,`RequestBody` or `RequestScheme`.
 
-* `selector`
+* `selector` match against a specific key when `variable` is set to `PostArgs` or `RequestHeader`. It cannot be used with `QueryString` and `RequestMethod`. Defaults to `null`.
 
 * `operator` can be set to `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith` or `EndsWith`
 
 * `transform` can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
 
-* `negate_condition` can be set to `true` or `false` to negate the given condition.
+* `negate_condition` can be set to `true` or `false` to negate the given condition. Defaults to `true`.
 
 * `value` (array) can contain one or more strings.


### PR DESCRIPTION
Small docs update for the `azurerm_frontdoor_rules_engine` resource. To highlight that `negate_condition` defaults to `true` and to add some guidance for the `selector` (which is still a bit special). Here's an example:

```hcl
    match_condition {
      variable = "RequestHeader"
      operator = "Equal"
      value = ["myvalue"]
      selector = "myparam"
    }
```

That `negate_condition` in `match_condition` defaults to `true` is indeed a bug and was not intended. I've raised a PR to change that here https://github.com/hashicorp/terraform-provider-azurerm/pull/13605. This will hopefully land in one of the next major releases.

Thanks to @ericjohnson2 and @aidapsibr for your hints in https://github.com/hashicorp/terraform-provider-azurerm/issues/7455. 