### PR TITLE
azurerm_storage_account: move to use getProperties API instead of List API when creating a storage account

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1071,7 +1071,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if val, ok := d.GetOk("queue_properties"); ok {
 		storageClient := meta.(*clients.Client).Storage
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 		}
@@ -1115,7 +1115,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		storageClient := meta.(*clients.Client).Storage
 
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 		}
@@ -1445,7 +1445,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if d.HasChange("queue_properties") {
 		storageClient := meta.(*clients.Client).Storage
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 		}
@@ -1489,7 +1489,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		storageClient := meta.(*clients.Client).Storage
 
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 		}
@@ -1695,7 +1695,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	storageClient := meta.(*clients.Client).Storage
-	account, err := storageClient.FindAccount(ctx, storageAccountName)
+	account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 	if err != nil {
 		return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 	}
@@ -1764,7 +1764,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if resp.Kind == storage.StorageV2 || resp.Kind == storage.BlockBlobStorage {
 		storageClient := meta.(*clients.Client).Storage
 
-		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		account, err := storageClient.FindAccountWithSpecifiedResourceGroup(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("retrieving Account %q: %s", storageAccountName, err)
 		}


### PR DESCRIPTION
The purpose of this PR:

When creating a storage account , it is no need to list all storage accounts in the subscription. Move to use getProperties API to retrieve the specified storage account instead list all storage account.

Fixes: [#issue 5299](https://github.com/hashicorp/terraform-provider-azurerm/issues/5299)

Test Results:
TF_ACC=1 go test ./internal/services/storage/ -v -parallel 11 -test.run=TestAccStorageAccount_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== RUN TestAccStorageAccount_requiresImport
=== PAUSE TestAccStorageAccount_requiresImport
=== RUN TestAccStorageAccount_tagCount
=== PAUSE TestAccStorageAccount_tagCount
=== RUN TestAccStorageAccount_writeLock
=== PAUSE TestAccStorageAccount_writeLock
=== RUN TestAccStorageAccount_premium
=== PAUSE TestAccStorageAccount_premium
=== RUN TestAccStorageAccount_disappears
=== PAUSE TestAccStorageAccount_disappears
=== RUN TestAccStorageAccount_blobConnectionString
=== PAUSE TestAccStorageAccount_blobConnectionString
=== RUN TestAccStorageAccount_enableHttpsTrafficOnly
=== PAUSE TestAccStorageAccount_enableHttpsTrafficOnly
=== RUN TestAccStorageAccount_minTLSVersion
=== PAUSE TestAccStorageAccount_minTLSVersion
=== RUN TestAccStorageAccount_allowBlobPublicAccess
=== PAUSE TestAccStorageAccount_allowBlobPublicAccess
=== RUN TestAccStorageAccount_isHnsEnabled
=== PAUSE TestAccStorageAccount_isHnsEnabled
=== RUN TestAccStorageAccount_isNFSv3Enabled
=== PAUSE TestAccStorageAccount_isNFSv3Enabled
=== RUN TestAccStorageAccount_blobStorageWithUpdate
=== PAUSE TestAccStorageAccount_blobStorageWithUpdate
=== RUN TestAccStorageAccount_blockBlobStorage
=== PAUSE TestAccStorageAccount_blockBlobStorage
=== RUN TestAccStorageAccount_fileStorageWithUpdate
=== PAUSE TestAccStorageAccount_fileStorageWithUpdate
=== RUN TestAccStorageAccount_storageV2WithUpdate
=== PAUSE TestAccStorageAccount_storageV2WithUpdate
=== RUN TestAccStorageAccount_storageV1ToV2Update
=== PAUSE TestAccStorageAccount_storageV1ToV2Update
=== RUN TestAccStorageAccount_NonStandardCasing
=== PAUSE TestAccStorageAccount_NonStandardCasing
=== RUN TestAccStorageAccount_systemAssignedIdentity
=== PAUSE TestAccStorageAccount_systemAssignedIdentity
=== RUN TestAccStorageAccount_userAssignedIdentity
=== PAUSE TestAccStorageAccount_userAssignedIdentity
=== RUN TestAccStorageAccount_systemAssignedUserAssignedIdentity
=== PAUSE TestAccStorageAccount_systemAssignedUserAssignedIdentity
=== RUN TestAccStorageAccount_updateResourceByEnablingIdentity
=== PAUSE TestAccStorageAccount_updateResourceByEnablingIdentity
=== RUN TestAccStorageAccount_networkRules
=== PAUSE TestAccStorageAccount_networkRules
=== RUN TestAccStorageAccount_networkRulesDeleted
=== PAUSE TestAccStorageAccount_networkRulesDeleted
=== RUN TestAccStorageAccount_privateLinkAccess
=== PAUSE TestAccStorageAccount_privateLinkAccess
=== RUN TestAccStorageAccount_networkRulesSynapseAccess
=== PAUSE TestAccStorageAccount_networkRulesSynapseAccess
=== RUN TestAccStorageAccount_blobProperties
=== PAUSE TestAccStorageAccount_blobProperties
=== RUN TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== PAUSE TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== RUN TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
=== PAUSE TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
=== RUN TestAccStorageAccount_queueProperties
=== PAUSE TestAccStorageAccount_queueProperties
=== RUN TestAccStorageAccount_staticWebsiteEnabled
=== PAUSE TestAccStorageAccount_staticWebsiteEnabled
=== RUN TestAccStorageAccount_staticWebsitePropertiesForStorageV2
=== PAUSE TestAccStorageAccount_staticWebsitePropertiesForStorageV2
=== RUN TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
=== PAUSE TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
=== RUN TestAccStorageAccount_replicationTypeGZRS
=== PAUSE TestAccStorageAccount_replicationTypeGZRS
=== RUN TestAccStorageAccount_largeFileShare
=== PAUSE TestAccStorageAccount_largeFileShare
=== RUN TestAccStorageAccount_hnsWithPremiumStorage
=== PAUSE TestAccStorageAccount_hnsWithPremiumStorage
=== RUN TestAccStorageAccount_allowSharedKeyAccess
=== PAUSE TestAccStorageAccount_allowSharedKeyAccess
=== CONT TestAccStorageAccount_basic
=== CONT TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
=== CONT TestAccStorageAccount_replicationTypeGZRS
=== CONT TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
=== CONT TestAccStorageAccount_staticWebsiteEnabled
=== CONT TestAccStorageAccount_fileStorageWithUpdate
=== CONT TestAccStorageAccount_updateResourceByEnablingIdentity
=== CONT TestAccStorageAccount_allowSharedKeyAccess
=== CONT TestAccStorageAccount_hnsWithPremiumStorage
=== CONT TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== CONT TestAccStorageAccount_staticWebsitePropertiesForStorageV2
--- PASS: TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders (221.38s)
=== CONT TestAccStorageAccount_blobProperties
--- PASS: TestAccStorageAccount_hnsWithPremiumStorage (228.65s)
=== CONT TestAccStorageAccount_networkRulesSynapseAccess
--- PASS: TestAccStorageAccount_fileStorageWithUpdate (286.38s)
=== CONT TestAccStorageAccount_privateLinkAccess
--- PASS: TestAccStorageAccount_allowSharedKeyAccess (294.81s)
=== CONT TestAccStorageAccount_networkRulesDeleted
--- PASS: TestAccStorageAccount_staticWebsitePropertiesForStorageV2 (300.52s)
=== CONT TestAccStorageAccount_networkRules
--- PASS: TestAccStorageAccount_replicationTypeGZRS (304.99s)
=== CONT TestAccStorageAccount_largeFileShare
=== CONT TestAccStorageAccount_queueProperties
--- PASS: TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage (307.10s)
--- PASS: TestAccStorageAccount_basic (311.73s)
=== CONT TestAccStorageAccount_systemAssignedIdentity
--- PASS: TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled (319.82s)
=== CONT TestAccStorageAccount_systemAssignedUserAssignedIdentity
--- PASS: TestAccStorageAccount_staticWebsiteEnabled (395.98s)
=== CONT TestAccStorageAccount_userAssignedIdentity
--- PASS: TestAccStorageAccount_updateResourceByEnablingIdentity (454.08s)
=== CONT TestAccStorageAccount_storageV1ToV2Update
--- PASS: TestAccStorageAccount_systemAssignedUserAssignedIdentity (162.39s)
=== CONT TestAccStorageAccount_NonStandardCasing
--- PASS: TestAccStorageAccount_systemAssignedIdentity (201.81s)
=== CONT TestAccStorageAccount_storageV2WithUpdate
--- PASS: TestAccStorageAccount_blobProperties (324.64s)
=== CONT TestAccStorageAccount_isNFSv3Enabled
--- PASS: TestAccStorageAccount_userAssignedIdentity (159.73s)
=== CONT TestAccStorageAccount_blockBlobStorage
--- PASS: TestAccStorageAccount_queueProperties (278.03s)
=== CONT TestAccStorageAccount_blobStorageWithUpdate
--- PASS: TestAccStorageAccount_networkRulesDeleted (332.67s)
=== CONT TestAccStorageAccount_enableHttpsTrafficOnly
--- PASS: TestAccStorageAccount_networkRules (328.67s)
=== CONT TestAccStorageAccount_premium
--- PASS: TestAccStorageAccount_storageV1ToV2Update (233.55s)
=== CONT TestAccStorageAccount_disappears
--- PASS: TestAccStorageAccount_largeFileShare (386.38s)
=== CONT TestAccStorageAccount_isHnsEnabled
--- PASS: TestAccStorageAccount_blockBlobStorage (143.64s)
=== CONT TestAccStorageAccount_allowBlobPublicAccess
--- PASS: TestAccStorageAccount_NonStandardCasing (245.58s)
=== CONT TestAccStorageAccount_tagCount
--- PASS: TestAccStorageAccount_storageV2WithUpdate (220.38s)
=== CONT TestAccStorageAccount_writeLock
--- PASS: TestAccStorageAccount_isNFSv3Enabled (246.69s)
=== CONT TestAccStorageAccount_requiresImport
--- PASS: TestAccStorageAccount_blobStorageWithUpdate (222.26s)
=== CONT TestAccStorageAccount_minTLSVersion
--- PASS: TestAccStorageAccount_premium (206.03s)
=== CONT TestAccStorageAccount_blobConnectionString
--- PASS: TestAccStorageAccount_privateLinkAccess (569.54s)
--- PASS: TestAccStorageAccount_disappears (176.70s)
--- PASS: TestAccStorageAccount_enableHttpsTrafficOnly (296.66s)
--- PASS: TestAccStorageAccount_tagCount (219.67s)
--- PASS: TestAccStorageAccount_writeLock (227.57s)
--- PASS: TestAccStorageAccount_isHnsEnabled (322.59s)
--- PASS: TestAccStorageAccount_requiresImport (238.79s)
--- PASS: TestAccStorageAccount_blobConnectionString (197.38s)
--- PASS: TestAccStorageAccount_allowBlobPublicAccess (377.42s)
--- PASS: TestAccStorageAccount_networkRulesSynapseAccess (991.29s)
--- PASS: TestAccStorageAccount_minTLSVersion (480.17s)
PASS
ok github.com/hashicorp/terraform-provider-azurerm/internal/services/storage 1287.970s