### PR TITLE
Fix #14152 by adding lock to avoid parallel race error on service side

### DIFF
--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -183,6 +184,9 @@ func resourceNetworkWatcherFlowLogCreateUpdate(d *pluginsdk.ResourceData, meta i
 	nsgId, _ := parse.NetworkSecurityGroupID(networkSecurityGroupID)
 	id := parse.NewFlowLogID(subscriptionId, resourceGroupName, networkWatcherName, *nsgId)
 
+	locks.ByID(nsgId.ID())
+	defer locks.UnlockByID(nsgId.ID())
+
 	loc := d.Get("location").(string)
 	if loc == "" {
 		// Get the containing network watcher in order to reuse its location if the "location" is not specified.
@@ -295,6 +299,9 @@ func resourceNetworkWatcherFlowLogDelete(d *pluginsdk.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
+
+	locks.ByID(id.NetworkSecurityGroupID())
+	defer locks.UnlockByID(id.NetworkSecurityGroupID())
 
 	future, err := client.Delete(ctx, id.ResourceGroupName, id.NetworkWatcherName, id.Name())
 	if err != nil {


### PR DESCRIPTION
As #14152 described, when create multiple `azurerm_network_watcher_flow_log` with same `network_security_group_id`, the service side would complain a "AnotherOperationInProgress".

This patch add an internal lock on nsg id to avoid this issue.

AccTest (The failed test also failed on main branch so I guess it's ok for this patch):

=== RUN   TestAccNetworkWatcher
--- FAIL: TestAccNetworkWatcher (3166.82s)
=== RUN   TestAccNetworkWatcher/FlowLog
    --- FAIL: TestAccNetworkWatcher/FlowLog (3166.82s)
=== RUN   TestAccNetworkWatcher/FlowLog/updateStorageAccount
        --- PASS: TestAccNetworkWatcher/FlowLog/updateStorageAccount (319.39s)
=== RUN   TestAccNetworkWatcher/FlowLog/trafficAnalytics
        --- PASS: TestAccNetworkWatcher/FlowLog/trafficAnalytics (630.38s)
=== RUN   TestAccNetworkWatcher/FlowLog/long_name_with_hyphen
    testcase.go:116: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating/updating NSG "acctestNSG01-" (Resource Group "acctestRG-watcher-01234567890123456789012345678902"): network.SecurityGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidResourceName" Message="Resource name acctestNSG01- is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'." Details=[]
        
          with azurerm_network_security_group.test,
          on terraform_plugin_test.tf line 12, in resource "azurerm_network_security_group" "test":
          12: resource "azurerm_network_security_group" "test" {
        
        --- FAIL: TestAccNetworkWatcher/FlowLog/long_name_with_hyphen (114.16s)



FAIL
=== RUN   TestAccNetworkWatcher/FlowLog/version
        --- PASS: TestAccNetworkWatcher/FlowLog/version (300.73s)
=== RUN   TestAccNetworkWatcher/FlowLog/location
        --- PASS: TestAccNetworkWatcher/FlowLog/location (176.99s)
=== RUN   TestAccNetworkWatcher/FlowLog/basic
        --- PASS: TestAccNetworkWatcher/FlowLog/basic (232.72s)
=== RUN   TestAccNetworkWatcher/FlowLog/disabled
        --- PASS: TestAccNetworkWatcher/FlowLog/disabled (292.15s)
=== RUN   TestAccNetworkWatcher/FlowLog/reenabled
        --- PASS: TestAccNetworkWatcher/FlowLog/reenabled (262.21s)
=== RUN   TestAccNetworkWatcher/FlowLog/retentionPolicy
        --- PASS: TestAccNetworkWatcher/FlowLog/retentionPolicy (349.49s)
=== RUN   TestAccNetworkWatcher/FlowLog/long_name
        --- PASS: TestAccNetworkWatcher/FlowLog/long_name (179.48s)
=== RUN   TestAccNetworkWatcher/FlowLog/tags
        --- PASS: TestAccNetworkWatcher/FlowLog/tags (394.80s)


FAIL