### PR TITLE
`azurerm_mssql_server` - support `azuread_authentication_only` on create

### DIFF
--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -163,7 +163,7 @@ func TestAccMsSqlServer_azureadAdminUpdate(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.aadAdminUpdate(data),
+			Config: r.aadAdminWithAADAuthOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -171,6 +171,21 @@ func TestAccMsSqlServer_azureadAdminUpdate(t *testing.T) {
 		data.ImportStep("administrator_login_password"),
 		{
 			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+	})
+}
+
+func TestAccMsSqlServer_azureadAdminWithAADAuthOnly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MsSqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.aadAdminWithAADAuthOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -607,7 +622,7 @@ resource "azurerm_mssql_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, os.Getenv("ARM_CLIENT_ID"))
 }
 
-func (MsSqlServerResource) aadAdminUpdate(data acceptance.TestData) string {
+func (MsSqlServerResource) aadAdminWithAADAuthOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
Missed scenario fixed while looking at another issue.

`azuread_authentication_only` worked only on update, now also on create.

### Acceptance Tests
```bash
go install && make acctests SERVICE='mssql' TESTARGS='-run=TestAccMsSqlServer_azureadAdmin'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/mssql -run=TestAccMsSqlServer_azureadAdmin -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMsSqlServer_azureadAdmin
=== PAUSE TestAccMsSqlServer_azureadAdmin
=== RUN   TestAccMsSqlServer_azureadAdminUpdate
=== PAUSE TestAccMsSqlServer_azureadAdminUpdate
=== RUN   TestAccMsSqlServer_azureadAdminWithAADAuthOnly
=== PAUSE TestAccMsSqlServer_azureadAdminWithAADAuthOnly
=== CONT  TestAccMsSqlServer_azureadAdmin
=== CONT  TestAccMsSqlServer_azureadAdminWithAADAuthOnly
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
=== CONT  TestAccMsSqlServer_azureadAdminWithAADAuthOnly
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
=== CONT  TestAccMsSqlServer_azureadAdminWithAADAuthOnly
=== CONT  TestAccMsSqlServer_azureadAdmin
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
--- PASS: TestAccMsSqlServer_azureadAdmin (480.10s)
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
--- PASS: TestAccMsSqlServer_azureadAdminWithAADAuthOnly (620.03s)
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
--- PASS: TestAccMsSqlServer_azureadAdminUpdate (1031.82s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql 1034.114s
```