### PR TITLE
App Service Beta - support for Load Balancer timeouts and VNet Route All.

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -46,7 +46,7 @@ type SiteConfigLinuxFunctionApp struct {
 	WebSockets                    bool                               `tfschema:"websockets_enabled"`
 	FtpsState                     string                             `tfschema:"ftps_state"`
 	HealthCheckPath               string                             `tfschema:"health_check_path"`
-	HealthCheckEvictionTime       int                                `tfschema:"health_check_eviction_time"`
+	HealthCheckEvictionTime       int                                `tfschema:"health_check_eviction_time_in_min"`
 	NumberOfWorkers               int                                `tfschema:"number_of_workers"`
 	ApplicationStack              []ApplicationStackLinuxFunctionApp `tfschema:"application_stack"`
 	MinTlsVersion                 string                             `tfschema:"minimum_tls_version"`
@@ -269,7 +269,7 @@ func SiteConfigSchemaLinuxFunctionApp() *pluginsdk.Schema {
 					Description: "The path to be checked for this function app health.",
 				},
 
-				"health_check_eviction_time": { // NOTE: Will evict the only node in single node configurations.
+				"health_check_eviction_time_in_min": { // NOTE: Will evict the only node in single node configurations.
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -563,7 +563,7 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 	linuxSiteConfig := siteConfig[0]
 
 	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
-		if linuxSiteConfig.HealthCheckPath != "" && metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time") {
+		if linuxSiteConfig.HealthCheckPath != "" && metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
 			v := strconv.Itoa(linuxSiteConfig.HealthCheckEvictionTime)
 			appSettings = append(appSettings, web.NameValuePair{
 				Name:  utils.String("WEBSITE_HEALTHCHECK_MAXPINGFAILURES"),

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -226,7 +226,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 				"use_32_bit_worker": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Default:  false,
+					Computed: true, // Variable default value depending on several factors, such as plan type.
 				},
 
 				"websockets_enabled": {

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -17,38 +17,40 @@ import (
 )
 
 type SiteConfigWindows struct {
-	AlwaysOn                 bool                      `tfschema:"always_on"`
-	ApiManagementConfigId    string                    `tfschema:"api_management_api_id"`
-	ApiDefinition            string                    `tfschema:"api_definition_url"`
-	AppCommandLine           string                    `tfschema:"app_command_line"`
-	AutoHeal                 bool                      `tfschema:"auto_heal"`
-	AutoHealSettings         []AutoHealSettingWindows  `tfschema:"auto_heal_setting"`
-	UseManagedIdentityACR    bool                      `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryUserMSI string                    `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments         []string                  `tfschema:"default_documents"`
-	Http2Enabled             bool                      `tfschema:"http2_enabled"`
-	IpRestriction            []IpRestriction           `tfschema:"ip_restriction"`
-	ScmUseMainIpRestriction  bool                      `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction         []IpRestriction           `tfschema:"scm_ip_restriction"`
-	LoadBalancing            string                    `tfschema:"load_balancing_mode"`
-	LocalMysql               bool                      `tfschema:"local_mysql"`
-	ManagedPipelineMode      string                    `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging          bool                      `tfschema:"remote_debugging"`
-	RemoteDebuggingVersion   string                    `tfschema:"remote_debugging_version"`
-	ScmType                  string                    `tfschema:"scm_type"`
-	Use32BitWorker           bool                      `tfschema:"use_32_bit_worker"`
-	WebSockets               bool                      `tfschema:"websockets_enabled"`
-	FtpsState                string                    `tfschema:"ftps_state"`
-	HealthCheckPath          string                    `tfschema:"health_check_path"`
-	NumberOfWorkers          int                       `tfschema:"number_of_workers"`
-	ApplicationStack         []ApplicationStackWindows `tfschema:"application_stack"`
-	VirtualApplications      []VirtualApplication      `tfschema:"virtual_application"`
-	MinTlsVersion            string                    `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion         string                    `tfschema:"scm_minimum_tls_version"`
-	AutoSwapSlotName         string                    `tfschema:"auto_swap_slot_name"`
-	Cors                     []CorsSetting             `tfschema:"cors"`
-	DetailedErrorLogging     bool                      `tfschema:"detailed_error_logging"`
-	WindowsFxVersion         string                    `tfschema:"windows_fx_version"`
+	AlwaysOn                 bool                     `tfschema:"always_on"`
+	ApiManagementConfigId    string                   `tfschema:"api_management_api_id"`
+	ApiDefinition            string                   `tfschema:"api_definition_url"`
+	AppCommandLine           string                   `tfschema:"app_command_line"`
+	AutoHeal                 bool                     `tfschema:"auto_heal"`
+	AutoHealSettings         []AutoHealSettingWindows `tfschema:"auto_heal_setting"`
+	UseManagedIdentityACR    bool                     `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryUserMSI string                   `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments         []string                 `tfschema:"default_documents"`
+	Http2Enabled             bool                     `tfschema:"http2_enabled"`
+	IpRestriction            []IpRestriction          `tfschema:"ip_restriction"`
+	ScmUseMainIpRestriction  bool                     `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction         []IpRestriction          `tfschema:"scm_ip_restriction"`
+	LoadBalancing            string                   `tfschema:"load_balancing_mode"`
+	LocalMysql               bool                     `tfschema:"local_mysql"`
+	ManagedPipelineMode      string                   `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging          bool                     `tfschema:"remote_debugging"`
+	RemoteDebuggingVersion   string                   `tfschema:"remote_debugging_version"`
+	ScmType                  string                   `tfschema:"scm_type"`
+	Use32BitWorker           bool                     `tfschema:"use_32_bit_worker"`
+	WebSockets               bool                     `tfschema:"websockets_enabled"`
+	FtpsState                string                   `tfschema:"ftps_state"`
+	HealthCheckPath          string                   `tfschema:"health_check_path"`
+	// TODO - Health check timeout
+	NumberOfWorkers      int                       `tfschema:"number_of_workers"`
+	ApplicationStack     []ApplicationStackWindows `tfschema:"application_stack"`
+	VirtualApplications  []VirtualApplication      `tfschema:"virtual_application"`
+	MinTlsVersion        string                    `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion     string                    `tfschema:"scm_minimum_tls_version"`
+	AutoSwapSlotName     string                    `tfschema:"auto_swap_slot_name"`
+	Cors                 []CorsSetting             `tfschema:"cors"`
+	DetailedErrorLogging bool                      `tfschema:"detailed_error_logging"`
+	WindowsFxVersion     string                    `tfschema:"windows_fx_version"`
+	VnetRouteAllEnabled  bool                      `tfschema:"vnet_route_all_enabled"`
 	// TODO new properties / blocks
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - ASE related for limiting App resource consumption
 	// PushSettings - Supported in SDK, but blocked by manual step needed for connecting app to notification hub.
@@ -86,6 +88,7 @@ type SiteConfigLinux struct {
 	Cors                    []CorsSetting           `tfschema:"cors"`
 	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging"`
 	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
+	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
 }
 
@@ -280,6 +283,13 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 
 				"virtual_application": virtualApplicationsSchema(),
 
+				"vnet_route_all_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
+				},
+
 				"auto_swap_slot_name": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
@@ -455,6 +465,11 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
+
+				"vnet_route_all_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
 			},
 		},
 	}
@@ -593,7 +608,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				"use_32_bit_worker": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Default:  false,
+					Default:  true,
 				},
 
 				"websockets_enabled": {
@@ -653,6 +668,13 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					// TODO - Add slot name validation here?
+				},
+
+				"vnet_route_all_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
 				},
 
 				"detailed_error_logging": {
@@ -815,6 +837,11 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"linux_fx_version": {
 					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"vnet_route_all_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
 			},
@@ -2723,7 +2750,9 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 
 	winSiteConfig := siteConfig[0]
 
-	expanded.AlwaysOn = utils.Bool(winSiteConfig.AlwaysOn)
+	if metadata.ResourceData.HasChange("site_config.0.always_on") {
+		expanded.AlwaysOn = utils.Bool(winSiteConfig.AlwaysOn)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -2762,7 +2791,9 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.VirtualApplications = expandVirtualApplications(winSiteConfig.VirtualApplications)
 	}
 
-	expanded.AcrUseManagedIdentityCreds = utils.Bool(winSiteConfig.UseManagedIdentityACR)
+	if metadata.ResourceData.HasChange("site_config.0.container_registry_use_managed_identity") {
+		expanded.AcrUseManagedIdentityCreds = utils.Bool(winSiteConfig.UseManagedIdentityACR)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.container_registry_managed_identity_client_id") {
 		expanded.AcrUserManagedIdentityID = utils.String(winSiteConfig.ContainerRegistryUserMSI)
@@ -2772,7 +2803,9 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.DefaultDocuments = &winSiteConfig.DefaultDocuments
 	}
 
-	expanded.HTTP20Enabled = utils.Bool(winSiteConfig.Http2Enabled)
+	if metadata.ResourceData.HasChange("site_config.0.http2_enabled") {
+		expanded.HTTP20Enabled = utils.Bool(winSiteConfig.Http2Enabled)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
 		ipRestrictions, err := ExpandIpRestrictions(winSiteConfig.IpRestriction)
@@ -2782,7 +2815,9 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
-	expanded.ScmIPSecurityRestrictionsUseMain = utils.Bool(winSiteConfig.ScmUseMainIpRestriction)
+	if metadata.ResourceData.HasChange("site_config.0.scm_use_main_ip_restriction") {
+		expanded.ScmIPSecurityRestrictionsUseMain = utils.Bool(winSiteConfig.ScmUseMainIpRestriction)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
 		scmIpRestrictions, err := ExpandIpRestrictions(winSiteConfig.ScmIpRestriction)
@@ -2792,7 +2827,9 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	expanded.LocalMySQLEnabled = utils.Bool(winSiteConfig.LocalMysql)
+	if metadata.ResourceData.HasChange("site_config.0.local_mysql") {
+		expanded.LocalMySQLEnabled = utils.Bool(winSiteConfig.LocalMysql)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.load_balancing_mode") {
 		expanded.LoadBalancing = web.SiteLoadBalancing(winSiteConfig.LoadBalancing)
@@ -2810,13 +2847,17 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.RemoteDebuggingVersion = utils.String(winSiteConfig.RemoteDebuggingVersion)
 	}
 
-	expanded.Use32BitWorkerProcess = utils.Bool(winSiteConfig.Use32BitWorker)
+	if metadata.ResourceData.HasChange("site_config.0.use_32_bit_worker") {
+		expanded.Use32BitWorkerProcess = utils.Bool(winSiteConfig.Use32BitWorker)
+	}
 
-	expanded.WebSocketsEnabled = utils.Bool(winSiteConfig.WebSockets)
+	if metadata.ResourceData.HasChange("site_config.0.websockets_enabled") {
+		expanded.WebSocketsEnabled = utils.Bool(winSiteConfig.WebSockets)
+	}
 
-	// if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
-	// }
-	expanded.FtpsState = web.FtpsState(winSiteConfig.FtpsState)
+	if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
+		expanded.FtpsState = web.FtpsState(winSiteConfig.FtpsState)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
 		expanded.HealthCheckPath = utils.String(winSiteConfig.HealthCheckPath)
@@ -2857,6 +2898,10 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.AutoHealRules = expandAutoHealSettingsWindows(winSiteConfig.AutoHealSettings)
 	}
 
+	if metadata.ResourceData.HasChange("site_config.0.vnet_route_all_enabled") {
+		expanded.VnetRouteAllEnabled = utils.Bool(winSiteConfig.VnetRouteAllEnabled)
+	}
+
 	return expanded, &currentStack, nil
 }
 
@@ -2871,7 +2916,9 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 
 	linuxSiteConfig := siteConfig[0]
 
-	expanded.AlwaysOn = utils.Bool(linuxSiteConfig.AlwaysOn)
+	if metadata.ResourceData.HasChange("site_config.0.always_on") {
+		expanded.AlwaysOn = utils.Bool(linuxSiteConfig.AlwaysOn)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
@@ -2932,7 +2979,9 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.DefaultDocuments = &linuxSiteConfig.DefaultDocuments
 	}
 
-	expanded.HTTP20Enabled = utils.Bool(linuxSiteConfig.Http2Enabled)
+	if metadata.ResourceData.HasChange("site_config.0.http2_enabled") {
+		expanded.HTTP20Enabled = utils.Bool(linuxSiteConfig.Http2Enabled)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
 		ipRestrictions, err := ExpandIpRestrictions(linuxSiteConfig.IpRestriction)
@@ -2952,7 +3001,9 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	expanded.LocalMySQLEnabled = utils.Bool(linuxSiteConfig.LocalMysql)
+	if metadata.ResourceData.HasChange("site_config.0.local_mysql") {
+		expanded.LocalMySQLEnabled = utils.Bool(linuxSiteConfig.LocalMysql)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.load_balancing_mode") {
 		expanded.LoadBalancing = web.SiteLoadBalancing(linuxSiteConfig.LoadBalancing)
@@ -2962,15 +3013,21 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.ManagedPipelineMode = web.ManagedPipelineMode(linuxSiteConfig.ManagedPipelineMode)
 	}
 
-	expanded.RemoteDebuggingEnabled = utils.Bool(linuxSiteConfig.RemoteDebugging)
+	if metadata.ResourceData.HasChange("site_config.0.remote_debugging") {
+		expanded.RemoteDebuggingEnabled = utils.Bool(linuxSiteConfig.RemoteDebugging)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_version") {
 		expanded.RemoteDebuggingVersion = utils.String(linuxSiteConfig.RemoteDebuggingVersion)
 	}
 
-	expanded.Use32BitWorkerProcess = utils.Bool(linuxSiteConfig.Use32BitWorker)
+	if metadata.ResourceData.HasChange("site_config.0.use_32_bit_worker") {
+		expanded.Use32BitWorkerProcess = utils.Bool(linuxSiteConfig.Use32BitWorker)
+	}
 
-	expanded.WebSocketsEnabled = utils.Bool(linuxSiteConfig.WebSockets)
+	if metadata.ResourceData.HasChange("site_config.0.websockets_enabled") {
+		expanded.WebSocketsEnabled = utils.Bool(linuxSiteConfig.WebSockets)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
 		expanded.FtpsState = web.FtpsState(linuxSiteConfig.FtpsState)
@@ -3006,10 +3063,16 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.Cors = cors
 	}
 
-	expanded.AutoHealEnabled = utils.Bool(linuxSiteConfig.AutoHeal)
+	if metadata.ResourceData.HasChange("site_config.0.auto_heal") {
+		expanded.AutoHealEnabled = utils.Bool(linuxSiteConfig.AutoHeal)
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.auto_heal_setting") {
 		expanded.AutoHealRules = expandAutoHealSettingsLinux(linuxSiteConfig.AutoHealSettings)
+	}
+
+	if metadata.ResourceData.HasChange("site_config.0.vnet_route_all_enabled") {
+		expanded.VnetRouteAllEnabled = utils.Bool(linuxSiteConfig.VnetRouteAllEnabled)
 	}
 
 	return expanded, nil
@@ -3371,15 +3434,31 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 	}
 
 	siteConfig := SiteConfigWindows{
-		ManagedPipelineMode: string(appSiteConfig.ManagedPipelineMode),
-		ScmType:             string(appSiteConfig.ScmType),
-		FtpsState:           string(appSiteConfig.FtpsState),
-		MinTlsVersion:       string(appSiteConfig.MinTLSVersion),
-		ScmMinTlsVersion:    string(appSiteConfig.ScmMinTLSVersion),
-	}
-
-	if appSiteConfig.AlwaysOn != nil {
-		siteConfig.AlwaysOn = *appSiteConfig.AlwaysOn
+		AlwaysOn:                 utils.NormaliseNilableBool(appSiteConfig.AlwaysOn),
+		AppCommandLine:           utils.NormalizeNilableString(appSiteConfig.AppCommandLine),
+		AutoHeal:                 utils.NormaliseNilableBool(appSiteConfig.AutoHealEnabled),
+		AutoHealSettings:         flattenAutoHealSettingsWindows(appSiteConfig.AutoHealRules),
+		ContainerRegistryUserMSI: utils.NormalizeNilableString(appSiteConfig.AcrUserManagedIdentityID),
+		DetailedErrorLogging:     utils.NormaliseNilableBool(appSiteConfig.DetailedErrorLoggingEnabled),
+		FtpsState:                string(appSiteConfig.FtpsState),
+		HealthCheckPath:          utils.NormalizeNilableString(appSiteConfig.HealthCheckPath),
+		Http2Enabled:             utils.NormaliseNilableBool(appSiteConfig.HTTP20Enabled),
+		IpRestriction:            FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions),
+		LoadBalancing:            string(appSiteConfig.LoadBalancing),
+		LocalMysql:               utils.NormaliseNilableBool(appSiteConfig.LocalMySQLEnabled),
+		ManagedPipelineMode:      string(appSiteConfig.ManagedPipelineMode),
+		MinTlsVersion:            string(appSiteConfig.MinTLSVersion),
+		NumberOfWorkers:          int(utils.NormaliseNilableInt32(appSiteConfig.NumberOfWorkers)),
+		RemoteDebugging:          utils.NormaliseNilableBool(appSiteConfig.RemoteDebuggingEnabled),
+		RemoteDebuggingVersion:   strings.ToUpper(utils.NormalizeNilableString(appSiteConfig.RemoteDebuggingVersion)),
+		ScmIpRestriction:         FlattenIpRestrictions(appSiteConfig.ScmIPSecurityRestrictions),
+		ScmMinTlsVersion:         string(appSiteConfig.ScmMinTLSVersion),
+		ScmType:                  string(appSiteConfig.ScmType),
+		ScmUseMainIpRestriction:  utils.NormaliseNilableBool(appSiteConfig.ScmIPSecurityRestrictionsUseMain),
+		Use32BitWorker:           utils.NormaliseNilableBool(appSiteConfig.Use32BitWorkerProcess),
+		UseManagedIdentityACR:    utils.NormaliseNilableBool(appSiteConfig.AcrUseManagedIdentityCreds),
+		VirtualApplications:      flattenVirtualApplications(appSiteConfig.VirtualApplications),
+		WebSockets:               utils.NormaliseNilableBool(appSiteConfig.WebSocketsEnabled),
 	}
 
 	if appSiteConfig.APIManagementConfig != nil && appSiteConfig.APIManagementConfig.ID != nil {
@@ -3390,65 +3469,8 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 		siteConfig.ApiDefinition = *appSiteConfig.APIDefinition.URL
 	}
 
-	if appSiteConfig.AppCommandLine != nil {
-		siteConfig.AppCommandLine = *appSiteConfig.AppCommandLine
-	}
-
 	if appSiteConfig.DefaultDocuments != nil {
 		siteConfig.DefaultDocuments = *appSiteConfig.DefaultDocuments
-	}
-
-	if appSiteConfig.AcrUseManagedIdentityCreds != nil {
-		siteConfig.UseManagedIdentityACR = *appSiteConfig.AcrUseManagedIdentityCreds
-	}
-
-	siteConfig.ContainerRegistryUserMSI = utils.NormalizeNilableString(appSiteConfig.AcrUserManagedIdentityID)
-
-	if v := appSiteConfig.DetailedErrorLoggingEnabled; v != nil {
-		siteConfig.DetailedErrorLogging = *v
-	}
-
-	if v := appSiteConfig.HTTP20Enabled; v != nil {
-		siteConfig.Http2Enabled = *v
-	}
-
-	if appSiteConfig.IPSecurityRestrictions != nil {
-		siteConfig.IpRestriction = FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions)
-	}
-
-	if v := appSiteConfig.ScmIPSecurityRestrictionsUseMain; v != nil {
-		siteConfig.ScmUseMainIpRestriction = *v
-	}
-
-	if appSiteConfig.ScmIPSecurityRestrictions != nil {
-		siteConfig.ScmIpRestriction = FlattenIpRestrictions(appSiteConfig.ScmIPSecurityRestrictions)
-	}
-
-	if v := appSiteConfig.LocalMySQLEnabled; v != nil {
-		siteConfig.LocalMysql = *v
-	}
-
-	siteConfig.LoadBalancing = string(appSiteConfig.LoadBalancing)
-
-	if v := appSiteConfig.RemoteDebuggingEnabled; v != nil {
-		siteConfig.RemoteDebugging = *v
-	}
-
-	if appSiteConfig.RemoteDebuggingVersion != nil {
-		// Note - this response is sometimes returned in lower case, so to avoid a diff func we ToUpper it here
-		siteConfig.RemoteDebuggingVersion = strings.ToUpper(*appSiteConfig.RemoteDebuggingVersion)
-	}
-
-	if appSiteConfig.Use32BitWorkerProcess != nil {
-		siteConfig.Use32BitWorker = *appSiteConfig.Use32BitWorkerProcess
-	}
-
-	if appSiteConfig.WebSocketsEnabled != nil {
-		siteConfig.WebSockets = *appSiteConfig.WebSocketsEnabled
-	}
-
-	if appSiteConfig.HealthCheckPath != nil {
-		siteConfig.HealthCheckPath = *appSiteConfig.HealthCheckPath
 	}
 
 	if appSiteConfig.NumberOfWorkers != nil {
@@ -3477,10 +3499,6 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 
 	siteConfig.ApplicationStack = []ApplicationStackWindows{winAppStack}
 
-	siteConfig.VirtualApplications = flattenVirtualApplications(appSiteConfig.VirtualApplications)
-
-	siteConfig.AutoSwapSlotName = utils.NormalizeNilableString(appSiteConfig.AutoSwapSlotName)
-
 	if appSiteConfig.Cors != nil {
 		cors := CorsSetting{}
 		corsSettings := appSiteConfig.Cors
@@ -3493,14 +3511,6 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 			siteConfig.Cors = []CorsSetting{cors}
 		}
 	}
-
-	autoHeal := false
-	if appSiteConfig.AutoHealEnabled != nil {
-		autoHeal = *appSiteConfig.AutoHealEnabled
-	}
-	siteConfig.AutoHeal = autoHeal
-
-	siteConfig.AutoHealSettings = flattenAutoHealSettingsWindows(appSiteConfig.AutoHealRules)
 
 	return []SiteConfigWindows{siteConfig}
 }
@@ -3511,15 +3521,31 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
 	}
 
 	siteConfig := SiteConfigLinux{
-		ManagedPipelineMode: string(appSiteConfig.ManagedPipelineMode),
-		ScmType:             string(appSiteConfig.ScmType),
-		FtpsState:           string(appSiteConfig.FtpsState),
-		MinTlsVersion:       string(appSiteConfig.MinTLSVersion),
-		ScmMinTlsVersion:    string(appSiteConfig.ScmMinTLSVersion),
-	}
-
-	if appSiteConfig.AlwaysOn != nil {
-		siteConfig.AlwaysOn = *appSiteConfig.AlwaysOn
+		AlwaysOn:                utils.NormaliseNilableBool(appSiteConfig.AlwaysOn),
+		AppCommandLine:          utils.NormalizeNilableString(appSiteConfig.AppCommandLine),
+		AutoHeal:                utils.NormaliseNilableBool(appSiteConfig.AutoHealEnabled),
+		AutoHealSettings:        flattenAutoHealSettingsLinux(appSiteConfig.AutoHealRules),
+		ContainerRegistryMSI:    utils.NormalizeNilableString(appSiteConfig.AcrUserManagedIdentityID),
+		DetailedErrorLogging:    utils.NormaliseNilableBool(appSiteConfig.DetailedErrorLoggingEnabled),
+		Http2Enabled:            utils.NormaliseNilableBool(appSiteConfig.HTTP20Enabled),
+		IpRestriction:           FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions),
+		ManagedPipelineMode:     string(appSiteConfig.ManagedPipelineMode),
+		ScmType:                 string(appSiteConfig.ScmType),
+		FtpsState:               string(appSiteConfig.FtpsState),
+		HealthCheckPath:         utils.NormalizeNilableString(appSiteConfig.HealthCheckPath),
+		LoadBalancing:           string(appSiteConfig.LoadBalancing),
+		LocalMysql:              utils.NormaliseNilableBool(appSiteConfig.LocalMySQLEnabled),
+		MinTlsVersion:           string(appSiteConfig.MinTLSVersion),
+		NumberOfWorkers:         int(utils.NormaliseNilableInt32(appSiteConfig.NumberOfWorkers)),
+		RemoteDebugging:         utils.NormaliseNilableBool(appSiteConfig.RemoteDebuggingEnabled),
+		RemoteDebuggingVersion:  strings.ToUpper(utils.NormalizeNilableString(appSiteConfig.RemoteDebuggingVersion)),
+		ScmIpRestriction:        FlattenIpRestrictions(appSiteConfig.ScmIPSecurityRestrictions),
+		ScmMinTlsVersion:        string(appSiteConfig.ScmMinTLSVersion),
+		ScmUseMainIpRestriction: utils.NormaliseNilableBool(appSiteConfig.ScmIPSecurityRestrictionsUseMain),
+		Use32BitWorker:          utils.NormaliseNilableBool(appSiteConfig.Use32BitWorkerProcess),
+		UseManagedIdentityACR:   utils.NormaliseNilableBool(appSiteConfig.AcrUseManagedIdentityCreds),
+		WebSockets:              utils.NormaliseNilableBool(appSiteConfig.WebSocketsEnabled),
+		VnetRouteAllEnabled:     utils.NormaliseNilableBool(appSiteConfig.VnetRouteAllEnabled),
 	}
 
 	if appSiteConfig.APIManagementConfig != nil && appSiteConfig.APIManagementConfig.ID != nil {
@@ -3530,71 +3556,8 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
 		siteConfig.ApiDefinition = *appSiteConfig.APIDefinition.URL
 	}
 
-	if appSiteConfig.AppCommandLine != nil {
-		siteConfig.AppCommandLine = *appSiteConfig.AppCommandLine
-	}
-
-	if appSiteConfig.AcrUseManagedIdentityCreds != nil {
-		siteConfig.UseManagedIdentityACR = *appSiteConfig.AcrUseManagedIdentityCreds
-	}
-
-	if appSiteConfig.AcrUseManagedIdentityCreds != nil && *appSiteConfig.AcrUseManagedIdentityCreds && appSiteConfig.AcrUserManagedIdentityID != nil {
-		siteConfig.ContainerRegistryMSI = *appSiteConfig.AcrUserManagedIdentityID
-	}
-
 	if appSiteConfig.DefaultDocuments != nil {
 		siteConfig.DefaultDocuments = *appSiteConfig.DefaultDocuments
-	}
-
-	if appSiteConfig.DetailedErrorLoggingEnabled != nil {
-		siteConfig.DetailedErrorLogging = *appSiteConfig.DetailedErrorLoggingEnabled
-	}
-
-	if appSiteConfig.HTTP20Enabled != nil {
-		siteConfig.Http2Enabled = *appSiteConfig.HTTP20Enabled
-	}
-
-	if appSiteConfig.IPSecurityRestrictions != nil {
-		siteConfig.IpRestriction = FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions)
-	}
-
-	if appSiteConfig.ScmIPSecurityRestrictionsUseMain != nil {
-		siteConfig.ScmUseMainIpRestriction = *appSiteConfig.ScmIPSecurityRestrictionsUseMain
-	}
-
-	if appSiteConfig.ScmIPSecurityRestrictions != nil {
-		siteConfig.ScmIpRestriction = FlattenIpRestrictions(appSiteConfig.ScmIPSecurityRestrictions)
-	}
-
-	if appSiteConfig.LocalMySQLEnabled != nil {
-		siteConfig.LocalMysql = *appSiteConfig.LocalMySQLEnabled
-	}
-
-	siteConfig.LoadBalancing = string(appSiteConfig.LoadBalancing)
-
-	if appSiteConfig.RemoteDebuggingEnabled != nil {
-		siteConfig.RemoteDebugging = *appSiteConfig.RemoteDebuggingEnabled
-	}
-
-	if appSiteConfig.RemoteDebuggingVersion != nil {
-		// Note - This is sometimes returned in lower case, so we ToUpper it to avoid the need for a diff suppression
-		siteConfig.RemoteDebuggingVersion = strings.ToUpper(*appSiteConfig.RemoteDebuggingVersion)
-	}
-
-	if appSiteConfig.Use32BitWorkerProcess != nil {
-		siteConfig.Use32BitWorker = *appSiteConfig.Use32BitWorkerProcess
-	}
-
-	if appSiteConfig.WebSocketsEnabled != nil {
-		siteConfig.WebSockets = *appSiteConfig.WebSocketsEnabled
-	}
-
-	if appSiteConfig.HealthCheckPath != nil {
-		siteConfig.HealthCheckPath = *appSiteConfig.HealthCheckPath
-	}
-
-	if appSiteConfig.NumberOfWorkers != nil {
-		siteConfig.NumberOfWorkers = int(*appSiteConfig.NumberOfWorkers)
 	}
 
 	if appSiteConfig.LinuxFxVersion != nil {
@@ -3603,14 +3566,6 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
 		// Decode the string to docker values
 		linuxAppStack = decodeApplicationStackLinux(siteConfig.LinuxFxVersion)
 		siteConfig.ApplicationStack = []ApplicationStackLinux{linuxAppStack}
-	}
-
-	if appSiteConfig.LinuxFxVersion != nil {
-		siteConfig.LinuxFxVersion = *appSiteConfig.LinuxFxVersion
-	}
-
-	if appSiteConfig.AutoSwapSlotName != nil {
-		siteConfig.AutoSwapSlotName = *appSiteConfig.AutoSwapSlotName
 	}
 
 	if appSiteConfig.Cors != nil {
@@ -3625,12 +3580,6 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
 			siteConfig.Cors = []CorsSetting{cors}
 		}
 	}
-
-	if appSiteConfig.AutoHealEnabled != nil {
-		siteConfig.AutoHeal = *appSiteConfig.AutoHealEnabled
-	}
-
-	siteConfig.AutoHealSettings = flattenAutoHealSettingsLinux(appSiteConfig.AutoHealRules)
 
 	return []SiteConfigLinux{siteConfig}
 }

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -17,40 +17,40 @@ import (
 )
 
 type SiteConfigWindows struct {
-	AlwaysOn                 bool                     `tfschema:"always_on"`
-	ApiManagementConfigId    string                   `tfschema:"api_management_api_id"`
-	ApiDefinition            string                   `tfschema:"api_definition_url"`
-	AppCommandLine           string                   `tfschema:"app_command_line"`
-	AutoHeal                 bool                     `tfschema:"auto_heal"`
-	AutoHealSettings         []AutoHealSettingWindows `tfschema:"auto_heal_setting"`
-	UseManagedIdentityACR    bool                     `tfschema:"container_registry_use_managed_identity"`
-	ContainerRegistryUserMSI string                   `tfschema:"container_registry_managed_identity_client_id"`
-	DefaultDocuments         []string                 `tfschema:"default_documents"`
-	Http2Enabled             bool                     `tfschema:"http2_enabled"`
-	IpRestriction            []IpRestriction          `tfschema:"ip_restriction"`
-	ScmUseMainIpRestriction  bool                     `tfschema:"scm_use_main_ip_restriction"`
-	ScmIpRestriction         []IpRestriction          `tfschema:"scm_ip_restriction"`
-	LoadBalancing            string                   `tfschema:"load_balancing_mode"`
-	LocalMysql               bool                     `tfschema:"local_mysql"`
-	ManagedPipelineMode      string                   `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging          bool                     `tfschema:"remote_debugging"`
-	RemoteDebuggingVersion   string                   `tfschema:"remote_debugging_version"`
-	ScmType                  string                   `tfschema:"scm_type"`
-	Use32BitWorker           bool                     `tfschema:"use_32_bit_worker"`
-	WebSockets               bool                     `tfschema:"websockets_enabled"`
-	FtpsState                string                   `tfschema:"ftps_state"`
-	HealthCheckPath          string                   `tfschema:"health_check_path"`
-	// TODO - Health check timeout
-	NumberOfWorkers      int                       `tfschema:"number_of_workers"`
-	ApplicationStack     []ApplicationStackWindows `tfschema:"application_stack"`
-	VirtualApplications  []VirtualApplication      `tfschema:"virtual_application"`
-	MinTlsVersion        string                    `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion     string                    `tfschema:"scm_minimum_tls_version"`
-	AutoSwapSlotName     string                    `tfschema:"auto_swap_slot_name"`
-	Cors                 []CorsSetting             `tfschema:"cors"`
-	DetailedErrorLogging bool                      `tfschema:"detailed_error_logging"`
-	WindowsFxVersion     string                    `tfschema:"windows_fx_version"`
-	VnetRouteAllEnabled  bool                      `tfschema:"vnet_route_all_enabled"`
+	AlwaysOn                 bool                      `tfschema:"always_on"`
+	ApiManagementConfigId    string                    `tfschema:"api_management_api_id"`
+	ApiDefinition            string                    `tfschema:"api_definition_url"`
+	AppCommandLine           string                    `tfschema:"app_command_line"`
+	AutoHeal                 bool                      `tfschema:"auto_heal"`
+	AutoHealSettings         []AutoHealSettingWindows  `tfschema:"auto_heal_setting"`
+	UseManagedIdentityACR    bool                      `tfschema:"container_registry_use_managed_identity"`
+	ContainerRegistryUserMSI string                    `tfschema:"container_registry_managed_identity_client_id"`
+	DefaultDocuments         []string                  `tfschema:"default_documents"`
+	Http2Enabled             bool                      `tfschema:"http2_enabled"`
+	IpRestriction            []IpRestriction           `tfschema:"ip_restriction"`
+	ScmUseMainIpRestriction  bool                      `tfschema:"scm_use_main_ip_restriction"`
+	ScmIpRestriction         []IpRestriction           `tfschema:"scm_ip_restriction"`
+	LoadBalancing            string                    `tfschema:"load_balancing_mode"`
+	LocalMysql               bool                      `tfschema:"local_mysql"`
+	ManagedPipelineMode      string                    `tfschema:"managed_pipeline_mode"`
+	RemoteDebugging          bool                      `tfschema:"remote_debugging"`
+	RemoteDebuggingVersion   string                    `tfschema:"remote_debugging_version"`
+	ScmType                  string                    `tfschema:"scm_type"`
+	Use32BitWorker           bool                      `tfschema:"use_32_bit_worker"`
+	WebSockets               bool                      `tfschema:"websockets_enabled"`
+	FtpsState                string                    `tfschema:"ftps_state"`
+	HealthCheckPath          string                    `tfschema:"health_check_path"`
+	HealthCheckEvictionTime  int                       `tfschema:"health_check_eviction_time"`
+	NumberOfWorkers          int                       `tfschema:"number_of_workers"`
+	ApplicationStack         []ApplicationStackWindows `tfschema:"application_stack"`
+	VirtualApplications      []VirtualApplication      `tfschema:"virtual_application"`
+	MinTlsVersion            string                    `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion         string                    `tfschema:"scm_minimum_tls_version"`
+	AutoSwapSlotName         string                    `tfschema:"auto_swap_slot_name"`
+	Cors                     []CorsSetting             `tfschema:"cors"`
+	DetailedErrorLogging     bool                      `tfschema:"detailed_error_logging"`
+	WindowsFxVersion         string                    `tfschema:"windows_fx_version"`
+	VnetRouteAllEnabled      bool                      `tfschema:"vnet_route_all_enabled"`
 	// TODO new properties / blocks
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - ASE related for limiting App resource consumption
 	// PushSettings - Supported in SDK, but blocked by manual step needed for connecting app to notification hub.
@@ -80,6 +80,7 @@ type SiteConfigLinux struct {
 	WebSockets              bool                    `tfschema:"websockets_enabled"`
 	FtpsState               string                  `tfschema:"ftps_state"`
 	HealthCheckPath         string                  `tfschema:"health_check_path"`
+	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time"`
 	NumberOfWorkers         int                     `tfschema:"number_of_workers"`
 	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
 	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
@@ -248,6 +249,14 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 				"health_check_path": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+				},
+
+				"health_check_eviction_time": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(2, 10),
+					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
 				"number_of_workers": {
@@ -429,6 +438,11 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 
 				"health_check_path": {
 					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"health_check_eviction_time": {
+					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},
 
@@ -633,6 +647,14 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					Optional: true,
 				},
 
+				"health_check_eviction_time": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(2, 10),
+					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
+				},
+
 				"number_of_workers": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
@@ -805,6 +827,11 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"health_check_path": {
 					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"health_check_eviction_time": {
+					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},
 
@@ -3428,7 +3455,7 @@ func onlyDefaultLoggingConfig(props web.SiteLogsConfigProperties) bool {
 	return true
 }
 
-func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string) []SiteConfigWindows {
+func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string, healthCheckCount *int) []SiteConfigWindows {
 	if appSiteConfig == nil {
 		return nil
 	}
@@ -3442,6 +3469,7 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 		DetailedErrorLogging:     utils.NormaliseNilableBool(appSiteConfig.DetailedErrorLoggingEnabled),
 		FtpsState:                string(appSiteConfig.FtpsState),
 		HealthCheckPath:          utils.NormalizeNilableString(appSiteConfig.HealthCheckPath),
+		HealthCheckEvictionTime:  utils.NormaliseNilableInt(healthCheckCount),
 		Http2Enabled:             utils.NormaliseNilableBool(appSiteConfig.HTTP20Enabled),
 		IpRestriction:            FlattenIpRestrictions(appSiteConfig.IPSecurityRestrictions),
 		LoadBalancing:            string(appSiteConfig.LoadBalancing),
@@ -3515,7 +3543,7 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 	return []SiteConfigWindows{siteConfig}
 }
 
-func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
+func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig, healthCheckCount *int) []SiteConfigLinux {
 	if appSiteConfig == nil {
 		return nil
 	}
@@ -3533,6 +3561,7 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig) []SiteConfigLinux {
 		ScmType:                 string(appSiteConfig.ScmType),
 		FtpsState:               string(appSiteConfig.FtpsState),
 		HealthCheckPath:         utils.NormalizeNilableString(appSiteConfig.HealthCheckPath),
+		HealthCheckEvictionTime: utils.NormaliseNilableInt(healthCheckCount),
 		LoadBalancing:           string(appSiteConfig.LoadBalancing),
 		LocalMysql:              utils.NormaliseNilableBool(appSiteConfig.LocalMySQLEnabled),
 		MinTlsVersion:           string(appSiteConfig.MinTLSVersion),
@@ -3646,22 +3675,29 @@ func ExpandAppSettings(settings map[string]string) *web.StringDictionary {
 	}
 }
 
-func FlattenAppSettings(input web.StringDictionary) map[string]string {
+func FlattenAppSettings(input web.StringDictionary) (map[string]string, *int) {
+	maxPingFailures := "WEBSITE_HEALTHCHECK_MAXPINGFAILURE"
 	unmanagedSettings := []string{
 		"DIAGNOSTICS_AZUREBLOBCONTAINERSASURL",
 		"DIAGNOSTICS_AZUREBLOBRETENTIONINDAYS",
 		"WEBSITE_HTTPLOGGING_CONTAINER_URL",
 		"WEBSITE_HTTPLOGGING_RETENTION_DAYS",
+		maxPingFailures,
 	}
 
+	var healthCheckCount *int
 	appSettings := FlattenWebStringDictionary(input)
+	if v, ok := appSettings[maxPingFailures]; ok {
+		h, _ := strconv.Atoi(v)
+		healthCheckCount = &h
+	}
 
 	// Remove the settings the service adds for legacy reasons when logging settings are specified.
 	for _, v := range unmanagedSettings { //nolint:typecheck
 		delete(appSettings, v)
 	}
 
-	return appSettings
+	return appSettings, healthCheckCount
 }
 
 func flattenVirtualApplications(appVirtualApplications *[]web.VirtualApplication) []VirtualApplication {

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -40,7 +40,7 @@ type SiteConfigWindows struct {
 	WebSockets               bool                      `tfschema:"websockets_enabled"`
 	FtpsState                string                    `tfschema:"ftps_state"`
 	HealthCheckPath          string                    `tfschema:"health_check_path"`
-	HealthCheckEvictionTime  int                       `tfschema:"health_check_eviction_time"`
+	HealthCheckEvictionTime  int                       `tfschema:"health_check_eviction_time_in_min"`
 	NumberOfWorkers          int                       `tfschema:"number_of_workers"`
 	ApplicationStack         []ApplicationStackWindows `tfschema:"application_stack"`
 	VirtualApplications      []VirtualApplication      `tfschema:"virtual_application"`
@@ -80,7 +80,7 @@ type SiteConfigLinux struct {
 	WebSockets              bool                    `tfschema:"websockets_enabled"`
 	FtpsState               string                  `tfschema:"ftps_state"`
 	HealthCheckPath         string                  `tfschema:"health_check_path"`
-	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time"`
+	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
 	NumberOfWorkers         int                     `tfschema:"number_of_workers"`
 	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
 	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
@@ -251,7 +251,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 					Optional: true,
 				},
 
-				"health_check_eviction_time": {
+				"health_check_eviction_time_in_min": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -441,7 +441,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"health_check_eviction_time": {
+				"health_check_eviction_time_in_min": {
 					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},
@@ -647,7 +647,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					Optional: true,
 				},
 
-				"health_check_eviction_time": {
+				"health_check_eviction_time_in_min": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -830,7 +830,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"health_check_eviction_time": {
+				"health_check_eviction_time_in_min": {
 					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -926,7 +926,7 @@ resource "azurerm_linux_function_app" "test" {
 
   site_config {
     health_check_path          = "/health"
-    health_check_eviction_time = 3
+    health_check_eviction_time_in_min = 3
   }
 }
 `, r.template(data, planSku), data.RandomInteger)

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -925,7 +925,7 @@ resource "azurerm_linux_function_app" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
-    health_check_path          = "/health"
+    health_check_path                 = "/health"
     health_check_eviction_time_in_min = 3
   }
 }

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -255,7 +255,8 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Site Publishing Credential information for Linux %s: %+v", id, err)
 			}
 
-			webApp.AppSettings = helpers.FlattenAppSettings(appSettings)
+			var healthCheckCount *int
+			webApp.AppSettings, healthCheckCount = helpers.FlattenAppSettings(appSettings)
 			webApp.Kind = utils.NormalizeNilableString(existing.Kind)
 			webApp.Location = location.NormalizeNilable(existing.Location)
 			webApp.Tags = tags.ToTypedObject(existing.Tags)
@@ -290,7 +291,7 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 
 			webApp.LogsConfig = helpers.FlattenLogsConfig(logsConfig)
 
-			webApp.SiteConfig = helpers.FlattenSiteConfigLinux(webAppSiteConfig.SiteConfig)
+			webApp.SiteConfig = helpers.FlattenSiteConfigLinux(webAppSiteConfig.SiteConfig, healthCheckCount)
 
 			webApp.StorageAccounts = helpers.FlattenStorageAccounts(storageAccounts)
 

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -3,6 +3,7 @@ package appservice
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -306,6 +307,10 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			appSettings := helpers.ExpandAppSettings(webApp.AppSettings)
+			if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time") {
+				appSettings.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURE"] = utils.String(strconv.Itoa(webApp.SiteConfig[0].HealthCheckEvictionTime))
+			}
+
 			if appSettings.Properties != nil {
 				if _, err := client.UpdateApplicationSettings(ctx, id.ResourceGroup, id.SiteName, *appSettings); err != nil {
 					return fmt.Errorf("setting App Settings for Linux %s: %+v", id, err)
@@ -432,9 +437,11 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 				Name:          id.SiteName,
 				ResourceGroup: id.ResourceGroup,
 				Location:      location.NormalizeNilable(webApp.Location),
-				AppSettings:   helpers.FlattenAppSettings(appSettings),
 				Tags:          tags.ToTypedObject(webApp.Tags),
 			}
+
+			var healthCheckCount *int
+			state.AppSettings, healthCheckCount = helpers.FlattenAppSettings(appSettings)
 
 			webAppProps := webApp.SiteProperties
 			if v := webAppProps.ServerFarmID; v != nil {
@@ -493,7 +500,7 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 
 			state.LogsConfig = helpers.FlattenLogsConfig(logsConfig)
 
-			state.SiteConfig = helpers.FlattenSiteConfigLinux(webAppSiteConfig.SiteConfig)
+			state.SiteConfig = helpers.FlattenSiteConfigLinux(webAppSiteConfig.SiteConfig, healthCheckCount)
 
 			state.StorageAccounts = helpers.FlattenStorageAccounts(storageAccounts)
 
@@ -600,6 +607,9 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
 			if metadata.ResourceData.HasChange("app_settings") {
 				appSettingsUpdate := helpers.ExpandAppSettings(state.AppSettings)
+				if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time") {
+					appSettingsUpdate.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURE"] = utils.String(strconv.Itoa(state.SiteConfig[0].HealthCheckEvictionTime))
+				}
 				if _, err := client.UpdateApplicationSettings(ctx, id.ResourceGroup, id.SiteName, *appSettingsUpdate); err != nil {
 					return fmt.Errorf("updating App Settings for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -307,7 +307,7 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			appSettings := helpers.ExpandAppSettings(webApp.AppSettings)
-			if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time") {
+			if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
 				appSettings.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURE"] = utils.String(strconv.Itoa(webApp.SiteConfig[0].HealthCheckEvictionTime))
 			}
 
@@ -607,7 +607,7 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
 			if metadata.ResourceData.HasChange("app_settings") {
 				appSettingsUpdate := helpers.ExpandAppSettings(state.AppSettings)
-				if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time") {
+				if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
 					appSettingsUpdate.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURE"] = utils.String(strconv.Itoa(state.SiteConfig[0].HealthCheckEvictionTime))
 				}
 				if _, err := client.UpdateApplicationSettings(ctx, id.ResourceGroup, id.SiteName, *appSettingsUpdate); err != nil {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1343,19 +1343,19 @@ resource "azurerm_linux_web_app" "test" {
       "third.aspx",
       "hostingstart.html",
     ]
-    http2_enabled               = false
-    scm_use_main_ip_restriction = false
-    local_mysql                 = false
-    managed_pipeline_mode       = "Integrated"
-    remote_debugging            = true
-    remote_debugging_version    = "VS2017"
-    websockets_enabled          = true
-    ftps_state                  = "FtpsOnly"
-    health_check_path           = "/health2"
-    health_check_eviction_time_in_min  = 7
-    number_of_workers           = 2
-    minimum_tls_version         = "1.2"
-    scm_minimum_tls_version     = "1.2"
+    http2_enabled                     = false
+    scm_use_main_ip_restriction       = false
+    local_mysql                       = false
+    managed_pipeline_mode             = "Integrated"
+    remote_debugging                  = true
+    remote_debugging_version          = "VS2017"
+    websockets_enabled                = true
+    ftps_state                        = "FtpsOnly"
+    health_check_path                 = "/health2"
+    health_check_eviction_time_in_min = 7
+    number_of_workers                 = 2
+    minimum_tls_version               = "1.2"
+    scm_minimum_tls_version           = "1.2"
     cors {
       allowed_origins = [
         "http://www.contoso.com",

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1352,6 +1352,7 @@ resource "azurerm_linux_web_app" "test" {
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health2"
+    health_check_eviction_time  = 7
     number_of_workers           = 2
     minimum_tls_version         = "1.2"
     scm_minimum_tls_version     = "1.2"

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1352,7 +1352,7 @@ resource "azurerm_linux_web_app" "test" {
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health2"
-    health_check_eviction_time  = 7
+    health_check_eviction_time_in_min  = 7
     number_of_workers           = 2
     minimum_tls_version         = "1.2"
     scm_minimum_tls_version     = "1.2"

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1383,7 +1383,8 @@ resource "azurerm_linux_web_app" "test" {
         minimum_process_execution_time = "00:05:00"
       }
     }
-    // auto_swap_slot_name = // TODO - Not supported yet
+
+    vnet_route_all_enabled = true
   }
 
   storage_account {

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -251,7 +251,8 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Site Metadata for Windows %s: %+v", id, err)
 			}
 
-			webApp.AppSettings = helpers.FlattenAppSettings(appSettings)
+			var healthCheckCount *int
+			webApp.AppSettings, healthCheckCount = helpers.FlattenAppSettings(appSettings)
 			webApp.Kind = utils.NormalizeNilableString(existing.Kind)
 			webApp.Location = location.NormalizeNilable(existing.Location)
 			webApp.Tags = tags.ToTypedObject(existing.Tags)
@@ -292,7 +293,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 			if ok {
 				currentStack = *currentStackPtr
 			}
-			webApp.SiteConfig = helpers.FlattenSiteConfigWindows(webAppSiteConfig.SiteConfig, currentStack)
+			webApp.SiteConfig = helpers.FlattenSiteConfigWindows(webAppSiteConfig.SiteConfig, currentStack, healthCheckCount)
 
 			webApp.StorageAccounts = helpers.FlattenStorageAccounts(storageAccounts)
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -434,9 +434,11 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				Name:          id.SiteName,
 				ResourceGroup: id.ResourceGroup,
 				Location:      location.NormalizeNilable(webApp.Location),
-				AppSettings:   helpers.FlattenAppSettings(appSettings),
 				Tags:          tags.ToTypedObject(webApp.Tags),
 			}
+
+			var healthCheckCount *int
+			state.AppSettings, healthCheckCount = helpers.FlattenAppSettings(appSettings)
 
 			webAppProps := webApp.SiteProperties
 			if v := webAppProps.ServerFarmID; v != nil {
@@ -499,7 +501,7 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				currentStack = *currentStackPtr
 			}
 
-			state.SiteConfig = helpers.FlattenSiteConfigWindows(webAppSiteConfig.SiteConfig, currentStack)
+			state.SiteConfig = helpers.FlattenSiteConfigWindows(webAppSiteConfig.SiteConfig, currentStack, healthCheckCount)
 
 			state.StorageAccounts = helpers.FlattenStorageAccounts(storageAccounts)
 

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -367,6 +367,8 @@ A `site_config` block exports the following:
 
 * `health_check_path` - The path to the Health Check endpoint.
 
+* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+
 * `http2_enabled` - Is HTTP2.0 enabled.
 
 * `ip_restriction` - A `ip_restriction` block as defined above.

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -367,7 +367,7 @@ A `site_config` block exports the following:
 
 * `health_check_path` - The path to the Health Check endpoint.
 
-* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+* `health_check_eviction_time_in_min` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
 
 * `http2_enabled` - Is HTTP2.0 enabled.
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -377,6 +377,8 @@ A `site_config` block exports the following:
 
 * `health_check_path` - The path to the Health Check endpoint.
 
+* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+
 * `http2_enabled` - Is HTTP2.0 enabled.
 
 * `ip_restriction` - A `ip_restriction` block as defined above.

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -377,7 +377,7 @@ A `site_config` block exports the following:
 
 * `health_check_path` - The path to the Health Check endpoint.
 
-* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+* `health_check_eviction_time_in_min` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
 
 * `http2_enabled` - Is HTTP2.0 enabled.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -395,7 +395,7 @@ A `site_config` block supports the following:
 
 * `health_check_path` - (Optional) The path to be checked for this function app health.
 
-* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+* `health_check_eviction_time_in_min` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
 
 * `http2_enabled` - (Optional) Specifies if the http2 protocol should be enabled. Defaults to `false`.
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -425,7 +425,7 @@ A `site_config` block supports the following:
 
 * `health_check_path` - (Optional) The path to the Health Check.
 
-* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+* `health_check_eviction_time_in_min` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
 
 * `http2_enabled` - (Optional) Should the HTTP2 be enabled?
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -449,7 +449,7 @@ A `site_config` block supports the following:
 
 * `scm_use_main_ip_restriction` - (Optional) Should the Linux Web App `ip_restriction` configuration be used for the SCM also.
 
-* `32_bit_worker` - (Optional) Should the Linux Web App use a 32-bit worker.
+* `use_32_bit_worker` - (Optional) Should the Linux Web App use a 32-bit worker. Defaults to `true`.
 
 * `websockets` - (Optional) Should Web Sockets be enabled. Defaults to `false`.
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -425,6 +425,8 @@ A `site_config` block supports the following:
 
 * `health_check_path` - (Optional) The path to the Health Check.
 
+* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+
 * `http2_enabled` - (Optional) Should the HTTP2 be enabled?
 
 * `ip_restriction` - (Optional) One or more `ip_restriction` blocks as defined above.

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -427,6 +427,8 @@ A `site_config` block supports the following:
 
 * `health_check_path` - (Optional) The path to the Health Check.
 
+* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+
 * `http2_enabled` - (Optional) Should the HTTP2 be enabled?
 
 * `ip_restriction` - (Optional) One or more `ip_restriction` blocks as defined above.

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -427,7 +427,7 @@ A `site_config` block supports the following:
 
 * `health_check_path` - (Optional) The path to the Health Check.
 
-* `health_check_eviction_time` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
+* `health_check_eviction_time_in_min` - (Optional) The amount of time in minutes that a node can be unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Only valid in conjunction with `health_check_path`.
 
 * `http2_enabled` - (Optional) Should the HTTP2 be enabled?
 


### PR DESCRIPTION
`azurerm_windows_web_app` - add support for `health_check_eviction_time` and `vnet_route_all_enabled`.
`azurerm_linux_web_app` - add support for `health_check_eviction_time` and `vnet_route_all_enabled`.
fixes a bug in the default value for `use_32_bit_worker`

Also addresses some delta-update changes and refactoring for `utils.NormaliseNilableBool`