### PR TITLE
`azurerm_sql_active_directory_administrator` - Support for `azuread_authentication_only`

### DIFF
--- a/internal/services/sql/client/client.go
+++ b/internal/services/sql/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2017-03-01-preview/sql"
 	msi "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2018-06-01-preview/sql"
+	aadAdmin "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v5.0/sql"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
@@ -18,7 +19,8 @@ type Client struct {
 	ServersClient                              *sql.ServersClient
 	ServerExtendedBlobAuditingPoliciesClient   *sql.ExtendedServerBlobAuditingPoliciesClient
 	ServerConnectionPoliciesClient             *sql.ServerConnectionPoliciesClient
-	ServerAzureADAdministratorsClient          *sql.ServerAzureADAdministratorsClient
+	ServerAzureADAdministratorsClient          *aadAdmin.ServerAzureADAdministratorsClient
+	ServerAzureADOnlyAuthenticationsClient     *aadAdmin.ServerAzureADOnlyAuthenticationsClient
 	ServerSecurityAlertPoliciesClient          *sql.ServerSecurityAlertPoliciesClient
 	VirtualNetworkRulesClient                  *sql.VirtualNetworkRulesClient
 }
@@ -55,8 +57,11 @@ func NewClient(o *common.ClientOptions) *Client {
 	serverConnectionPoliciesClient := sql.NewServerConnectionPoliciesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&serverConnectionPoliciesClient.Client, o.ResourceManagerAuthorizer)
 
-	serverAzureADAdministratorsClient := sql.NewServerAzureADAdministratorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	serverAzureADAdministratorsClient := aadAdmin.NewServerAzureADAdministratorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&serverAzureADAdministratorsClient.Client, o.ResourceManagerAuthorizer)
+
+	serverAzureADOnlyAuthenticationsClient := aadAdmin.NewServerAzureADOnlyAuthenticationsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&serverAzureADOnlyAuthenticationsClient.Client, o.ResourceManagerAuthorizer)
 
 	virtualNetworkRulesClient := sql.NewVirtualNetworkRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&virtualNetworkRulesClient.Client, o.ResourceManagerAuthorizer)
@@ -78,6 +83,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		ManagedDatabasesClient:                     &managedDatabasesClient,
 		ServersClient:                              &serversClient,
 		ServerAzureADAdministratorsClient:          &serverAzureADAdministratorsClient,
+		ServerAzureADOnlyAuthenticationsClient:     &serverAzureADOnlyAuthenticationsClient,
 		ServerConnectionPoliciesClient:             &serverConnectionPoliciesClient,
 		ServerExtendedBlobAuditingPoliciesClient:   &serverExtendedBlobAuditingPoliciesClient,
 		ServerSecurityAlertPoliciesClient:          &serverSecurityAlertPoliciesClient,

--- a/internal/services/sql/sql_administrator_resource_test.go
+++ b/internal/services/sql/sql_administrator_resource_test.go
@@ -36,6 +36,38 @@ func TestAccSqlAdministrator_basic(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.aadOnlyAuthEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("azuread_authentication_only").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSqlAdministrator_aadOnlyAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sql_active_directory_administrator", "test")
+	r := SqlAdministratorResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.aadOnlyAuthEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("azuread_authentication_only").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.aadOnlyAuthEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("azuread_authentication_only").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -172,4 +204,38 @@ resource "azurerm_sql_active_directory_administrator" "test" {
   object_id           = data.azurerm_client_config.current.client_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r SqlAdministratorResource) aadOnlyAuthEnabled(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_sql_server" "test" {
+  name                         = "acctestsqlserver%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "mradministrator"
+  administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_active_directory_administrator" "test" {
+  server_name                 = azurerm_sql_server.test.name
+  resource_group_name         = azurerm_resource_group.test.name
+  login                       = "sqladmin"
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  object_id                   = data.azurerm_client_config.current.client_id
+  azuread_authentication_only = %t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
 }

--- a/website/docs/r/sql_active_directory_administrator.html.markdown
+++ b/website/docs/r/sql_active_directory_administrator.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `tenant_id` - (Required) The Azure Tenant ID
 
+* `azuread_authentication_only` - (Optional) Specifies whether only AD Users and administrators can be used to login (`true`) or also local database users (`false`).
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Fixes #12252

### Acceptance Tests
```bash
--- PASS: TestAccSqlAdministrator_basic (615.25s)
--- PASS: TestAccSqlAdministrator_aadOnlyAuth (616.39s)
```