### PR TITLE
`azurerm_key_vault_certificate`: Prevent `certificate.contents` to be empty

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -66,10 +66,11 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"contents": {
-							Type:      pluginsdk.TypeString,
-							Required:  true,
-							ForceNew:  true,
-							Sensitive: true,
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"password": {
 							Type:      pluginsdk.TypeString,


### PR DESCRIPTION
Fixes #14040