### PR TITLE
apimanagement: make subscription_required optional with default value of true

### DIFF
--- a/internal/services/apimanagement/api_management_product_resource.go
+++ b/internal/services/apimanagement/api_management_product_resource.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -48,11 +51,20 @@ func resourceApiManagementProduct() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"subscription_required": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+			"subscription_required": func() *schema.Schema {
+				if features.ThreePointOh() {
+					return &schema.Schema{
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					}
+				}
+
+				return &schema.Schema{
+					Type:     pluginsdk.TypeBool,
+					Required: true,
+				}
+			}(),
 
 			"published": {
 				Type:     pluginsdk.TypeBool,

--- a/internal/services/apimanagement/api_management_product_resource.go
+++ b/internal/services/apimanagement/api_management_product_resource.go
@@ -50,7 +50,8 @@ func resourceApiManagementProduct() *pluginsdk.Resource {
 
 			"subscription_required": {
 				Type:     pluginsdk.TypeBool,
-				Required: true,
+				Optional: true,
+				Default:  true,
 			},
 
 			"published": {

--- a/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_resource_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -156,6 +158,10 @@ func TestAccApiManagementProduct_approvalRequiredError(t *testing.T) {
 }
 
 func TestAccApiManagementProduct_subscriptionRequiredDefault(t *testing.T) {
+	if !features.ThreePointOh() {
+		t.Skip("Skipping since 3.0 mode is disabled")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product", "test")
 	r := ApiManagementProductResource{}
 

--- a/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_resource_test.go
@@ -400,13 +400,13 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_product" "test" {
-  product_id            = "test-product"
-  api_management_name   = azurerm_api_management.test.name
-  resource_group_name   = azurerm_resource_group.test.name
-  display_name          = "Test Product"
-  approval_required     = true
-  subscriptions_limit   = 1
-  published             = true
+  product_id          = "test-product"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  display_name        = "Test Product"
+  approval_required   = true
+  subscriptions_limit = 1
+  published           = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Summary
This pull request makes the `subscriptionRequired` field optional and sets its default value to `true` for the `azurerm_api_management_product` resource. This change will help get the Terraform implementation of this resource in sync with the [Azure API](https://docs.microsoft.com/en-us/rest/api/apimanagement/2020-12-01/product/create-or-update#request-body) and [ARM](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/service/products?tabs=json) documentation.

Fixes: #14077

```
$ make acctests SERVICE='apimanagement' TESTARGS='-run="^TestAccApiManagementProduct_"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/apimanagement -run="^TestAccApiManagementProduct_" -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementProduct_basic
=== PAUSE TestAccApiManagementProduct_basic
=== RUN   TestAccApiManagementProduct_requiresImport
=== PAUSE TestAccApiManagementProduct_requiresImport
=== RUN   TestAccApiManagementProduct_update
=== PAUSE TestAccApiManagementProduct_update
=== RUN   TestAccApiManagementProduct_subscriptionsLimit
=== PAUSE TestAccApiManagementProduct_subscriptionsLimit
=== RUN   TestAccApiManagementProduct_complete
=== PAUSE TestAccApiManagementProduct_complete
=== RUN   TestAccApiManagementProduct_approvalRequiredError
=== PAUSE TestAccApiManagementProduct_approvalRequiredError
=== RUN   TestAccApiManagementProduct_subscriptionRequiredDefault
=== PAUSE TestAccApiManagementProduct_subscriptionRequiredDefault
=== CONT  TestAccApiManagementProduct_basic
=== CONT  TestAccApiManagementProduct_complete
=== CONT  TestAccApiManagementProduct_update
=== CONT  TestAccApiManagementProduct_requiresImport
=== CONT  TestAccApiManagementProduct_subscriptionRequiredDefault
=== CONT  TestAccApiManagementProduct_subscriptionsLimit
=== CONT  TestAccApiManagementProduct_approvalRequiredError
--- PASS: TestAccApiManagementProduct_basic (304.28s)
--- PASS: TestAccApiManagementProduct_approvalRequiredError (308.37s)
--- PASS: TestAccApiManagementProduct_requiresImport (312.81s)
--- PASS: TestAccApiManagementProduct_subscriptionsLimit (356.90s)
--- PASS: TestAccApiManagementProduct_subscriptionRequiredDefault (364.10s)
--- PASS: TestAccApiManagementProduct_complete (364.25s)
--- PASS: TestAccApiManagementProduct_update (447.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement	447.785s

```