### PR TITLE
`r\managed_disk` Add support for `on_demand_bursting_enabled`

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -209,6 +209,11 @@ func resourceManagedDisk() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"bursting_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -259,9 +264,9 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		},
 	}
 
-	if v := d.Get("disk_size_gb"); v != 0 {
-		diskSize := int32(v.(int))
-		props.DiskSizeGB = &diskSize
+	diskSizeGB := d.Get("disk_size_gb").(int)
+	if diskSizeGB != 0 {
+		props.DiskSizeGB = utils.Int32(int32(diskSizeGB))
 	}
 
 	if maxShares != 0 {
@@ -387,6 +392,21 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
+	if d.Get("bursting_enabled").(bool) {
+		switch storageAccountType {
+		case string(compute.StorageAccountTypesPremiumLRS):
+		case string(compute.StorageAccountTypesPremiumZRS):
+		default:
+			return fmt.Errorf("`bursting_enabled` can only be set to true when `storage_account_type` is set to `Premium_LRS` or `Premium_ZRS`")
+		}
+
+		if diskSizeGB != 0 && diskSizeGB <= 512 {
+			return fmt.Errorf("`bursting_enabled` can only be set to true when `disk_size_gb` is larger than 512")
+		}
+
+		props.BurstingEnabled = utils.Bool(true)
+	}
+
 	createDisk := compute.Disk{
 		Name:           &name,
 		Location:       &location,
@@ -431,6 +451,8 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	resourceGroup := d.Get("resource_group_name").(string)
 	maxShares := d.Get("max_shares").(int)
 	storageAccountType := d.Get("storage_account_type").(string)
+	diskSizeGB := d.Get("disk_size_gb").(int)
+	burstingEnabled := d.Get("bursting_enabled").(bool)
 	shouldShutDown := false
 
 	disk, err := client.Get(ctx, resourceGroup, name)
@@ -561,6 +583,24 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		default:
 			diskUpdate.DiskAccessID = nil
 		}
+	}
+
+	if burstingEnabled {
+		switch storageAccountType {
+		case string(compute.StorageAccountTypesPremiumLRS):
+		case string(compute.StorageAccountTypesPremiumZRS):
+		default:
+			return fmt.Errorf("`bursting_enabled` can only be set to true when `storage_account_type` is set to `Premium_LRS` or `Premium_ZRS`")
+		}
+
+		if diskSizeGB != 0 && diskSizeGB <= 512 {
+			return fmt.Errorf("`bursting_enabled` can only be set to true when `disk_size_gb` is larger than 512")
+		}
+	}
+
+	if d.HasChange("bursting_enabled") {
+		shouldShutDown = true
+		diskUpdate.BurstingEnabled = utils.Bool(burstingEnabled)
 	}
 
 	// whilst we need to shut this down, if we're not attached to anything there's no point
@@ -764,6 +804,7 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			}
 		}
 		d.Set("trusted_launch_enabled", trustedLaunchEnabled)
+		d.Set("bursting_enabled", props.BurstingEnabled)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -496,6 +496,28 @@ func TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing
 	})
 }
 
+func TestAccAzureRMManagedDisk_update_withBurstingEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.empty(data),
+			Check: resource.ComposeTestCheckFunc(
+			check.That(data.ResourceName).ExistsInAzure(r),
+		),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update_withBurstingEnabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ManagedDiskResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ManagedDiskID(state.ID)
 	if err != nil {
@@ -1545,6 +1567,31 @@ resource "azurerm_managed_disk" "test" {
   max_shares           = "2"
   zones                = ["1"]
 
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ManagedDiskResource) update_withBurstingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctestd-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1024"
+  bursting_enabled     = true
   tags = {
     environment = "acctest"
     cost-center = "ops"

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -496,20 +496,35 @@ func TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing
 	})
 }
 
-func TestAccAzureRMManagedDisk_update_withOnDemandBursting(t *testing.T) {
+func TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.create_withOnDemandBursting(data),
+			Config: r.create_withOnDemandBurstingEnabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.empty(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.update_withOnDemandBursting(data),
+			Config: r.update_withOnDemandBurstingEnabled(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1575,7 +1590,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (ManagedDiskResource) create_withOnDemandBursting(data acceptance.TestData) string {
+func (ManagedDiskResource) create_withOnDemandBurstingEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1591,7 +1606,7 @@ resource "azurerm_managed_disk" "test" {
   storage_account_type       = "Premium_LRS"
   create_option              = "Empty"
   disk_size_gb               = "1024"
-  on_demand_bursting_enabled = false
+  on_demand_bursting_enabled = true
   tags = {
     environment = "acctest"
     cost-center = "ops"
@@ -1600,7 +1615,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (ManagedDiskResource) update_withOnDemandBursting(data acceptance.TestData) string {
+func (ManagedDiskResource) update_withOnDemandBurstingEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -496,7 +496,7 @@ func TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing
 	})
 }
 
-func TestAccAzureRMManagedDisk_update_withBurstingEnabled(t *testing.T) {
+func TestAccAzureRMManagedDisk_update_withOnDemandBursting(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -502,14 +502,14 @@ func TestAccAzureRMManagedDisk_update_withBurstingEnabled(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.empty(data),
+			Config: r.create_withOnDemandBursting(data),
 			Check: resource.ComposeTestCheckFunc(
-			check.That(data.ResourceName).ExistsInAzure(r),
-		),
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.update_withBurstingEnabled(data),
+			Config: r.update_withOnDemandBursting(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1575,7 +1575,8 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (ManagedDiskResource) update_withBurstingEnabled(data acceptance.TestData) string {
+
+func (ManagedDiskResource) create_withOnDemandBursting(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1585,13 +1586,39 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 resource "azurerm_managed_disk" "test" {
-  name                 = "acctestd-%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  storage_account_type = "Premium_LRS"
-  create_option        = "Empty"
-  disk_size_gb         = "1024"
-  bursting_enabled     = true
+  name                       = "acctestd-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  storage_account_type       = "Premium_LRS"
+  create_option              = "Empty"
+  disk_size_gb               = "1024"
+  on_demand_bursting_enabled = false
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+
+func (ManagedDiskResource) update_withOnDemandBursting(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+resource "azurerm_managed_disk" "test" {
+  name                       = "acctestd-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  storage_account_type       = "Premium_LRS"
+  create_option              = "Empty"
+  disk_size_gb               = "1024"
+  on_demand_bursting_enabled = true
   tags = {
     environment = "acctest"
     cost-center = "ops"

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -1575,7 +1575,6 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-
 func (ManagedDiskResource) create_withOnDemandBursting(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1600,7 +1599,6 @@ resource "azurerm_managed_disk" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
-
 
 func (ManagedDiskResource) update_withOnDemandBursting(data acceptance.TestData) string {
 	return fmt.Sprintf(`

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -137,7 +137,9 @@ The following arguments are supported:
 
 -> **Note:** Trusted Launch can only be enabled when `create_option` is `FromImage` or `Import`.
 
-* `bursting_enabled` (Optional) Specifies if the disk-level bursting is enabled for the Managed Disk. Defaults to `false`.
+* `on_demand_bursting_enabled` (Optional) Specifies if On-Demand Bursting is enabled for the Managed Disk. Defaults to `false`.
+
+-> **Note:** Credit-Based Bursting is enabled by default on all eligible disks. More information on [Credit-Based and On-Demand Bursting can be found in the documentation](https://docs.microsoft.com/azure/virtual-machines/disk-bursting#disk-level-bursting).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -137,6 +137,8 @@ The following arguments are supported:
 
 -> **Note:** Trusted Launch can only be enabled when `create_option` is `FromImage` or `Import`.
 
+* `bursting_enabled` (Optional) Specifies if the disk-level bursting is enabled for the Managed Disk. Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `zones` - (Optional) A collection containing the availability zone to allocate the Managed Disk in.


### PR DESCRIPTION
- Support disk bursting https://docs.microsoft.com/en-us/azure/virtual-machines/disk-bursting
- It can only be enabled for `Premium_LRS` and `Premium_ZRS`, with disk size greater than 512 GB
- Test result:
$ TF_ACC=1 go test -v ./internal/services/compute -run=withOnDemandBursting -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"                      === RUN   TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled
=== PAUSE TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled
=== RUN   TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled
=== PAUSE TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled
=== CONT  TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled
=== CONT  TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled
--- PASS: TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled (346.92s)
--- PASS: TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled (543.01s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       543.700s