### PR TITLE
`azurerm_cosmosdb_cassandra_cluster` - Fix SP Obj ID Lookup

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -132,7 +132,7 @@ func (td TestData) providers() map[string]func() (*schema.Provider, error) {
 func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"azuread": {
-			VersionConstraint: "=2.8.0",
+			VersionConstraint: "=2.9.0",
 			Source:            "registry.terraform.io/hashicorp/azuread",
 		},
 	}

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -71,6 +71,15 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "azure_cosmos_db" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.AzureCosmosDb
+  use_existing   = true
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctest-ca-%[1]d"
   location = "%[2]s"
@@ -93,7 +102,7 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_role_assignment" "test" {
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
-  principal_id         = "255f3c8e-0c3d-4f06-ba9d-2fb68af0faed"
+  principal_id         = azuread_service_principal.azure_cosmos_db.object_id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -91,16 +91,12 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
-  depends_on = [azuread_service_principal.azure_cosmos_db]
-
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
   principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {
-  depends_on = [azurerm_role_assignment.test]
-
   name                           = "acctca-mi-cluster-%[1]d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location
@@ -116,8 +112,6 @@ func (CassandraClusterResource) requiresImport(data acceptance.TestData) string 
 %s
 
 resource "azurerm_cosmosdb_cassandra_cluster" "import" {
-  depends_on = [azurerm_cosmosdb_cassandra_cluster.test]
-
   name                           = azurerm_cosmosdb_cassandra_cluster.test.name
   resource_group_name            = azurerm_cosmosdb_cassandra_cluster.test.resource_group_name
   location                       = azurerm_cosmosdb_cassandra_cluster.test.location

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -90,10 +90,17 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.1.0/24"]
 }
 
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "test" {
+  application_id = data.azuread_application_published_app_ids.well_known.result["AzureCosmosDb"]
+  use_existing   = true
+}
+
 resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_virtual_network.test.id
+  principal_id         = azuread_service_principal.test.object_id
   role_definition_name = "Network Contributor"
-  principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
+  scope                = azurerm_virtual_network.test.id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -100,12 +100,16 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
+  depends_on = [azuread_service_principal.azure_cosmos_db]
+
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
   principal_id         = azuread_service_principal.azure_cosmos_db.object_id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {
+  depends_on = [azurerm_role_assignment.test]
+
   name                           = "acctca-mi-cluster-%[1]d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location
@@ -121,6 +125,8 @@ func (CassandraClusterResource) requiresImport(data acceptance.TestData) string 
 %s
 
 resource "azurerm_cosmosdb_cassandra_cluster" "import" {
+  depends_on = [azurerm_cosmosdb_cassandra_cluster.test]
+
   name                           = azurerm_cosmosdb_cassandra_cluster.test.name
   resource_group_name            = azurerm_cosmosdb_cassandra_cluster.test.resource_group_name
   location                       = azurerm_cosmosdb_cassandra_cluster.test.location

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -71,15 +71,6 @@ provider "azurerm" {
   features {}
 }
 
-provider "azuread" {}
-
-data "azuread_application_published_app_ids" "well_known" {}
-
-resource "azuread_service_principal" "azure_cosmos_db" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.AzureCosmosDb
-  use_existing   = true
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctest-ca-%[1]d"
   location = "%[2]s"
@@ -104,7 +95,7 @@ resource "azurerm_role_assignment" "test" {
 
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
-  principal_id         = azuread_service_principal.azure_cosmos_db.object_id
+  principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -73,15 +73,6 @@ provider "azurerm" {
   features {}
 }
 
-provider "azuread" {}
-
-data "azuread_application_published_app_ids" "well_known" {}
-
-resource "azuread_service_principal" "azure_cosmos_db" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.AzureCosmosDb
-  use_existing   = true
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-ca-%[1]d"
   location = "%[2]s"
@@ -106,7 +97,7 @@ resource "azurerm_role_assignment" "test" {
 
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
-  principal_id         = azuread_service_principal.azure_cosmos_db.object_id
+  principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -102,12 +102,16 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
+  depends_on = [azuread_service_principal.azure_cosmos_db]
+
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
   principal_id         = azuread_service_principal.azure_cosmos_db.object_id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {
+  depends_on = [azurerm_role_assignment.test]
+
   name                           = "acctca-mi-cluster-%[1]d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -92,10 +92,17 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.1.0/24"]
 }
 
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "test" {
+  application_id = data.azuread_application_published_app_ids.well_known.result["AzureCosmosDb"]
+  use_existing   = true
+}
+
 resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_virtual_network.test.id
+  principal_id         = azuread_service_principal.test.object_id
   role_definition_name = "Network Contributor"
-  principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
+  scope                = azurerm_virtual_network.test.id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -93,16 +93,12 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
-  depends_on = [azuread_service_principal.azure_cosmos_db]
-
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
   principal_id         = "e531a17d-006c-4736-9de9-d8d745730738"
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {
-  depends_on = [azurerm_role_assignment.test]
-
   name                           = "acctca-mi-cluster-%[1]d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -73,6 +73,15 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "azure_cosmos_db" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.AzureCosmosDb
+  use_existing   = true
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-ca-%[1]d"
   location = "%[2]s"
@@ -95,7 +104,7 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_role_assignment" "test" {
   scope                = azurerm_virtual_network.test.id
   role_definition_name = "Network Contributor"
-  principal_id         = "255f3c8e-0c3d-4f06-ba9d-2fb68af0faed"
+  principal_id         = azuread_service_principal.azure_cosmos_db.object_id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -10,6 +10,12 @@ description: |-
 
 Manages a Cassandra Cluster.
 
+~> ** NOTE: ** In order for the `Azure Managed Instances for Apache Cassandra` to work properly the product requires the `Azure Cosmos DB` Application ID to be present and working in your tenant. If the `Azure Cosmos DB` Application ID is missing in your environment you will need to have an administrator of your tenant run the following command to add the `Azure Cosmos DB` Application ID to your tenant:
+
+```powershell
+New-AzADServicePrincipal -ApplicationId a232010e-820c-4083-83bb-3ace5fc29d0b
+```
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
@@ -10,6 +10,12 @@ description: |-
 
 Manages a Cassandra Datacenter.
 
+~> ** NOTE: ** In order for the `Azure Managed Instances for Apache Cassandra` to work properly the product requires the `Azure Cosmos DB` Application ID to be present and working in your tenant. If the `Azure Cosmos DB` Application ID is missing in your environment you will need to have an administrator of your tenant run the following command to add the `Azure Cosmos DB` Application ID to your tenant:
+
+```powershell
+New-AzADServicePrincipal -ApplicationId a232010e-820c-4083-83bb-3ace5fc29d0b
+```
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
* Updated test case version of azuread to current 2.0.1 from 1.5.1
* Updated Cassandra MI test cases to use azuread to lookup correct SP Object ID