### PR TITLE
Fix consumption data source panic

### DIFF
--- a/internal/services/consumption/consumption_budget_resource_group_data_source.go
+++ b/internal/services/consumption/consumption_budget_resource_group_data_source.go
@@ -158,6 +158,10 @@ func resourceArmConsumptionBudgetResourceGroupDataSource() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeInt,
 							Computed: true,
 						},
+						"threshold_type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 						"operator": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,

--- a/internal/services/consumption/consumption_budget_subscription_data_source.go
+++ b/internal/services/consumption/consumption_budget_subscription_data_source.go
@@ -158,6 +158,10 @@ func resourceArmConsumptionBudgetSubscriptionDataSource() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeInt,
 							Computed: true,
 						},
+						"threshold_type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 						"operator": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,


### PR DESCRIPTION
These tests were failing in main because they were missing `threshold_type` in the schema

- TestAccDataSourceConsumptionBudgetResourceGroup_basic
- TestAccDataSourceConsumptionBudgetSubscription_basic

![image](https://user-images.githubusercontent.com/25562180/141115484-2eded2f9-0dd5-4f62-a625-6fd6375aad54.png)
