### PR TITLE
Fix cross sub creation failure on keyvault embedded resources

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -526,40 +526,13 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 }
 
 func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	keyVaultsClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
-	resourcesClient := meta.(*clients.Client).Resource
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ParseNestedItemID(d.Id())
 	if err != nil {
 		return err
-	}
-
-	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
-	if err != nil {
-		return fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
-	}
-	if keyVaultIdRaw == nil {
-		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-
-	keyVaultId, err := parse.VaultID(*keyVaultIdRaw)
-	if err != nil {
-		return err
-	}
-
-	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("checking if %s for Certificate %q exists: %v", *keyVaultId, id.Name, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Certificate %q was not found in %s - removing from state", id.Name, *keyVaultId)
-		d.SetId("")
-		return nil
 	}
 
 	cert, err := client.GetCertificate(ctx, id.KeyVaultBaseUrl, id.Name, "")

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -336,39 +336,13 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 }
 
 func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	keyVaultsClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
-	resourcesClient := meta.(*clients.Client).Resource
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ParseNestedItemID(d.Id())
 	if err != nil {
 		return err
-	}
-
-	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
-	if err != nil {
-		return fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
-	}
-	if keyVaultIdRaw == nil {
-		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-	keyVaultId, err := parse.VaultID(*keyVaultIdRaw)
-	if err != nil {
-		return err
-	}
-
-	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("checking if key vault %q for Key %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
 	}
 
 	resp, err := client.GetKey(ctx, id.KeyVaultBaseUrl, id.Name, "")

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -290,39 +290,13 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	keyVaultsClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
-	resourcesClient := meta.(*clients.Client).Resource
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ParseNestedItemID(d.Id())
 	if err != nil {
 		return err
-	}
-
-	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
-	if err != nil {
-		return fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
-	}
-	if keyVaultIdRaw == nil {
-		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-	keyVaultId, err := parse.VaultID(*keyVaultIdRaw)
-	if err != nil {
-		return err
-	}
-
-	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("checking if key vault %q for Secret %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
 	}
 
 	// we always want to get the latest version


### PR DESCRIPTION
The existance check on the Keyvault in the Keyvault embedded resources are redundent here. 

Even worse, it will cause failures to create a a embedded resource (e.g. a secret) from **subB** in a Keyvault that is created in the **subA**, since the Resource list API used will default to assume the scope is **subB** in the `Read` function of the embedded resource, which causes issues described in #11059.

Also, removing the existance check on the Keyvault also eliminates the potential issues caused by the resource list API as discussed in #13719. 

Fixes #11059.