### PR TITLE
New attribute `virtual_network_address_space` (azurerm_virtual_network_peering)

### DIFF
--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -52,6 +53,19 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			// we use `virtual_network_address_space` as an input parameter
+			// that forces an in-place update of the peering resource is changed.
+			// The actual values are not used in any backend calls.
+			"virtual_network_address_space": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
 			},
 
 			"remote_virtual_network_id": {

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -120,6 +120,11 @@ The following arguments are supported:
 * `virtual_network_name` - (Required) The name of the virtual network. Changing
     this forces a new resource to be created.
 
+* `virtual_network_address_space` - (Optional) A list of addresses that are configured
+    in the virtual network. Changes to this list force a resynchronization of the
+    local address spaces to the peered virtual network. It's recommended to reference
+    the `address_space` attribute of the local virtual network.
+
 * `remote_virtual_network_id` - (Required) The full Azure resource ID of the
     remote virtual network.  Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Its possible to re-sync local vnet address spaces to the peered virtual network without recreation. The required parameter is already set in the current implementation, we just need a way to force the in-place update:

```golang
future, err := vnetPeeringsClient.CreateOrUpdate(ctx, resGroup, vnetName, name, peer, network.SyncRemoteAddressSpaceTrue)
```

This PR adds a new attribute `virtual_network_address_space` that can be updated to force the resynchronization of the address_space by changing the list values.

It recommended to just use the address_space attribute of the local virtual network like so:

```hcl
resource "azurerm_virtual_network" "example-1" {
  name                = "peternetwork1"
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.0.1.0/24"]
  location            = "West US"
}

resource "azurerm_virtual_network" "example-2" {
  name                = "peternetwork2"
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.0.2.0/24"]
  location            = "West US"
}

resource "azurerm_virtual_network_peering" "example-1" {
  name                      = "peer1to2"
  resource_group_name       = azurerm_resource_group.example.name
  virtual_network_name      = azurerm_virtual_network.example-1.name
  virtual_network_address_space = azurerm_virtual_network.example-1.address_space
  remote_virtual_network_id = azurerm_virtual_network.example-2.id
}

resource "azurerm_virtual_network_peering" "example-2" {
  name                      = "peer2to1"
  resource_group_name       = azurerm_resource_group.example.name
  virtual_network_name      = azurerm_virtual_network.example-2.name
  virtual_network_address_space = azurerm_virtual_network.example-2.address_space
  remote_virtual_network_id = azurerm_virtual_network.example-1.id
}
```

The use-case and process is described here:
https://azure.microsoft.com/en-us/blog/how-to-resize-azure-virtual-networks-that-are-peered-now-in-preview/?cdn=disable

