### PR TITLE
apimanagement: make description field required

### DIFF
--- a/internal/services/apimanagement/api_management_product_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_api_resource_test.go
@@ -92,6 +92,7 @@ resource "azurerm_api_management_product" "test" {
   subscription_required = true
   approval_required     = false
   published             = true
+  description           = "This is an example description"
 }
 
 resource "azurerm_api_management_api" "test" {

--- a/internal/services/apimanagement/api_management_product_group_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_group_resource_test.go
@@ -92,6 +92,7 @@ resource "azurerm_api_management_product" "test" {
   subscription_required = true
   approval_required     = false
   published             = true
+  description           = "This is an example description"
 }
 
 resource "azurerm_api_management_group" "test" {

--- a/internal/services/apimanagement/api_management_product_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_policy_resource_test.go
@@ -122,6 +122,7 @@ resource "azurerm_api_management_product" "test" {
   display_name          = "Test Product"
   subscription_required = false
   published             = false
+  description           = "This is an example description"
 }
 
 resource "azurerm_api_management_product_policy" "test" {
@@ -173,6 +174,7 @@ resource "azurerm_api_management_product" "test" {
   display_name          = "Test Product"
   subscription_required = false
   published             = false
+  description           = "This is an example description"
 }
 
 resource "azurerm_api_management_product_policy" "test" {

--- a/internal/services/apimanagement/api_management_product_resource.go
+++ b/internal/services/apimanagement/api_management_product_resource.go
@@ -63,7 +63,7 @@ func resourceApiManagementProduct() *pluginsdk.Resource {
 
 			"description": {
 				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Required: true,
 			},
 
 			"terms": {

--- a/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_resource_test.go
@@ -27,7 +27,7 @@ func TestAccApiManagementProduct_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("approval_required").HasValue("false"),
-				check.That(data.ResourceName).Key("description").HasValue(""),
+				check.That(data.ResourceName).Key("description").HasValue("This is an example description"),
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Product"),
 				check.That(data.ResourceName).Key("product_id").HasValue("test-product"),
 				check.That(data.ResourceName).Key("published").HasValue("false"),
@@ -64,7 +64,7 @@ func TestAccApiManagementProduct_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("approval_required").HasValue("false"),
-				check.That(data.ResourceName).Key("description").HasValue(""),
+				check.That(data.ResourceName).Key("description").HasValue("This is an example description"),
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Product"),
 				check.That(data.ResourceName).Key("product_id").HasValue("test-product"),
 				check.That(data.ResourceName).Key("published").HasValue("false"),
@@ -78,7 +78,7 @@ func TestAccApiManagementProduct_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("approval_required").HasValue("true"),
-				check.That(data.ResourceName).Key("description").HasValue(""),
+				check.That(data.ResourceName).Key("description").HasValue("This is an updated example description"),
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Updated Product"),
 				check.That(data.ResourceName).Key("product_id").HasValue("test-product"),
 				check.That(data.ResourceName).Key("published").HasValue("true"),
@@ -91,7 +91,7 @@ func TestAccApiManagementProduct_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("description").HasValue(""),
+				check.That(data.ResourceName).Key("description").HasValue("This is an example description"),
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Product"),
 				check.That(data.ResourceName).Key("product_id").HasValue("test-product"),
 				check.That(data.ResourceName).Key("published").HasValue("false"),
@@ -200,6 +200,7 @@ resource "azurerm_api_management_product" "test" {
   display_name          = "Test Product"
   subscription_required = false
   published             = false
+  description           = "This is an example description"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -216,6 +217,7 @@ resource "azurerm_api_management_product" "import" {
   subscription_required = azurerm_api_management_product.test.subscription_required
   approval_required     = azurerm_api_management_product.test.approval_required
   published             = azurerm_api_management_product.test.published
+  description           = azurerm_api_management_product.test.description
 }
 `, r.basic(data))
 }
@@ -250,6 +252,7 @@ resource "azurerm_api_management_product" "test" {
   approval_required     = true
   subscriptions_limit   = 1
   published             = true
+  description           = "This is an updated example description"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -284,6 +287,7 @@ resource "azurerm_api_management_product" "test" {
   approval_required     = true
   subscriptions_limit   = 2
   published             = false
+  description           = "This is an example description"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -344,6 +344,7 @@ resource "azurerm_api_management_product" "test" {
   subscription_required = true
   approval_required     = false
   published             = true
+  description           = "This is an example description"
 }
 
 resource "azurerm_api_management_user" "test" {

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -17,7 +17,7 @@ data "azurerm_api_management_product" "example" {
   product_id          = "my-product"
   api_management_name = "example-apim"
   resource_group_name = "search-service"
-  description = "My Product description"
+  description         = "My Product description"
 }
 
 output "product_terms" {

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -17,6 +17,7 @@ data "azurerm_api_management_product" "example" {
   product_id          = "my-product"
   api_management_name = "example-apim"
   resource_group_name = "search-service"
+  description = "My Product description"
 }
 
 output "product_terms" {


### PR DESCRIPTION
**Summary**
This pull request makes the `Description` field required for the `azurerm_api_management_product` resource. 

Fixes: #13856

Output from acceptance testing:
```
$ make acctests SERVICE='apimanagement' TESTARGS='-run="^TestAccApiManagementProduct_"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/apimanagement -run="^TestAccApiManagementProduct_" -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementProduct_basic
=== PAUSE TestAccApiManagementProduct_basic
=== RUN   TestAccApiManagementProduct_requiresImport
=== PAUSE TestAccApiManagementProduct_requiresImport
=== RUN   TestAccApiManagementProduct_update
=== PAUSE TestAccApiManagementProduct_update
=== RUN   TestAccApiManagementProduct_subscriptionsLimit
=== PAUSE TestAccApiManagementProduct_subscriptionsLimit
=== RUN   TestAccApiManagementProduct_complete
=== PAUSE TestAccApiManagementProduct_complete
=== RUN   TestAccApiManagementProduct_approvalRequiredError
=== PAUSE TestAccApiManagementProduct_approvalRequiredError
=== CONT  TestAccApiManagementProduct_basic
=== CONT  TestAccApiManagementProduct_complete
=== CONT  TestAccApiManagementProduct_approvalRequiredError
=== CONT  TestAccApiManagementProduct_update
=== CONT  TestAccApiManagementProduct_requiresImport
=== CONT  TestAccApiManagementProduct_subscriptionsLimit
--- PASS: TestAccApiManagementProduct_approvalRequiredError (253.04s)
--- PASS: TestAccApiManagementProduct_basic (288.47s)
--- PASS: TestAccApiManagementProduct_complete (349.35s)
--- PASS: TestAccApiManagementProduct_subscriptionsLimit (350.10s)
--- PASS: TestAccApiManagementProduct_update (449.63s)
--- PASS: TestAccApiManagementProduct_requiresImport (499.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement	499.832s
```