### PR TITLE
Added Support for 84TB Cache and 16GB Throughput in hpc_cache

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -59,6 +59,7 @@ func resourceHPCCache() *pluginsdk.Resource {
 					12288,
 					24576,
 					49152,
+					86491,
 				}),
 			},
 
@@ -77,6 +78,7 @@ func resourceHPCCache() *pluginsdk.Resource {
 					"Standard_2G",
 					"Standard_4G",
 					"Standard_8G",
+					"Standard_L16G",
 				}, false),
 			},
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -56,11 +56,11 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure Region where the HPC Cache should be created. Changing this forces a new resource to be created.
 
-* `cache_size_in_gb` - (Required) The size of the HPC Cache, in GB. Possible values are `3072`, `6144`, `12288`, `24576`, and `49152`. Changing this forces a new resource to be created.
+* `cache_size_in_gb` - (Required) The size of the HPC Cache, in GB. Possible values are `3072`, `6144`, `12288`, `24576`, `49152` and `86491`. Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet for the HPC Cache. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The SKU of HPC Cache to use. Possible values are `Standard_2G`, `Standard_4G` and `Standard_8G`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) The SKU of HPC Cache to use. Possible values are `Standard_2G`, `Standard_4G`, `Standard_8G` and `Standard_L16G`. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Per https://github.com/hashicorp/terraform-provider-azurerm/issues/13995

Added support for High-throughput Read Only in the hpc_cache resource.
_(84TB Cache and 16GB Throughput)_

Deployment example:

```
resource "azurerm_hpc_cache" "example" {
  name                = "ro_hpc_cache"
  resource_group_name = "example"
  location            = "eastus2"
  cache_size_in_gb    = 86491
  subnet_id           = "XYZ"
  sku_name            = "Standard_L16G"
}
```
 

Tested and confirmed working:
![image](https://user-images.githubusercontent.com/62932202/140315719-2af0669e-8378-496d-893f-6e4349667689.png)
