### PR TITLE
`azurerm_kubernetes_cluster` - Support for `outbound_type = "*NATGateway"` and `nat_gateway_profile`

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -506,7 +506,9 @@ A `network_profile` block supports the following:
 
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.
 
-* `outbound_type` - (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are `loadBalancer` and `userDefinedRouting`. Defaults to `loadBalancer`.
+* `outbound_type` - (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are `loadBalancer`, `userDefinedRouting`, `managedNATGateway` and `userAssignedNATGateway`. Defaults to `loadBalancer`.
+
+~> **NOTE:** Outbound NAT Gateway is in Public Preview - more information and details on how to opt into the Preview [can be found in this article](https://docs.microsoft.com/azure/aks/nat-gateway#register-the-aks-natgatewaypreview-feature-flag).
 
 * `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. This field can only be set when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
@@ -519,6 +521,8 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 * `load_balancer_sku` - (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are `Basic` and `Standard`. Defaults to `Standard`.
 
 * `load_balancer_profile` - (Optional) A `load_balancer_profile` block. This can only be specified when `load_balancer_sku` is set to `Standard`.
+
+* `nat_gateway_profile` - (Optional) A `nat_gateway_profile` block. This can only be specified when `load_balancer_sku` is set to `Standard` and `outbound_type` is set to `managedNATGateway` or `userAssignedNATGateway`.
 
 ---
 
@@ -541,6 +545,14 @@ A `load_balancer_profile` block supports the following:
 * `outbound_ip_address_ids` - (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.
 
 -> **NOTE** User has to explicitly set `outbound_ip_address_ids` to empty slice (`[]`) to remove it.
+
+---
+
+A `nat_gateway_profile` block supports the following:
+
+* `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `120` inclusive. Defaults to `4`.
+
+* `managed_outbound_ip_count` - (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be between `1` and `100` inclusive.
 
 ---
 
@@ -715,6 +727,12 @@ A `http_application_routing` block exports the following:
 ---
 
 A `load_balancer_profile` block exports the following:
+
+* `effective_outbound_ips` - The outcome (resource IDs) of the specified arguments.
+
+---
+
+A `nat_gateway_profile` block exports the following:
 
 * `effective_outbound_ips` - The outcome (resource IDs) of the specified arguments.
 


### PR DESCRIPTION
Fixes #14138

### Acceptance Tests
- [x] `outboundType = "managedNATGateway"`
```bash
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesCluster_managedNatGateway -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_managedNatGateway
=== PAUSE TestAccKubernetesCluster_managedNatGateway
=== CONT  TestAccKubernetesCluster_managedNatGateway
--- PASS: TestAccKubernetesCluster_managedNatGateway (589.09s)
PASS
ok   github.com/hashicorp/terraform-provider-azurerm/internal/services/containers     590.831s
```
- [x] `outboundType = "managedNATGateway"` with `nat_gateway_profile` settings
```bash
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesCluster_natGatewayProfile -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_natGatewayProfile
=== PAUSE TestAccKubernetesCluster_natGatewayProfile
=== CONT  TestAccKubernetesCluster_natGatewayProfile
--- PASS: TestAccKubernetesCluster_natGatewayProfile (748.23s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/service
```
- [x] `outboundType = "userAssignedNATGateway"`
```bash
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesCluster_userAssignedNatGateway -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_userAssignedNatGateway
=== PAUSE TestAccKubernetesCluster_userAssignedNatGateway
=== CONT  TestAccKubernetesCluster_userAssignedNatGateway
--- PASS: TestAccKubernetesCluster_userAssignedNatGateway (647.71s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers     649.450s
```