### PR TITLE
`azurerm_container_registry` - add supports of `anonymous_pull_enabled`, `data_endpoint_enabled` and `network_rule_bypass_option`

### DIFF
--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -575,6 +575,93 @@ func TestAccContainerRegistry_geoReplicationRegionEndpoint(t *testing.T) {
 	})
 }
 
+func TestAccContainerRegistry_anonymousPull(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_registry", "test")
+	r := ContainerRegistryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.anonymousPullStandard(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.anonymousPullStandard(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.anonymousPullStandard(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerRegistry_dataEndpoint(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_registry", "test")
+	r := ContainerRegistryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dataEndpointPremium(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataEndpointPremium(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataEndpointPremium(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerRegistry_networkRuleBypassOption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_registry", "test")
+	r := ContainerRegistryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkRuleBypassOptionsPremium(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.networkRuleBypassOptionsPremium(data, "AzureServices"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.networkRuleBypassOptionsPremium(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t ContainerRegistryResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.RegistryID(state.ID)
 	if err != nil {
@@ -1187,4 +1274,67 @@ resource "azurerm_container_registry" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary)
+}
+
+func (ContainerRegistryResource) anonymousPullStandard(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-acr-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_registry" "test" {
+  name                   = "testacccr%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  sku                    = "Standard"
+  anonymous_pull_enabled = "%t"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
+}
+
+func (ContainerRegistryResource) dataEndpointPremium(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-acr-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_registry" "test" {
+  name                  = "testacccr%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  sku                   = "Premium"
+  data_endpoint_enabled = "%t"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
+}
+
+func (ContainerRegistryResource) networkRuleBypassOptionsPremium(data acceptance.TestData, opt string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-acr-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_registry" "test" {
+  name                       = "testacccr%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  sku                        = "Premium"
+  network_rule_bypass_option = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, opt)
 }

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -139,6 +139,12 @@ The following arguments are supported:
 
 * `encryption` - (Optional) An `encryption` block as documented below.
 
+* `anonymous_pull_enabled` - (Optional) Whether allows anonymous (unauthenticated) pull access to this Container Registry? Defaults to `false`. This is only supported on resources with the `Standard` or `Premium` SKU.
+
+* `data_endpoint_enabled` - (Optional) Whether to enable dedicated data endpoints for this Container Registry? Defaults to `false`. This is only supported on resources with the `Premium` SKU.
+
+* `network_rule_bypass_option` - (Optional) Whether to allow trusted Azure services to access a network restricted Container Registry? Possible values are `None` and `AzureServices`. Defaults to `AzureServices`.
+
 ---
 
 `georeplications` supports the following:


### PR DESCRIPTION
This PR adds supports of `anonymous_pull_enabled`, `data_endpoint_enabled` and `network_rule_bypass_option` to the `azurerm_container_registry`.

The Azure reference for each of the properties can be found below:

- `anonymous_pull_enabled` https://docs.microsoft.com/en-us/azure/container-registry/anonymous-pull-access
- `data_endpoint_enabled` 
    - https://azure.microsoft.com/en-us/blog/azure-container-registry-mitigating-data-exfiltration-with-dedicated-data-endpoints/
    -  https://docs.microsoft.com/en-us/azure/container-registry/container-registry-firewall-access-rules#enable-dedicated-data-endpoints
- `network_rule_bypass_option` https://docs.microsoft.com/en-us/azure/container-registry/container-registry-access-selected-networks

## Test

```shell
💢 TF_ACC=1 go test -timeout=3h -v ./internal/services/containers -run='TestAccContainerRegistry_basic_basic'
=== RUN   TestAccContainerRegistry_basic_basic
=== PAUSE TestAccContainerRegistry_basic_basic
=== RUN   TestAccContainerRegistry_basic_basic2Premium2basic
=== PAUSE TestAccContainerRegistry_basic_basic2Premium2basic
=== CONT  TestAccContainerRegistry_basic_basic
=== CONT  TestAccContainerRegistry_basic_basic2Premium2basic
--- PASS: TestAccContainerRegistry_basic_basic (85.77s)
--- PASS: TestAccContainerRegistry_basic_basic2Premium2basic (173.97s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    173.990s
💤 TF_ACC=1 go test -timeout=3h -v ./internal/services/containers -run='TestAccContainerRegistry_networkRuleBypassOption'
=== RUN   TestAccContainerRegistry_networkRuleBypassOption
=== PAUSE TestAccContainerRegistry_networkRuleBypassOption
=== CONT  TestAccContainerRegistry_networkRuleBypassOption
--- PASS: TestAccContainerRegistry_networkRuleBypassOption (218.30s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    218.319s
💢 TF_ACC=1 go test -timeout=3h -v ./internal/services/containers -run='TestAccContainerRegistry_anonymousPull'
=== RUN   TestAccContainerRegistry_anonymousPull
=== PAUSE TestAccContainerRegistry_anonymousPull
=== CONT  TestAccContainerRegistry_anonymousPull
--- PASS: TestAccContainerRegistry_anonymousPull (156.94s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    156.975s
💤 TF_ACC=1 go test -timeout=3h -v ./internal/services/containers -run='TestAccContainerRegistry_dataEndpoint'
=== RUN   TestAccContainerRegistry_dataEndpoint
=== PAUSE TestAccContainerRegistry_dataEndpoint
=== CONT  TestAccContainerRegistry_dataEndpoint
--- PASS: TestAccContainerRegistry_dataEndpoint (249.84s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    249.878s

```