### PR TITLE
dependencies: upgrading to `v0.17.1` of `github.com/hashicorp/go-azure-helpers`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-azure-helpers v0.17.0
+	github.com/hashicorp/go-azure-helpers v0.17.1
 	github.com/hashicorp/go-getter v1.5.4
 	github.com/hashicorp/go-hclog v0.16.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.17.0 h1:HQF6kVNzofmwOhbRK/h/RWEVl/zu6kjB6mjoIxFL0A0=
-github.com/hashicorp/go-azure-helpers v0.17.0/go.mod h1:L4ny2lW2muOESZR1XjbM59c3Pq+7SA9Yt1Nry5UfKZc=
+github.com/hashicorp/go-azure-helpers v0.17.1 h1:qkvhSgyPzK3UwWQDocGLFmZ9iRjTj1Dv4CzeyhwfoIs=
+github.com/hashicorp/go-azure-helpers v0.17.1/go.mod h1:L4ny2lW2muOESZR1XjbM59c3Pq+7SA9Yt1Nry5UfKZc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/parse.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/parse.go
@@ -167,6 +167,12 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		return nil, fmt.Errorf("expected %d segments but got %d for %q", len(p.segments), len(parsed), input)
 	}
 
+	for k, v := range parsed {
+		if v == "" {
+			return nil, fmt.Errorf("segment %q is required but got an empty value", k)
+		}
+	}
+
 	return &ParseResult{
 		Parsed: parsed,
 	}, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,7 @@ github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.17.0
+# github.com/hashicorp/go-azure-helpers v0.17.1
 ## explicit
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates


### PR DESCRIPTION
Fixes a bug where the last segment of new Resource ID parsers would be allowed to be empty