### PR TITLE
Updated documentation for `azurerm_frontdoor_rules_engine`

### DIFF
--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_frontdoor_rules_engine" "example_rules_engine" {
     priority = 1
 
     action {
-      response_header_actions {
+      response_header {
         header_action_type = "Append"
         header_name        = "X-TEST-HEADER"
         value              = "Append Header Rule"


### PR DESCRIPTION
Tiny docs fix for `azurerm_frontdoor_rules_engine` resource.

Updated `response_header_actions` to `response_header`, 

```bash
Error: Unsupported block type

  on main.tf line 449, in resource "azurerm_frontdoor_rules_engine" "frontend_default_rules_engine":
 449:       response_header_actions {

Blocks of type "response_header_actions" are not expected here.
```