### PR TITLE
Fix the HCL example in the sentinel documents

### DIFF
--- a/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
+++ b/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "pergb2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "example" {
   name                       = "example-ml-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   alert_rule_template_guid   = "737a2ce1-70a3-4968-9e90-3e6aca836abf"
 }
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "pergb2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_alert_rule_fusion" "example" {
   name                       = "example-fusion-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   alert_rule_template_guid   = "f71aba3d-28fb-450b-b192-4e76a83015c8"
 }
 ```

--- a/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
@@ -29,9 +29,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "pergb2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "example" {
   name                       = "example-ms-security-incident-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "example rule"
   severity_filter            = ["High"]

--- a/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
@@ -29,9 +29,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "pergb2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_alert_rule_scheduled" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   display_name               = "example"
   severity                   = "High"
   query                      = <<QUERY

--- a/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
+++ b/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_aws_cloud_trail" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   aws_role_arn               = "arn:aws:iam::000000000000:role/role1"
 }
 ```

--- a/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_azure_active_directory" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
@@ -27,9 +27,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_azure_security_center" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
@@ -27,9 +27,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_office_365" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
@@ -25,9 +25,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
 resource "azurerm_sentinel_data_connector_threat_intelligence" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 ```
 


### PR DESCRIPTION
Adding the missing step that register the log analytics solution in the sentinel resource documents. Fixes #11128.