### PR TITLE
`managed_disk_resource`: Add `disk_iops_read_only`, `disk_mbps_read_only`

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -145,6 +145,20 @@ func resourceManagedDisk() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"disk_iops_read_only": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+
+			"disk_mbps_read_only": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+
 			"disk_encryption_set_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -227,6 +241,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	createOption := compute.DiskCreateOption(d.Get("create_option").(string))
 	storageAccountType := d.Get("storage_account_type").(string)
 	osType := d.Get("os_type").(string)
+	maxShares := d.Get("max_shares").(int)
 
 	t := d.Get("tags").(map[string]interface{})
 	zones := azure.ExpandZones(d.Get("zones").([]interface{}))
@@ -247,8 +262,8 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		props.DiskSizeGB = &diskSize
 	}
 
-	if v, ok := d.GetOk("max_shares"); ok {
-		props.MaxShares = utils.Int32(int32(v.(int)))
+	if maxShares != 0 {
+		props.MaxShares = utils.Int32(int32(maxShares))
 	}
 
 	if storageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) {
@@ -264,11 +279,27 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 			props.DiskMBpsReadWrite = &diskMBps
 		}
 
+		if v, ok := d.GetOk("disk_iops_read_only"); ok {
+			if maxShares == 0 {
+				return fmt.Errorf("[ERROR] disk_iops_read_only is only available for UltraSSD disks with shared disk enabled")
+			}
+
+			props.DiskIOPSReadOnly = utils.Int64(int64(v.(int)))
+		}
+
+		if v, ok := d.GetOk("disk_mbps_read_only"); ok {
+			if maxShares == 0 {
+				return fmt.Errorf("[ERROR] disk_mbps_read_only is only available for UltraSSD disks with shared disk enabled")
+			}
+
+			props.DiskMBpsReadOnly = utils.Int64(int64(v.(int)))
+		}
+
 		if v, ok := d.GetOk("logical_sector_size"); ok {
 			props.CreationData.LogicalSectorSize = utils.Int32(int32(v.(int)))
 		}
-	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") || d.HasChange("logical_sector_size") {
-		return fmt.Errorf("[ERROR] disk_iops_read_write, disk_mbps_read_write and logical_sector_size are only available for UltraSSD disks")
+	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") || d.HasChange("disk_iops_read_only") || d.HasChange("disk_mbps_read_only") || d.HasChange("logical_sector_size") {
+		return fmt.Errorf("[ERROR] disk_iops_read_write, disk_mbps_read_write, disk_iops_read_only, disk_mbps_read_only and logical_sector_size are only available for UltraSSD disks")
 	}
 
 	if createOption == compute.DiskCreateOptionImport {
@@ -396,6 +427,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
+	maxShares := d.Get("max_shares").(int)
 	storageAccountType := d.Get("storage_account_type").(string)
 	shouldShutDown := false
 
@@ -413,9 +445,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("max_shares") {
-		v := d.Get("max_shares")
-		maxShares := int32(v.(int))
-		diskUpdate.MaxShares = &maxShares
+		diskUpdate.MaxShares = utils.Int32(int32(maxShares))
 		var skuName compute.DiskStorageAccountTypes
 		for _, v := range compute.PossibleDiskStorageAccountTypesValues() {
 			if strings.EqualFold(storageAccountType, string(v)) {
@@ -466,8 +496,27 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			diskMBps := int64(v.(int))
 			diskUpdate.DiskMBpsReadWrite = &diskMBps
 		}
-	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") {
-		return fmt.Errorf("[ERROR] disk_iops_read_write and disk_mbps_read_write are only available for UltraSSD disks")
+
+		if d.HasChange("disk_iops_read_only") {
+			if maxShares == 0 {
+				return fmt.Errorf("[ERROR] disk_iops_read_only is only available for UltraSSD disks with shared disk enabled")
+			}
+
+			v := d.Get("disk_iops_read_only")
+			diskUpdate.DiskIOPSReadOnly = utils.Int64(int64(v.(int)))
+		}
+
+		if d.HasChange("disk_mbps_read_only") {
+			if maxShares == 0 {
+				return fmt.Errorf("[ERROR] disk_mbps_read_only is only available for UltraSSD disks with shared disk enabled")
+			}
+
+			v := d.Get("disk_mbps_read_only")
+			diskUpdate.DiskMBpsReadOnly = utils.Int64(int64(v.(int)))
+		}
+
+	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") || d.HasChange("disk_iops_read_only") || d.HasChange("disk_mbps_read_only") {
+		return fmt.Errorf("[ERROR] disk_iops_read_write, disk_mbps_read_write, disk_iops_read_only and disk_mbps_read_only are only available for UltraSSD disks")
 	}
 
 	if d.HasChange("os_type") {
@@ -685,6 +734,8 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("disk_size_gb", props.DiskSizeGB)
 		d.Set("disk_iops_read_write", props.DiskIOPSReadWrite)
 		d.Set("disk_mbps_read_write", props.DiskMBpsReadWrite)
+		d.Set("disk_iops_read_only", props.DiskIOPSReadOnly)
+		d.Set("disk_mbps_read_only", props.DiskMBpsReadOnly)
 		d.Set("os_type", props.OsType)
 		d.Set("tier", props.Tier)
 		d.Set("max_shares", props.MaxShares)

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -101,6 +101,10 @@ The following arguments are supported:
 
 * `disk_mbps_read_write` - (Optional) The bandwidth allowed for this disk; only settable for UltraSSD disks. MBps means millions of bytes per second.
 
+* `disk_iops_read_only` - (Optional) The number of IOPS allowed across all VMs mounting the shared disk as read-only; only settable for UltraSSD disks with shared disk enabled. One operation can transfer between 4k and 256k bytes.
+
+* `disk_mbps_read_only` - (Optional) The bandwidth allowed across all VMs mounting the shared disk as read-only; only settable for UltraSSD disks with shared disk enabled. MBps means millions of bytes per second.
+
 * `disk_size_gb` - (Optional, Required for a new managed disk) Specifies the size of the managed disk to create in gigabytes. If `create_option` is `Copy` or `FromImage`, then the value must be equal to or greater than the source's size. The size can only be increased.
 
 ~> **NOTE:** Changing this value is disruptive if the disk is attached to a Virtual Machine. The VM will be shut down and de-allocated as required by Azure to action the change. Terraform will attempt to start the machine again after the update if it was in a `running` state when the apply was started.


### PR DESCRIPTION
- Add support for [DiskIOPSReadOnly and DiskMBpsReadOnly](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-shared#ultra-disk-performance-throttles)
- These two properties are the read-only version of DiskIOPSReadWrite and DiskMBpsReadWrite, which specify the read-only IOps and MBps to the disk
- These two properties are only available for Ultra disk, and only available if it is a shared disk.
- Test result:
$ TF_ACC=1 go test -v ./internal/services/compute -run=TestAccAzureRMManagedDisk -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMManagedDisk_networkPolicy
=== PAUSE TestAccAzureRMManagedDisk_networkPolicy
=== RUN   TestAccAzureRMManagedDisk_networkPolicy_update
=== PAUSE TestAccAzureRMManagedDisk_networkPolicy_update
=== RUN   TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate
=== PAUSE TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate
=== RUN   TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate
=== PAUSE TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate
=== RUN   TestAccAzureRMManagedDisk_update_withMaxShares
=== PAUSE TestAccAzureRMManagedDisk_update_withMaxShares
=== RUN   TestAccAzureRMManagedDisk_create_withLogicalSectorSize
=== PAUSE TestAccAzureRMManagedDisk_create_withLogicalSectorSize
=== RUN   TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled
=== PAUSE TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled
=== RUN   TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly
=== PAUSE TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly
=== CONT  TestAccAzureRMManagedDisk_networkPolicy
=== CONT  TestAccAzureRMManagedDisk_update_withMaxShares
=== CONT  TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled
=== CONT  TestAccAzureRMManagedDisk_networkPolicy_update
=== CONT  TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate
=== CONT  TestAccAzureRMManagedDisk_create_withLogicalSectorSize
=== CONT  TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate
=== CONT  TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly
--- PASS: TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled (412.26s)
--- PASS: TestAccAzureRMManagedDisk_networkPolicy (412.75s)
--- PASS: TestAccAzureRMManagedDisk_create_withLogicalSectorSize (412.81s)
--- PASS: TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate (444.44s)
--- PASS: TestAccAzureRMManagedDisk_update_withMaxShares (560.07s)
--- PASS: TestAccAzureRMManagedDisk_networkPolicy_update (588.01s)
--- PASS: TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly (588.29s)
--- PASS: TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate (601.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       602.573s