### PR TITLE
`azurerm_eventhub_namespace` - Swap TypeList to TypeSet for `network_rulesets.x.virtual_network_rule`

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -621,10 +621,10 @@ func resourceVnetRuleHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["subnet_id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s", strings.ToLower(v.(string))))
+			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
 		}
 		if v, ok := m["ignore_missing_virtual_network_service_endpoint"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 		}
 	}
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -137,7 +137,7 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 						},
 
 						// 128 limit per https://docs.microsoft.com/azure/event-hubs/event-hubs-quotas
-						// Returned value of the nested property subnet_id does not honor the input order,
+						// Returned value of the `virtual_network_rule` array does not honor the input order,
 						// possibly a service design, thus changed to TypeSet
 						"virtual_network_rule": {
 							Type:       pluginsdk.TypeSet,

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -137,6 +137,10 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 						},
 
 						// 128 limit per https://docs.microsoft.com/azure/event-hubs/event-hubs-quotas
+						// Returned value of the nested property subnet_id does not honor the input order,
+						// possibly a service design, thus changed to TypeSet
+						// Case sensitivity issue of subnet_id: https://github.com/Azure/azure-sdk-for-go/issues/5855
+						// & the default caseDiff suppress func is not working in TypeSet
 						"virtual_network_rule": {
 							Type:       pluginsdk.TypeSet,
 							Optional:   true,

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -150,7 +150,6 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 
 									// the API returns the subnet ID's resource group name in lowercase
 									// https://github.com/Azure/azure-sdk-for-go/issues/5855
-									// default caseDiff suppress func is not working in TypeSet
 									"subnet_id": {
 										Type:             pluginsdk.TypeString,
 										Required:         true,
@@ -619,6 +618,8 @@ func flattenEventHubIdentity(input *identity.SystemUserAssignedIdentityMap) []in
 	return eventhubNamespaceIdentityType{}.Flatten(&config)
 }
 
+// The resource id of subnet_id that's being returned by API is always lower case &
+// the default caseDiff suppress func is not working in TypeSet
 func resourceVnetRuleHash(v interface{}) int {
 	var buf bytes.Buffer
 

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -139,8 +139,6 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 						// 128 limit per https://docs.microsoft.com/azure/event-hubs/event-hubs-quotas
 						// Returned value of the nested property subnet_id does not honor the input order,
 						// possibly a service design, thus changed to TypeSet
-						// Case sensitivity issue of subnet_id: https://github.com/Azure/azure-sdk-for-go/issues/5855
-						// & the default caseDiff suppress func is not working in TypeSet
 						"virtual_network_rule": {
 							Type:       pluginsdk.TypeSet,
 							Optional:   true,
@@ -152,6 +150,7 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 
 									// the API returns the subnet ID's resource group name in lowercase
 									// https://github.com/Azure/azure-sdk-for-go/issues/5855
+									// default caseDiff suppress func is not working in TypeSet
 									"subnet_id": {
 										Type:             pluginsdk.TypeString,
 										Required:         true,

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -666,6 +666,7 @@ resource "azurerm_eventhub_namespace" "test" {
     default_action = "Deny"
     ip_rule {
       ip_mask = "10.0.0.0/16"
+      action  = "Allow"
     }
   }
 }
@@ -695,6 +696,7 @@ resource "azurerm_eventhub_namespace" "test" {
     trusted_service_access_enabled = true
     ip_rule {
       ip_mask = "10.0.0.0/16"
+      action  = "Allow"
     }
   }
 }
@@ -806,10 +808,12 @@ resource "azurerm_eventhub_namespace" "test" {
 
     ip_rule {
       ip_mask = "10.0.1.0/24"
+      action  = "Allow"
     }
 
     ip_rule {
       ip_mask = "10.1.1.0/24"
+      action  = "Allow"
     }
   }
 }

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -564,8 +564,7 @@ resource "azurerm_eventhub_namespace_disaster_recovery_config" "test" {
 
 func (EventHubNamespaceResource) requiresImport(data acceptance.TestData) string {
 	template := EventHubNamespaceResource{}.basic(data)
-	return fmt.Sprintf(
-		`
+	return fmt.Sprintf(`
 %s
 
 resource "azurerm_eventhub_namespace" "import" {
@@ -939,8 +938,7 @@ resource "azurerm_eventhub_namespace" "test" {
 }
 
 func (EventHubNamespaceResource) capacity(data acceptance.TestData, capacity int) string {
-	return fmt.Sprintf(
-		`
+	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -564,7 +564,8 @@ resource "azurerm_eventhub_namespace_disaster_recovery_config" "test" {
 
 func (EventHubNamespaceResource) requiresImport(data acceptance.TestData) string {
 	template := EventHubNamespaceResource{}.basic(data)
-	return fmt.Sprintf(`
+	return fmt.Sprintf(
+		`
 %s
 
 resource "azurerm_eventhub_namespace" "import" {
@@ -696,7 +697,6 @@ resource "azurerm_eventhub_namespace" "test" {
     trusted_service_access_enabled = true
     ip_rule {
       ip_mask = "10.0.0.0/16"
-      action  = "Allow"
     }
   }
 }
@@ -808,12 +808,10 @@ resource "azurerm_eventhub_namespace" "test" {
 
     ip_rule {
       ip_mask = "10.0.1.0/24"
-      action  = "Allow"
     }
 
     ip_rule {
       ip_mask = "10.1.1.0/24"
-      action  = "Allow"
     }
   }
 }
@@ -941,7 +939,8 @@ resource "azurerm_eventhub_namespace" "test" {
 }
 
 func (EventHubNamespaceResource) capacity(data acceptance.TestData, capacity int) string {
-	return fmt.Sprintf(`
+	return fmt.Sprintf(
+		`
 provider "azurerm" {
   features {}
 }


### PR DESCRIPTION
The property [virtual_network_rule](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2021-01-01-preview/networkrulessets-preview.json) currently has the following unexpected behaviors:
1. The returned value of the nested property ```subnet_id``` does not honor the input order. Considering the order does not matter in this case, changing the property type of virtual_network_rule  from TypeList to TypeSet.
2. The resource id of the property ```subnet_id``` returned by the API is always lower case. This behavior is currently being marked as a bug which can be tracked[https://github.com/Azure/azure-sdk-for-go/issues/5855]

Making this PR  to digest these 2 behaviors to unblock client usage experience as well as some TCs