### PR TITLE
`azurerm_storage_encryption_scope`: Allow versionless `key_vault_key_id`

### DIFF
--- a/internal/services/keyvault/validate/child_id.go
+++ b/internal/services/keyvault/validate/child_id.go
@@ -19,3 +19,17 @@ func KeyVaultChildID(i interface{}, k string) (warnings []string, errors []error
 
 	return warnings, errors
 }
+
+func KeyVaultChildIDWithOptionalVersion(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := parse.ParseOptionallyVersionedNestedItemID(v); err != nil {
+		errors = append(errors, fmt.Errorf("can not parse %q as a Key Vault Child resource id: %v", k, err))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/storage/storage_encryption_scope_resource.go
+++ b/internal/services/storage/storage_encryption_scope_resource.go
@@ -64,7 +64,7 @@ func resourceStorageEncryptionScope() *pluginsdk.Resource {
 			"key_vault_key_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: keyVaultValidate.KeyVaultChildID,
+				ValidateFunc: keyVaultValidate.KeyVaultChildIDWithOptionalVersion,
 			},
 
 			"infrastructure_encryption_required": {

--- a/internal/services/storage/storage_encryption_scope_resource_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_test.go
@@ -32,6 +32,21 @@ func TestAccStorageEncryptionScope_keyVaultKey(t *testing.T) {
 	})
 }
 
+func TestAccStorageEncryptionScope_keyVaultKeyVersionless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_encryption_scope", "test")
+	r := StorageEncryptionScopeResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.keyVaultKeyVersionless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("source").HasValue("Microsoft.KeyVault"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageEncryptionScope_keyVaultKeyRequireInfrastructureEncryption(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_encryption_scope", "test")
 	r := StorageEncryptionScopeResource{}
@@ -202,6 +217,28 @@ resource "azurerm_storage_encryption_scope" "test" {
   storage_account_id = azurerm_storage_account.test.id
   source             = "Microsoft.KeyVault"
   key_vault_key_id   = azurerm_key_vault_key.first.id
+}
+`, template, data.RandomInteger)
+}
+
+func (t StorageEncryptionScopeResource) keyVaultKeyVersionless(data acceptance.TestData) string {
+	template := t.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+%s
+
+resource "azurerm_storage_encryption_scope" "test" {
+  name               = "acctestES%d"
+  storage_account_id = azurerm_storage_account.test.id
+  source             = "Microsoft.KeyVault"
+  key_vault_key_id   = azurerm_key_vault_key.first.versionless_id
 }
 `, template, data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #14069

### Acceptance Tests
```bash
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageEncryptionScope_keyVaultKeyVersionless -timeout 1800m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageEncryptionScope_keyVaultKeyVersionless
=== PAUSE TestAccStorageEncryptionScope_keyVaultKeyVersionless
=== CONT  TestAccStorageEncryptionScope_keyVaultKeyVersionless
--- PASS: TestAccStorageEncryptionScope_keyVaultKeyVersionless (254.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	254.550s
```