### PR TITLE
[new resource] API management recipient user

### DIFF
--- a/internal/services/apimanagement/api_management_notification_recipient_user.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_user.go
@@ -1,0 +1,183 @@
+package apimanagement
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2020-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ApiManagementNotificationRecipientUserModel struct {
+	ApiManagementId  string `tfschema:"api_management_id"`
+	NotificationName string `tfschema:"notification_type"`
+	UserId           string `tfschema:"user_id"`
+}
+
+type ApiManagementNotificationRecipientUserResource struct{}
+
+var _ sdk.Resource = ApiManagementNotificationRecipientUserResource{}
+
+func (r ApiManagementNotificationRecipientUserResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"api_management_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ApiManagementID,
+		},
+
+		"notification_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(apimanagement.AccountClosedPublisher),
+				string(apimanagement.BCC),
+				string(apimanagement.NewApplicationNotificationMessage),
+				string(apimanagement.NewIssuePublisherNotificationMessage),
+				string(apimanagement.PurchasePublisherNotificationMessage),
+				string(apimanagement.QuotaLimitApproachingPublisherNotificationMessage),
+				string(apimanagement.RequestPublisherNotificationMessage),
+			}, false),
+		},
+
+		"user_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) Attributes() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) ModelObject() interface{} {
+	return &ApiManagementNotificationRecipientUserModel{}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) ResourceType() string {
+	return "azurerm_api_management_notification_recipient_user"
+}
+
+func (r ApiManagementNotificationRecipientUserResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ApiManagement.NotificationRecipientUserClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model ApiManagementNotificationRecipientUserModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			apiManagementId, err := parse.ApiManagementID(model.ApiManagementId)
+			if err != nil {
+				return err
+			}
+
+			id := parse.NewNotificationRecipientUserID(subscriptionId, apiManagementId.ResourceGroup, apiManagementId.ServiceName, model.NotificationName, model.UserId)
+
+			// CheckEntityExists can not be used, it returns autorest error
+			users, err := client.ListByNotification(ctx, id.ResourceGroup, id.ServiceName, apimanagement.NotificationName(id.NotificationName))
+			if err != nil {
+				if !utils.ResponseWasNotFound(users.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if users.Value != nil {
+				for _, existing := range *users.Value {
+					if existing.Name != nil && *existing.Name == model.UserId {
+						return metadata.ResourceRequiresImport(r.ResourceType(), id)
+					}
+				}
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, apimanagement.NotificationName(id.NotificationName), id.RecipientUserName); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ApiManagement.NotificationRecipientUserClient
+			id, err := parse.NotificationRecipientUserID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			// CheckEntityExists can not be used, it returns autorest error
+			users, err := client.ListByNotification(ctx, id.ResourceGroup, id.ServiceName, apimanagement.NotificationName(id.NotificationName))
+			if err != nil {
+				if !utils.ResponseWasNotFound(users.Response) {
+					return fmt.Errorf("retrieving %s: %+v", id, err)
+				}
+			}
+
+			found := false
+			if users.Value != nil {
+				for _, existing := range *users.Value {
+					if existing.Name != nil && *existing.Name == id.RecipientUserName {
+						found = true
+					}
+				}
+			}
+			if !found {
+				return metadata.MarkAsGone(id)
+			}
+
+			model := ApiManagementNotificationRecipientUserModel{
+				ApiManagementId:  parse.NewApiManagementID(id.SubscriptionId, id.ResourceGroup, id.ServiceName).ID(),
+				NotificationName: id.NotificationName,
+				UserId:           id.RecipientUserName,
+			}
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ApiManagement.NotificationRecipientUserClient
+
+			id, err := parse.NotificationRecipientUserID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			_, err = client.Delete(ctx, id.ResourceGroup, id.ServiceName, apimanagement.NotificationName(id.NotificationName), id.RecipientUserName)
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ApiManagementNotificationRecipientUserResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.NotificationRecipientUserID
+}

--- a/internal/services/apimanagement/api_management_notification_recipient_user_test.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_user_test.go
@@ -16,39 +16,6 @@ import (
 
 type ApiManagementNotificationRecipientUserResource struct{}
 
-//var config = `
-//data "azurerm_api_management" "example" {
-//  name                = "xz3-apim"
-//  resource_group_name = "xz3-apimanagement-test"
-//}
-//
-////resource "azurerm_api_management_notification_recipient_email" "example" {
-////  api_management_id = data.azurerm_api_management.example.id
-////  notification_type = "AccountClosedPublisher"
-////  email           = "foo@bar.com"
-////}
-//
-//resource "azurerm_api_management_notification_recipient_user" "example" {
-// api_management_id = data.azurerm_api_management.example.id
-// notification_type = "AccountClosedPublisher"
-// user_id           = "test-test-com"
-//}
-//`
-//
-//func TestAccApiManagementNotificationRecipientUser_DD(t *testing.T) {
-//	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
-//	r := ApiManagementNotificationRecipientUserResource{}
-//
-//	data.ResourceTest(t, r, []acceptance.TestStep{
-//		{
-//			Config: config,
-//			Check: acceptance.ComposeTestCheckFunc(
-//				check.That(data.ResourceName).ExistsInAzure(r),
-//			),
-//		},
-//	})
-//}
-
 func TestAccApiManagementNotificationRecipientUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
 	r := ApiManagementNotificationRecipientUserResource{}
@@ -93,7 +60,7 @@ func (ApiManagementNotificationRecipientUserResource) Exists(ctx context.Context
 	}
 	if users.Value != nil {
 		for _, existing := range *users.Value {
-			if existing.RecipientUsersContractProperties != nil && existing.RecipientUsersContractProperties.UserID != nil && *existing.RecipientUsersContractProperties.UserID == id.RecipientUserName {
+			if existing.Name != nil && *existing.Name == id.RecipientUserName {
 				return utils.Bool(true), nil
 			}
 		}
@@ -105,8 +72,8 @@ func (r ApiManagementNotificationRecipientUserResource) basic(data acceptance.Te
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_api_management_user" "example" {
-  user_id             = "test_user"
+resource "azurerm_api_management_user" "test" {
+  user_id             = "123"
   api_management_name = azurerm_api_management.test.name
   resource_group_name = azurerm_resource_group.test.name
   first_name          = "Example"
@@ -118,7 +85,7 @@ resource "azurerm_api_management_user" "example" {
 resource "azurerm_api_management_notification_recipient_user" "test" {
   api_management_id = azurerm_api_management.test.id
   notification_type = "AccountClosedPublisher"
-  user_id           = azurerm_api_management_user.example.user_id
+  user_id           = azurerm_api_management_user.test.user_id
 }
 `, ApiManagementResource{}.basic(data))
 }
@@ -127,7 +94,7 @@ func (r ApiManagementNotificationRecipientUserResource) requiresImport(data acce
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_api_manageme_notification_recipient_user" "import" {
+resource "azurerm_api_management_notification_recipient_user" "import" {
   api_management_id = azurerm_api_management.test.id
   notification_type = azurerm_api_management_notification_recipient_user.test.notification_type
   user_id           = azurerm_api_management_notification_recipient_user.test.user_id

--- a/internal/services/apimanagement/api_management_notification_recipient_user_test.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_user_test.go
@@ -1,0 +1,136 @@
+package apimanagement_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2020-12-01/apimanagement"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ApiManagementNotificationRecipientUserResource struct{}
+
+//var config = `
+//data "azurerm_api_management" "example" {
+//  name                = "xz3-apim"
+//  resource_group_name = "xz3-apimanagement-test"
+//}
+//
+////resource "azurerm_api_management_notification_recipient_email" "example" {
+////  api_management_id = data.azurerm_api_management.example.id
+////  notification_type = "AccountClosedPublisher"
+////  email           = "foo@bar.com"
+////}
+//
+//resource "azurerm_api_management_notification_recipient_user" "example" {
+// api_management_id = data.azurerm_api_management.example.id
+// notification_type = "AccountClosedPublisher"
+// user_id           = "test-test-com"
+//}
+//`
+//
+//func TestAccApiManagementNotificationRecipientUser_DD(t *testing.T) {
+//	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
+//	r := ApiManagementNotificationRecipientUserResource{}
+//
+//	data.ResourceTest(t, r, []acceptance.TestStep{
+//		{
+//			Config: config,
+//			Check: acceptance.ComposeTestCheckFunc(
+//				check.That(data.ResourceName).ExistsInAzure(r),
+//			),
+//		},
+//	})
+//}
+
+func TestAccApiManagementNotificationRecipientUser_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
+	r := ApiManagementNotificationRecipientUserResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementNotificationRecipientUser_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
+	r := ApiManagementNotificationRecipientUserResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (ApiManagementNotificationRecipientUserResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.NotificationRecipientUserID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := client.ApiManagement.NotificationRecipientUserClient.ListByNotification(ctx, id.ResourceGroup, id.ServiceName, apimanagement.NotificationName(id.NotificationName))
+	if err != nil {
+		if !utils.ResponseWasNotFound(users.Response) {
+			return nil, fmt.Errorf("retrieving Api Management Notification Recipient User %q (Resource Group %q): %+v", id.RecipientUserName, id.ResourceGroup, err)
+		}
+	}
+	if users.Value != nil {
+		for _, existing := range *users.Value {
+			if existing.RecipientUsersContractProperties != nil && existing.RecipientUsersContractProperties.UserID != nil && *existing.RecipientUsersContractProperties.UserID == id.RecipientUserName {
+				return utils.Bool(true), nil
+			}
+		}
+	}
+	return utils.Bool(false), nil
+}
+
+func (r ApiManagementNotificationRecipientUserResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "example" {
+  user_id             = "test_user"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  first_name          = "Example"
+  last_name           = "User"
+  email               = "foo@bar.com"
+  state               = "active"
+}
+
+resource "azurerm_api_management_notification_recipient_user" "test" {
+  api_management_id = azurerm_api_management.test.id
+  notification_type = "AccountClosedPublisher"
+  user_id           = azurerm_api_management_user.example.user_id
+}
+`, ApiManagementResource{}.basic(data))
+}
+
+func (r ApiManagementNotificationRecipientUserResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_manageme_notification_recipient_user" "import" {
+  api_management_id = azurerm_api_management.test.id
+  notification_type = azurerm_api_management_notification_recipient_user.test.notification_type
+  user_id           = azurerm_api_management_notification_recipient_user.test.user_id
+}
+`, r.basic(data))
+}

--- a/internal/services/apimanagement/client/client.go
+++ b/internal/services/apimanagement/client/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	LoggerClient                     *apimanagement.LoggerClient
 	NamedValueClient                 *apimanagement.NamedValueClient
 	NotificationRecipientEmailClient *apimanagement.NotificationRecipientEmailClient
+	NotificationRecipientUserClient  *apimanagement.NotificationRecipientUserClient
 	OpenIdConnectClient              *apimanagement.OpenIDConnectProviderClient
 	PolicyClient                     *apimanagement.PolicyClient
 	ProductsClient                   *apimanagement.ProductClient
@@ -111,6 +112,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	notificationRecipientEmailClient := apimanagement.NewNotificationRecipientEmailClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&notificationRecipientEmailClient.Client, o.ResourceManagerAuthorizer)
 
+	notificationRecipientUserClient := apimanagement.NewNotificationRecipientUserClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&notificationRecipientUserClient.Client, o.ResourceManagerAuthorizer)
+
 	loggerClient := apimanagement.NewLoggerClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loggerClient.Client, o.ResourceManagerAuthorizer)
 
@@ -177,6 +181,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		LoggerClient:                     &loggerClient,
 		NamedValueClient:                 &namedValueClient,
 		NotificationRecipientEmailClient: &notificationRecipientEmailClient,
+		NotificationRecipientUserClient:  &notificationRecipientUserClient,
 		OpenIdConnectClient:              &openIdConnectClient,
 		PolicyClient:                     &policyClient,
 		ProductsClient:                   &productsClient,

--- a/internal/services/apimanagement/parse/notification_recipient_user.go
+++ b/internal/services/apimanagement/parse/notification_recipient_user.go
@@ -1,0 +1,81 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type NotificationRecipientUserId struct {
+	SubscriptionId    string
+	ResourceGroup     string
+	ServiceName       string
+	NotificationName  string
+	RecipientUserName string
+}
+
+func NewNotificationRecipientUserID(subscriptionId, resourceGroup, serviceName, notificationName, recipientUserName string) NotificationRecipientUserId {
+	return NotificationRecipientUserId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroup:     resourceGroup,
+		ServiceName:       serviceName,
+		NotificationName:  notificationName,
+		RecipientUserName: recipientUserName,
+	}
+}
+
+func (id NotificationRecipientUserId) String() string {
+	segments := []string{
+		fmt.Sprintf("Recipient User Name %q", id.RecipientUserName),
+		fmt.Sprintf("Notification Name %q", id.NotificationName),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Notification Recipient User", segmentsStr)
+}
+
+func (id NotificationRecipientUserId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/notifications/%s/recipientUsers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ServiceName, id.NotificationName, id.RecipientUserName)
+}
+
+// NotificationRecipientUserID parses a NotificationRecipientUser ID into an NotificationRecipientUserId struct
+func NotificationRecipientUserID(input string) (*NotificationRecipientUserId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NotificationRecipientUserId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.ServiceName, err = id.PopSegment("service"); err != nil {
+		return nil, err
+	}
+	if resourceId.NotificationName, err = id.PopSegment("notifications"); err != nil {
+		return nil, err
+	}
+	if resourceId.RecipientUserName, err = id.PopSegment("recipientUsers"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/apimanagement/parse/notification_recipient_user_test.go
+++ b/internal/services/apimanagement/parse/notification_recipient_user_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = NotificationRecipientUserId{}
+
+func TestNotificationRecipientUserIDFormatter(t *testing.T) {
+	actual := NewNotificationRecipientUserID("12345678-1234-9876-4563-123456789012", "resGroup1", "apimservice1", "notificationName1", "userid1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/recipientUsers/userid1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNotificationRecipientUserID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NotificationRecipientUserId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing ServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/",
+			Error: true,
+		},
+
+		{
+			// missing value for ServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Error: true,
+		},
+
+		{
+			// missing NotificationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/",
+			Error: true,
+		},
+
+		{
+			// missing value for NotificationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/",
+			Error: true,
+		},
+
+		{
+			// missing RecipientUserName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/",
+			Error: true,
+		},
+
+		{
+			// missing value for RecipientUserName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/recipientUsers/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/recipientUsers/userid1",
+			Expected: &NotificationRecipientUserId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:     "resGroup1",
+				ServiceName:       "apimservice1",
+				NotificationName:  "notificationName1",
+				RecipientUserName: "userid1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.APIMANAGEMENT/SERVICE/APIMSERVICE1/NOTIFICATIONS/NOTIFICATIONNAME1/RECIPIENTUSERS/USERID1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NotificationRecipientUserID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.ServiceName != v.Expected.ServiceName {
+			t.Fatalf("Expected %q but got %q for ServiceName", v.Expected.ServiceName, actual.ServiceName)
+		}
+		if actual.NotificationName != v.Expected.NotificationName {
+			t.Fatalf("Expected %q but got %q for NotificationName", v.Expected.NotificationName, actual.NotificationName)
+		}
+		if actual.RecipientUserName != v.Expected.RecipientUserName {
+			t.Fatalf("Expected %q but got %q for RecipientUserName", v.Expected.RecipientUserName, actual.RecipientUserName)
+		}
+	}
+}

--- a/internal/services/apimanagement/registration.go
+++ b/internal/services/apimanagement/registration.go
@@ -84,5 +84,6 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		ApiManagementNotificationRecipientEmailResource{},
+		ApiManagementNotificationRecipientUserResource{},
 	}
 }

--- a/internal/services/apimanagement/validate/notification_recipient_user_id.go
+++ b/internal/services/apimanagement/validate/notification_recipient_user_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
+)
+
+func NotificationRecipientUserID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.NotificationRecipientUserID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/apimanagement/validate/notification_recipient_user_id_test.go
+++ b/internal/services/apimanagement/validate/notification_recipient_user_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestNotificationRecipientUserID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing ServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Valid: false,
+		},
+
+		{
+			// missing NotificationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for NotificationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/",
+			Valid: false,
+		},
+
+		{
+			// missing RecipientUserName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for RecipientUserName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/recipientUsers/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/apimservice1/notifications/notificationName1/recipientUsers/userid1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.APIMANAGEMENT/SERVICE/APIMSERVICE1/NOTIFICATIONS/NOTIFICATIONNAME1/RECIPIENTUSERS/USERID1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := NotificationRecipientUserID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/api_management_notification_recipient_user.html.markdown
+++ b/website/docs/r/api_management_notification_recipient_user.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_api_management_user" "example" {
 resource "azurerm_api_management_notification_recipient_user" "example" {
   api_management_id = azurerm_api_management.example.id
   notification_type = "AccountClosedPublisher"
-  user_id             = azurerm_api_management_user.example.user_id
+  user_id           = azurerm_api_management_user.example.user_id
 }
 ```
 

--- a/website/docs/r/api_management_notification_recipient_user.html.markdown
+++ b/website/docs/r/api_management_notification_recipient_user.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_notification_recipient_user"
+description: |-
+  Manages a API Management Notification Recipient User.
+---
+
+# azurerm_api_management_notification_recipient_user
+
+Manages a API Management Notification Recipient User.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-apim"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+
+  sku_name = "Developer_1"
+}
+
+resource "azurerm_api_management_user" "example" {
+  user_id             = "123"
+  api_management_name = azurerm_api_management.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  first_name          = "Example"
+  last_name           = "User"
+  email               = "foo@bar.com"
+  state               = "active"
+}
+
+resource "azurerm_api_management_notification_recipient_user" "example" {
+  api_management_id = azurerm_api_management.example.id
+  notification_type = "AccountClosedPublisher"
+  user_id             = azurerm_api_management_user.example.user_id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_id` - (Required) The ID of the API Management Service from which to create this Notification Recipient User. Changing this forces a new API Management Notification Recipient User to be created.
+
+* `user_id` - (Required) The recipient user ID. Changing this forces a new API Management Notification Recipient User to be created.
+
+* `notification_type` - (Required) The Notification Name to be received. Changing this forces a new API Management Notification Recipient User to be created. Possible values are `AccountClosedPublisher`, `BCC`, `NewApplicationNotificationMessage`, `NewIssuePublisherNotificationMessage`, `PurchasePublisherNotificationMessage`, `QuotaLimitApproachingPublisherNotificationMessage`, and `RequestPublisherNotificationMessage`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the API Management Notification Recipient User.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Notification Recipient User.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Notification Recipient User.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Notification Recipient User.
+
+## Import
+
+API Management Notification Recipient Users can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_notification_recipient_user.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/notifications/notificationName1/recipientUsers/userid1
+```


### PR DESCRIPTION
**New Resource:** API management recipient user
```log
TF_ACC=1 go test -v ./internal/services/apimanagement -run=TestAccApiManagementNotificationRecipientUser -timeout 200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementNotificationRecipientUser_basic
=== PAUSE TestAccApiManagementNotificationRecipientUser_basic
=== RUN   TestAccApiManagementNotificationRecipientUser_requiresImport
=== PAUSE TestAccApiManagementNotificationRecipientUser_requiresImport
=== CONT  TestAccApiManagementNotificationRecipientUser_basic
=== CONT  TestAccApiManagementNotificationRecipientUser_requiresImport
--- PASS: TestAccApiManagementNotificationRecipientUser_basic (3372.56s)
--- PASS: TestAccApiManagementNotificationRecipientUser_requiresImport (4233.72s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 4237.606s

```