### PR TITLE
r/redis_cache: case-insensitively parsing the Subnet ID to normalise it

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -2,12 +2,12 @@ package redis
 
 import (
 	"fmt"
-	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
+	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"fmt"
+	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -257,11 +258,22 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("minimum_tls_version", string(props.MinimumTLSVersion))
 		d.Set("port", props.Port)
 		d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+		shardCount := 0
 		if props.ShardCount != nil {
-			d.Set("shard_count", props.ShardCount)
+			shardCount = int(*props.ShardCount)
 		}
+		d.Set("shard_count", shardCount)
 		d.Set("private_static_ip_address", props.StaticIP)
-		d.Set("subnet_id", props.SubnetID)
+		subnetId := ""
+		if props.SubnetID != nil {
+			parsed, err := networkParse.SubnetIDInsensitively(*props.SubnetID)
+			if err != nil {
+				return err
+			}
+
+			subnetId = parsed.ID()
+		}
+		d.Set("subnet_id", subnetId)
 	}
 
 	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)


### PR DESCRIPTION
This PR fixes #13838 by parsing the `subnet_id` field case-insensitively rather than case-sensitively.

This also applies this change to the Data Source so these values are consistently normalised (and ensures that the `shardCount` field always has the default value, which was spotted in passing)

Supersedes the work done by @damienpontifex in #13870