### PR TITLE
`r\purview_account`: Add support for `managed_resource_group_name`

### DIFF
--- a/internal/services/purview/purview_account_resource_test.go
+++ b/internal/services/purview/purview_account_resource_test.go
@@ -48,19 +48,14 @@ func TestAccPurviewAccount_requiresImport(t *testing.T) {
 func TestAccPurviewAccount_withManagedResourceGroupName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_purview_account", "test")
 	r := PurviewAccountResource{}
+	managedResourceGroupName := fmt.Sprintf("acctestRG-purview-managed-%d", data.RandomInteger)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withManagedResourceGroupName(data),
+			Config: r.withManagedResourceGroupName(data, managedResourceGroupName),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.withManagedResourceGroupNameUpdated(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").HasValue(managedResourceGroupName),
 			),
 		},
 		data.ImportStep(),
@@ -123,7 +118,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r PurviewAccountResource) withManagedResourceGroupName(data acceptance.TestData) string {
+func (r PurviewAccountResource) withManagedResourceGroupName(data acceptance.TestData, managedResourceGroupName string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -132,21 +127,7 @@ resource "azurerm_purview_account" "test" {
   name                        = "acctestsw%d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  managed_resource_group_name = "acctestRG-purview-managed-%d"
+  managed_resource_group_name = "%s"
 }
-`, template, data.RandomInteger, data.RandomInteger)
-}
-
-func (r PurviewAccountResource) withManagedResourceGroupNameUpdated(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_purview_account" "test" {
-  name                        = "acctestsw%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  managed_resource_group_name = "acctestRG-purview-managed2-%d"
-}
-`, template, data.RandomInteger, data.RandomInteger)
+`, template, data.RandomInteger, managedResourceGroupName)
 }

--- a/website/docs/r/purview_account.html.markdown
+++ b/website/docs/r/purview_account.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `public_network_enabled` - (Optional) Should the Purview Account be visible to the public network? Defaults to `true`.
 
-* `managed_resource_group_name` - (Optional) The name of the Resource Group where Purview Account creates the managed resources.
+* `managed_resource_group_name` - (Optional) The name which should be used for the new Resource Group where Purview Account creates the managed resources. Changing this forces a new Purview Account to be created.
 
 ~> **Note**: `managed_resource_group_name` must be a new Resource Group
 

--- a/website/docs/r/purview_account.html.markdown
+++ b/website/docs/r/purview_account.html.markdown
@@ -39,6 +39,10 @@ The following arguments are supported:
 
 * `public_network_enabled` - (Optional) Should the Purview Account be visible to the public network? Defaults to `true`.
 
+* `managed_resource_group_name` - (Optional) The name of the Resource Group where Purview Account creates the managed resources.
+
+~> **Note**: `managed_resource_group_name` must be a new Resource Group
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Purview Account.
 
 ## Attributes Reference


### PR DESCRIPTION
- When creating a Purview Account, a new resource group will be created automatically together with it. The name of this resource group is decided by server by default, and user can override it. This change adds support for the override capability.
- The update API accepts the managedResourceGroupName, but it doesn't change the actual value, so the property is set to ForceNew
- Validation is azure.ValidateResourceGroupName since it needs to be a valid resource group name
- Test result:
$ TF_ACC=1 go test -v ./internal/services/purview -run=TestAccPurviewAccount_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPurviewAccount_basic
=== PAUSE TestAccPurviewAccount_basic
=== RUN   TestAccPurviewAccount_requiresImport
=== PAUSE TestAccPurviewAccount_requiresImport
=== RUN   TestAccPurviewAccount_withManagedResourceGroupName
=== PAUSE TestAccPurviewAccount_withManagedResourceGroupName
=== CONT  TestAccPurviewAccount_basic
=== CONT  TestAccPurviewAccount_withManagedResourceGroupName
=== CONT  TestAccPurviewAccount_requiresImport
--- PASS: TestAccPurviewAccount_withManagedResourceGroupName (642.22s)
--- PASS: TestAccPurviewAccount_requiresImport (663.07s)
--- PASS: TestAccPurviewAccount_basic (735.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/purview       736.292s
