### PR TITLE
`r\managed_disk`: Add support for `public_network_access_enabled`

### DIFF
--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -153,6 +153,8 @@ The following arguments are supported:
 
 ~> **Note**: `disk_access_id` is only supported when `network_access_policy` is set to `AllowPrivate`.
 
+* `public_network_access_enabled` - (Optional) Whether it is allowed to access the disk via public network. Defaults to `true`.
+
 For more information on managed disks, such as sizing options and pricing, please check out the [Azure Documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview).
 
 ---


### PR DESCRIPTION
This is a new property in [2021-04-01/compute](https://github.com/Azure/azure-rest-api-specs/blob/48e3687f073bee2cdc03b1bab8b2cbbee07dcf49/specification/compute/resource-manager/Microsoft.Compute/stable/2021-04-01/disk.json#L2544) which controls the public network access of the disk (whether a SAS url can be generated to access the disk). Its default value is `true`. When set to `false`, it will disallow the public network access even if `network_access_policy` is `AllowAll`.

Test result:
$ TF_ACC=1 go test -v ./internal/services/compute -run=TestAccAzureRMManagedDisk_publicNetworkAccess -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMManagedDisk_publicNetworkAccessDefault
=== PAUSE TestAccAzureRMManagedDisk_publicNetworkAccessDefault
=== RUN   TestAccAzureRMManagedDisk_publicNetworkAccessDisabled
=== PAUSE TestAccAzureRMManagedDisk_publicNetworkAccessDisabled
=== RUN   TestAccAzureRMManagedDisk_publicNetworkAccessUpdated
=== PAUSE TestAccAzureRMManagedDisk_publicNetworkAccessUpdated
=== CONT  TestAccAzureRMManagedDisk_publicNetworkAccessDefault
=== CONT  TestAccAzureRMManagedDisk_publicNetworkAccessUpdated
=== CONT  TestAccAzureRMManagedDisk_publicNetworkAccessDisabled
--- PASS: TestAccAzureRMManagedDisk_publicNetworkAccessDisabled (366.65s)
--- PASS: TestAccAzureRMManagedDisk_publicNetworkAccessDefault (368.29s)
--- PASS: TestAccAzureRMManagedDisk_publicNetworkAccessUpdated (542.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       542.872s