### PR TITLE
`azurerm_virtual_network_gateway`: Enable configuration of an active-active zone redundant gateway with P2S

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -122,7 +122,7 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 			"ip_configuration": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
-				MaxItems: 2,
+				MaxItems: 3,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -93,6 +93,20 @@ func TestAccVirtualNetworkGateway_activeActive(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.activeActiveZoneRedundantWithP2S(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccVirtualNetworkGateway_standard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
@@ -603,6 +617,118 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) activeActiveZoneRedundantWithP2S(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "first" {
+  name = "acctestpip1-%[1]d"
+
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  availability_zone   = "Zone-Redundant"
+}
+
+resource "azurerm_public_ip" "second" {
+  name = "acctestpip2-%[1]d"
+
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  availability_zone   = "Zone-Redundant"
+}
+
+resource "azurerm_public_ip" "thirth" {
+  name = "acctestpip3-%[1]d"
+
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  availability_zone   = "Zone-Redundant"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  depends_on = [
+    azurerm_public_ip.first,
+    azurerm_public_ip.second,
+    azurerm_public_ip.thirth,
+  ]
+  name                = "acctestvng-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "VpnGw1AZ"
+
+  active_active = true
+  enable_bgp    = true
+
+  ip_configuration {
+    name                 = "gw-ip1"
+    public_ip_address_id = azurerm_public_ip.first.id
+
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  ip_configuration {
+    name                 = "gw-ip2"
+    public_ip_address_id = azurerm_public_ip.second.id
+
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  ip_configuration {
+    name                 = "gw-ip3"
+    public_ip_address_id = azurerm_public_ip.thirth.id
+
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  vpn_client_configuration {
+    address_space        = ["10.2.0.0/24"]
+    vpn_client_protocols = ["OpenVPN"]
+
+    aad_tenant   = "https://login.microsoftonline.com/%[3]s/"
+    aad_audience = "41b23e61-6c1e-4545-b367-cd054e0ed4b4"
+    aad_issuer   = "https://sts.windows.net/%[3]s/"
+  }
+
+  bgp_settings {
+    asn = "65010"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.Client().TenantID)
 }
 
 func (VirtualNetworkGatewayResource) vpnClientConfig(data acceptance.TestData) string {

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -152,9 +152,10 @@ The following arguments are supported:
 
 -> **NOTE:** The available values depend on the `type` and `sku` arguments - where `Generation2` is only value for a `sku` larger than `VpnGw2` or `VpnGw2AZ`.
 
-* `ip_configuration` (Required) One or two `ip_configuration` blocks documented below.
-    An active-standby gateway requires exactly one `ip_configuration` block whereas
-    an active-active gateway requires exactly two `ip_configuration` blocks.
+* `ip_configuration` (Required) One, two or three `ip_configuration` blocks documented below.
+    An active-standby gateway requires exactly one `ip_configuration` block,
+    an active-active gateway requires exactly two `ip_configuration` blocks whereas
+    an active-active zone redundant gateway with P2S configuration requires exactly three `ip_configuration` blocks.
 
 * `vpn_client_configuration` (Optional) A `vpn_client_configuration` block which
     is documented below. In this block the Virtual Network Gateway can be configured


### PR DESCRIPTION
Fixes #14044

### Acceptance Tests
```hcl
TF_ACC=1 go test -v ./internal/services/network -run=TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
=== PAUSE TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
=== CONT  TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
--- PASS: TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S (2485.66s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network     2487.232s
```