### PR TITLE
azurerm_logic_app_standard : Updated documentation to use WorkflowStandard app plan

### DIFF
--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -802,8 +802,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -845,8 +845,8 @@ resource "azurerm_app_service_plan" "test" {
   reserved            = true
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -890,8 +890,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -929,8 +929,8 @@ resource "azurerm_app_service_plan" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 resource "azurerm_logic_app_standard" "test" {
@@ -968,8 +968,8 @@ resource "azurerm_app_service_plan" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 resource "azurerm_logic_app_standard" "test" {
@@ -1027,8 +1027,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1072,8 +1072,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1118,8 +1118,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1160,8 +1160,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1207,8 +1207,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1259,8 +1259,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1304,8 +1304,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1349,8 +1349,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1396,8 +1396,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1441,8 +1441,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1483,8 +1483,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1528,8 +1528,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1582,8 +1582,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1627,8 +1627,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1672,8 +1672,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1718,8 +1718,8 @@ resource "azurerm_app_service_plan" "test" {
   kind                = "elastic"
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1764,8 +1764,8 @@ resource "azurerm_app_service_plan" "test" {
   kind                = "elastic"
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1805,8 +1805,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1852,8 +1852,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1913,8 +1913,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -1960,8 +1960,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2019,8 +2019,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2064,8 +2064,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2105,8 +2105,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2148,8 +2148,8 @@ resource "azurerm_app_service_plan" "test" {
   kind                = "elastic"
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2194,8 +2194,8 @@ resource "azurerm_app_service_plan" "test" {
   kind                = "elastic"
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2240,8 +2240,8 @@ resource "azurerm_app_service_plan" "test" {
   kind                = "elastic"
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -2287,8 +2287,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -36,8 +36,8 @@ resource "azurerm_app_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 
@@ -77,8 +77,8 @@ resource "azurerm_app_service_plan" "example" {
   reserved            = true
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "WorkflowStandard"
+    size = "WS1"
   }
 }
 


### PR DESCRIPTION
ElasticPremium app plans are no longer supported for logic app standard, updated docs to use WorkflowStandard 