### PR TITLE
hpc_cache Added support for readonly SKUs

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -379,16 +379,14 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 	skuName := d.Get("sku_name").(string)
 
 	// SKU Cache Combo Validation
-	if skuName == "Standard_L4_5G" && cacheSize != 21623 {
+	switch {
+	case skuName == "Standard_L4_5G" && cacheSize != 21623:
 		return fmt.Errorf("The Standard_L4_5G SKU only supports a cache size of 21623")
-	} else if skuName == "Standard_L9G" && cacheSize != 43246 {
+	case skuName == "Standard_L9G" && cacheSize != 43246:
 		return fmt.Errorf("The Standard_L9G SKU only supports a cache size of 43246")
-	} else if skuName == "Standard_L16G" && cacheSize != 86491 {
+	case skuName == "Standard_L16G" && cacheSize != 86491:
 		return fmt.Errorf("The Standard_L16G SKU only supports a cache size of 86491")
-	}
-
-	// Read Only Cache Sizes
-	if (cacheSize == 21623 || cacheSize == 43246 || cacheSize == 86491) && (skuName == "Standard_2G" || skuName == "Standard_4G" || skuName == "Standard_8G") {
+	case (cacheSize == 21623 || cacheSize == 43246 || cacheSize == 86491) && (skuName == "Standard_2G" || skuName == "Standard_4G" || skuName == "Standard_8G"):
 		return fmt.Errorf("Incompatible cache size chosen. 21623, 43246 and 86491 are reserved for Read Only resources.")
 	}
 

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -57,8 +57,11 @@ func resourceHPCCache() *pluginsdk.Resource {
 					3072,
 					6144,
 					12288,
+					21623,
 					24576,
+					43246,
 					49152,
+					86491,
 				}),
 			},
 
@@ -77,6 +80,9 @@ func resourceHPCCache() *pluginsdk.Resource {
 					"Standard_2G",
 					"Standard_4G",
 					"Standard_8G",
+					"Standard_L4_5G",
+					"Standard_L9G",
+					"Standard_L16G",
 				}, false),
 			},
 
@@ -371,6 +377,20 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 	cacheSize := d.Get("cache_size_in_gb").(int)
 	subnet := d.Get("subnet_id").(string)
 	skuName := d.Get("sku_name").(string)
+
+	// SKU Cache Combo Validation
+	if skuName == "Standard_L4_5G" && cacheSize != 21623 {
+		return fmt.Errorf("The Standard_L4_5G SKU only supports a cache size of 21623")
+	} else if skuName == "Standard_L9G" && cacheSize != 43246 {
+		return fmt.Errorf("The Standard_L9G SKU only supports a cache size of 43246")
+	} else if skuName == "Standard_L16G" && cacheSize != 86491 {
+		return fmt.Errorf("The Standard_L16G SKU only supports a cache size of 86491")
+	}
+
+	// Read Only Cache Sizes
+	if (cacheSize == 21623 || cacheSize == 43246 || cacheSize == 86491) && (skuName == "Standard_2G" || skuName == "Standard_4G" || skuName == "Standard_8G") {
+		return fmt.Errorf("Incompatible cache size chosen. 21623, 43246 and 86491 are reserved for Read Only resources.")
+	}
 
 	var accessPolicies []storagecache.NfsAccessPolicy
 	if !d.IsNewResource() {

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -56,11 +56,15 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure Region where the HPC Cache should be created. Changing this forces a new resource to be created.
 
-* `cache_size_in_gb` - (Required) The size of the HPC Cache, in GB. Possible values are `3072`, `6144`, `12288`, `24576`, and `49152`. Changing this forces a new resource to be created.
+* `cache_size_in_gb` - (Required) The size of the HPC Cache, in GB. Possible values are `3072`, `6144`, `12288`, `21623`, `24576`, `43246`, `49152` and `86491`. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `21623`, `43246` and `86491` sizes are restricted to read only resources.
 
 * `subnet_id` - (Required) The ID of the Subnet for the HPC Cache. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The SKU of HPC Cache to use. Possible values are `Standard_2G`, `Standard_4G` and `Standard_8G`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) The SKU of HPC Cache to use. Possible values are (ReadWrite) - `Standard_2G`, `Standard_4G` `Standard_8G` or (ReadOnly) - `Standard_L4_5G`, `Standard_L9G`, and `Standard_L16G`. Changing this forces a new resource to be created.
+
+-> **NOTE:** The read-only SKUs have restricted cache sizes. `Standard_L4_5G` must be set to `21623`. `Standard_L9G` to `43246` and `Standard_L16G` to `86491`.
 
 ---
 


### PR DESCRIPTION
Per https://github.com/hashicorp/terraform-provider-azurerm/issues/13995

Added support for Read Only SKUs in the hpc_cache resource.

Deployment example:

```
resource "azurerm_hpc_cache" "example" {
  name                = "ro_hpc_cache"
  resource_group_name = "example"
  location            = "eastus2"
  cache_size_in_gb    = 86491
  subnet_id           = "XYZ"
  sku_name            = "Standard_L16G"
}
```
 
Tested and confirmed working:
![image](https://user-images.githubusercontent.com/62932202/140315719-2af0669e-8378-496d-893f-6e4349667689.png)
