### PR TITLE
azurerm_monitor_smart_detector_alert_rule: Support additional detector types

### DIFF
--- a/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
+++ b/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
@@ -55,6 +55,11 @@ func resourceMonitorSmartDetectorAlertRule() *pluginsdk.Resource {
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"FailureAnomaliesDetector",
+					"RequestPerformanceDegradationDetector",
+					"DependencyPerformanceDegradationDetector",
+					"ExceptionVolumeChangedDetector",
+					"TraceSeverityDetector",
+					"MemoryLeakDetector",
 				}, false),
 			},
 

--- a/website/docs/r/monitor_smart_detector_alert_rule.html.markdown
+++ b/website/docs/r/monitor_smart_detector_alert_rule.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the resource group in which the Monitor Smart Detector Alert Rule should exist. Changing this forces a new resource to be created.
 
-* `detector_type` - (Required) Specifies the Built-In Smart Detector type that this alert rule will use. Currently the only possible value is `FailureAnomaliesDetector`.
+* `detector_type` - (Required) Specifies the Built-In Smart Detector type that this alert rule will use. Currently the only possible values are `FailureAnomaliesDetector`, `RequestPerformanceDegradationDetector`, `DependencyPerformanceDegradationDetector`, `ExceptionVolumeChangedDetector`, `TraceSeverityDetector`, `MemoryLeakDetector`.
 
 * `scope_resource_ids` - (Required) Specifies the scopes of this Smart Detector Alert Rule.
 


### PR DESCRIPTION
PR raised to implement #13997

Azure Monitor App Insights now supports additional detector types "RequestPerformanceDegradationDetector", "DependencyPerformanceDegradationDetector", "ExceptionVolumeChangedDetector", "TraceSeverityDetector", "MemoryLeakDetector" as smart detection alerts.

See [Migrate Azure Monitor Application Insights smart detection to alerts (Preview)](https://docs.microsoft.com/en-gb/azure/azure-monitor/alerts/alerts-smart-detections-migration)

This PR updates the client side validation to allow the additional detector types for `azurerm_monitor_smart_detector_alert_rule` to be deployable via Terraform.


Once deployed the alert rules are understood as Signal Type = "Smart Detector" with the Condition text populated by Azure.
![image](https://user-images.githubusercontent.com/52744495/139910607-494f23e4-b857-4d49-90fb-62fb321c1d61.png)


