### PR TITLE
azurerm_backup_protected_file_share: Fix issue about file share is added to an exist storage account but it cannot be listed by Backup Protectable Items

### DIFF
--- a/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
@@ -361,5 +361,23 @@ resource "azurerm_backup_protected_file_share" "test" {
   source_file_share_name    = azurerm_storage_share.testshare3.name
   backup_policy_id          = azurerm_backup_policy_file_share.test.id
 }
-`, r.baseMultiple(data))
+
+resource "azurerm_storage_share" "testshare" {
+  name                 = "acctest-ss-%[2]d"
+  storage_account_name = "${azurerm_storage_account.test2.name}"
+  metadata             = {}
+
+  lifecycle {
+    ignore_changes = [metadata] // Ignore changes Azure Backup makes to the metadata
+  }
+}
+
+resource "azurerm_backup_protected_file_share" "test1" {
+  resource_group_name       = azurerm_resource_group.test.name
+  recovery_vault_name       = azurerm_recovery_services_vault.test.name
+  source_storage_account_id = azurerm_backup_container_storage_account.test2.storage_account_id
+  source_file_share_name    = azurerm_storage_share.testshare.name
+  backup_policy_id          = azurerm_backup_policy_file_share.test.id
+}
+`, r.baseMultiple(data), data.RandomInteger)
 }

--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -8,20 +8,21 @@ import (
 )
 
 type Client struct {
-	ProtectableItemsClient           *backup.ProtectableItemsClient
-	ProtectedItemsClient             *backup.ProtectedItemsClient
-	ProtectedItemsGroupClient        *backup.ProtectedItemsGroupClient
-	ProtectionPoliciesClient         *backup.ProtectionPoliciesClient
-	BackupProtectionContainersClient *backup.ProtectionContainersClient
-	BackupOperationStatusesClient    *backup.OperationStatusesClient
-	VaultsClient                     *recoveryservices.VaultsClient
-	VaultsConfigsClient              *backup.ResourceVaultConfigsClient // Not sure why this is in backup, but https://github.com/Azure/azure-sdk-for-go/issues/7279
-	FabricClient                     func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient
-	ProtectionContainerClient        func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainersClient
-	ReplicationPoliciesClient        func(resourceGroupName string, vaultName string) siterecovery.ReplicationPoliciesClient
-	ContainerMappingClient           func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainerMappingsClient
-	NetworkMappingClient             func(resourceGroupName string, vaultName string) siterecovery.ReplicationNetworkMappingsClient
-	ReplicationMigrationItemsClient  func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectedItemsClient
+	ProtectableItemsClient                    *backup.ProtectableItemsClient
+	ProtectedItemsClient                      *backup.ProtectedItemsClient
+	ProtectedItemsGroupClient                 *backup.ProtectedItemsGroupClient
+	ProtectionPoliciesClient                  *backup.ProtectionPoliciesClient
+	ProtectionContainerOperationResultsClient *backup.ProtectionContainerOperationResultsClient
+	BackupProtectionContainersClient          *backup.ProtectionContainersClient
+	BackupOperationStatusesClient             *backup.OperationStatusesClient
+	VaultsClient                              *recoveryservices.VaultsClient
+	VaultsConfigsClient                       *backup.ResourceVaultConfigsClient // Not sure why this is in backup, but https://github.com/Azure/azure-sdk-for-go/issues/7279
+	FabricClient                              func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient
+	ProtectionContainerClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainersClient
+	ReplicationPoliciesClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationPoliciesClient
+	ContainerMappingClient                    func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainerMappingsClient
+	NetworkMappingClient                      func(resourceGroupName string, vaultName string) siterecovery.ReplicationNetworkMappingsClient
+	ReplicationMigrationItemsClient           func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectedItemsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -48,6 +49,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	backupOperationStatusesClient := backup.NewOperationStatusesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&backupOperationStatusesClient.Client, o.ResourceManagerAuthorizer)
+
+	backupProtectionContainerOperationResultsClient := backup.NewProtectionContainerOperationResultsClient(o.SubscriptionId)
+	o.ConfigureClient(&backupProtectionContainerOperationResultsClient.Client, o.ResourceManagerAuthorizer)
 
 	fabricClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient {
 		client := siterecovery.NewReplicationFabricsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
@@ -86,19 +90,20 @@ func NewClient(o *common.ClientOptions) *Client {
 	}
 
 	return &Client{
-		ProtectableItemsClient:           &protectableItemsClient,
-		ProtectedItemsClient:             &protectedItemsClient,
-		ProtectedItemsGroupClient:        &protectedItemsGroupClient,
-		ProtectionPoliciesClient:         &protectionPoliciesClient,
-		BackupProtectionContainersClient: &backupProtectionContainersClient,
-		BackupOperationStatusesClient:    &backupOperationStatusesClient,
-		VaultsClient:                     &vaultsClient,
-		VaultsConfigsClient:              &vaultConfigsClient,
-		FabricClient:                     fabricClient,
-		ProtectionContainerClient:        protectionContainerClient,
-		ReplicationPoliciesClient:        replicationPoliciesClient,
-		ContainerMappingClient:           containerMappingClient,
-		NetworkMappingClient:             networkMappingClient,
-		ReplicationMigrationItemsClient:  replicationMigrationItemsClient,
+		ProtectableItemsClient:                    &protectableItemsClient,
+		ProtectedItemsClient:                      &protectedItemsClient,
+		ProtectedItemsGroupClient:                 &protectedItemsGroupClient,
+		ProtectionPoliciesClient:                  &protectionPoliciesClient,
+		ProtectionContainerOperationResultsClient: &backupProtectionContainerOperationResultsClient,
+		BackupProtectionContainersClient:          &backupProtectionContainersClient,
+		BackupOperationStatusesClient:             &backupOperationStatusesClient,
+		VaultsClient:                              &vaultsClient,
+		VaultsConfigsClient:                       &vaultConfigsClient,
+		FabricClient:                              fabricClient,
+		ProtectionContainerClient:                 protectionContainerClient,
+		ReplicationPoliciesClient:                 replicationPoliciesClient,
+		ContainerMappingClient:                    containerMappingClient,
+		NetworkMappingClient:                      networkMappingClient,
+		ReplicationMigrationItemsClient:           replicationMigrationItemsClient,
 	}
 }


### PR DESCRIPTION
The purposes of this PR:

When a new file share is added to an exist storage account, it cannot be listed by Backup Protectable Items - List API after the storage account is registered with a RSV. After confirming with the service team, whenever new file shares are added, we need to run an 'inquire' API. but inquiry APIs are long running APIs and hence can't be included in GET API's (Backup Protectable Items - List) response. Therefore, add 'inquire' API to inquire all unprotected files shares under a storage account to fix this usecase.

fix: [#issue11184](https://github.com/hashicorp/terraform-provider-azurerm/issues/11184)

Test results:
TF_ACC=1 go test ./internal/services/recoveryservices/ -v -parallel 11 -test.run=TestAccBackupProtectedFileShare_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN TestAccBackupProtectedFileShare_basic
=== PAUSE TestAccBackupProtectedFileShare_basic
=== RUN TestAccBackupProtectedFileShare_multiple
=== PAUSE TestAccBackupProtectedFileShare_multiple
=== RUN TestAccBackupProtectedFileShare_requiresImport
=== PAUSE TestAccBackupProtectedFileShare_requiresImport
=== RUN TestAccBackupProtectedFileShare_updateBackupPolicyId
=== PAUSE TestAccBackupProtectedFileShare_updateBackupPolicyId
=== CONT TestAccBackupProtectedFileShare_basic
=== CONT TestAccBackupProtectedFileShare_updateBackupPolicyId
=== CONT TestAccBackupProtectedFileShare_requiresImport
=== CONT TestAccBackupProtectedFileShare_multiple
--- PASS: TestAccBackupProtectedFileShare_multiple (790.92s)
--- PASS: TestAccBackupProtectedFileShare_requiresImport (715.26s)
--- PASS: TestAccBackupProtectedFileShare_basic (813.61s)
--- PASS: TestAccBackupProtectedFileShare_updateBackupPolicyId (820.94s)