### PR TITLE
`azurerm_search_service` - Wait for provisioning state on create/update

### DIFF
--- a/internal/services/search/search_service_resource_test.go
+++ b/internal/services/search/search_service_resource_test.go
@@ -179,12 +179,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_search_service" "test" {
-  name                = "acctestsearchservice%d"
+  name                = "acctestsearchservice%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
@@ -193,13 +193,14 @@ resource "azurerm_search_service" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (SearchServiceResource) requiresImport(data acceptance.TestData) string {
 	template := SearchServiceResource{}.basic(data)
 	return fmt.Sprintf(`
-%s
+%[1]s
+
 resource "azurerm_search_service" "import" {
   name                = azurerm_search_service.test.name
   resource_group_name = azurerm_search_service.test.resource_group_name
@@ -220,12 +221,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_search_service" "test" {
-  name                = "acctestsearchservice%d"
+  name                = "acctestsearchservice%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
@@ -239,7 +240,7 @@ resource "azurerm_search_service" "test" {
     residential = "Area"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (SearchServiceResource) ipRules(data acceptance.TestData) string {
@@ -249,12 +250,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-search-%d"
-  location = "%s"
+  name     = "acctestRG-search-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_search_service" "test" {
-  name                = "acctestsearchservice%d"
+  name                = "acctestsearchservice%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
@@ -265,7 +266,7 @@ resource "azurerm_search_service" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (SearchServiceResource) identity(data acceptance.TestData) string {
@@ -275,12 +276,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_search_service" "test" {
-  name                = "acctestsearchservice%d"
+  name                = "acctestsearchservice%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
@@ -293,5 +294,5 @@ resource "azurerm_search_service" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request waits for the provisioning state of a search service to reach `Succeeded`, thereby blocking any downstream operations from starting prematurely.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='search' TESTARGS='-run=TestAccSearchService_'  
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/search -run=TestAccSearchService_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSearchService_basic
=== PAUSE TestAccSearchService_basic
=== RUN   TestAccSearchService_requiresImport
=== PAUSE TestAccSearchService_requiresImport
=== RUN   TestAccSearchService_complete
=== PAUSE TestAccSearchService_complete
=== RUN   TestAccSearchService_update
=== PAUSE TestAccSearchService_update
=== RUN   TestAccSearchService_ipRules
=== PAUSE TestAccSearchService_ipRules
=== RUN   TestAccSearchService_identity
=== PAUSE TestAccSearchService_identity
=== CONT  TestAccSearchService_basic
=== CONT  TestAccSearchService_update
=== CONT  TestAccSearchService_identity
=== CONT  TestAccSearchService_ipRules
=== CONT  TestAccSearchService_complete
=== CONT  TestAccSearchService_requiresImport
--- PASS: TestAccSearchService_requiresImport (154.65s)
--- PASS: TestAccSearchService_identity (298.49s)
--- PASS: TestAccSearchService_basic (925.75s)
--- PASS: TestAccSearchService_complete (1047.64s)
--- PASS: TestAccSearchService_ipRules (1121.89s)
--- PASS: TestAccSearchService_update (2381.40s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/search        2384.218s
```
