### PR TITLE
`windows_virtual_machine_scale_set`/`linux_virtual_machine_scale_set` - `source_image_reference.offer` and `source_image_reference.publisher` are now ForceNew

### DIFF
--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -351,13 +351,13 @@ func sourceImageReferenceSchema(isVirtualMachine bool) *pluginsdk.Schema {
 				"publisher": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ForceNew:     isVirtualMachine,
+					ForceNew:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 				"offer": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ForceNew:     isVirtualMachine,
+					ForceNew:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 				"sku": {


### PR DESCRIPTION
As #13657 described, `source_image_reference.offer` and `source_image_reference.publisher` should be `ForceNew` because service side doesn't support update these two properties. This patch change two properties `ForceNew` to true. The `sourceImageReferenceSchema` function was used by two different resource types: VIrtualMachine and VirtualMachine Scale Set. In VirtualMachine resource code, the `isVirtualMachine` parameter is true already, so this patch won't affect them.

As our subscription has some security policy so I cannot run the acc tests, sorry about that.