### PR TITLE
New attribute for `r/virtual_desktop_application_group`

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_application_group_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_group_resource_test.go
@@ -127,12 +127,12 @@ resource "azurerm_virtual_desktop_host_pool" "test" {
 }
 
 resource "azurerm_virtual_desktop_application_group" "test" {
-  name                = "acctestAG%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  type                = "Desktop"
+  name                         = "acctestAG%d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  type                         = "Desktop"
   default_desktop_display_name = "Acceptance Test"
-  host_pool_id        = azurerm_virtual_desktop_host_pool.test.id
+  host_pool_id                 = azurerm_virtual_desktop_host_pool.test.id
 }
 `, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8))
 }
@@ -159,14 +159,14 @@ resource "azurerm_virtual_desktop_host_pool" "test" {
 }
 
 resource "azurerm_virtual_desktop_application_group" "test" {
-  name                = "acctestAG%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  type                = "Desktop"
-  host_pool_id        = azurerm_virtual_desktop_host_pool.test.id
-  friendly_name       = "TestAppGroup"
+  name                         = "acctestAG%d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  type                         = "Desktop"
+  host_pool_id                 = azurerm_virtual_desktop_host_pool.test.id
+  friendly_name                = "TestAppGroup"
   default_desktop_display_name = "Acceptance Test"
-  description         = "Acceptance Test: An application group"
+  description                  = "Acceptance Test: An application group"
   tags = {
     Purpose = "Acceptance-Testing"
   }

--- a/internal/services/desktopvirtualization/virtual_desktop_application_group_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_group_resource_test.go
@@ -131,6 +131,7 @@ resource "azurerm_virtual_desktop_application_group" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   type                = "Desktop"
+  default_desktop_display_name = "Acceptance Test"
   host_pool_id        = azurerm_virtual_desktop_host_pool.test.id
 }
 `, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8))
@@ -164,6 +165,7 @@ resource "azurerm_virtual_desktop_application_group" "test" {
   type                = "Desktop"
   host_pool_id        = azurerm_virtual_desktop_host_pool.test.id
   friendly_name       = "TestAppGroup"
+  default_desktop_display_name = "Acceptance Test"
   description         = "Acceptance Test: An application group"
   tags = {
     Purpose = "Acceptance-Testing"

--- a/website/docs/r/virtual_desktop_application_group.html.markdown
+++ b/website/docs/r/virtual_desktop_application_group.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `friendly_name` - (Optional) Option to set a friendly name for the Virtual Desktop Application Group.
 
+* `default_desktop_display_name` - (Optional) Option to set the display name for the default sessionDesktop desktop when `type` is set to `Desktop`.
+
 * `description` - (Optional) Option to set a description for the Virtual Desktop Application Group.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
This pull adds a new `default_desktop_display_name` attribute for the `virtual_desktop_application_group` resource

When creating a new Desktop application group - a default desktop is created named sessionDesktop with a display name of sessionDesktop. There is no means through the application group API to modify this.

This leverages the Desktops API to allow users to configure the display name of the default desktop resource in-line as part of the application group resource when a Desktop type is created.

I did consider a new resource to implement this, however the DesktopsClient is limited in that it only supports the updating of Desktops not the Creation or Deletion, so didn't seem appropriate.

Acceptance Tests:

=== RUN   TestAccVirtualDesktopApplicationGroup_basic
=== PAUSE TestAccVirtualDesktopApplicationGroup_basic
=== RUN   TestAccVirtualDesktopApplicationGroup_complete
=== PAUSE TestAccVirtualDesktopApplicationGroup_complete
=== RUN   TestAccVirtualDesktopApplicationGroup_update
=== PAUSE TestAccVirtualDesktopApplicationGroup_update
=== RUN   TestAccVirtualDesktopApplicationGroup_requiresImport
=== PAUSE TestAccVirtualDesktopApplicationGroup_requiresImport
=== CONT  TestAccVirtualDesktopApplicationGroup_basic
=== CONT  TestAccVirtualDesktopApplicationGroup_update
=== CONT  TestAccVirtualDesktopApplicationGroup_requiresImport
=== CONT  TestAccVirtualDesktopApplicationGroup_complete
--- PASS: TestAccVirtualDesktopApplicationGroup_complete (98.26s)
--- PASS: TestAccVirtualDesktopApplicationGroup_basic (99.34s)
--- PASS: TestAccVirtualDesktopApplicationGroup_requiresImport (123.13s)
--- PASS: TestAccVirtualDesktopApplicationGroup_update (203.24s)
PASS