### PR TITLE
F/14092 expand pricing tier options

### DIFF
--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -214,7 +214,7 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 								"GP_S_Gen5_1", "GP_S_Gen5_2", "GP_S_Gen5_4", "GP_S_Gen5_6", "GP_S_Gen5_8", "GP_S_Gen5_10", "GP_S_Gen5_12", "GP_S_Gen5_14", "GP_S_Gen5_16", "GP_S_Gen5_18", "GP_S_Gen5_20", "GP_S_Gen5_24", "GP_S_Gen5_32", "GP_S_Gen5_40",
 								"GP_Gen5_2", "GP_Gen5_4", "GP_Gen5_6", "GP_Gen5_8", "GP_Gen5_10", "GP_Gen5_12", "GP_Gen5_14", "GP_Gen5_16", "GP_Gen5_18", "GP_Gen5_20", "GP_Gen5_24", "GP_Gen5_32", "GP_Gen5_40", "GP_Gen5_80",
 								"BC_Gen5_2", "BC_Gen5_4", "BC_Gen5_6", "BC_Gen5_8", "BC_Gen5_10", "BC_Gen5_12", "BC_Gen5_14", "BC_Gen5_16", "BC_Gen5_18", "BC_Gen5_20", "BC_Gen5_24", "BC_Gen5_32", "BC_Gen5_40", "BC_Gen5_80",
-								"HS_Gen5_2", "HS_Gen5_4", "HS_Gen5_6", "HS_Gen5_8", "HS_Gen5_10", "HS_Gen5_12", "HS_Gen5_14", "HS_Gen5_16", "HS_Gen5_18", "HS_Gen5_20", "HS_Gen5_24", "HS_Gen5_32", "HS_Gen5_40", "HS_Gen5_80"
+								"HS_Gen5_2", "HS_Gen5_4", "HS_Gen5_6", "HS_Gen5_8", "HS_Gen5_10", "HS_Gen5_12", "HS_Gen5_14", "HS_Gen5_16", "HS_Gen5_18", "HS_Gen5_20", "HS_Gen5_24", "HS_Gen5_32", "HS_Gen5_40", "HS_Gen5_80",
 							}, false),
 						},
 						"dual_standby_pair_name": {

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -207,12 +207,15 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 						"pricing_tier": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  string(datafactory.IntegrationRuntimeSsisCatalogPricingTierBasic),
+							Default:  "Basic",
 							ValidateFunc: validation.StringInSlice([]string{
-								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierBasic),
-								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierStandard),
-								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierPremium),
-								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierPremiumRS),
+								"Basic",
+								"S0", "S1", "S2", "S3", "S4", "S6", "S7", "S9", "S12",
+								"P1", "P2", "P4", "P6", "P11", "P15",
+								"GP_S_Gen5_1", "GP_S_Gen5_2", "GP_S_Gen5_4", "GP_S_Gen5_6", "GP_S_Gen5_8", "GP_S_Gen5_10", "GP_S_Gen5_12", "GP_S_Gen5_14", "GP_S_Gen5_16", "GP_S_Gen5_18", "GP_S_Gen5_20", "GP_S_Gen5_24", "GP_S_Gen5_32", "GP_S_Gen5_40",
+								"GP_Gen5_2", "GP_Gen5_4", "GP_Gen5_6", "GP_Gen5_8", "GP_Gen5_10", "GP_Gen5_12", "GP_Gen5_14", "GP_Gen5_16", "GP_Gen5_18", "GP_Gen5_20", "GP_Gen5_24", "GP_Gen5_32", "GP_Gen5_40", "GP_Gen5_80",
+								"BC_Gen5_2", "BC_Gen5_4", "BC_Gen5_6", "BC_Gen5_8", "BC_Gen5_10", "BC_Gen5_12", "BC_Gen5_14", "BC_Gen5_16", "BC_Gen5_18", "BC_Gen5_20", "BC_Gen5_24", "BC_Gen5_32", "BC_Gen5_40", "BC_Gen5_80",
+								"HS_Gen5_2", "HS_Gen5_4", "HS_Gen5_6", "HS_Gen5_8", "HS_Gen5_10", "HS_Gen5_12", "HS_Gen5_14", "HS_Gen5_16", "HS_Gen5_18", "HS_Gen5_20", "HS_Gen5_24", "HS_Gen5_32", "HS_Gen5_40", "HS_Gen5_80"
 							}, false),
 						},
 						"dual_standby_pair_name": {

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -207,7 +207,6 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 						"pricing_tier": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  "Basic",
 							ValidateFunc: validation.StringInSlice([]string{
 								"Basic",
 								"S0", "S1", "S2", "S3", "S4", "S6", "S7", "S9", "S12",

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
@@ -43,7 +43,47 @@ func TestAccDataFactoryIntegrationRuntimeManagedSsis_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, "Basic"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"catalog_info.0.administrator_password",
+			"custom_setup_script.0.sas_token",
+			"express_custom_setup.0.component.0.license",
+			"express_custom_setup.0.command_key.0.password",
+		),
+	})
+}
+
+func TestAccDataFactoryIntegrationRuntimeManagedSsis_SSISDBpricingtier_GP_S_Gen5_1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_azure_ssis", "test")
+	r := IntegrationRuntimeManagedSsisResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data, "GP_S_Gen5_1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"catalog_info.0.administrator_password",
+			"custom_setup_script.0.sas_token",
+			"express_custom_setup.0.component.0.license",
+			"express_custom_setup.0.command_key.0.password",
+		),
+	})
+}
+
+func TestAccDataFactoryIntegrationRuntimeManagedSsis_SSISDBpricingtier_S0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_azure_ssis", "test")
+	r := IntegrationRuntimeManagedSsisResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data, "S0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -137,7 +177,7 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (IntegrationRuntimeManagedSsisResource) complete(data acceptance.TestData) string {
+func (IntegrationRuntimeManagedSsisResource) complete(data acceptance.TestData, pricingTier string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -288,7 +328,7 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
     server_endpoint        = "${azurerm_sql_server.test.fully_qualified_domain_name}"
     administrator_login    = "ssis_catalog_admin"
     administrator_password = "my-s3cret-p4ssword!"
-    pricing_tier           = "Basic"
+    pricing_tier           = "%[4]s"
     dual_standby_pair_name = "dual_name"
   }
 
@@ -332,7 +372,7 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
     path                                 = "containerpath"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, pricingTier)
 }
 
 func (IntegrationRuntimeManagedSsisResource) vnetIntegration(data acceptance.TestData) string {


### PR DESCRIPTION
Replaced the use of the datafactory.IntegrationRuntimeSsisCatalogPricingTier options with what is currently available in the Azure Portal when creating Data Factory SSIS Integration Runtimes.  Removed the default to support working against SQL Managed Instance as those don't require the use of the pricing_tier option.

#14092