### PR TITLE
`azurerm_firewall_policy - add supports for the `insights`

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/validate"
+	logAnalytiscValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/validate"
 	msiValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -299,6 +302,44 @@ func resourceFirewallPolicy() *pluginsdk.Resource {
 				},
 			},
 
+			"insights": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Required: true,
+						},
+						"default_log_analytics_workspace_id": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: logAnalytiscValidate.LogAnalyticsWorkspaceID,
+						},
+						"retention_in_days": {
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+						"log_analytics_workspace": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: logAnalytiscValidate.LogAnalyticsWorkspaceID,
+									},
+									"firewall_location": location.SchemaWithoutForceNew(),
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"child_policies": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -369,6 +410,7 @@ func resourceFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			DNSSettings:          expandFirewallPolicyDNSSetting(d.Get("dns").([]interface{})),
 			IntrusionDetection:   expandFirewallPolicyIntrusionDetection(d.Get("intrusion_detection").([]interface{})),
 			TransportSecurity:    expandFirewallPolicyTransportSecurity(d.Get("tls_certificate").([]interface{})),
+			Insights:             expandFirewallPolicyInsights(d.Get("insights").([]interface{})),
 		},
 		Identity: expandFirewallPolicyIdentity(d.Get("identity").([]interface{})),
 		Location: utils.String(location.Normalize(d.Get("location").(string))),
@@ -482,6 +524,10 @@ func resourceFirewallPolicyRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 		if err := d.Set("private_ip_ranges", privateIPRanges); err != nil {
 			return fmt.Errorf("setting `private_ip_ranges`: %+v", err)
+		}
+
+		if err := d.Set("insights", flattenFirewallPolicyInsights(prop.Insights)); err != nil {
+			return fmt.Errorf(`setting "insights": %+v`, err)
 		}
 	}
 
@@ -626,6 +672,45 @@ func expandFirewallPolicyIdentity(input []interface{}) *network.ManagedServiceId
 		TenantID:               utils.String(v["tenant_id"].(string)),
 		UserAssignedIdentities: userAssignedIdentities,
 	}
+}
+
+func expandFirewallPolicyInsights(input []interface{}) *network.FirewallPolicyInsights {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	output := &network.FirewallPolicyInsights{
+		IsEnabled:             utils.Bool(raw["enabled"].(bool)),
+		RetentionDays:         utils.Int32(int32(raw["retention_in_days"].(int))),
+		LogAnalyticsResources: expandFirewallPolicyLogAnalyticsResources(raw["default_log_analytics_workspace_id"].(string), raw["log_analytics_workspace"].([]interface{})),
+	}
+
+	return output
+}
+
+func expandFirewallPolicyLogAnalyticsResources(defaultWorkspaceId string, workspaces []interface{}) *network.FirewallPolicyLogAnalyticsResources {
+	output := &network.FirewallPolicyLogAnalyticsResources{
+		DefaultWorkspaceID: &network.SubResource{
+			ID: &defaultWorkspaceId,
+		},
+	}
+
+	var workspaceList []network.FirewallPolicyLogAnalyticsWorkspace
+	for _, workspace := range workspaces {
+		workspace := workspace.(map[string]interface{})
+		workspaceList = append(workspaceList, network.FirewallPolicyLogAnalyticsWorkspace{
+			Region: utils.String(location.Normalize(workspace["firewall_location"].(string))),
+			WorkspaceID: &network.SubResource{
+				ID: utils.String(workspace["id"].(string)),
+			},
+		})
+	}
+	if workspaceList != nil {
+		output.Workspaces = &workspaceList
+	}
+
+	return output
 }
 
 func flattenFirewallPolicyThreatIntelWhitelist(input *network.FirewallPolicyThreatIntelWhitelist) []interface{} {
@@ -793,4 +878,61 @@ func flattenFirewallPolicyIdentity(identity *network.ManagedServiceIdentity) []i
 			"user_assigned_identity_ids": userAssignedIdentities,
 		},
 	}
+}
+
+func flattenFirewallPolicyInsights(input *network.FirewallPolicyInsights) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var enabled bool
+	if input.IsEnabled != nil {
+		enabled = *input.IsEnabled
+	}
+
+	var retentionInDays int
+	if input.RetentionDays != nil {
+		retentionInDays = int(*input.RetentionDays)
+	}
+
+	defaultLogAnalyticsWorspaceId, logAnalyticsWorkspaces := flattenFirewallPolicyLogAnalyticsResources(input.LogAnalyticsResources)
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled":                            enabled,
+			"retention_in_days":                  retentionInDays,
+			"default_log_analytics_workspace_id": defaultLogAnalyticsWorspaceId,
+			"log_analytics_workspace":            logAnalyticsWorkspaces,
+		},
+	}
+}
+
+func flattenFirewallPolicyLogAnalyticsResources(input *network.FirewallPolicyLogAnalyticsResources) (string, []interface{}) {
+	if input == nil {
+		return "", []interface{}{}
+	}
+
+	var defaultLogAnalyticsWorkspaceId string
+	if input.DefaultWorkspaceID != nil && input.DefaultWorkspaceID.ID != nil {
+		defaultLogAnalyticsWorkspaceId = *input.DefaultWorkspaceID.ID
+	}
+
+	var workspaceList []interface{}
+	if input.Workspaces != nil {
+		for _, workspace := range *input.Workspaces {
+			loc := location.NormalizeNilable(workspace.Region)
+
+			var id string
+			if workspace.WorkspaceID != nil && workspace.WorkspaceID.ID != nil {
+				id = *workspace.WorkspaceID.ID
+			}
+
+			workspaceList = append(workspaceList, map[string]interface{}{
+				"id":                id,
+				"firewall_location": loc,
+			})
+		}
+	}
+
+	return defaultLogAnalyticsWorkspaceId, workspaceList
 }

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below. Changing this forces a new Firewall Policy to be created.
 
+* `insights` - (Optional) An `insights` block as defined below.
+
 * `intrusion_detection` - (Optional) A `intrusion_detection` block as defined below.
 
 * `private_ip_ranges` - (Optional) A list of private IP ranges to which traffic will not be SNAT.
@@ -72,6 +74,18 @@ A `identity` block supports the following:
 
 ---
 
+An `insights` block supports the following:
+
+* `enabled` - (Required) Whether the insights functionality is enabled for this Firewall Policy.
+
+* `default_log_analytics_workspace_id` - (Required) The ID of the default Log Analytics Workspace that the Firewalls associated with this Firewall Policy will send their logs to, when there is no location matches in the `log_analytics_workspace`.
+
+* `retention_in_days` - (Optional) The log retention period in days. 
+
+* `log_analytics_workspace` - (Optional) A list of `log_analytics_workspace` block as defined below.
+
+---
+
 A `intrusion_detection` block supports the following:
 
 * `mode` - (Optional) In which mode you want to run intrusion detection: "Off", "Alert" or "Deny".
@@ -79,6 +93,14 @@ A `intrusion_detection` block supports the following:
 * `signature_overrides` - (Optional) One or more `signature_overrides` blocks as defined below.
 
 * `traffic_bypass` - (Optional) One or more `traffic_bypass` blocks as defined below.
+
+---
+
+A `log_analytisc_workspace` block supports the following:
+
+* `id` - (Required) The ID of the Log Analytics Workspace that the Firewalls associated with this Firewall Policy will send their logs to when their locations match the `firewall_location`.
+
+* `firewall_location` - (Required) The location of the Firewalls, that when matches this Log Analytics Workspace will be used to consume their logs.
 
 ---
 


### PR DESCRIPTION
This PR add supports of the `insights` for the `azurerm_firewall_policy`.

This feature logs additional information in the backend and these workspaces are used for logging. Firewall policy can be associated with one or more Firewalls. The cost of logging data across regions is expensive. Imagine a firewall running in India West logging to East US. It’s way too expensive. This feature provide an ability to control where the Firewall will log based on the region where it’s deployed. If Firewall is in an unspecified region, the default workspace ID kicks in.

## Test

```shell
💢 TF_ACC=1 go test -v -timeout=20h ./internal/services/firewall -run="TestAccFirewallPolicy_insights"
=== RUN   TestAccFirewallPolicy_insights
=== PAUSE TestAccFirewallPolicy_insights
=== CONT  TestAccFirewallPolicy_insights
--- PASS: TestAccFirewallPolicy_insights (464.12s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      464.151s
```