### PR TITLE
`r\managed_disk`: Add support for `gallery_image_reference_id`

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -819,8 +819,7 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 				d.Set("logical_sector_size", creationData.LogicalSectorSize)
 			}
 
-			// When galleryImageReference is used, imageReference should be empty, but it is set to the same value as well by API
-			// Check for galleryImageReference first and only set one of gallery_image_reference_id and image_reference_id
+			// imageReference is returned as well when galleryImageRefernece is used, only check imageReference when galleryImageReference is not returned
 			galleryImageReferenceId := ""
 			imageReferenceId := ""
 			if galleryImageReference := creationData.GalleryImageReference; galleryImageReference != nil && galleryImageReference.ID != nil {

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -120,6 +120,21 @@ func TestAccManagedDisk_fromPlatformImage(t *testing.T) {
 	})
 }
 
+func TestAccManagedDisk_fromGalleryImageDataDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.galleryImageDataDisk(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccManagedDisk_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
@@ -886,6 +901,110 @@ resource "azurerm_managed_disk" "test" {
   storage_account_type = "Standard_LRS"
 }
 `, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r ManagedDiskResource) galleryImageDataDisk(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%d-disk1"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_linux_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  specialized         = true
+
+  identifier {
+    publisher = "AccTesPublisher%d"
+    offer     = "AccTesOffer%d"
+    sku       = "AccTesSku%d"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_linux_virtual_machine.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+
+  tags = {
+    "foo" = "bar"
+  }
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.test,
+  ]
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctestd-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  os_type              = "Linux"
+  create_option        = "FromImage"
+  image_reference_id   = azurerm_shared_image_version.test.id
+  image_reference_lun  = 0
+  storage_account_type = "Standard_LRS"
+}
+`, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (ManagedDiskResource) encryption(data acceptance.TestData) string {

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -120,13 +120,13 @@ func TestAccManagedDisk_fromPlatformImage(t *testing.T) {
 	})
 }
 
-func TestAccManagedDisk_fromGalleryImageDataDisk(t *testing.T) {
+func TestAccManagedDisk_fromGalleryImage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.galleryImageDataDisk(data),
+			Config: r.galleryImage(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -903,7 +903,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r ManagedDiskResource) galleryImageDataDisk(data acceptance.TestData) string {
+func (r ManagedDiskResource) galleryImage(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -933,22 +933,6 @@ resource "azurerm_linux_virtual_machine" "test" {
     sku       = "16.04-LTS"
     version   = "latest"
   }
-}
-
-resource "azurerm_managed_disk" "test" {
-  name                 = "%d-disk1"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  storage_account_type = "Standard_LRS"
-  create_option        = "Empty"
-  disk_size_gb         = 10
-}
-
-resource "azurerm_virtual_machine_data_disk_attachment" "test" {
-  managed_disk_id    = azurerm_managed_disk.test.id
-  virtual_machine_id = azurerm_linux_virtual_machine.test.id
-  lun                = "0"
-  caching            = "None"
 }
 
 resource "azurerm_shared_image_gallery" "test" {
@@ -988,23 +972,18 @@ resource "azurerm_shared_image_version" "test" {
   tags = {
     "foo" = "bar"
   }
-
-  depends_on = [
-    azurerm_virtual_machine_data_disk_attachment.test,
-  ]
 }
 
-resource "azurerm_managed_disk" "test2" {
-  name                 = "acctestd-%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  os_type              = "Linux"
-  create_option        = "FromImage"
-  image_reference_id   = azurerm_shared_image_version.test.id
-  image_reference_lun  = 0
-  storage_account_type = "Standard_LRS"
+resource "azurerm_managed_disk" "test" {
+  name                       = "acctestd-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  os_type                    = "Linux"
+  create_option              = "FromImage"
+  gallery_image_reference_id = azurerm_shared_image_version.test.id
+  storage_account_type       = "Standard_LRS"
 }
-`, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (ManagedDiskResource) encryption(data acceptance.TestData) string {

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -979,6 +979,7 @@ resource "azurerm_managed_disk" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   os_type                    = "Linux"
+  hyper_v_generation         = "V1"
   create_option              = "FromImage"
   gallery_image_reference_id = azurerm_shared_image_version.test.id
   storage_account_type       = "Standard_LRS"

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -113,9 +113,9 @@ The following arguments are supported:
 
 * `hyper_v_generation` - (Optional) The HyperV Generation of the Disk when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Possible values are `V1` and `V2`. Changing this forces a new resource to be created.
 
-* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image or gallery image version to copy when `create_option` is `FromImage`.
+* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image to copy when `create_option` is `FromImage`. This field cannot be specified if gallery_image_reference_id is specified.
 
-* `image_reference_lun` - (Optional) Index of the data disk in the image when copying from a data disk. Defaults to `-1`, which means to copy from os disk.
+* `gallery_image_reference_id` - (Optional) ID of a Gallery Image Version to copy when `create_option` is `FromImage`. This field cannot be specified if image_reference_id is specified.
 
 * `logical_sector_size` - (Optional) Logical Sector Size. Possible values are: `512` and `4096`. Defaults to `4096`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -113,7 +113,9 @@ The following arguments are supported:
 
 * `hyper_v_generation` - (Optional) The HyperV Generation of the Disk when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Possible values are `V1` and `V2`. Changing this forces a new resource to be created.
 
-* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image to copy when `create_option` is `FromImage`.
+* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image or gallery image version to copy when `create_option` is `FromImage`.
+
+* `image_reference_lun` - (Optional) Index of the data disk in the image when copying from a data disk. Defaults to `-1`, which means to copy from os disk.
 
 * `logical_sector_size` - (Optional) Logical Sector Size. Possible values are: `512` and `4096`. Defaults to `4096`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
- Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/9890, add a new property `gallery_image_reference_id` to support creating a disk from a gallery image version id
- Test result:
![image](https://user-images.githubusercontent.com/10579712/144786829-9c430297-9b22-4d16-85b6-545e50349c93.png)