### PR TITLE
Add `key_vault_reference_identity_id` attribute for `azurerm_app_service_slot`

### DIFF
--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -172,6 +172,8 @@ The following arguments are supported:
 
 * `identity` - (Optional) A Managed Service Identity block as defined below.
 
+* `key_vault_reference_identity_id` - (Optional) The User Assigned Identity Id used for looking up KeyVault secrets. The identity must be assigned to the application. See [Access vaults with a user-assigned identity](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity) for more information.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
This PR is related to PR #13720 and #13962 and adds support for `key_vault_reference_identity_id` to `azurerm_app_service_slot`. This work is based on @patst's work in PR #13720. 

```console
=== RUN   TestAccAppServiceSlot_keyVaultUserAssignedIdentity
=== PAUSE TestAccAppServiceSlot_keyVaultUserAssignedIdentity
=== CONT  TestAccAppServiceSlot_keyVaultUserAssignedIdentity
--- PASS: TestAccAppServiceSlot_keyVaultUserAssignedIdentity (233.09s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/web   233.130s
```

This PR closes #13968 


