### PR TITLE
Corrected all "aci-helloworld" and "aci-tutorial-sidecar" Docker image references in examples/docs

### DIFF
--- a/examples/container-instance/image-registry-credentials/main.tf
+++ b/examples/container-instance/image-registry-credentials/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "hw"
-    image  = "microsoft/aci-helloworld:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 

--- a/examples/container-instance/image-registry-credentials/main.tf
+++ b/examples/container-instance/image-registry-credentials/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "sidecar"
-    image  = "microsoft/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
     cpu    = "0.5"
     memory = "1.5"
   }

--- a/examples/container-instance/multiple-containers/main.tf
+++ b/examples/container-instance/multiple-containers/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "hw"
-    image  = "microsoft/aci-helloworld:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 

--- a/examples/container-instance/multiple-containers/main.tf
+++ b/examples/container-instance/multiple-containers/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "sidecar"
-    image  = "microsoft/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
     cpu    = "0.5"
     memory = "1.5"
   }

--- a/examples/container-instance/network-profile/main.tf
+++ b/examples/container-instance/network-profile/main.tf
@@ -56,7 +56,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "hello-world"
-    image  = "microsoft/aci-helloworld:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 

--- a/examples/container-instance/network-profile/main.tf
+++ b/examples/container-instance/network-profile/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "sidecar"
-    image  = "microsoft/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
     cpu    = "0.5"
     memory = "1.5"
   }

--- a/examples/kubernetes/aci_connector_linux/virtual-node.yaml
+++ b/examples/kubernetes/aci_connector_linux/virtual-node.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: aci-helloworld
-        image: microsoft/aci-helloworld
+        image: mcr.microsoft.com/azuredocs/aci-helloworld
         ports:
         - containerPort: 80
       nodeSelector:

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "hello-world"
-    image  = "microsoft/aci-helloworld:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_container_group" "example" {
 
   container {
     name   = "sidecar"
-    image  = "microsoft/aci-tutorial-sidecar"
+    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
     cpu    = "0.5"
     memory = "1.5"
   }


### PR DESCRIPTION
Fixes #14063

- Corrected all "aci-helloworld" Docker image references in examples/docs. Use new Microsoft Container Registry image instead of deprecated Docker Hub image. See: https://hub.docker.com/_/microsoft-azuredocs-aci-helloworld
- Corrected all "aci-tutorial-sidecar" Docker image references. Use new Microsoft Container Registry image instead of deprecated Docker Hub image. See: https://hub.docker.com/_/microsoft-azuredocs-aci-tutorial-sidecar

