### PR TITLE
`azurerm_firewall_policy_rule_collection_group` - add supports of `translatedFqdn` for NAT rule

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -394,13 +394,18 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 									},
 									"translated_address": {
 										Type:         pluginsdk.TypeString,
-										Required:     true,
+										Optional:     true,
 										ValidateFunc: validation.IsIPAddress,
 									},
 									"translated_port": {
 										Type:         pluginsdk.TypeInt,
 										Required:     true,
 										ValidateFunc: validation.IsPortNumber,
+									},
+									"translated_fqdn": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
 							},
@@ -447,7 +452,13 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 	var rulesCollections []network.BasicFirewallPolicyRuleCollection
 	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionApplication(d.Get("application_rule_collection").(*pluginsdk.Set).List())...)
 	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionNetwork(d.Get("network_rule_collection").(*pluginsdk.Set).List())...)
-	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionNat(d.Get("nat_rule_collection").(*pluginsdk.Set).List())...)
+
+	natRules, err := expandFirewallPolicyRuleCollectionNat(d.Get("nat_rule_collection").(*pluginsdk.Set).List())
+	if err != nil {
+		return fmt.Errorf("expanding NAT rule collection: %w", err)
+	}
+	rulesCollections = append(rulesCollections, natRules...)
+
 	param.FirewallPolicyRuleCollectionGroupProperties.RuleCollections = &rulesCollections
 
 	future, err := client.CreateOrUpdate(ctx, policyId.ResourceGroup, policyId.Name, name, param)
@@ -552,10 +563,14 @@ func expandFirewallPolicyRuleCollectionNetwork(input []interface{}) []network.Ba
 	return expandFirewallPolicyFilterRuleCollection(input, expandFirewallPolicyRuleNetwork)
 }
 
-func expandFirewallPolicyRuleCollectionNat(input []interface{}) []network.BasicFirewallPolicyRuleCollection {
+func expandFirewallPolicyRuleCollectionNat(input []interface{}) ([]network.BasicFirewallPolicyRuleCollection, error) {
 	result := make([]network.BasicFirewallPolicyRuleCollection, 0)
 	for _, e := range input {
 		rule := e.(map[string]interface{})
+		rules, err := expandFirewallPolicyRuleNat(rule["rule"].(*pluginsdk.Set).List())
+		if err != nil {
+			return nil, err
+		}
 		output := &network.FirewallPolicyNatRuleCollection{
 			RuleCollectionType: network.RuleCollectionTypeFirewallPolicyNatRuleCollection,
 			Name:               utils.String(rule["name"].(string)),
@@ -563,11 +578,11 @@ func expandFirewallPolicyRuleCollectionNat(input []interface{}) []network.BasicF
 			Action: &network.FirewallPolicyNatRuleCollectionAction{
 				Type: network.FirewallPolicyNatRuleCollectionActionType(rule["action"].(string)),
 			},
-			Rules: expandFirewallPolicyRuleNat(rule["rule"].(*pluginsdk.Set).List()),
+			Rules: rules,
 		}
 		result = append(result, output)
 	}
-	return result
+	return result, nil
 }
 
 func expandFirewallPolicyFilterRuleCollection(input []interface{}, f func(input []interface{}) *[]network.BasicFirewallPolicyRule) []network.BasicFirewallPolicyRuleCollection {
@@ -643,7 +658,7 @@ func expandFirewallPolicyRuleNetwork(input []interface{}) *[]network.BasicFirewa
 	return &result
 }
 
-func expandFirewallPolicyRuleNat(input []interface{}) *[]network.BasicFirewallPolicyRule {
+func expandFirewallPolicyRuleNat(input []interface{}) (*[]network.BasicFirewallPolicyRule, error) {
 	result := make([]network.BasicFirewallPolicyRule, 0)
 	for _, e := range input {
 		condition := e.(map[string]interface{})
@@ -652,6 +667,14 @@ func expandFirewallPolicyRuleNat(input []interface{}) *[]network.BasicFirewallPo
 			protocols = append(protocols, network.FirewallPolicyRuleNetworkProtocol(p.(string)))
 		}
 		destinationAddresses := []string{condition["destination_address"].(string)}
+
+		// Exactly one of `translated_address` and `translated_fqdn` should be set.
+		if condition["translated_address"].(string) != "" && condition["translated_fqdn"].(string) != "" {
+			return nil, fmt.Errorf("can't specify both `translated_address` and `translated_fqdn` in rule %s", condition["name"].(string))
+		}
+		if condition["translated_address"].(string) == "" && condition["translated_fqdn"].(string) == "" {
+			return nil, fmt.Errorf("should specify either `translated_address` or `translated_fqdn` in rule %s", condition["name"].(string))
+		}
 		output := &network.NatRule{
 			Name:                 utils.String(condition["name"].(string)),
 			RuleType:             network.RuleTypeNatRule,
@@ -660,12 +683,17 @@ func expandFirewallPolicyRuleNat(input []interface{}) *[]network.BasicFirewallPo
 			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].(*pluginsdk.Set).List()),
 			DestinationAddresses: &destinationAddresses,
 			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].(*pluginsdk.Set).List()),
-			TranslatedAddress:    utils.String(condition["translated_address"].(string)),
 			TranslatedPort:       utils.String(strconv.Itoa(condition["translated_port"].(int))),
+		}
+		if condition["translated_address"].(string) != "" {
+			output.TranslatedAddress = utils.String(condition["translated_address"].(string))
+		}
+		if condition["translated_fqdn"].(string) != "" {
+			output.TranslatedFqdn = utils.String(condition["translated_fqdn"].(string))
 		}
 		result = append(result, output)
 	}
-	return &result
+	return &result, nil
 }
 
 func flattenFirewallPolicyRuleCollection(input *[]network.BasicFirewallPolicyRuleCollection) ([]interface{}, []interface{}, []interface{}, error) {
@@ -896,6 +924,16 @@ func flattenFirewallPolicyRuleNat(input *[]network.BasicFirewallPolicyRule) ([]i
 			translatedPort = port
 		}
 
+		translatedAddress := ""
+		if rule.TranslatedAddress != nil {
+			translatedAddress = *rule.TranslatedAddress
+		}
+
+		translatedFQDN := ""
+		if rule.TranslatedFqdn != nil {
+			translatedFQDN = *rule.TranslatedFqdn
+		}
+
 		output = append(output, map[string]interface{}{
 			"name":                name,
 			"protocols":           protocols,
@@ -903,8 +941,9 @@ func flattenFirewallPolicyRuleNat(input *[]network.BasicFirewallPolicyRule) ([]i
 			"source_ip_groups":    utils.FlattenStringSlice(rule.SourceIPGroups),
 			"destination_address": destinationAddr,
 			"destination_ports":   utils.FlattenStringSlice(rule.DestinationPorts),
-			"translated_address":  rule.TranslatedAddress,
-			"translated_port":     &translatedPort,
+			"translated_address":  translatedAddress,
+			"translated_port":     translatedPort,
+			"translated_fqdn":     translatedFQDN,
 		})
 	}
 	return output, nil

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -303,6 +303,15 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
       translated_address  = "192.168.0.1"
       translated_port     = "8080"
     }
+    rule {
+      name                = "nat_rule_collection1_rule3"
+      protocols           = ["TCP", "UDP"]
+      source_addresses    = ["10.0.0.1", "10.0.0.2"]
+      destination_address = "192.168.1.1"
+      destination_ports   = ["80"]
+      translated_fqdn     = "time.microsoft.com"
+      translated_port     = "8080"
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -194,7 +194,11 @@ A `rule` (nat rule) block supports the following:
 
 * `destination_ports` - (Optional) Specifies a list of destination ports.
 
-* `translated_address` - (Required) Specifies the translated address.
+* `translated_address` - (Optional) Specifies the translated address.
+ 
+* `translated_fqdn` - (Optional) Specifies the translated FQDN.
+
+~> **NOTE:** Exactly one of `translated_address` and `translated_fqdn` should be set.
 
 * `translated_port` - (Required) Specifies the translated port.
 


### PR DESCRIPTION
## Test Result

```bash
💢 TF_ACC=1 go test -v -timeout=20h ./internal/services/firewall -run="TestAccFirewallPolicyRuleCollectionGroup_complete$"
=== RUN   TestAccFirewallPolicyRuleCollectionGroup_complete
=== PAUSE TestAccFirewallPolicyRuleCollectionGroup_complete
=== CONT  TestAccFirewallPolicyRuleCollectionGroup_complete
--- PASS: TestAccFirewallPolicyRuleCollectionGroup_complete (253.91s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      253.947s
```