### PR TITLE
`azurerm_key_vault_certificate` - Make `certificate_policy` optional for imported certs

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -62,6 +62,10 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				ForceNew: true,
+				AtLeastOneOf: []string{
+					"certificate_policy",
+					"certificate",
+				},
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -84,8 +88,13 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 
 			"certificate_policy": {
 				Type:     pluginsdk.TypeList,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				AtLeastOneOf: []string{
+					"certificate_policy",
+					"certificate",
+				},
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -693,6 +702,10 @@ func (d deleteAndPurgeCertificate) NestedItemHasBeenPurged(ctx context.Context) 
 
 func expandKeyVaultCertificatePolicy(d *pluginsdk.ResourceData) (*keyvault.CertificatePolicy, error) {
 	policies := d.Get("certificate_policy").([]interface{})
+	if len(policies) == 0 || policies[0] == nil {
+		return nil, nil
+	}
+
 	policyRaw := policies[0].(map[string]interface{})
 	policy := keyvault.CertificatePolicy{}
 

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -27,6 +27,7 @@ func TestAccKeyVaultCertificate_basicImportPFX(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("certificate_data").Exists(),
 				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
+				check.That(data.ResourceName).Key("certificate_policy.0.secret_properties.0.content_type").HasValue("application/x-pkcs12"),
 			),
 		},
 		data.ImportStep("certificate"),
@@ -389,23 +390,6 @@ resource "azurerm_key_vault_certificate" "test" {
     contents = filebase64("testdata/keyvaultcert.pfx")
     password = ""
   }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
-  }
 }
 `, r.template(data), data.RandomString)
 }
@@ -425,24 +409,6 @@ resource "azurerm_key_vault_certificate" "test" {
   certificate {
     contents = filebase64("testdata/ecdsa.pem")
     password = ""
-  }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      curve      = "P-256"
-      exportable = true
-      key_size   = 256
-      key_type   = "EC"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pem-file"
-    }
   }
 }
 `, r.template(data), data.RandomString)
@@ -464,24 +430,6 @@ resource "azurerm_key_vault_certificate" "test" {
     contents = filebase64("testdata/ecdsa.pfx")
     password = ""
   }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      curve      = "P-256"
-      exportable = true
-      key_size   = 256
-      key_type   = "EC"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
-  }
 }
 `, r.template(data), data.RandomString)
 }
@@ -501,23 +449,6 @@ resource "azurerm_key_vault_certificate" "test" {
   certificate {
     contents = filebase64("testdata/rsa_bundle.pfx")
     password = ""
-  }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
   }
 }
 `, r.template(data), data.RandomString)
@@ -539,23 +470,6 @@ resource "azurerm_key_vault_certificate" "test" {
     contents = filebase64("testdata/rsa_single.pem")
     password = ""
   }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 4096
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pem-file"
-    }
-  }
 }
 `, r.template(data), data.RandomString)
 }
@@ -576,23 +490,6 @@ resource "azurerm_key_vault_certificate" "test" {
     contents = filebase64("testdata/rsa_bundle.pem")
     password = ""
   }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 4096
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pem-file"
-    }
-  }
 }
 `, r.template(data), data.RandomString)
 }
@@ -608,23 +505,6 @@ resource "azurerm_key_vault_certificate" "import" {
   certificate {
     contents = filebase64("testdata/keyvaultcert.pfx")
     password = ""
-  }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
   }
 }
 `, r.basicImportPFX(data))

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -89,23 +89,6 @@ resource "azurerm_key_vault_certificate" "example" {
     contents = filebase64("certificate-to-import.pfx")
     password = ""
   }
-
-  certificate_policy {
-    issuer_parameters {
-      name = "Self"
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = false
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
-  }
 }
 ```
 
@@ -245,7 +228,9 @@ The following arguments are supported:
 
 * `certificate` - (Optional) A `certificate` block as defined below, used to Import an existing certificate.
 
-* `certificate_policy` - (Required) A `certificate_policy` block as defined below.
+* `certificate_policy` - (Optional) A `certificate_policy` block as defined below.
+
+~> **NOTE:** When creating a Key Vault Certificate, at least one of `certificate` or `certificate_policy` is required. Provide `certificate` to import an existing certificate, `certificate_policy` to generate a new certificate.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fixes #2804

### AccTests
```bash
TF_ACC=1 go test -v ./internal/services/keyvault -run=TestAccKeyVaultCertificate_basicImportPFX -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVaultCertificate_basicImportPFX
=== PAUSE TestAccKeyVaultCertificate_basicImportPFX
=== CONT  TestAccKeyVaultCertificate_basicImportPFX
--- PASS: TestAccKeyVaultCertificate_basicImportPFX (262.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      264.417s
```