### PR TITLE
azurerm_application_insights -  increase allowed validate for the daily_data_cap_in_gb property

### DIFF
--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -113,7 +113,7 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeFloat,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.FloatBetween(0, 1000),
+				ValidateFunc: validation.FloatAtLeast(0),
 			},
 
 			"daily_data_cap_notifications_disabled": {


### PR DESCRIPTION
- While there is a documented cap of 1,000 GB/day, a customer can request more

From the docs
> The maximum cap in Application Insights is 1,000 GB/day unless you request a higher maximum for a high-traffic application.

Ref: https://docs.microsoft.com/en-us/azure/azure-monitor/app/pricing#managing-your-data-volume

- Removing upper limit here as this isn't a hard limit, just the default initial limit
- If a customer has a higher limit, then terraform fails, but azure will accept the higher limit for them