### PR TITLE
`azurerm_logic_app_standard` - fixes error when working on private network

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1300,8 +1300,7 @@ func expandLogicAppStandardIdentity(input []interface{}) *web.ManagedServiceIden
 }
 
 func expandLogicAppStandardSettings(d *pluginsdk.ResourceData, endpointSuffix string) (map[string]*string, error) {
-
-	output := make(map[string]*string, 0)
+	output := make(map[string]*string)
 	appSettings := expandAppSettings(d)
 	basicAppSettings, err := getBasicLogicAppSettings(d, endpointSuffix)
 	if err != nil {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -283,7 +283,11 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 		kind = "functionapp,linux,container,workflowapp"
 	}
 
-	siteConfig.AppSettings = &basicAppSettings
+	// Some appSettings declared by user are required at creation time so we will combine both settings
+	appSettings := expandAppSettings(d)
+	appSettings = append(appSettings, basicAppSettings...)
+
+	siteConfig.AppSettings = &appSettings
 
 	siteEnvelope := web.Site{
 		Kind:     &kind,
@@ -1296,25 +1300,30 @@ func expandLogicAppStandardIdentity(input []interface{}) *web.ManagedServiceIden
 }
 
 func expandLogicAppStandardSettings(d *pluginsdk.ResourceData, endpointSuffix string) (map[string]*string, error) {
-	output := expandAppSettings(d)
 
+	output := make(map[string]*string, 0)
+	appSettings := expandAppSettings(d)
 	basicAppSettings, err := getBasicLogicAppSettings(d, endpointSuffix)
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range basicAppSettings {
+	for _, p := range append(basicAppSettings, appSettings...) {
 		output[*p.Name] = p.Value
 	}
 
 	return output, nil
 }
 
-func expandAppSettings(d *pluginsdk.ResourceData) map[string]*string {
+func expandAppSettings(d *pluginsdk.ResourceData) []web.NameValuePair {
 	input := d.Get("app_settings").(map[string]interface{})
-	output := make(map[string]*string, len(input))
+	output := make([]web.NameValuePair, 0)
 
 	for k, v := range input {
-		output[k] = utils.String(v.(string))
+		nameValue := web.NameValuePair{
+			Name:  utils.String(k),
+			Value: utils.String(v.(string)),
+		}
+		output = append(output, nameValue)
 	}
 
 	return output


### PR DESCRIPTION
Hi 

fixes #13780 

Currently the app settings defined in `app_settings` property are updated after the resource is created, so basically the resource is performing the following steps:
1. Create Logic app wiht basic settings (resource defined settings)
2. Calls update resource to update `app_settings` with user defined settings.

The problem is there are some app_settings must be defined at creation time for example in order to create a logic app using storage account with private endpoints `WEBSITE_CONTENTOVERVNET` is required at creation time. [See microsoft docs for more details](https://docs.microsoft.com/en-us/azure/logic-apps/secure-single-tenant-workflow-virtual-network-private-endpoint#connect-to-storage-account-with-private-endpoints).

So In this PR I'm modifying the resource to create the custom settings (defined in `app_settings`) and the basic settings (resource defined app settings) at the same logic app creation time.


 
