### PR TITLE
Enchancing `azurerm_key_vault_certificate` by making `tags` updatable due to #13315

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -520,8 +520,7 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 		patch.Tags = tags.Expand(t.(map[string]interface{}))
 	}
 
-	_, err = client.UpdateCertificate(ctx, id.KeyVaultBaseUrl, id.Name, id.Version, patch)
-	if err != nil {
+	if _, err = client.UpdateCertificate(ctx, id.KeyVaultBaseUrl, id.Name, id.Version, patch); err != nil {
 		return err
 	}
 	return resourceKeyVaultCertificateRead(d, meta)

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -247,7 +247,7 @@ The following arguments are supported:
 
 * `certificate_policy` - (Required) A `certificate_policy` block as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 


### PR DESCRIPTION
As #13315 said, changing  `azurerm_key_vault_certificate.tags` would cause a force new, and api do support update `tags` now. This patch make `tags` updatable, while changing `certificate_policy` would be rejected by api even there is policy field in certificate update parameters.