### PR TITLE
azurerm_backup_protected_vm: Support exclude_disk_luns and include_disk_luns properties for backup protected VM resource

### DIFF
--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -119,6 +119,33 @@ func TestAccBackupProtectedVm_updateBackupPolicyId(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
+	r := BackupProtectedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		{
+			Config: r.updateDiskExclusion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			// vault cannot be deleted unless we unregister all backups
+			Config: r.base(data),
+		},
+	})
+}
+
 func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ProtectedItemID(state.ID)
 	if err != nil {
@@ -200,7 +227,7 @@ resource "azurerm_virtual_machine" "test" {
   name                  = "acctestvm"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  vm_size               = "Standard_A0"
+  vm_size               = "Standard_D1_v2"
   network_interface_ids = [azurerm_network_interface.test.id]
 
   storage_image_reference {
@@ -224,6 +251,14 @@ resource "azurerm_virtual_machine" "test" {
     disk_size_gb      = azurerm_managed_disk.test.disk_size_gb
     create_option     = "Attach"
     lun               = 0
+  }
+
+  storage_data_disk {
+    name              = "acctest-another-datadisk"
+    create_option     = "Empty"
+    disk_size_gb      = "1"
+    lun               = 1
+    managed_disk_type = "Standard_LRS"
   }
 
   os_profile {
@@ -277,6 +312,29 @@ resource "azurerm_backup_protected_vm" "test" {
   recovery_vault_name = azurerm_recovery_services_vault.test.name
   source_vm_id        = azurerm_virtual_machine.test.id
   backup_policy_id    = azurerm_backup_policy_vm.test.id
+
+  disk_exclusion {
+    disk_lun_list     = [0]
+    is_inclusion_list = true
+  }
+}
+`, r.base(data))
+}
+
+func (r BackupProtectedVmResource) updateDiskExclusion(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_protected_vm" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  source_vm_id        = azurerm_virtual_machine.test.id
+  backup_policy_id    = azurerm_backup_policy_vm.test.id
+
+  disk_exclusion {
+    disk_lun_list     = [0, 1]
+    is_inclusion_list = false
+  }
 }
 `, r.base(data))
 }

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -133,10 +133,6 @@ func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// vault cannot be deleted unless we unregister all backups
-			Config: r.base(data),
-		},
-		{
 			Config: r.updateDiskExclusion(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -145,10 +141,6 @@ func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// vault cannot be deleted unless we unregister all backups
-			Config: r.base(data),
-		},
-		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -156,10 +148,6 @@ func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			// vault cannot be deleted unless we unregister all backups
-			Config: r.base(data),
-		},
 	})
 }
 

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -131,8 +131,25 @@ func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
 			),
 		},
+		data.ImportStep(),
+		{
+			// vault cannot be deleted unless we unregister all backups
+			Config: r.base(data),
+		},
 		{
 			Config: r.updateDiskExclusion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			// vault cannot be deleted unless we unregister all backups
+			Config: r.base(data),
+		},
+		{
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -318,10 +318,7 @@ resource "azurerm_backup_protected_vm" "test" {
   source_vm_id        = azurerm_virtual_machine.test.id
   backup_policy_id    = azurerm_backup_policy_vm.test.id
 
-  disk_exclusion {
-    disk_lun_list     = [0]
-    is_inclusion_list = true
-  }
+  include_disk_luns = [0]
 }
 `, r.base(data))
 }
@@ -336,10 +333,7 @@ resource "azurerm_backup_protected_vm" "test" {
   source_vm_id        = azurerm_virtual_machine.test.id
   backup_policy_id    = azurerm_backup_policy_vm.test.id
 
-  disk_exclusion {
-    disk_lun_list     = [0, 1]
-    is_inclusion_list = false
-  }
+  exclude_disk_luns = [0, 1]
 }
 `, r.base(data))
 }

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -56,7 +56,19 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) Specifies the id of the backup policy to use.
 
+* `disk_exclusion` - (Optional) A `disk_exclusion` block as defined below.
+* 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+The `disk_exclusion` block supports the following:
+
+* `disk_lun_list` - (Required) A list of Disks' Logical Unit Numbers(LUN) to be used for VM Protection.
+
+* `is_inclusion_list` - (Optional) The flag to indicate whether the `disk_lun_list` is to be included/excluded from backup.
+
+---
 
 ## Attributes Reference
 

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -56,19 +56,11 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) Specifies the id of the backup policy to use.
 
-* `disk_exclusion` - (Optional) A `disk_exclusion` block as defined below.
-* 
+* `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be excluded for VM Protection.
+
+* `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be included for VM Protection.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
-
----
-
-The `disk_exclusion` block supports the following:
-
-* `disk_lun_list` - (Required) A list of Disks' Logical Unit Numbers(LUN) to be used for VM Protection.
-
-* `is_inclusion_list` - (Optional) The flag to indicate whether the `disk_lun_list` is to be included/excluded from backup.
-
----
 
 ## Attributes Reference
 


### PR DESCRIPTION
The purpose of this PR:

Supports exclude_disk_luns and include_disk_luns properties for backup protected VM resource.

Fixes: [#issue 13570](https://github.com/hashicorp/terraform-provider-azurerm/issues/13570)

Output from acceptance testing:
TF_ACC=1 go test ./internal/services/recoveryservices/ -v -parallel 11 -test.run=TestAccBackupProtectedVm_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN TestAccBackupProtectedVm_basic
=== PAUSE TestAccBackupProtectedVm_basic
=== RUN TestAccBackupProtectedVm_requiresImport
=== PAUSE TestAccBackupProtectedVm_requiresImport
=== RUN TestAccBackupProtectedVm_separateResourceGroups
=== PAUSE TestAccBackupProtectedVm_separateResourceGroups
=== RUN TestAccBackupProtectedVm_updateBackupPolicyId
=== PAUSE TestAccBackupProtectedVm_updateBackupPolicyId
=== RUN TestAccBackupProtectedVm_updateDiskExclusion
=== PAUSE TestAccBackupProtectedVm_updateDiskExclusion
=== CONT TestAccBackupProtectedVm_basic
=== CONT TestAccBackupProtectedVm_updateBackupPolicyId
=== CONT TestAccBackupProtectedVm_updateDiskExclusion
=== CONT TestAccBackupProtectedVm_separateResourceGroups
=== CONT TestAccBackupProtectedVm_requiresImport
--- PASS: TestAccBackupProtectedVm_requiresImport (692.96s)
--- PASS: TestAccBackupProtectedVm_separateResourceGroups (734.60s)
--- PASS: TestAccBackupProtectedVm_basic (832.72s)
--- PASS: TestAccBackupProtectedVm_updateDiskExclusion (1153.77s)
--- PASS: TestAccBackupProtectedVm_updateBackupPolicyId (1422.38s)
PASS
ok github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices