### PR TITLE
GHA link-milestone for PRs from forked repos

### DIFF
--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -1,7 +1,7 @@
 ---
 name: Link Milestone
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: ['closed']
 
@@ -16,7 +16,6 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17.3'


### PR DESCRIPTION
The `link-milestone` script gets the next milestone for release from information available in GH only.

This change:
- Removes the explicit checkout of code
- uses `pull_request_target`