### PR TITLE
Support new property flow_timeout_in_minutes for azurerm_virtual_network

### DIFF
--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -100,6 +100,12 @@ func resourceVirtualNetwork() *pluginsdk.Resource {
 				},
 			},
 
+			"flow_timeout_in_minutes": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(4, 30),
+			},
+
 			// TODO 3.0: Remove this property
 			"vm_protection_enabled": {
 				Type:       pluginsdk.TypeBool,
@@ -186,6 +192,10 @@ func resourceVirtualNetworkCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		Tags:                           tags.Expand(t),
 	}
 
+	if v, ok := d.GetOk("flow_timeout_in_minutes"); ok {
+		vnet.VirtualNetworkPropertiesFormat.FlowTimeoutInMinutes = utils.Int32(int32(v.(int)))
+	}
+
 	networkSecurityGroupNames := make([]string, 0)
 	for _, subnet := range *vnet.VirtualNetworkPropertiesFormat.Subnets {
 		if subnet.NetworkSecurityGroup != nil {
@@ -257,6 +267,7 @@ func resourceVirtualNetworkRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if props := resp.VirtualNetworkPropertiesFormat; props != nil {
 		d.Set("guid", props.ResourceGUID)
+		d.Set("flow_timeout_in_minutes", props.FlowTimeoutInMinutes)
 
 		if space := props.AddressSpace; space != nil {
 			d.Set("address_space", utils.FlattenStringSlice(space.AddressPrefixes))

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -307,11 +307,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                    = "acctestvirtnet%d"
-  address_space           = ["10.0.0.0/16", "10.10.0.0/16"]
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  dns_servers             = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16", "10.10.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_servers         = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
 
   subnet {
     name           = "subnet1"

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -48,6 +48,42 @@ func TestAccVirtualNetwork_complete(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetwork_updateFlowTimeoutInMinutes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateFlowTimeoutInMinutes(data, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateFlowTimeoutInMinutes(data, 6),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualNetwork_basicUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
@@ -271,11 +307,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["10.0.0.0/16", "10.10.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_servers         = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
+  name                    = "acctestvirtnet%d"
+  address_space           = ["10.0.0.0/16", "10.10.0.0/16"]
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  dns_servers             = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
 
   subnet {
     name           = "subnet1"
@@ -449,4 +485,25 @@ resource "azurerm_virtual_network" "test" {
   bgp_community = "12076:20000"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (VirtualNetworkResource) updateFlowTimeoutInMinutes(data acceptance.TestData, flowTimeout int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                    = "acctestvirtnet%d"
+  address_space           = ["10.0.0.0/16"]
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  flow_timeout_in_minutes = %d
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, flowTimeout)
 }

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 -> **NOTE** Since `dns_servers` can be configured both inline and via the separate `azurerm_virtual_network_dns_servers` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 
-* `flow_timeout_in_minutes` - (Optional) The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Valid values are between `4` and `30` minutes.
+* `flow_timeout_in_minutes` - (Optional) The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between `4` and `30` minutes.
 
 * `subnet` - (Optional) Can be specified multiple times to define multiple subnets. Each `subnet` block supports fields documented below.
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -93,6 +93,8 @@ The following arguments are supported:
 
 -> **NOTE** Since `dns_servers` can be configured both inline and via the separate `azurerm_virtual_network_dns_servers` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 
+* `flow_timeout_in_minutes` - (Optional) The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Valid values are between `4` and `30` minutes.
+
 * `subnet` - (Optional) Can be specified multiple times to define multiple subnets. Each `subnet` block supports fields documented below.
 
 -> **NOTE** Since `subnet` can be configured both inline and via the separate `azurerm_subnet` resource, we have to explicitly set it to empty slice (`[]`) to remove it.


### PR DESCRIPTION
This PR to support new property flow_timeout_in_minutes for Virtual Network.

![image](https://user-images.githubusercontent.com/19754191/142090546-a0b54828-0000-492d-99a8-a2eeb1b3b813.png)

