### PR TITLE
new resource `azurerm_stream_analytics_output_synapse`

### DIFF
--- a/internal/services/streamanalytics/registration.go
+++ b/internal/services/streamanalytics/registration.go
@@ -49,6 +49,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_stream_analytics_output_eventhub":         resourceStreamAnalyticsOutputEventHub(),
 		"azurerm_stream_analytics_output_servicebus_queue": resourceStreamAnalyticsOutputServiceBusQueue(),
 		"azurerm_stream_analytics_output_servicebus_topic": resourceStreamAnalyticsOutputServiceBusTopic(),
+		"azurerm_stream_analytics_output_synapse":          resourceStreamAnalyticsOutputSynapse(),
 		"azurerm_stream_analytics_reference_input_blob":    resourceStreamAnalyticsReferenceInputBlob(),
 		"azurerm_stream_analytics_reference_input_mssql":   resourceStreamAnalyticsReferenceMsSql(),
 		"azurerm_stream_analytics_stream_input_blob":       resourceStreamAnalyticsStreamInputBlob(),

--- a/internal/services/streamanalytics/stream_analytics_output.go
+++ b/internal/services/streamanalytics/stream_analytics_output.go
@@ -1,0 +1,65 @@
+package streamanalytics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/streamanalytics/mgmt/2020-03-01-preview/streamanalytics"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func importStreamAnalyticsOutput(expectType streamanalytics.TypeBasicOutputDataSource) pluginsdk.ImporterFunc {
+	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
+		id, err := parse.OutputID(d.Id())
+		if err != nil {
+			return nil, err
+		}
+
+		client := meta.(*clients.Client).StreamAnalytics.OutputsClient
+		resp, err := client.Get(ctx, id.ResourceGroup, id.StreamingjobName, id.Name)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+		}
+
+		if props := resp.OutputProperties; props != nil {
+			var actualType streamanalytics.TypeBasicOutputDataSource
+
+			if datasource, ok := props.Datasource.AsBlobOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsAzureTableOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsEventHubOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsEventHubV2OutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsAzureSQLDatabaseOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsAzureSynapseOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsDocumentDbOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsAzureFunctionOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsServiceBusQueueOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsServiceBusTopicOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsPowerBIOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsAzureDataLakeStoreOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else if datasource, ok := props.Datasource.AsOutputDataSource(); ok {
+				actualType = datasource.Type
+			} else {
+				return nil, fmt.Errorf("unable to convert output data source: %+v", props.Datasource)
+			}
+
+			if actualType != expectType {
+				return nil, fmt.Errorf("stream analytics output has mismatched type, expected: %q, got %q", expectType, actualType)
+			}
+		}
+		return []*pluginsdk.ResourceData{d}, nil
+	}
+}

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
@@ -1,0 +1,208 @@
+package streamanalytics
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/streamanalytics/mgmt/2020-03-01-preview/streamanalytics"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceStreamAnalyticsOutputSynapse() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceStreamAnalyticsOutputSynapseCreateUpdate,
+		Read:   resourceStreamAnalyticsOutputSynapseRead,
+		Update: resourceStreamAnalyticsOutputSynapseCreateUpdate,
+		Delete: resourceStreamAnalyticsOutputSynapseDelete,
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.OutputID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"stream_analytics_job_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"server": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"database": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"table": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"user": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"password": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+
+func resourceStreamAnalyticsOutputSynapseCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).StreamAnalytics.OutputsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	id := parse.NewOutputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.StreamingjobName, id.Name)
+		if err != nil && !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for presence of %s: %+v", id, err)
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_stream_analytics_output_synapse", id.ID())
+		}
+	}
+
+	server := d.Get("server").(string)
+	databaseName := d.Get("database").(string)
+	tableName := d.Get("table").(string)
+	sqlUser := d.Get("user").(string)
+	sqlUserPassword := d.Get("password").(string)
+
+	props := streamanalytics.Output{
+		Name: utils.String(id.Name),
+		OutputProperties: &streamanalytics.OutputProperties{
+			Datasource: &streamanalytics.AzureSynapseOutputDataSource{
+				Type: streamanalytics.TypeMicrosoftSQLServerDataWarehouse,
+				AzureSynapseOutputDataSourceProperties: &streamanalytics.AzureSynapseOutputDataSourceProperties{
+					Server:   utils.String(server),
+					Database: utils.String(databaseName),
+					User:     utils.String(sqlUser),
+					Password: utils.String(sqlUserPassword),
+					Table:    utils.String(tableName),
+				},
+			},
+		},
+	}
+
+	if d.IsNewResource() {
+		if _, err := client.CreateOrReplace(ctx, props, id.ResourceGroup, id.StreamingjobName, id.Name, "", ""); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+
+		d.SetId(id.ID())
+	} else if _, err := client.Update(ctx, props, id.ResourceGroup, id.StreamingjobName, id.Name, ""); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	return resourceStreamAnalyticsOutputSynapseRead(d, meta)
+}
+
+func resourceStreamAnalyticsOutputSynapseRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).StreamAnalytics.OutputsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.OutputID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.StreamingjobName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] %s was not found - removing from state!", id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retreving %s: %+v", *id, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("stream_analytics_job_name", id.StreamingjobName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
+	if props := resp.OutputProperties; props != nil {
+		v, ok := props.Datasource.AsAzureSynapseOutputDataSource()
+		if !ok {
+			return fmt.Errorf("converting Output Data Source to Synapse Output: %+v", err)
+		}
+
+		d.Set("server", v.Server)
+		d.Set("database", v.Database)
+		d.Set("table", v.Table)
+		d.Set("user", v.User)
+	}
+
+	return nil
+}
+
+func resourceStreamAnalyticsOutputSynapseDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).StreamAnalytics.OutputsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.OutputID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.Delete(ctx, id.ResourceGroup, id.StreamingjobName, id.Name); err != nil {
+		if !response.WasNotFound(resp.Response) {
+			return fmt.Errorf("deleting %s: %+v", *id, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -81,16 +82,17 @@ func TestAccStreamAnalyticsOutputSynapse_requiresImport(t *testing.T) {
 }
 
 func (r StreamAnalyticsOutputSynapseResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	name := state.Attributes["name"]
-	jobName := state.Attributes["stream_analytics_job_name"]
-	resourceGroup := state.Attributes["resource_group_name"]
+	id, err := parse.OutputID(state.ID)
+	if err != nil {
+		return nil, err
+	}
 
-	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, resourceGroup, jobName, name)
+	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, id.ResourceGroup, id.StreamingjobName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retrieving Stream Output %q (Stream Analytics Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 	return utils.Bool(true), nil
 }

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -1,0 +1,235 @@
+package streamanalytics_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type StreamAnalyticsOutputSynapseResource struct{}
+
+func TestAccStreamAnalyticsOutputSynapse_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_synapse", "test")
+	r := StreamAnalyticsOutputSynapseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("password"),
+	})
+}
+
+func TestAccStreamAnalyticsOutputSynapse_sqlPool(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_synapse", "test")
+	r := StreamAnalyticsOutputSynapseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sqlPool(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("password"),
+	})
+}
+
+func TestAccStreamAnalyticsOutputSynapse_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_synapse", "test")
+	r := StreamAnalyticsOutputSynapseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("password"),
+	})
+}
+
+func TestAccStreamAnalyticsOutputSynapse_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_synapse", "test")
+	r := StreamAnalyticsOutputSynapseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r StreamAnalyticsOutputSynapseResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	name := state.Attributes["name"]
+	jobName := state.Attributes["stream_analytics_job_name"]
+	resourceGroup := state.Attributes["resource_group_name"]
+
+	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, resourceGroup, jobName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving Stream Output %q (Stream Analytics Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r StreamAnalyticsOutputSynapseResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_stream_analytics_output_synapse" "test" {
+  name                      = "acctestoutput-%[2]d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+
+  server   = azurerm_synapse_workspace.test.connectivity_endpoints["sqlOnDemand"]
+  user     = azurerm_synapse_workspace.test.sql_administrator_login
+  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  database = "master"
+  table    = "AccTestTable"
+}
+`, template, data.RandomInteger)
+}
+
+func (r StreamAnalyticsOutputSynapseResource) sqlPool(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_synapse_sql_pool" "test" {
+  name                 = "acctestSP%[3]s"
+  synapse_workspace_id = azurerm_synapse_workspace.test.id
+  sku_name             = "DW100c"
+  create_mode          = "Default"
+}
+
+resource "azurerm_stream_analytics_output_synapse" "test" {
+  name                      = "acctestoutput-%[2]d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+
+  server   = azurerm_synapse_workspace.test.connectivity_endpoints["sql"]
+  user     = azurerm_synapse_workspace.test.sql_administrator_login
+  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  database = azurerm_synapse_sql_pool.test.name
+  table    = "AccTestTable"
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r StreamAnalyticsOutputSynapseResource) updated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_stream_analytics_output_synapse" "test" {
+  name                      = "acctestoutput-updated-%[2]d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+
+  server   = azurerm_synapse_workspace.test.connectivity_endpoints["sqlOnDemand"]
+  user     = azurerm_synapse_workspace.test.sql_administrator_login
+  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  database = "master"
+  table    = "AccTestTable"
+}
+`, template, data.RandomInteger)
+}
+
+func (r StreamAnalyticsOutputSynapseResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_stream_analytics_output_synapse" "import" {
+  name                      = azurerm_stream_analytics_output_synapse.test.name
+  stream_analytics_job_name = azurerm_stream_analytics_output_synapse.test.stream_analytics_job_name
+  resource_group_name       = azurerm_stream_analytics_output_synapse.test.resource_group_name
+
+  server   = azurerm_synapse_workspace.test.connectivity_endpoints["sqlOnDemand"]
+  user     = azurerm_synapse_workspace.test.sql_administrator_login
+  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  database = "master"
+  table    = "AccTestTable"
+}
+`, template)
+}
+
+func (r StreamAnalyticsOutputSynapseResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
+  name               = "acctestdlfs%[3]s"
+  storage_account_id = azurerm_storage_account.test.id
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%[3]s"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+}
+
+resource "azurerm_stream_analytics_job" "test" {
+  name                                     = "acctestjob-%[3]s"
+  resource_group_name                      = azurerm_resource_group.test.name
+  location                                 = azurerm_resource_group.test.location
+  compatibility_level                      = "1.0"
+  data_locale                              = "en-GB"
+  events_late_arrival_max_delay_in_seconds = 60
+  events_out_of_order_max_delay_in_seconds = 50
+  events_out_of_order_policy               = "Adjust"
+  output_error_policy                      = "Drop"
+  streaming_units                          = 3
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/docs/r/stream_analytics_output_synapse.html.markdown
+++ b/website/docs/r/stream_analytics_output_synapse.html.markdown
@@ -83,16 +83,16 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ID of the Stream Analytics Output Microsoft SQL Server Database.
+* `id` - The ID of the Stream Analytics Output to an Azure Synapse Analytics Workspace.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output Microsoft SQL Server Database.
-* `update` - (Defaults to 30 minutes) Used when updating the Stream Analytics Output Microsoft SQL Server Database.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics Output Microsoft SQL Server Database.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Stream Analytics Output Microsoft SQL Server Database.
+* `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output to an Azure Synapse Analytics Workspace.
+* `update` - (Defaults to 30 minutes) Used when updating the Stream Analytics Output to an Azure Synapse Analytics Workspace.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics Output to an Azure Synapse Analytics Workspace.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Stream Analytics Output to an Azure Synapse Analytics Workspace.
 
 ## Import
 

--- a/website/docs/r/stream_analytics_output_synapse.html.markdown
+++ b/website/docs/r/stream_analytics_output_synapse.html.markdown
@@ -1,0 +1,103 @@
+---
+subcategory: "Stream Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_stream_analytics_output_synapse"
+description: |-
+  Manages a Stream Analytics Output to an Azure Synapse Analytics Workspace.
+---
+
+# azurerm_stream_analytics_output_synapse
+
+Manages a Stream Analytics Output to an Azure Synapse Analytics Workspace.
+
+## Example Usage
+
+```hcl
+data "azurerm_resource_group" "example" {
+  name = "example-resources"
+}
+
+data "azurerm_stream_analytics_job" "example" {
+  name                = "example-job"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageacc"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  is_hns_enabled           = "true"
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "example" {
+  name               = "example"
+  storage_account_id = azurerm_storage_account.example.id
+}
+
+resource "azurerm_synapse_workspace" "example" {
+  name                                 = "example"
+  resource_group_name                  = azurerm_resource_group.example.name
+  location                             = azurerm_resource_group.example.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+}
+
+resource "azurerm_stream_analytics_output_synapse" "example" {
+  name                      = "example-output-synapse"
+  stream_analytics_job_name = azurerm_stream_analytics_job.example.name
+  resource_group_name       = azurerm_stream_analytics_job.example.resource_group_name
+
+  server   = azurerm_synapse_workspace.test.connectivity_endpoints["sqlOnDemand"]
+  user     = azurerm_synapse_workspace.test.sql_administrator_login
+  password = azurerm_synapse_workspace.test.sql_administrator_login_password
+  database = "master"
+  table    = "ExampleTable"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Stream Output. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Stream Analytics Job exists. Changing this forces a new resource to be created.
+
+* `stream_analytics_job_name` - (Required) The name of the Stream Analytics Job. Changing this forces a new resource to be created.
+
+* `server` - (Required) The name of the SQL server containing the Azure SQL database. Changing this forces a new resource to be created.
+
+* `database` - (Required) The name of the Azure SQL database. Changing this forces a new resource to be created.
+
+* `user` - (Required) The user name that will be used to connect to the Azure SQL database. Changing this forces a new resource to be created.
+
+* `password` - (Required) The password that will be used to connect to the Azure SQL database. Changing this forces a new resource to be created.
+
+* `table` - (Required) The name of the table in the Azure SQL database. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ID of the Stream Analytics Output Microsoft SQL Server Database.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output Microsoft SQL Server Database.
+* `update` - (Defaults to 30 minutes) Used when updating the Stream Analytics Output Microsoft SQL Server Database.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics Output Microsoft SQL Server Database.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Stream Analytics Output Microsoft SQL Server Database.
+
+## Import
+
+A Stream Analytics Output to an Azure Synapse Analytics Workspace can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_stream_analytics_output_synapse.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request adds a new resource to manage a Stream Analytics output to a Synapse Workspace.

Fixes: #8881

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='streamanalytics' TESTARGS='-run="^TestAccStreamAnalyticsOutputSynapse_"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/streamanalytics -run="^TestAccStreamAnalyticsOutputSynapse_" -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStreamAnalyticsOutputSynapse_basic
=== PAUSE TestAccStreamAnalyticsOutputSynapse_basic
=== RUN   TestAccStreamAnalyticsOutputSynapse_sqlPool
=== PAUSE TestAccStreamAnalyticsOutputSynapse_sqlPool
=== RUN   TestAccStreamAnalyticsOutputSynapse_update
=== PAUSE TestAccStreamAnalyticsOutputSynapse_update
=== RUN   TestAccStreamAnalyticsOutputSynapse_requiresImport
=== PAUSE TestAccStreamAnalyticsOutputSynapse_requiresImport
=== CONT  TestAccStreamAnalyticsOutputSynapse_basic
=== CONT  TestAccStreamAnalyticsOutputSynapse_update
=== CONT  TestAccStreamAnalyticsOutputSynapse_requiresImport
=== CONT  TestAccStreamAnalyticsOutputSynapse_sqlPool
--- PASS: TestAccStreamAnalyticsOutputSynapse_basic (629.72s)
--- PASS: TestAccStreamAnalyticsOutputSynapse_requiresImport (794.48s)
--- PASS: TestAccStreamAnalyticsOutputSynapse_update (895.11s)
--- PASS: TestAccStreamAnalyticsOutputSynapse_sqlPool (1147.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       1150.196s
```
