### PR TITLE
GHA Concurrency limit 

### DIFF
--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   depscheck:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -8,6 +8,10 @@ on:
       - 'azurerm/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   gencheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -8,11 +8,13 @@ on:
       - 'vendor/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   golint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -9,8 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -9,8 +9,6 @@ jobs:
   link-milestone:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/teamcity-test.yaml
+++ b/.github/workflows/teamcity-test.yaml
@@ -9,11 +9,13 @@ on:
       - '.teamcity/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   teamcity-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -8,11 +8,13 @@ on:
       - 'vendor/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   tflint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -8,11 +8,13 @@ on:
       - 'vendor/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   compatibility-32bit-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,11 +8,13 @@ on:
       - 'vendor/**'
       - '.github/workflows/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -7,11 +7,13 @@ on:
       - '.github/workflows/**'
       - 'examples/**'
 
+concurrency:
+  group: '${{ github.head_ref }}'
+  cancel-in-progress: true
+
 jobs:
   website-lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -10,8 +10,6 @@ on:
 jobs:
   website-lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
update workflows for single concurrency per PR. remove redundant `strategy` block (only used for matrix configs)