### PR TITLE
linting: increasing the timeout to 60m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 40m
+  timeout: 60m
   modules-download-mode: vendor
   skip-dirs:
     - /sdk/ # Excluding sdk folders as these are externally generated


### PR DESCRIPTION
This is temporary to workaround the embedded SDK's