### PR TITLE
Update link milestone GHA to securely link milestones for PRs from forked repos

### DIFF
--- a/.github/workflows/link-milestone-upload-pr.yaml
+++ b/.github/workflows/link-milestone-upload-pr.yaml
@@ -1,0 +1,25 @@
+---
+name: Link Milestone Upload PR Number
+on:
+  pull_request:
+    branches: [main]
+    types: ['closed']
+
+jobs:
+  link-milestone:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/nr
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/link-milestone-upload-pr.yaml
+++ b/.github/workflows/link-milestone-upload-pr.yaml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
     steps:
       - run: |
           mkdir -p ./pr

--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -1,14 +1,17 @@
 ---
 name: Link Milestone
 on:
-  pull_request:
-    branches: [main]
-    types: ['closed']
+  workflow_run:
+    workflows: ['Link Milestone Upload PR Number']
+    types:
+      - completed
 
 jobs:
   link-milestone:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: true
     permissions:
@@ -17,6 +20,28 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: |
+          unzip pr.zip
+          echo "PR_NUMBER=$(cat nr)" >> $GITHUB_ENV
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.7'
@@ -24,6 +49,5 @@ jobs:
           go install github.com/stephybun/link-milestone@latest
           link-milestone
         env:
-          PR_NUMBER: ${{ github.event.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
As per security guidelines an explicit checkout should be avoided when using `pull_request_target`. Unfortunately this functionality relies on the contents of the CHANGELOG.md in order to determine the version number of the next release which corresponds to the milestones used in this project. Thus a checkout of the code is unavoidable and this needed to be split into two separate GHA.