### PR TITLE
feat(storage_blob): implement control_cache

### DIFF
--- a/internal/services/storage/blobs.go
+++ b/internal/services/storage/blobs.go
@@ -27,6 +27,7 @@ type BlobUpload struct {
 	ContainerName string
 
 	BlobType      string
+	CacheControl  string
 	ContentType   string
 	ContentMD5    string
 	MetaData      map[string]string

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -294,15 +294,15 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("cache_control") {
-		log.Printf("[DEBUG] Updating Properties for Blob %q (Container %q / Account %q)...", id.BlobName, id.ContainerName, id.AccountName)
+		log.Printf("[DEBUG] Updating Cache Control for Blob %q (Container %q / Account %q)...", id.BlobName, id.ContainerName, id.AccountName)
 		input := blobs.SetPropertiesInput{
 			CacheControl: utils.String(d.Get("cache_control").(string)),
 		}
 
 		if _, err := blobsClient.SetProperties(ctx, id.AccountName, id.ContainerName, id.BlobName, input); err != nil {
-			return fmt.Errorf("updating Properties for Blob %q (Container %q / Account %q): %s", id.BlobName, id.ContainerName, id.AccountName, err)
+			return fmt.Errorf("updating Cache Control for Blob %q (Container %q / Account %q): %s", id.BlobName, id.ContainerName, id.AccountName, err)
 		}
-		log.Printf("[DEBUG] Updated Properties for Blob %q (Container %q / Account %q).", id.BlobName, id.ContainerName, id.AccountName)
+		log.Printf("[DEBUG] Updated Cache Control for Blob %q (Container %q / Account %q).", id.BlobName, id.ContainerName, id.AccountName)
 	}
 
 	return resourceStorageBlobRead(d, meta)

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -97,6 +97,11 @@ func resourceStorageBlob() *pluginsdk.Resource {
 				Default:  "application/octet-stream",
 			},
 
+			"cache_control": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+
 			"source": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
@@ -199,6 +204,7 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		Client:        blobsClient,
 
 		BlobType:      d.Get("type").(string),
+		CacheControl:  d.Get("cache_control").(string),
 		ContentType:   d.Get("content_type").(string),
 		ContentMD5:    contentMD5,
 		MetaData:      ExpandMetaData(metaDataRaw),
@@ -287,6 +293,18 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		log.Printf("[DEBUG] Updated MetaData for Blob %q (Container %q / Account %q).", id.BlobName, id.ContainerName, id.AccountName)
 	}
 
+	if d.HasChange("cache_control") {
+		log.Printf("[DEBUG] Updating Properties for Blob %q (Container %q / Account %q)...", id.BlobName, id.ContainerName, id.AccountName)
+		input := blobs.SetPropertiesInput{
+			CacheControl: utils.String(d.Get("cache_control").(string)),
+		}
+
+		if _, err := blobsClient.SetProperties(ctx, id.AccountName, id.ContainerName, id.BlobName, input); err != nil {
+			return fmt.Errorf("updating Properties for Blob %q (Container %q / Account %q): %s", id.BlobName, id.ContainerName, id.AccountName, err)
+		}
+		log.Printf("[DEBUG] Updated Properties for Blob %q (Container %q / Account %q).", id.BlobName, id.ContainerName, id.AccountName)
+	}
+
 	return resourceStorageBlobRead(d, meta)
 }
 
@@ -334,6 +352,7 @@ func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	d.Set("access_tier", string(props.AccessTier))
 	d.Set("content_type", props.ContentType)
+	d.Set("cache_control", props.CacheControl)
 
 	// Set the ContentMD5 value to md5 hash in hex
 	contentMD5 := ""

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -243,6 +243,28 @@ func TestAccStorageBlob_blockFromLocalFileWithContentMd5(t *testing.T) {
 	})
 }
 
+func TestAccStorageBlob_cacheControl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_blob", "test")
+	r := StorageBlobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.contentType(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "type"),
+		{
+			Config: r.contentTypeUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parallelism", "size", "type"),
+	})
+}
+
 func TestAccStorageBlob_contentType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_blob", "test")
 	r := StorageBlobResource{}
@@ -983,6 +1005,27 @@ resource "azurerm_storage_blob" "test" {
     hello = "world"
     panda = "pops"
   }
+}
+`, template)
+}
+
+func (r StorageBlobResource) cacheControl(data acceptance.TestData) string {
+	template := r.template(data, "private")
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "example.ext"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Page"
+  size                   = 5120
+  content_type           = "image/png"
+  cache_control          = "no-cache"
 }
 `, template)
 }

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -249,14 +249,14 @@ func TestAccStorageBlob_cacheControl(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cacheControl(data),
+			Config: r.cacheControl(data, "no-cache"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("parallelism", "size", "type"),
 		{
-			Config: r.cacheControlUpdated(data),
+			Config: r.cacheControl(data, "max-age=3600"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1009,7 +1009,7 @@ resource "azurerm_storage_blob" "test" {
 `, template)
 }
 
-func (r StorageBlobResource) cacheControl(data acceptance.TestData) string {
+func (r StorageBlobResource) cacheControl(data acceptance.TestData, cacheControl string) string {
 	template := r.template(data, "private")
 	return fmt.Sprintf(`
 %s
@@ -1025,9 +1025,9 @@ resource "azurerm_storage_blob" "test" {
   type                   = "Page"
   size                   = 5120
   content_type           = "image/png"
-  cache_control          = "no-cache"
+  cache_control          = "%s"
 }
-`, template)
+`, template, cacheControl)
 }
 
 func (r StorageBlobResource) template(data acceptance.TestData, accessLevel string) string {

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -249,14 +249,14 @@ func TestAccStorageBlob_cacheControl(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.contentType(data),
+			Config: r.cacheControl(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("parallelism", "size", "type"),
 		{
-			Config: r.contentTypeUpdated(data),
+			Config: r.cacheControlUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `access_tier` - (Optional) The access tier of the storage blob. Possible values are `Archive`, `Cool` and `Hot`.
 
+* `cache_control` - (Optional) Controls the [cache control header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) content of the response when blob is requested .
+
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
 * `content_md5` - (Optional) The MD5 sum of the blob contents. Cannot be defined if `source_uri` is defined, or if blob type is Append or Page. Changing this forces a new resource to be created.   


### PR DESCRIPTION
Fixes #6236

Adds the ability to set `cache_control` for blobs in a `storage_account`  