### PR TITLE
Fix #9454 by setting `eviction_policy` and `node_taints` as Computed

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -102,10 +102,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					isSpot := d.Get("priority").(string) == string(containerservice.ScaleSetPrioritySpot)
-					return isSpot && !d.HasChange("eviction_policy")
-				},
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.ScaleSetEvictionPolicyDelete),
 					string(containerservice.ScaleSetEvictionPolicyDeallocate),
@@ -182,10 +179,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				ForceNew: true,
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					isSpot := d.Get("priority").(string) == string(containerservice.ScaleSetPrioritySpot)
-					return isSpot && !d.HasChange("node_taints")
-				},
+				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -102,6 +102,10 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					isSpot := d.Get("priority").(string) == string(containerservice.ScaleSetPrioritySpot)
+					return isSpot && !d.HasChange("eviction_policy")
+				},
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.ScaleSetEvictionPolicyDelete),
 					string(containerservice.ScaleSetEvictionPolicyDeallocate),
@@ -178,6 +182,10 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					isSpot := d.Get("priority").(string) == string(containerservice.ScaleSetPrioritySpot)
+					return isSpot && !d.HasChange("node_taints")
+				},
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -683,6 +683,23 @@ func testAccKubernetesClusterNodePool_spot(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t)
+}
+
+func testAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.spotConfigWithoutEvictionPolicyAndTaints(data),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
 	testAccKubernetesClusterNodePool_upgradeSettings(t)
@@ -1756,6 +1773,28 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
   ]
+}
+`, r.templateConfig(data))
+}
+
+func (r KubernetesClusterNodePoolResource) spotConfigWithoutEvictionPolicyAndTaints(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  priority              = "Spot"
+  spot_max_price        = 0.5 # high, but this is a maximum (we pay less) so ensures this won't fail
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
 }
 `, r.templateConfig(data))
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1792,9 +1792,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   priority              = "Spot"
   spot_max_price        = 0.5 # high, but this is a maximum (we pay less) so ensures this won't fail
-  node_labels = {
-    "kubernetes.azure.com/scalesetpriority" = "spot"
-  }
 }
 `, r.templateConfig(data))
 }


### PR DESCRIPTION
#9454 complains that after created a Aks node pool with `priority = "Spot"` , re-apply would found that `node_taints` and `eviction_policy` been changed by service side, which caused a force new.

According to this [document](https://docs.microsoft.com/en-us/azure/aks/spot-node-pool#limitations):

>A spot node pool will have the label kubernetes.azure.com/scalesetpriority:spot, the taint kubernetes.azure.com/scalesetpriority=spot:NoSchedule, and system pods will have anti-affinity.

As same reason the service side would set `eviction_policy` to `Delete` when no policy was set explicitly.

This patch suppress these two arguments' diffs when `priority` is `Spot` and no change was made via tf code, and as swagger and cli implied, there's no way change these two properties from server side after creation of pool so I think this suppression should be safe. I've added a new acc test `TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy`, which can easily reproduce origin issue.

=== RUN TestAccKubernetesClusterNodePool_autoScale
=== PAUSE TestAccKubernetesClusterNodePool_autoScale
=== CONT TestAccKubernetesClusterNodePool_autoScale
=== RUN TestAccKubernetesClusterNodePool_autoScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_autoScaleUpdate
=== RUN TestAccKubernetesClusterNodePool_availabilityZones
=== PAUSE TestAccKubernetesClusterNodePool_availabilityZones
=== RUN TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== PAUSE TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== RUN TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== RUN TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== RUN TestAccKubernetesClusterNodePool_other
=== PAUSE TestAccKubernetesClusterNodePool_other
=== RUN TestAccKubernetesClusterNodePool_multiplePools
=== PAUSE TestAccKubernetesClusterNodePool_multiplePools
=== RUN TestAccKubernetesClusterNodePool_manualScale
=== PAUSE TestAccKubernetesClusterNodePool_manualScale
=== RUN TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== RUN TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== RUN TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== RUN TestAccKubernetesClusterNodePool_manualScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleUpdate
=== RUN TestAccKubernetesClusterNodePool_manualScaleVMSku
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleVMSku
=== RUN TestAccKubernetesClusterNodePool_modeSystem
=== PAUSE TestAccKubernetesClusterNodePool_modeSystem
=== RUN TestAccKubernetesClusterNodePool_modeUpdate
=== PAUSE TestAccKubernetesClusterNodePool_modeUpdate
=== RUN TestAccKubernetesClusterNodePool_nodeLabels
=== PAUSE TestAccKubernetesClusterNodePool_nodeLabels
=== RUN TestAccKubernetesClusterNodePool_nodePublicIP
=== PAUSE TestAccKubernetesClusterNodePool_nodePublicIP
=== RUN TestAccKubernetesClusterNodePool_nodeTaints
=== PAUSE TestAccKubernetesClusterNodePool_nodeTaints
=== RUN TestAccKubernetesClusterNodePool_podSubnet
=== PAUSE TestAccKubernetesClusterNodePool_podSubnet
=== CONT TestAccKubernetesClusterNodePool_podSubnet
=== RUN TestAccKubernetesClusterNodePool_osDiskSizeGB
=== PAUSE TestAccKubernetesClusterNodePool_osDiskSizeGB
=== RUN TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== PAUSE TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== RUN TestAccKubernetesClusterNodePool_osDiskType
=== PAUSE TestAccKubernetesClusterNodePool_osDiskType
=== RUN TestAccKubernetesClusterNodePool_requiresImport
=== PAUSE TestAccKubernetesClusterNodePool_requiresImport
=== RUN TestAccKubernetesClusterNodePool_spot
=== PAUSE TestAccKubernetesClusterNodePool_spot
=== RUN TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy
=== PAUSE TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy
=== RUN TestAccKubernetesClusterNodePool_upgradeSettings
=== PAUSE TestAccKubernetesClusterNodePool_upgradeSettings
=== RUN TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== RUN TestAccKubernetesClusterNodePool_virtualNetworkManual
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkManual
=== RUN TestAccKubernetesClusterNodePool_windows
=== PAUSE TestAccKubernetesClusterNodePool_windows
=== CONT TestAccKubernetesClusterNodePool_windows
=== RUN TestAccKubernetesClusterNodePool_windowsAndLinux
=== PAUSE TestAccKubernetesClusterNodePool_windowsAndLinux
=== RUN TestAccKubernetesClusterNodePool_zeroSize
=== PAUSE TestAccKubernetesClusterNodePool_zeroSize
=== RUN TestAccKubernetesClusterNodePool_hostEncryption
=== PAUSE TestAccKubernetesClusterNodePool_hostEncryption
=== RUN TestAccKubernetesClusterNodePool_maxSize
=== PAUSE TestAccKubernetesClusterNodePool_maxSize
=== CONT TestAccKubernetesClusterNodePool_maxSize
=== RUN TestAccKubernetesClusterNodePool_sameSize
=== PAUSE TestAccKubernetesClusterNodePool_sameSize
=== CONT TestAccKubernetesClusterNodePool_sameSize
=== RUN TestAccKubernetesClusterNodePool_ultraSSD
=== PAUSE TestAccKubernetesClusterNodePool_ultraSSD
=== CONT TestAccKubernetesClusterNodePool_ultraSSD
=== RUN TestAccKubernetesClusterNodePool_osSku
=== PAUSE TestAccKubernetesClusterNodePool_osSku
=== CONT TestAccKubernetesClusterNodePool_osSku
=== RUN TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== PAUSE TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== CONT TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
--- PASS: TestAccKubernetesClusterNodePool_osSku (1095.52s)
=== CONT TestAccKubernetesClusterNodePool_hostEncryption
--- PASS: TestAccKubernetesClusterNodePool_sameSize (1218.87s)
=== CONT TestAccKubernetesClusterNodePool_zeroSize
--- PASS: TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings (1248.41s)
=== CONT TestAccKubernetesClusterNodePool_windowsAndLinux
--- PASS: TestAccKubernetesClusterNodePool_maxSize (1291.85s)
=== CONT TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
--- PASS: TestAccKubernetesClusterNodePool_ultraSSD (1405.15s)
=== CONT TestAccKubernetesClusterNodePool_nodeTaints
--- PASS: TestAccKubernetesClusterNodePool_windows (1456.64s)
=== CONT TestAccKubernetesClusterNodePool_nodePublicIP
=== CONT TestAccKubernetesClusterNodePool_nodeLabels
--- PASS: TestAccKubernetesClusterNodePool_podSubnet (1518.86s)
--- PASS: TestAccKubernetesClusterNodePool_autoScale (1788.13s)
=== CONT TestAccKubernetesClusterNodePool_modeUpdate
--- PASS: TestAccKubernetesClusterNodePool_zeroSize (1101.18s)
=== CONT TestAccKubernetesClusterNodePool_modeSystem
--- PASS: TestAccKubernetesClusterNodePool_hostEncryption (1307.25s)
=== CONT TestAccKubernetesClusterNodePool_manualScaleVMSku
--- PASS: TestAccKubernetesClusterNodePool_nodeTaints (1225.21s)
=== CONT TestAccKubernetesClusterNodePool_manualScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_nodePublicIP (1205.36s)
=== CONT TestAccKubernetesClusterNodePool_spot
--- PASS: TestAccKubernetesClusterNodePool_windowsAndLinux (1519.40s)
=== CONT TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate (1669.45s)
=== CONT TestAccKubernetesClusterNodePool_virtualNetworkManual
--- PASS: TestAccKubernetesClusterNodePool_modeUpdate (1682.94s)
=== CONT TestAccKubernetesClusterNodePool_upgradeSettings
--- PASS: TestAccKubernetesClusterNodePool_modeSystem (1282.18s)
=== CONT TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy
--- PASS: TestAccKubernetesClusterNodePool_nodeLabels (2098.89s)
=== CONT TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
--- PASS: TestAccKubernetesClusterNodePool_spot (1201.25s)
=== CONT TestAccKubernetesClusterNodePool_errorForAvailabilitySet
--- PASS: TestAccKubernetesClusterNodePool_manualScaleVMSku (1724.39s)
=== CONT TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
--- PASS: TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges (1813.49s)
=== CONT TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
--- PASS: TestAccKubernetesClusterNodePool_manualScaleUpdate (1961.26s)
=== CONT TestAccKubernetesClusterNodePool_manualScaleMultiplePools
--- PASS: TestAccKubernetesClusterNodePool_errorForAvailabilitySet (737.44s)
=== CONT TestAccKubernetesClusterNodePool_availabilityZones
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkManual (1726.49s)
=== CONT TestAccKubernetesClusterNodePool_manualScale
--- PASS: TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy (1338.06s)
=== CONT TestAccKubernetesClusterNodePool_autoScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkAutomatic (1543.19s)
=== CONT TestAccKubernetesClusterNodePool_multiplePools
--- PASS: TestAccKubernetesClusterNodePool_upgradeSettings (1834.63s)
=== CONT TestAccKubernetesClusterNodePool_osDiskType
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial (1257.89s)
=== CONT TestAccKubernetesClusterNodePool_other
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig (1221.97s)
=== CONT TestAccKubernetesClusterNodePool_requiresImport
--- PASS: TestAccKubernetesClusterNodePool_manualScale (1185.33s)
=== CONT TestAccKubernetesClusterNodePool_proximityPlacementGroupId
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePools (1306.63s)
=== CONT TestAccKubernetesClusterNodePool_osDiskSizeGB
--- PASS: TestAccKubernetesClusterNodePool_availabilityZones (1478.87s)
--- PASS: TestAccKubernetesClusterNodePool_multiplePools (1352.93s)
--- PASS: TestAccKubernetesClusterNodePool_osDiskType (1291.37s)
--- PASS: TestAccKubernetesClusterNodePool_other (1315.19s)
--- PASS: TestAccKubernetesClusterNodePool_autoScaleUpdate (1793.01s)
--- PASS: TestAccKubernetesClusterNodePool_requiresImport (1213.37s)
--- PASS: TestAccKubernetesClusterNodePool_proximityPlacementGroupId (1253.18s)
--- PASS: TestAccKubernetesClusterNodePool_osDiskSizeGB (1230.47s)
PASS

Process finished with the exit code 0