### PR TITLE
Update documentation for topic_type available values in EG system topic

### DIFF
--- a/website/docs/d/eventgrid_system_topic.html.markdown
+++ b/website/docs/d/eventgrid_system_topic.html.markdown
@@ -40,10 +40,12 @@ The following attributes are exported:
 
 * `source_arm_resource_id` - The ID of the Event Grid System Topic ARM Source.
 
-* `topic_type` - The Topic Type of the Event Grid System Topic. Possible values are: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`
+* `topic_type` - The Topic Type of the Event Grid System Topic. Some possible values are: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`
 , `Microsoft.ContainerRegistry.Registries`, `Microsoft.Devices.IoTHubs`, `Microsoft.EventGrid.Domains`, `Microsoft.EventGrid.Topics`, `Microsoft.Eventhub.Namespaces`, `Microsoft.KeyVault.vaults`, `Microsoft.MachineLearningServices.Workspaces`, `Microsoft.Maps.Accounts`, `Microsoft.Media.MediaServices`, `Microsoft.Resources.ResourceGroups`, `Microsoft.Resources.Subscriptions`, `Microsoft.ServiceBus.Namespaces`, `Microsoft.SignalRService.SignalR`, `Microsoft.Storage.StorageAccounts`, `Microsoft.Web.ServerFarms` and `Microsoft.Web.Sites`. Changing this forces a new Event Grid System Topic to be created.
 
 ~> **NOTE:** Some `topic_type`s (e.g. **Microsoft.Resources.Subscriptions**) have location set to `Global` instead of a real location like `West US`.
+
+~> **NOTE:** You can use Azure CLI to get a full list of the possible topic type's: `az eventgrid topic-type  list --output json | grep -w id`
 
 * `tags` - A mapping of tags which are assigned to the Event Grid System Topic.
 

--- a/website/docs/d/eventgrid_system_topic.html.markdown
+++ b/website/docs/d/eventgrid_system_topic.html.markdown
@@ -40,12 +40,7 @@ The following attributes are exported:
 
 * `source_arm_resource_id` - The ID of the Event Grid System Topic ARM Source.
 
-* `topic_type` - The Topic Type of the Event Grid System Topic. Some possible values are: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`
-, `Microsoft.ContainerRegistry.Registries`, `Microsoft.Devices.IoTHubs`, `Microsoft.EventGrid.Domains`, `Microsoft.EventGrid.Topics`, `Microsoft.Eventhub.Namespaces`, `Microsoft.KeyVault.vaults`, `Microsoft.MachineLearningServices.Workspaces`, `Microsoft.Maps.Accounts`, `Microsoft.Media.MediaServices`, `Microsoft.Resources.ResourceGroups`, `Microsoft.Resources.Subscriptions`, `Microsoft.ServiceBus.Namespaces`, `Microsoft.SignalRService.SignalR`, `Microsoft.Storage.StorageAccounts`, `Microsoft.Web.ServerFarms` and `Microsoft.Web.Sites`. Changing this forces a new Event Grid System Topic to be created.
-
-~> **NOTE:** Some `topic_type`s (e.g. **Microsoft.Resources.Subscriptions**) have location set to `Global` instead of a real location like `West US`.
-
-~> **NOTE:** You can use Azure CLI to get a full list of the possible topic type's: `az eventgrid topic-type  list --output json | grep -w id`
+* `topic_type` - The Topic Type of the Event Grid System Topic.
 
 * `tags` - A mapping of tags which are assigned to the Event Grid System Topic.
 

--- a/website/docs/r/eventgrid_system_topic.html.markdown
+++ b/website/docs/r/eventgrid_system_topic.html.markdown
@@ -59,7 +59,6 @@ The following arguments are supported:
 
 ~> **NOTE:** You can use Azure CLI to get a full list of the available topic types: `az eventgrid topic-type  list --output json | grep -w id`
 
-
 ---
 
 A `identity` block supports the following:

--- a/website/docs/r/eventgrid_system_topic.html.markdown
+++ b/website/docs/r/eventgrid_system_topic.html.markdown
@@ -53,10 +53,12 @@ The following arguments are supported:
 
 * `source_arm_resource_id` - (Required) The ID of the Event Grid System Topic ARM Source. Changing this forces a new Event Grid System Topic to be created.
 
-* `topic_type` - (Required) The Topic Type of the Event Grid System Topic. Possible values are: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`
-, `Microsoft.ContainerRegistry.Registries`, `Microsoft.Devices.IoTHubs`, `Microsoft.EventGrid.Domains`, `Microsoft.EventGrid.Topics`, `Microsoft.Eventhub.Namespaces`, `Microsoft.KeyVault.vaults`, `Microsoft.MachineLearningServices.Workspaces`, `Microsoft.Maps.Accounts`, `Microsoft.Media.MediaServices`, `Microsoft.Resources.ResourceGroups`, `Microsoft.Resources.Subscriptions`, `Microsoft.ServiceBus.Namespaces`, `Microsoft.SignalRService.SignalR`, `Microsoft.Storage.StorageAccounts`, `Microsoft.Web.ServerFarms` and `Microsoft.Web.Sites`. Changing this forces a new Event Grid System Topic to be created.
+* `topic_type` - (Required) The Topic Type of the Event Grid System Topic. The topic type is validated by Azure and there may be additional topic types beyond the following: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`, `Microsoft.ContainerRegistry.Registries`, `Microsoft.Devices.IoTHubs`, `Microsoft.EventGrid.Domains`, `Microsoft.EventGrid.Topics`, `Microsoft.Eventhub.Namespaces`, `Microsoft.KeyVault.vaults`, `Microsoft.MachineLearningServices.Workspaces`, `Microsoft.Maps.Accounts`, `Microsoft.Media.MediaServices`, `Microsoft.Resources.ResourceGroups`, `Microsoft.Resources.Subscriptions`, `Microsoft.ServiceBus.Namespaces`, `Microsoft.SignalRService.SignalR`, `Microsoft.Storage.StorageAccounts`, `Microsoft.Web.ServerFarms` and `Microsoft.Web.Sites`. Changing this forces a new Event Grid System Topic to be created.
 
 ~> **NOTE:** Some `topic_type`s (e.g. **Microsoft.Resources.Subscriptions**) requires location to be set to `Global` instead of a real location like `West US`.
+
+~> **NOTE:** You can use Azure CLI to get a full list of the available topic types: `az eventgrid topic-type  list --output json | grep -w id`
+
 
 ---
 


### PR DESCRIPTION
Updated documentation to indicate:

- topic_type is passed through to Azure and not validated by the provider
- The full list of topic types can be retrieved through a CLI command