### PR TITLE
`azurerm_kubernetes_cluster`  `azurerm_kubernetes_cluster_node_pool` Fix #13919 by adding state migration to `azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -301,6 +301,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
+	if kubernetesClusterId.SubscriptionId != clustersClient.SubscriptionID {
+		return fmt.Errorf("`kuberentes_cluster_id`'s subscription id is different than provider's subscription")
+	}
+
 	resourceGroup := kubernetesClusterId.ResourceGroup
 	clusterName := kubernetesClusterId.ManagedClusterName
 	name := d.Get("name").(string)
@@ -499,20 +503,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("waiting for completion of Managed Kubernetes Cluster Node Pool %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	read, err := poolsClient.Get(ctx, resourceGroup, clusterName, name)
-	if err != nil {
-		return fmt.Errorf("retrieving Managed Kubernetes Cluster Node Pool %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read ID for Managed Kubernetes Cluster Node Pool %q (Resource Group %q)", name, resourceGroup)
-	}
-
-	id, err := parse.NodePoolID(*read.ID)
-	if err != nil {
-		return err
-	}
-
+	id := parse.NewNodePoolID(poolsClient.SubscriptionID, resourceGroup, clusterName, name)
 	d.SetId(id.ID())
 
 	return resourceKubernetesClusterNodePoolRead(d, meta)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -690,7 +690,9 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 	}
 
 	d.Set("name", id.AgentPoolName)
-	d.Set("kubernetes_cluster_id", cluster.ID)
+
+	clusterId := parse.NewClusterID(id.SubscriptionId, id.ResourceGroup, id.ManagedClusterName)
+	d.Set("kubernetes_cluster_id", clusterId)
 
 	if props := resp.ManagedClusterAgentPoolProfileProperties; props != nil {
 		if err := d.Set("availability_zones", utils.FlattenStringSlice(props.AvailabilityZones)); err != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -301,10 +301,6 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	if kubernetesClusterId.SubscriptionId != clustersClient.SubscriptionID {
-		return fmt.Errorf("`kuberentes_cluster_id`'s subscription id is different than provider's subscription")
-	}
-
 	resourceGroup := kubernetesClusterId.ResourceGroup
 	clusterName := kubernetesClusterId.ManagedClusterName
 	name := d.Get("name").(string)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -692,7 +692,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 	d.Set("name", id.AgentPoolName)
 
 	clusterId := parse.NewClusterID(id.SubscriptionId, id.ResourceGroup, id.ManagedClusterName)
-	d.Set("kubernetes_cluster_id", clusterId)
+	d.Set("kubernetes_cluster_id", clusterId.ID())
 
 	if props := resp.ManagedClusterAgentPoolProfileProperties; props != nil {
 		if err := d.Set("availability_zones", utils.FlattenStringSlice(props.AvailabilityZones)); err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1550,11 +1550,6 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
-	// for "resourcegroups" in `terraform import`
-	if d.Id() != id.ID() {
-		d.SetId(id.ID())
-	}
-
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ManagedClusterName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1151,15 +1151,6 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("waiting for creation of Managed Kubernetes Cluster %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	read, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		return fmt.Errorf("retrieving Managed Kubernetes Cluster %q (Resource Group %q): %+v", name, resGroup, err)
-	}
-
-	if read.ID == nil {
-		return fmt.Errorf("cannot read ID for Managed Kubernetes Cluster %q (Resource Group %q)", name, resGroup)
-	}
-
 	if maintenanceConfigRaw, ok := d.GetOk("maintenance_window"); ok {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
 		parameters := containerservice.MaintenanceConfiguration{
@@ -1170,12 +1161,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	// Normalize Cluster ID, service side may returns resource id contains `resourcegroups` instead of `resourceGroups`
-	id, err := parse.ClusterID(*read.ID)
-	if err != nil {
-		return err
-	}
-
+	id := parse.NewClusterID(client.SubscriptionID, resGroup, name)
 	d.SetId(id.ID())
 
 	return resourceKubernetesClusterRead(d, meta)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1550,6 +1550,11 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
+	// for "resourcegroups" in `terraform import`
+	if d.Id() != id.ID() {
+		d.SetId(id.ID())
+	}
+
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ManagedClusterName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {

--- a/internal/services/containers/migration/kubernetes_cluster.go
+++ b/internal/services/containers/migration/kubernetes_cluster.go
@@ -1,0 +1,1423 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-08-01/containerservice"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
+	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
+	logAnalyticsValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+)
+
+var _ pluginsdk.StateUpgrade = KubernetesClusterV0ToV1{}
+
+type KubernetesClusterV0ToV1 struct{}
+
+func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:             schema.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			StateFunc:        location.StateFunc,
+			DiffSuppressFunc: location.DiffSuppressFunc,
+		},
+
+		"resource_group_name": {
+			Type:       pluginsdk.TypeString,
+			Optional:   true,
+			Deprecated: "This field is no longer used and will be removed in the next major version of the Azure Provider",
+		},
+
+		"dns_prefix": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"dns_prefix", "dns_prefix_private_cluster"},
+			ValidateFunc: containerValidate.KubernetesDNSPrefix,
+		},
+
+		"dns_prefix_private_cluster": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"dns_prefix", "dns_prefix_private_cluster"},
+		},
+
+		"kubernetes_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"default_node_pool": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					// Required
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  string(containerservice.AgentPoolTypeVirtualMachineScaleSets),
+					},
+
+					"vm_size": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					// Optional
+					"availability_zones": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"enable_auto_scaling": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
+					"enable_node_public_ip": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"enable_host_encryption": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"kubelet_config": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"cpu_manager_policy": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"cpu_cfs_quota_enabled": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"cpu_cfs_quota_period": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"image_gc_high_threshold": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"image_gc_low_threshold": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"topology_manager_policy": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"allowed_unsafe_sysctls": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									ForceNew: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"container_log_max_size_mb": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"container_log_max_line": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"pod_max_pid": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+							},
+						},
+					},
+
+					"linux_os_config": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"sysctl_config": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									ForceNew: true,
+									MaxItems: 1,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"fs_aio_max_nr": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"fs_file_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"fs_inotify_max_user_watches": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"fs_nr_open": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"kernel_threads_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_netdev_max_backlog": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_optmem_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_rmem_default": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_rmem_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_somaxconn": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_wmem_default": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_core_wmem_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_ip_local_port_range_min": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_ip_local_port_range_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_neigh_default_gc_thresh1": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_neigh_default_gc_thresh2": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_neigh_default_gc_thresh3": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_fin_timeout": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_keepalive_intvl": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_keepalive_probes": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_keepalive_time": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_max_syn_backlog": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_max_tw_buckets": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_ipv4_tcp_tw_reuse": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_netfilter_nf_conntrack_buckets": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"net_netfilter_nf_conntrack_max": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"vm_max_map_count": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"vm_swappiness": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+
+											"vm_vfs_cache_pressure": {
+												Type:     pluginsdk.TypeInt,
+												Optional: true,
+												ForceNew: true,
+											},
+										},
+									},
+								},
+
+								"transparent_huge_page_enabled": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"transparent_huge_page_defrag": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"swap_file_size_mb": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+							},
+						},
+					},
+
+					"fips_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"kubelet_disk_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+
+					"max_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+
+					"max_pods": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"min_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+
+					"node_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+
+					"node_labels": {
+						Type:     pluginsdk.TypeMap,
+						ForceNew: true,
+						Optional: true,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"node_public_ip_prefix_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						RequiredWith: []string{"default_node_pool.0.enable_node_public_ip"},
+					},
+
+					"node_taints": {
+						Type:     pluginsdk.TypeList,
+						ForceNew: true,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"tags": tags.Schema(),
+
+					"os_disk_size_gb": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+						Computed: true,
+					},
+
+					"os_disk_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  containerservice.OSDiskTypeManaged,
+					},
+
+					"os_sku": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Computed: true, // defaults to Ubuntu if using Linux
+					},
+
+					"ultra_ssd_enabled": {
+						Type:     pluginsdk.TypeBool,
+						ForceNew: true,
+						Default:  false,
+						Optional: true,
+					},
+
+					"vnet_subnet_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+					"orchestrator_version": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"pod_subnet_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+					"proximity_placement_group_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+					"only_critical_addons_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"upgrade_settings": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"max_surge": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Optional
+		"addon_profile": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"aci_connector_linux": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+
+								"subnet_name": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+
+					"azure_policy": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"kube_dashboard": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"http_application_routing": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"http_application_routing_zone_name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"oms_agent": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"log_analytics_workspace_id": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: logAnalyticsValidate.LogAnalyticsWorkspaceID,
+								},
+								"oms_agent_identity": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"client_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+											"object_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+											"user_assigned_identity_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+
+					"ingress_application_gateway": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+								"gateway_id": {
+									Type:          pluginsdk.TypeString,
+									Optional:      true,
+									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+								},
+								"gateway_name": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"subnet_cidr": {
+									Type:          pluginsdk.TypeString,
+									Optional:      true,
+									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+								},
+								"subnet_id": {
+									Type:          pluginsdk.TypeString,
+									Optional:      true,
+									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_cidr"},
+								},
+								"effective_gateway_id": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"ingress_application_gateway_identity": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"client_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+											"object_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+											"user_assigned_identity_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+
+					"open_service_mesh": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"api_server_authorized_ip_ranges": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"auto_scaler_profile": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"balance_similar_node_groups": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"expander": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"max_graceful_termination_sec": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"max_node_provisioning_time": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  "15m",
+					},
+					"max_unready_nodes": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  3,
+					},
+					"max_unready_percentage": {
+						Type:     pluginsdk.TypeFloat,
+						Optional: true,
+						Default:  45,
+					},
+					"new_pod_scale_up_delay": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scan_interval": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_delay_after_add": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_delay_after_delete": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_delay_after_failure": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_unneeded": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_unready": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"scale_down_utilization_threshold": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"empty_bulk_delete_max": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"skip_nodes_with_local_storage": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+					"skip_nodes_with_system_pods": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+				},
+			},
+		},
+
+		"disk_encryption_set_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"enable_pod_security_policy": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"identity": {
+			Type:         pluginsdk.TypeList,
+			Optional:     true,
+			ExactlyOneOf: []string{"identity", "service_principal"},
+			MaxItems:     1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"user_assigned_identity_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"principal_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"tenant_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"kubelet_identity": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"client_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ForceNew:     true,
+						RequiredWith: []string{"kubelet_identity.0.object_id", "kubelet_identity.0.user_assigned_identity_id", "identity.0.user_assigned_identity_id"},
+					},
+					"object_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ForceNew:     true,
+						RequiredWith: []string{"kubelet_identity.0.client_id", "kubelet_identity.0.user_assigned_identity_id", "identity.0.user_assigned_identity_id"},
+					},
+					"user_assigned_identity_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ForceNew:     true,
+						RequiredWith: []string{"kubelet_identity.0.client_id", "kubelet_identity.0.object_id", "identity.0.user_assigned_identity_id"},
+					},
+				},
+			},
+		},
+
+		"linux_profile": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"admin_username": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+					"ssh_key": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						ForceNew: true,
+						MaxItems: 1,
+
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"key_data": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ForceNew: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"local_account_disabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"maintenance_window": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"allowed": {
+						Type:         pluginsdk.TypeSet,
+						Optional:     true,
+						AtLeastOneOf: []string{"maintenance_window.0.allowed", "maintenance_window.0.not_allowed"},
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"day": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+
+								"hours": {
+									Type:     pluginsdk.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeInt,
+									},
+								},
+							},
+						},
+					},
+
+					"not_allowed": {
+						Type:         pluginsdk.TypeSet,
+						Optional:     true,
+						AtLeastOneOf: []string{"maintenance_window.0.allowed", "maintenance_window.0.not_allowed"},
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"end": {
+									Type:             pluginsdk.TypeString,
+									Required:         true,
+									DiffSuppressFunc: suppress.RFC3339Time,
+								},
+
+								"start": {
+									Type:             pluginsdk.TypeString,
+									Required:         true,
+									DiffSuppressFunc: suppress.RFC3339Time,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"network_profile": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"network_plugin": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"network_mode": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"network_policy": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"dns_service_ip": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"docker_bridge_cidr": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"pod_cidr": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"service_cidr": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"load_balancer_sku": {
+						Type:             pluginsdk.TypeString,
+						Optional:         true,
+						Default:          string(containerservice.LoadBalancerSkuStandard),
+						ForceNew:         true,
+						DiffSuppressFunc: suppress.CaseDifference,
+					},
+
+					"outbound_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  string(containerservice.OutboundTypeLoadBalancer),
+					},
+
+					"load_balancer_profile": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						ForceNew: true,
+						Optional: true,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"outbound_ports_allocated": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  0,
+								},
+								"idle_timeout_in_minutes": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  30,
+								},
+								"managed_outbound_ip_count": {
+									Type:          pluginsdk.TypeInt,
+									Optional:      true,
+									Computed:      true,
+									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids", "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"},
+								},
+								"outbound_ip_prefix_ids": {
+									Type:          pluginsdk.TypeSet,
+									Optional:      true,
+									Computed:      true,
+									ConfigMode:    pluginsdk.SchemaConfigModeAttr,
+									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"},
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"outbound_ip_address_ids": {
+									Type:          pluginsdk.TypeSet,
+									Optional:      true,
+									Computed:      true,
+									ConfigMode:    pluginsdk.SchemaConfigModeAttr,
+									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids"},
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"effective_outbound_ips": {
+									Type:       pluginsdk.TypeSet,
+									Computed:   true,
+									ConfigMode: pluginsdk.SchemaConfigModeAttr,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"node_resource_group": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"private_fqdn": { // privateFqdn
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"portal_fqdn": { // azurePortalFqdn
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"private_link_enabled": {
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true,
+			ConflictsWith: []string{"private_cluster_enabled"},
+			Deprecated:    "Deprecated in favour of `private_cluster_enabled`", // TODO -- remove this in next major version
+		},
+
+		"private_cluster_enabled": {
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true, // TODO -- remove this when deprecation resolves
+			ConflictsWith: []string{"private_link_enabled"},
+		},
+
+		"private_cluster_public_fqdn_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"private_dns_zone_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true, // a Private Cluster is `System` by default even if unspecified
+			ForceNew: true,
+		},
+
+		"role_based_access_control": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"enabled": {
+						Type:     pluginsdk.TypeBool,
+						Required: true,
+						ForceNew: true,
+					},
+					"azure_active_directory": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"client_app_id": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+
+								"server_app_id": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+
+								"server_app_secret": {
+									Type:      pluginsdk.TypeString,
+									Optional:  true,
+									Sensitive: true,
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+
+								"tenant_id": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Computed: true,
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+
+								"managed": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+
+								"azure_rbac_enabled": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+								},
+
+								"admin_group_object_ids": {
+									Type:       pluginsdk.TypeSet,
+									Optional:   true,
+									ConfigMode: pluginsdk.SchemaConfigModeAttr,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
+										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
+										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"service_principal": {
+			Type:         pluginsdk.TypeList,
+			Optional:     true,
+			ExactlyOneOf: []string{"identity", "service_principal"},
+			MaxItems:     1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"client_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"client_secret": {
+						Type:      pluginsdk.TypeString,
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+			},
+		},
+
+		"sku_tier": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(containerservice.ManagedClusterSKUTierFree),
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"windows_profile": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"admin_username": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+					"admin_password": {
+						Type:      pluginsdk.TypeString,
+						Optional:  true,
+						Sensitive: true,
+					},
+					"license": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"automatic_channel_upgrade": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"kube_admin_config": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"host": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"username": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"password": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"client_certificate": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"client_key": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"cluster_ca_certificate": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+				},
+			},
+		},
+
+		"kube_admin_config_raw": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"kube_config": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"host": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"username": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"password": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"client_certificate": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"client_key": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+					"cluster_ca_certificate": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+				},
+			},
+		},
+
+		"kube_config_raw": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+	}
+}
+
+func (k KubernetesClusterV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Printf("[DEBUG] Migrating ID to correct casing for Kubernetes Cluster")
+		rawId := rawState["id"].(string)
+
+		id, err := parse.ClusterID(rawId)
+		if err != nil {
+			return nil, err
+		}
+
+		rawState["id"] = id.ID()
+		return rawState, nil
+	}
+}

--- a/internal/services/containers/migration/kubernetes_cluster.go
+++ b/internal/services/containers/migration/kubernetes_cluster.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-08-01/containerservice"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
-	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 )
 
 var _ pluginsdk.StateUpgrade = KubernetesClusterV0ToV1{}
@@ -38,36 +33,26 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"location": {
-			Type:             schema.TypeString,
-			Required:         true,
-			ForceNew:         true,
-			StateFunc:        location.StateFunc,
-			DiffSuppressFunc: location.DiffSuppressFunc,
+			Type:     schema.TypeString,
+			Required: true,
 		},
 
 		"resource_group_name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"dns_prefix": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			ExactlyOneOf: []string{"dns_prefix", "dns_prefix_private_cluster"},
-			ValidateFunc: containerValidate.KubernetesDNSPrefix,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
 		},
 
 		"dns_prefix_private_cluster": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			ExactlyOneOf: []string{"dns_prefix", "dns_prefix_private_cluster"},
+			Type:     pluginsdk.TypeString,
+			Optional: true,
 		},
 
 		"kubernetes_version": {
@@ -79,34 +64,26 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"default_node_pool": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					// Required
 					"name": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 
 					"type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
-						Default:  string(containerservice.AgentPoolTypeVirtualMachineScaleSets),
 					},
 
 					"vm_size": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 
-					// Optional
 					"availability_zones": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -120,62 +97,51 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"enable_node_public_ip": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"enable_host_encryption": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"kubelet_config": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
-						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"cpu_manager_policy": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"cpu_cfs_quota_enabled": {
 									Type:     pluginsdk.TypeBool,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"cpu_cfs_quota_period": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"image_gc_high_threshold": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"image_gc_low_threshold": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"topology_manager_policy": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"allowed_unsafe_sysctls": {
 									Type:     pluginsdk.TypeSet,
 									Optional: true,
-									ForceNew: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
@@ -184,19 +150,16 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 								"container_log_max_size_mb": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"container_log_max_line": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"pod_max_pid": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 							},
 						},
@@ -205,189 +168,156 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"linux_os_config": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
-						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"sysctl_config": {
 									Type:     pluginsdk.TypeList,
 									Optional: true,
-									ForceNew: true,
-									MaxItems: 1,
 									Elem: &pluginsdk.Resource{
 										Schema: map[string]*pluginsdk.Schema{
 											"fs_aio_max_nr": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"fs_file_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"fs_inotify_max_user_watches": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"fs_nr_open": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"kernel_threads_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_netdev_max_backlog": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_optmem_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_rmem_default": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_rmem_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_somaxconn": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_wmem_default": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_core_wmem_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_ip_local_port_range_min": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_ip_local_port_range_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_neigh_default_gc_thresh1": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_neigh_default_gc_thresh2": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_neigh_default_gc_thresh3": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_fin_timeout": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_keepalive_intvl": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_keepalive_probes": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_keepalive_time": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_max_syn_backlog": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_max_tw_buckets": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_ipv4_tcp_tw_reuse": {
 												Type:     pluginsdk.TypeBool,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_netfilter_nf_conntrack_buckets": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"net_netfilter_nf_conntrack_max": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"vm_max_map_count": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"vm_swappiness": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 
 											"vm_vfs_cache_pressure": {
 												Type:     pluginsdk.TypeInt,
 												Optional: true,
-												ForceNew: true,
 											},
 										},
 									},
@@ -396,19 +326,16 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 								"transparent_huge_page_enabled": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"transparent_huge_page_defrag": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"swap_file_size_mb": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 							},
 						},
@@ -417,7 +344,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"fips_enabled": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"kubelet_disk_type": {
@@ -435,7 +361,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"min_count": {
@@ -451,7 +376,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"node_labels": {
 						Type:     pluginsdk.TypeMap,
-						ForceNew: true,
 						Optional: true,
 						Computed: true,
 						Elem: &pluginsdk.Schema{
@@ -460,47 +384,45 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					},
 
 					"node_public_ip_prefix_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ForceNew:     true,
-						RequiredWith: []string{"default_node_pool.0.enable_node_public_ip"},
+						Type:     pluginsdk.TypeString,
+						Optional: true,
 					},
 
 					"node_taints": {
 						Type:     pluginsdk.TypeList,
-						ForceNew: true,
 						Optional: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
 					},
 
-					"tags": tags.Schema(),
+					"tags": {
+						Type:     pluginsdk.TypeMap,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
 
 					"os_disk_size_gb": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 						Computed: true,
 					},
 
 					"os_disk_type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
-						Default:  containerservice.OSDiskTypeManaged,
 					},
 
 					"os_sku": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
-						Computed: true, // defaults to Ubuntu if using Linux
+						Computed: true,
 					},
 
 					"ultra_ssd_enabled": {
 						Type:     pluginsdk.TypeBool,
-						ForceNew: true,
 						Default:  false,
 						Optional: true,
 					},
@@ -508,7 +430,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"vnet_subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 					"orchestrator_version": {
 						Type:     pluginsdk.TypeString,
@@ -518,23 +439,19 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"pod_subnet_id": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 					"proximity_placement_group_id": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 					"only_critical_addons_enabled": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"upgrade_settings": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"max_surge": {
@@ -551,14 +468,12 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		// Optional
 		"addon_profile": {
 			Type:     pluginsdk.TypeList,
-			MaxItems: 1,
 			Optional: true,
 			Computed: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"aci_connector_linux": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -577,7 +492,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"azure_policy": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -591,7 +505,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"kube_dashboard": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -605,7 +518,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"http_application_routing": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -623,7 +535,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"oms_agent": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -661,7 +572,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"ingress_application_gateway": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -670,23 +580,20 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 									Required: true,
 								},
 								"gateway_id": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+									Type:     pluginsdk.TypeString,
+									Optional: true,
 								},
 								"gateway_name": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
 								},
 								"subnet_cidr": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+									Type:     pluginsdk.TypeString,
+									Optional: true,
 								},
 								"subnet_id": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_cidr"},
+									Type:     pluginsdk.TypeString,
+									Optional: true,
 								},
 								"effective_gateway_id": {
 									Type:     pluginsdk.TypeString,
@@ -718,7 +625,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 
 					"open_service_mesh": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -745,13 +651,11 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"balance_similar_node_groups": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  false,
 					},
 					"expander": {
 						Type:     pluginsdk.TypeString,
@@ -766,17 +670,14 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"max_node_provisioning_time": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						Default:  "15m",
 					},
 					"max_unready_nodes": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						Default:  3,
 					},
 					"max_unready_percentage": {
 						Type:     pluginsdk.TypeFloat,
 						Optional: true,
-						Default:  45,
 					},
 					"new_pod_scale_up_delay": {
 						Type:     pluginsdk.TypeString,
@@ -826,12 +727,10 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"skip_nodes_with_local_storage": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  true,
 					},
 					"skip_nodes_with_system_pods": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  true,
 					},
 				},
 			},
@@ -840,7 +739,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"disk_encryption_set_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"enable_pod_security_policy": {
@@ -849,10 +747,8 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"identity": {
-			Type:         pluginsdk.TypeList,
-			Optional:     true,
-			ExactlyOneOf: []string{"identity", "service_principal"},
-			MaxItems:     1,
+			Type:     pluginsdk.TypeList,
+			Optional: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"type": {
@@ -879,29 +775,22 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"client_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ForceNew:     true,
-						RequiredWith: []string{"kubelet_identity.0.object_id", "kubelet_identity.0.user_assigned_identity_id", "identity.0.user_assigned_identity_id"},
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
 					},
 					"object_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ForceNew:     true,
-						RequiredWith: []string{"kubelet_identity.0.client_id", "kubelet_identity.0.user_assigned_identity_id", "identity.0.user_assigned_identity_id"},
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
 					},
 					"user_assigned_identity_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ForceNew:     true,
-						RequiredWith: []string{"kubelet_identity.0.client_id", "kubelet_identity.0.object_id", "identity.0.user_assigned_identity_id"},
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
 					},
 				},
 			},
@@ -910,26 +799,21 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"linux_profile": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"admin_username": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 					"ssh_key": {
 						Type:     pluginsdk.TypeList,
 						Required: true,
-						ForceNew: true,
-						MaxItems: 1,
 
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"key_data": {
 									Type:     pluginsdk.TypeString,
 									Required: true,
-									ForceNew: true,
 								},
 							},
 						},
@@ -946,13 +830,11 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"maintenance_window": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"allowed": {
-						Type:         pluginsdk.TypeSet,
-						Optional:     true,
-						AtLeastOneOf: []string{"maintenance_window.0.allowed", "maintenance_window.0.not_allowed"},
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"day": {
@@ -963,7 +845,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 								"hours": {
 									Type:     pluginsdk.TypeSet,
 									Required: true,
-									MinItems: 1,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeInt,
 									},
@@ -973,21 +854,18 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					},
 
 					"not_allowed": {
-						Type:         pluginsdk.TypeSet,
-						Optional:     true,
-						AtLeastOneOf: []string{"maintenance_window.0.allowed", "maintenance_window.0.not_allowed"},
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"end": {
-									Type:             pluginsdk.TypeString,
-									Required:         true,
-									DiffSuppressFunc: suppress.RFC3339Time,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 
 								"start": {
-									Type:             pluginsdk.TypeString,
-									Required:         true,
-									DiffSuppressFunc: suppress.RFC3339Time,
+									Type:     pluginsdk.TypeString,
+									Required: true,
 								},
 							},
 						},
@@ -1000,77 +878,61 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			ForceNew: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"network_plugin": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 
 					"network_mode": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"network_policy": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"dns_service_ip": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"docker_bridge_cidr": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"pod_cidr": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"service_cidr": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
 						Computed: true,
-						ForceNew: true,
 					},
 
 					"load_balancer_sku": {
-						Type:             pluginsdk.TypeString,
-						Optional:         true,
-						Default:          string(containerservice.LoadBalancerSkuStandard),
-						ForceNew:         true,
-						DiffSuppressFunc: suppress.CaseDifference,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
 					},
 
 					"outbound_type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
-						Default:  string(containerservice.OutboundTypeLoadBalancer),
 					},
 
 					"load_balancer_profile": {
 						Type:     pluginsdk.TypeList,
-						MaxItems: 1,
-						ForceNew: true,
 						Optional: true,
 						Computed: true,
 						Elem: &pluginsdk.Resource{
@@ -1078,43 +940,35 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 								"outbound_ports_allocated": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									Default:  0,
 								},
 								"idle_timeout_in_minutes": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									Default:  30,
 								},
 								"managed_outbound_ip_count": {
-									Type:          pluginsdk.TypeInt,
-									Optional:      true,
-									Computed:      true,
-									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids", "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"},
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Computed: true,
 								},
 								"outbound_ip_prefix_ids": {
-									Type:          pluginsdk.TypeSet,
-									Optional:      true,
-									Computed:      true,
-									ConfigMode:    pluginsdk.SchemaConfigModeAttr,
-									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"},
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Computed: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
 								},
 								"outbound_ip_address_ids": {
-									Type:          pluginsdk.TypeSet,
-									Optional:      true,
-									Computed:      true,
-									ConfigMode:    pluginsdk.SchemaConfigModeAttr,
-									ConflictsWith: []string{"network_profile.0.load_balancer_profile.0.managed_outbound_ip_count", "network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids"},
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									Computed: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
 								},
 								"effective_outbound_ips": {
-									Type:       pluginsdk.TypeSet,
-									Computed:   true,
-									ConfigMode: pluginsdk.SchemaConfigModeAttr,
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 									},
@@ -1130,7 +984,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Computed: true,
-			ForceNew: true,
 		},
 
 		"private_fqdn": { // privateFqdn
@@ -1144,98 +997,67 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"private_link_enabled": {
-			Type:          pluginsdk.TypeBool,
-			Optional:      true,
-			ForceNew:      true,
-			Computed:      true,
-			ConflictsWith: []string{"private_cluster_enabled"},
-			Deprecated:    "Deprecated in favour of `private_cluster_enabled`", // TODO -- remove this in next major version
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
 		},
 
 		"private_cluster_enabled": {
-			Type:          pluginsdk.TypeBool,
-			Optional:      true,
-			ForceNew:      true,
-			Computed:      true, // TODO -- remove this when deprecation resolves
-			ConflictsWith: []string{"private_link_enabled"},
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
 		},
 
 		"private_cluster_public_fqdn_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			Default:  false,
 		},
 
 		"private_dns_zone_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Computed: true, // a Private Cluster is `System` by default even if unspecified
-			ForceNew: true,
 		},
 
 		"role_based_access_control": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"enabled": {
 						Type:     pluginsdk.TypeBool,
 						Required: true,
-						ForceNew: true,
 					},
 					"azure_active_directory": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"client_app_id": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
-									},
 								},
 
 								"server_app_id": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
-									},
 								},
 
 								"server_app_secret": {
-									Type:      pluginsdk.TypeString,
-									Optional:  true,
-									Sensitive: true,
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
-									},
+									Type:     pluginsdk.TypeString,
+									Optional: true,
 								},
 
 								"tenant_id": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
 									Computed: true,
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
-									},
 								},
 
 								"managed": {
 									Type:     pluginsdk.TypeBool,
 									Optional: true,
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
-									},
 								},
 
 								"azure_rbac_enabled": {
@@ -1244,15 +1066,10 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 								},
 
 								"admin_group_object_ids": {
-									Type:       pluginsdk.TypeSet,
-									Optional:   true,
-									ConfigMode: pluginsdk.SchemaConfigModeAttr,
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
-									},
-									AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
-										"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
-										"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
 									},
 								},
 							},
@@ -1263,10 +1080,8 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"service_principal": {
-			Type:         pluginsdk.TypeList,
-			Optional:     true,
-			ExactlyOneOf: []string{"identity", "service_principal"},
-			MaxItems:     1,
+			Type:     pluginsdk.TypeList,
+			Optional: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"client_id": {
@@ -1275,9 +1090,8 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					},
 
 					"client_secret": {
-						Type:      pluginsdk.TypeString,
-						Required:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Required: true,
 					},
 				},
 			},
@@ -1286,7 +1100,6 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"sku_tier": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  string(containerservice.ManagedClusterSKUTierFree),
 		},
 
 		"tags": {
@@ -1301,18 +1114,15 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"admin_username": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
-						ForceNew: true,
 					},
 					"admin_password": {
-						Type:      pluginsdk.TypeString,
-						Optional:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
 					},
 					"license": {
 						Type:     pluginsdk.TypeString,
@@ -1346,33 +1156,28 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 						Computed: true,
 					},
 					"password": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"client_certificate": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"client_key": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"cluster_ca_certificate": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
 		},
 
 		"kube_admin_config_raw": {
-			Type:      pluginsdk.TypeString,
-			Computed:  true,
-			Sensitive: true,
+			Type:     pluginsdk.TypeString,
+			Computed: true,
 		},
 
 		"kube_config": {
@@ -1389,33 +1194,28 @@ func (k KubernetesClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 						Computed: true,
 					},
 					"password": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"client_certificate": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"client_key": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 					"cluster_ca_certificate": {
-						Type:      pluginsdk.TypeString,
-						Computed:  true,
-						Sensitive: true,
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
 		},
 
 		"kube_config_raw": {
-			Type:      pluginsdk.TypeString,
-			Computed:  true,
-			Sensitive: true,
+			Type:     pluginsdk.TypeString,
+			Computed: true,
 		},
 	}
 }

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool.go
@@ -1,0 +1,538 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-08-01/containerservice"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = KubernetesClusterNodePoolV0ToV1{}
+
+type KubernetesClusterNodePoolV0ToV1 struct{}
+
+func (k KubernetesClusterNodePoolV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Printf("[DEBUG] Migrating ID to correct casing for Kubernetes Cluster")
+
+		originClusterId := rawState["kubernetes_cluster_id"].(string)
+		clusterId, err := parse.ClusterID(originClusterId)
+		if err != nil {
+			return nil, err
+		}
+		rawState["kubernetes_cluster_id"] = clusterId.ID()
+
+		id := rawState["id"].(string)
+		poolId, err := parse.NodePoolID(id)
+		if err != nil {
+			return nil, err
+		}
+		rawState["id"] = poolId.ID()
+
+		return rawState, nil
+	}
+}
+
+func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"kubernetes_cluster_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"node_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"vm_size": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		// Optional
+		"availability_zones": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"enable_auto_scaling": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"enable_host_encryption": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"enable_node_public_ip": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"eviction_policy": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"kubelet_config": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"cpu_manager_policy": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"cpu_cfs_quota_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"cpu_cfs_quota_period": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"image_gc_high_threshold": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"image_gc_low_threshold": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"topology_manager_policy": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"allowed_unsafe_sysctls": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						ForceNew: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"container_log_max_size_mb": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"container_log_max_line": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"pod_max_pid": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+				},
+			},
+		},
+
+		"linux_os_config": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"sysctl_config": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						ForceNew: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"fs_aio_max_nr": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"fs_file_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"fs_inotify_max_user_watches": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"fs_nr_open": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"kernel_threads_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_netdev_max_backlog": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_optmem_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_rmem_default": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_rmem_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_somaxconn": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_wmem_default": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_core_wmem_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_ip_local_port_range_min": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_ip_local_port_range_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_neigh_default_gc_thresh1": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_neigh_default_gc_thresh2": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_neigh_default_gc_thresh3": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_fin_timeout": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_keepalive_intvl": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_keepalive_probes": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_keepalive_time": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_max_syn_backlog": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_max_tw_buckets": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_ipv4_tcp_tw_reuse": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_netfilter_nf_conntrack_buckets": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"net_netfilter_nf_conntrack_max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"vm_max_map_count": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"vm_swappiness": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+
+								"vm_vfs_cache_pressure": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									ForceNew: true,
+								},
+							},
+						},
+					},
+
+					"transparent_huge_page_enabled": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"transparent_huge_page_defrag": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"swap_file_size_mb": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						ForceNew: true,
+					},
+				},
+			},
+		},
+
+		"fips_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"kubelet_disk_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"max_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"max_pods": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"mode": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(containerservice.AgentPoolModeUser),
+		},
+
+		"min_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"node_labels": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			ForceNew: true,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"node_public_ip_prefix_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			RequiredWith: []string{"enable_node_public_ip"},
+		},
+
+		"node_taints": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"orchestrator_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"os_disk_size_gb": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			ForceNew: true,
+			Computed: true,
+		},
+
+		"os_disk_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  containerservice.OSDiskTypeManaged,
+		},
+
+		"os_sku": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Computed: true, // defaults to Ubuntu if using Linux
+		},
+
+		"os_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(containerservice.OSTypeLinux),
+		},
+
+		"pod_subnet_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"priority": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(containerservice.ScaleSetPriorityRegular),
+		},
+
+		"proximity_placement_group_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"spot_max_price": {
+			Type:     pluginsdk.TypeFloat,
+			Optional: true,
+			ForceNew: true,
+			Default:  -1.0,
+		},
+
+		"ultra_ssd_enabled": {
+			Type:     pluginsdk.TypeBool,
+			ForceNew: true,
+			Default:  false,
+			Optional: true,
+		},
+
+		"vnet_subnet_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"upgrade_settings": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"max_surge": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-08-01/containerservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -40,13 +39,11 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"kubernetes_cluster_id": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"node_count": {
@@ -66,14 +63,11 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"vm_size": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
-		// Optional
 		"availability_zones": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			ForceNew: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
@@ -87,68 +81,56 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"enable_host_encryption": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"enable_node_public_ip": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"eviction_policy": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"kubelet_config": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			ForceNew: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"cpu_manager_policy": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"cpu_cfs_quota_enabled": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"cpu_cfs_quota_period": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"image_gc_high_threshold": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"image_gc_low_threshold": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"topology_manager_policy": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"allowed_unsafe_sysctls": {
 						Type:     pluginsdk.TypeSet,
 						Optional: true,
-						ForceNew: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -157,19 +139,16 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"container_log_max_size_mb": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"container_log_max_line": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"pod_max_pid": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 				},
 			},
@@ -178,189 +157,156 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"linux_os_config": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			ForceNew: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"sysctl_config": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
-						ForceNew: true,
-						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"fs_aio_max_nr": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"fs_file_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"fs_inotify_max_user_watches": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"fs_nr_open": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"kernel_threads_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_netdev_max_backlog": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_optmem_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_rmem_default": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_rmem_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_somaxconn": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_wmem_default": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_core_wmem_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_ip_local_port_range_min": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_ip_local_port_range_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_neigh_default_gc_thresh1": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_neigh_default_gc_thresh2": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_neigh_default_gc_thresh3": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_fin_timeout": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_keepalive_intvl": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_keepalive_probes": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_keepalive_time": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_max_syn_backlog": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_max_tw_buckets": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_ipv4_tcp_tw_reuse": {
 									Type:     pluginsdk.TypeBool,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_netfilter_nf_conntrack_buckets": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"net_netfilter_nf_conntrack_max": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"vm_max_map_count": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"vm_swappiness": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 
 								"vm_vfs_cache_pressure": {
 									Type:     pluginsdk.TypeInt,
 									Optional: true,
-									ForceNew: true,
 								},
 							},
 						},
@@ -369,19 +315,16 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 					"transparent_huge_page_enabled": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"transparent_huge_page_defrag": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ForceNew: true,
 					},
 
 					"swap_file_size_mb": {
 						Type:     pluginsdk.TypeInt,
 						Optional: true,
-						ForceNew: true,
 					},
 				},
 			},
@@ -390,7 +333,6 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"fips_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"kubelet_disk_type": {
@@ -408,13 +350,11 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
 			Computed: true,
-			ForceNew: true,
 		},
 
 		"mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  string(containerservice.AgentPoolModeUser),
 		},
 
 		"min_count": {
@@ -425,7 +365,6 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"node_labels": {
 			Type:     pluginsdk.TypeMap,
 			Optional: true,
-			ForceNew: true,
 			Computed: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
@@ -433,16 +372,13 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"node_public_ip_prefix_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			RequiredWith: []string{"enable_node_public_ip"},
+			Type:     pluginsdk.TypeString,
+			Optional: true,
 		},
 
 		"node_taints": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			ForceNew: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
@@ -457,74 +393,58 @@ func (k KubernetesClusterNodePoolV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"os_disk_size_gb": {
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
-			ForceNew: true,
 			Computed: true,
 		},
 
 		"os_disk_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
-			Default:  containerservice.OSDiskTypeManaged,
 		},
 
 		"os_sku": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 			Computed: true, // defaults to Ubuntu if using Linux
 		},
 
 		"os_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
-			Default:  string(containerservice.OSTypeLinux),
 		},
 
 		"pod_subnet_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"priority": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
-			Default:  string(containerservice.ScaleSetPriorityRegular),
 		},
 
 		"proximity_placement_group_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"spot_max_price": {
 			Type:     pluginsdk.TypeFloat,
 			Optional: true,
-			ForceNew: true,
-			Default:  -1.0,
 		},
 
 		"ultra_ssd_enabled": {
 			Type:     pluginsdk.TypeBool,
-			ForceNew: true,
-			Default:  false,
 			Optional: true,
 		},
 
 		"vnet_subnet_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"upgrade_settings": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"max_surge": {

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool_test.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool_test.go
@@ -1,0 +1,112 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func TestKubernetesClusterNodePoolV0ToV1_id(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "missing id",
+			input: map[string]interface{}{
+				"id":                    "",
+				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: nil,
+		},
+		{
+			name: "old id",
+			input: map[string]interface{}{
+				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
+				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
+				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
+		},
+	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := KubernetesClusterNodePoolV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
+			if err != nil && test.expected == nil {
+				return
+			} else {
+				if err == nil && test.expected == nil {
+					t.Fatalf("Expected an error but didn't get one")
+				} else if err != nil && test.expected != nil {
+					t.Fatalf("Expected no error but got: %+v", err)
+				}
+			}
+
+			actualId := result["id"].(string)
+			if *test.expected != actualId {
+				t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+			}
+		})
+	}
+}
+
+func TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "missing id",
+			input: map[string]interface{}{
+				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
+				"kubernetes_cluster_id": "",
+			},
+			expected: nil,
+		},
+		{
+			name: "old id",
+			input: map[string]interface{}{
+				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
+				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
+				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+		},
+	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := KubernetesClusterNodePoolV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
+			if err != nil && test.expected == nil {
+				return
+			} else {
+				if err == nil && test.expected == nil {
+					t.Fatalf("Expected an error but didn't get one")
+				} else if err != nil && test.expected != nil {
+					t.Fatalf("Expected no error but got: %+v", err)
+				}
+			}
+
+			actualId := result["kubernetes_cluster_id"].(string)
+			if *test.expected != actualId {
+				t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+			}
+		})
+	}
+}

--- a/internal/services/containers/migration/kubernetes_cluster_test.go
+++ b/internal/services/containers/migration/kubernetes_cluster_test.go
@@ -1,0 +1,57 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func TestKubernetesClusterV0ToV1(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "missing id",
+			input: map[string]interface{}{
+				"id": "",
+			},
+			expected: nil,
+		},
+		{
+			name: "old id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+		},
+	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := KubernetesClusterV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
+			if err != nil && test.expected == nil {
+				return
+			} else {
+				if err == nil && test.expected == nil {
+					t.Fatalf("Expected an error but didn't get one")
+				} else if err != nil && test.expected != nil {
+					t.Fatalf("Expected no error but got: %+v", err)
+				}
+			}
+
+			actualId := result["id"].(string)
+			if *test.expected != actualId {
+				t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As #13919 said, if we import an aks and aks node pool by id like `/subscriptions/subscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.ContainerService/managedClusters/myCluster`, it would caused a force new. That's because the service API returned incorrect aks id which contains `resourcegroups` instead of `resourceGroups`. When we created everything from scratch, everything would be fine, but when user imported a correct aks id, this id which contains `resourceGroups` would be set to aks id in state file, then caused this config drift.

This patch add migration functions to `azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` resources, which correct `azurerm_kubernetes_cluster.id` and `azurerm_kubernetes_cluster_node_pool.id` and `azurerm_kubernetes_cluster_node_pool.kubernetes_cluster_id`. Further more, this patch will set parsed cluster id to state instead of response from service API, so any new resources' id would be correct.

I've added some unit tests for migration upgrade function, here's the test results:

=== RUN   TestKubernetesClusterNodePoolV0ToV1_id
=== RUN   TestKubernetesClusterNodePoolV0ToV1_id/missing_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterNodePoolV0ToV1_id/old_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterNodePoolV0ToV1_id/new_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
--- PASS: TestKubernetesClusterNodePoolV0ToV1_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_id/missing_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_id/old_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_id/new_id (0.00s)
=== RUN   TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id
=== RUN   TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/missing_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/old_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/new_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
--- PASS: TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/missing_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/old_id (0.00s)
    --- PASS: TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id/new_id (0.00s)
=== RUN   TestKubernetesClusterV0ToV1
=== RUN   TestKubernetesClusterV0ToV1/missing_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterV0ToV1/old_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
=== RUN   TestKubernetesClusterV0ToV1/new_id
2021/11/18 13:16:30 [DEBUG] Migrating ID to correct casing for Kubernetes Cluster
--- PASS: TestKubernetesClusterV0ToV1 (0.00s)
    --- PASS: TestKubernetesClusterV0ToV1/missing_id (0.00s)
    --- PASS: TestKubernetesClusterV0ToV1/old_id (0.00s)
    --- PASS: TestKubernetesClusterV0ToV1/new_id (0.00s)
PASS

As the Point-In-Time schema snapshot in migration function contains more than one thousand lines, it's hard for human to check whether this snapshot is equal to current schema defined in resource code, I've wrote a [helper function](https://github.com/lonegunmanb/migrationSchemaComparer) to help us check(which contains some unit test). As the schema defined in resource code would be changed in the future, we cannot just add a unit test to do this check and then push it into repository as the test would fail eventually, we can add a temporary unit test, run it, then delete it. Here's my temporary unit test added in resource code folder:

```go
package containers

import (
	"fmt"
	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
	"reflect"
	"testing"
)

func TestKubernetesClusterSchemaSnapshotV0ToV1(t *testing.T) {
	v1 := migration.KubernetesClusterV0ToV1{}
	migrationSchema := v1.Schema()
	resourceSchema := resourceKubernetesCluster().Schema
	if err := Equal(resourceSchema, migrationSchema, "root"); err != nil {
		t.Fatal(err.Error())
	}
}

func TestKubernetesClusterNodePoolSchemaSnapshotV0toV1(t *testing.T) {
	v1 := migration.KubernetesClusterNodePoolV0ToV1{}
	v1Schema := v1.Schema()
	v0Schema := resourceKubernetesClusterNodePool().Schema
	if err := Equal(v0Schema, v1Schema, "root"); err != nil {
		t.Fatal(err.Error())
	}
}

func Equal(resourceSchemas, migrationSchemas map[string]*schema.Schema, currentPath string) error {
	if len(resourceSchemas) != len(migrationSchemas) {
		return fmt.Errorf("different count, path:%s, resource:%+v, migration:%+v", currentPath, resourceSchemas, migrationSchemas)
	}
	CleanObjectValidations(resourceSchemas)
	CleanObjectValidations(migrationSchemas)
	for key, resourceSchema := range resourceSchemas {
		migrationSchema, ok := migrationSchemas[key]
		if !ok {
			return fmt.Errorf("expected %s.%s not existd in migration", currentPath, key)
		}
		if !reflect.DeepEqual(resourceSchema, migrationSchema) {
			if resourceSchema.Type == schema.TypeList || resourceSchema.Type == schema.TypeSet || resourceSchema.Type == schema.TypeMap {
				switch t := resourceSchema.Elem.(type) {
				case *schema.Resource:
					return Equal(t.Schema, migrationSchema.Elem.(*schema.Resource).Schema, fmt.Sprintf("%s.%s", currentPath, key))
				}
			}
			return fmt.Errorf("%s.%s different, resource:%+v, migration:%+v", currentPath, key, *resourceSchema, *migrationSchema)
		}
	}
	return nil
}

func CleanObjectValidations(object map[string]*schema.Schema) {
	for _, s := range object {
		CleanSchemaValidation(s)
	}
}

func CleanSchemaValidation(s *schema.Schema) {
	s.ValidateFunc = nil
	s.DiffSuppressFunc = nil
	s.StateFunc = nil
	s.ValidateDiagFunc = nil
	s.DefaultFunc = nil
	if s.Type == schema.TypeList || s.Type == schema.TypeSet || s.Type == schema.TypeMap {
		switch t := s.Elem.(type) {
		case *schema.Schema:
			CleanSchemaValidation(t)
		case *schema.Resource:
			CleanObjectValidations(t.Schema)
		}
	}
}
```

The helper functions were copied from my repository. The test results:

=== RUN   TestKubernetesClusterSchemaSnapshotV0ToV1
--- PASS: TestKubernetesClusterSchemaSnapshotV0ToV1 (0.00s)
=== RUN   TestKubernetesClusterNodePoolSchemaSnapshotV0toV1
--- PASS: TestKubernetesClusterNodePoolSchemaSnapshotV0toV1 (0.00s)
PASS

The Acc test results are here:

=== RUN   TestAccKubernetesClusterNodePool_autoScale
=== PAUSE TestAccKubernetesClusterNodePool_autoScale
=== CONT  TestAccKubernetesClusterNodePool_autoScale
--- PASS: TestAccKubernetesClusterNodePool_autoScale (1690.59s)
=== RUN   TestAccKubernetesClusterNodePool_autoScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_autoScaleUpdate
=== CONT  TestAccKubernetesClusterNodePool_autoScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_autoScaleUpdate (1677.19s)
=== RUN   TestAccKubernetesClusterNodePool_availabilityZones
=== PAUSE TestAccKubernetesClusterNodePool_availabilityZones
=== CONT  TestAccKubernetesClusterNodePool_availabilityZones
--- PASS: TestAccKubernetesClusterNodePool_availabilityZones (1343.35s)
=== RUN   TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== PAUSE TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== CONT  TestAccKubernetesClusterNodePool_errorForAvailabilitySet
--- PASS: TestAccKubernetesClusterNodePool_errorForAvailabilitySet (865.98s)
=== RUN   TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== CONT  TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig (1266.38s)
=== RUN   TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== CONT  TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial (1209.10s)
=== RUN   TestAccKubernetesClusterNodePool_other
=== PAUSE TestAccKubernetesClusterNodePool_other
=== CONT  TestAccKubernetesClusterNodePool_other
--- PASS: TestAccKubernetesClusterNodePool_other (1472.13s)
=== RUN   TestAccKubernetesClusterNodePool_multiplePools
=== PAUSE TestAccKubernetesClusterNodePool_multiplePools
=== CONT  TestAccKubernetesClusterNodePool_multiplePools
--- PASS: TestAccKubernetesClusterNodePool_multiplePools (1629.33s)
=== RUN   TestAccKubernetesClusterNodePool_manualScale
=== PAUSE TestAccKubernetesClusterNodePool_manualScale
=== CONT  TestAccKubernetesClusterNodePool_manualScale
--- PASS: TestAccKubernetesClusterNodePool_manualScale (1292.14s)
=== RUN   TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== CONT  TestAccKubernetesClusterNodePool_manualScaleMultiplePools
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePools (1390.35s)
=== RUN   TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== CONT  TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate (1693.79s)
=== RUN   TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== CONT  TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
--- PASS: TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges (1445.54s)
=== RUN   TestAccKubernetesClusterNodePool_manualScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleUpdate
=== CONT  TestAccKubernetesClusterNodePool_manualScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_manualScaleUpdate (2076.41s)
=== RUN   TestAccKubernetesClusterNodePool_manualScaleVMSku
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleVMSku
=== CONT  TestAccKubernetesClusterNodePool_manualScaleVMSku
--- PASS: TestAccKubernetesClusterNodePool_manualScaleVMSku (1755.84s)
=== RUN   TestAccKubernetesClusterNodePool_modeSystem
=== PAUSE TestAccKubernetesClusterNodePool_modeSystem
=== CONT  TestAccKubernetesClusterNodePool_modeSystem
--- PASS: TestAccKubernetesClusterNodePool_modeSystem (1426.93s)
=== RUN   TestAccKubernetesClusterNodePool_modeUpdate
=== PAUSE TestAccKubernetesClusterNodePool_modeUpdate
=== CONT  TestAccKubernetesClusterNodePool_modeUpdate
--- PASS: TestAccKubernetesClusterNodePool_modeUpdate (1746.16s)
=== RUN   TestAccKubernetesClusterNodePool_nodeLabels
=== PAUSE TestAccKubernetesClusterNodePool_nodeLabels
=== CONT  TestAccKubernetesClusterNodePool_nodeLabels
--- PASS: TestAccKubernetesClusterNodePool_nodeLabels (2123.89s)
=== RUN   TestAccKubernetesClusterNodePool_nodePublicIP
=== PAUSE TestAccKubernetesClusterNodePool_nodePublicIP
=== CONT  TestAccKubernetesClusterNodePool_nodePublicIP
--- PASS: TestAccKubernetesClusterNodePool_nodePublicIP (1244.69s)
=== RUN   TestAccKubernetesClusterNodePool_nodeTaints
=== PAUSE TestAccKubernetesClusterNodePool_nodeTaints
=== CONT  TestAccKubernetesClusterNodePool_nodeTaints
--- PASS: TestAccKubernetesClusterNodePool_nodeTaints (1309.42s)
=== RUN   TestAccKubernetesClusterNodePool_podSubnet
=== PAUSE TestAccKubernetesClusterNodePool_podSubnet
=== CONT  TestAccKubernetesClusterNodePool_podSubnet
--- PASS: TestAccKubernetesClusterNodePool_podSubnet (1455.45s)
=== RUN   TestAccKubernetesClusterNodePool_osDiskSizeGB
=== PAUSE TestAccKubernetesClusterNodePool_osDiskSizeGB
=== CONT  TestAccKubernetesClusterNodePool_osDiskSizeGB
--- PASS: TestAccKubernetesClusterNodePool_osDiskSizeGB (1198.28s)
=== RUN   TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== PAUSE TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== CONT  TestAccKubernetesClusterNodePool_proximityPlacementGroupId
--- PASS: TestAccKubernetesClusterNodePool_proximityPlacementGroupId (1230.81s)
=== RUN   TestAccKubernetesClusterNodePool_osDiskType
=== PAUSE TestAccKubernetesClusterNodePool_osDiskType
=== CONT  TestAccKubernetesClusterNodePool_osDiskType
--- PASS: TestAccKubernetesClusterNodePool_osDiskType (1201.63s)
=== RUN   TestAccKubernetesClusterNodePool_requiresImport
=== PAUSE TestAccKubernetesClusterNodePool_requiresImport
=== CONT  TestAccKubernetesClusterNodePool_requiresImport
--- PASS: TestAccKubernetesClusterNodePool_requiresImport (1223.05s)
=== RUN   TestAccKubernetesClusterNodePool_spot
=== PAUSE TestAccKubernetesClusterNodePool_spot
=== CONT  TestAccKubernetesClusterNodePool_spot
--- PASS: TestAccKubernetesClusterNodePool_spot (1146.35s)
=== RUN   TestAccKubernetesClusterNodePool_upgradeSettings
=== PAUSE TestAccKubernetesClusterNodePool_upgradeSettings
=== CONT  TestAccKubernetesClusterNodePool_upgradeSettings
--- PASS: TestAccKubernetesClusterNodePool_upgradeSettings (1752.40s)
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkAutomatic (1282.61s)
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkManual
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkManual
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkManual
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkManual (1344.51s)
=== RUN   TestAccKubernetesClusterNodePool_windows
=== PAUSE TestAccKubernetesClusterNodePool_windows
=== CONT  TestAccKubernetesClusterNodePool_windows
--- PASS: TestAccKubernetesClusterNodePool_windows (1506.26s)
=== RUN   TestAccKubernetesClusterNodePool_windowsAndLinux
=== PAUSE TestAccKubernetesClusterNodePool_windowsAndLinux
=== CONT  TestAccKubernetesClusterNodePool_windowsAndLinux
--- PASS: TestAccKubernetesClusterNodePool_windowsAndLinux (1552.75s)
=== RUN   TestAccKubernetesClusterNodePool_zeroSize
=== PAUSE TestAccKubernetesClusterNodePool_zeroSize
=== CONT  TestAccKubernetesClusterNodePool_zeroSize
--- PASS: TestAccKubernetesClusterNodePool_zeroSize (988.16s)
=== RUN   TestAccKubernetesClusterNodePool_hostEncryption
=== PAUSE TestAccKubernetesClusterNodePool_hostEncryption
=== CONT  TestAccKubernetesClusterNodePool_hostEncryption
--- PASS: TestAccKubernetesClusterNodePool_hostEncryption (1245.28s)
=== RUN   TestAccKubernetesClusterNodePool_maxSize
=== PAUSE TestAccKubernetesClusterNodePool_maxSize
=== CONT  TestAccKubernetesClusterNodePool_maxSize
--- PASS: TestAccKubernetesClusterNodePool_maxSize (1228.43s)
=== RUN   TestAccKubernetesClusterNodePool_sameSize
=== PAUSE TestAccKubernetesClusterNodePool_sameSize
=== CONT  TestAccKubernetesClusterNodePool_sameSize
--- PASS: TestAccKubernetesClusterNodePool_sameSize (1228.87s)
=== RUN   TestAccKubernetesClusterNodePool_ultraSSD
=== PAUSE TestAccKubernetesClusterNodePool_ultraSSD
=== CONT  TestAccKubernetesClusterNodePool_ultraSSD
--- PASS: TestAccKubernetesClusterNodePool_ultraSSD (1280.45s)
=== RUN   TestAccKubernetesClusterNodePool_osSku
=== PAUSE TestAccKubernetesClusterNodePool_osSku
=== CONT  TestAccKubernetesClusterNodePool_osSku
--- PASS: TestAccKubernetesClusterNodePool_osSku (1009.85s)
=== RUN   TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== PAUSE TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== CONT  TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
--- PASS: TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings (1258.31s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileAciConnectorLinux
=== PAUSE TestAccKubernetesCluster_addonProfileAciConnectorLinux
=== CONT  TestAccKubernetesCluster_addonProfileAciConnectorLinux
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinux (1221.23s)
=== RUN   TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
=== PAUSE TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
=== CONT  TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled (1075.80s)
=== RUN   TestAccKubernetesCluster_addonProfileAzurePolicy
=== PAUSE TestAccKubernetesCluster_addonProfileAzurePolicy
=== CONT  TestAccKubernetesCluster_addonProfileAzurePolicy
--- PASS: TestAccKubernetesCluster_addonProfileAzurePolicy (1412.18s)
=== RUN   TestAccKubernetesCluster_addonProfileKubeDashboard
=== PAUSE TestAccKubernetesCluster_addonProfileKubeDashboard
=== CONT  TestAccKubernetesCluster_addonProfileKubeDashboard
--- PASS: TestAccKubernetesCluster_addonProfileKubeDashboard (899.99s)
=== RUN   TestAccKubernetesCluster_addonProfileOMS
=== PAUSE TestAccKubernetesCluster_addonProfileOMS
=== CONT  TestAccKubernetesCluster_addonProfileOMS
--- PASS: TestAccKubernetesCluster_addonProfileOMS (991.97s)
=== RUN   TestAccKubernetesCluster_addonProfileOMSToggle
=== PAUSE TestAccKubernetesCluster_addonProfileOMSToggle
=== CONT  TestAccKubernetesCluster_addonProfileOMSToggle
--- PASS: TestAccKubernetesCluster_addonProfileOMSToggle (2118.67s)
=== RUN   TestAccKubernetesCluster_addonProfileRoutingToggle
=== PAUSE TestAccKubernetesCluster_addonProfileRoutingToggle
=== CONT  TestAccKubernetesCluster_addonProfileRoutingToggle
--- PASS: TestAccKubernetesCluster_addonProfileRoutingToggle (1279.40s)
=== RUN   TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
=== PAUSE TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
=== CONT  TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId (1657.39s)
=== RUN   TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR
=== PAUSE TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR
=== CONT  TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR (1206.08s)
=== RUN   TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId
=== PAUSE TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId
=== CONT  TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId (1316.13s)
=== RUN   TestAccKubernetesCluster_addonProfileOpenServiceMesh
=== PAUSE TestAccKubernetesCluster_addonProfileOpenServiceMesh
=== CONT  TestAccKubernetesCluster_addonProfileOpenServiceMesh
--- PASS: TestAccKubernetesCluster_addonProfileOpenServiceMesh (964.98s)
=== RUN   TestAccKubernetesCluster_apiServerAuthorizedIPRanges
=== PAUSE TestAccKubernetesCluster_apiServerAuthorizedIPRanges
=== CONT  TestAccKubernetesCluster_apiServerAuthorizedIPRanges
--- PASS: TestAccKubernetesCluster_apiServerAuthorizedIPRanges (973.87s)
=== RUN   TestAccKubernetesCluster_managedClusterIdentity
=== PAUSE TestAccKubernetesCluster_managedClusterIdentity
=== CONT  TestAccKubernetesCluster_managedClusterIdentity
--- PASS: TestAccKubernetesCluster_managedClusterIdentity (967.90s)
=== RUN   TestAccKubernetesCluster_userAssignedIdentity
=== PAUSE TestAccKubernetesCluster_userAssignedIdentity
=== CONT  TestAccKubernetesCluster_userAssignedIdentity
--- PASS: TestAccKubernetesCluster_userAssignedIdentity (986.22s)
=== RUN   TestAccKubernetesCluster_updateWithUserAssignedIdentity
=== PAUSE TestAccKubernetesCluster_updateWithUserAssignedIdentity
=== CONT  TestAccKubernetesCluster_updateWithUserAssignedIdentity
--- PASS: TestAccKubernetesCluster_updateWithUserAssignedIdentity (1192.05s)
=== RUN   TestAccKubernetesCluster_userAssignedKubeletIdentity
=== PAUSE TestAccKubernetesCluster_userAssignedKubeletIdentity
=== CONT  TestAccKubernetesCluster_userAssignedKubeletIdentity
--- PASS: TestAccKubernetesCluster_userAssignedKubeletIdentity (982.31s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControl
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControl
=== CONT  TestAccKubernetesCluster_roleBasedAccessControl
--- PASS: TestAccKubernetesCluster_roleBasedAccessControl (991.85s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAAD
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAAD
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAAD
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAAD (655.20s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManaged (866.43s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManagedSensitive
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManagedSensitive
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManagedSensitive
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADUpdateToManagedSensitive (768.25s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADManaged
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADManaged
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADManaged
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADManaged (1023.49s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabled
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabled
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabled
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabled (905.58s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabledUpdated
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabledUpdated
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabledUpdated
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADManagedWithLocalAccountDisabledUpdated (1351.92s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAADManagedChange
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAADManagedChange
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAADManagedChange
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAADManagedChange (1318.73s)
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAzure
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAzure
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAzure
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAzure (1383.74s)
=== RUN   TestAccKubernetesCluster_servicePrincipal
=== PAUSE TestAccKubernetesCluster_servicePrincipal
=== CONT  TestAccKubernetesCluster_servicePrincipal
--- PASS: TestAccKubernetesCluster_servicePrincipal (1168.23s)
=== RUN   TestAccKubernetesCluster_servicePrincipalToSystemAssignedIdentity
=== PAUSE TestAccKubernetesCluster_servicePrincipalToSystemAssignedIdentity
=== CONT  TestAccKubernetesCluster_servicePrincipalToSystemAssignedIdentity
--- PASS: TestAccKubernetesCluster_servicePrincipalToSystemAssignedIdentity (1127.98s)
=== RUN   TestAccKubernetesCluster_servicePrincipalToUserAssignedIdentity
=== PAUSE TestAccKubernetesCluster_servicePrincipalToUserAssignedIdentity
=== CONT  TestAccKubernetesCluster_servicePrincipalToUserAssignedIdentity
--- PASS: TestAccKubernetesCluster_servicePrincipalToUserAssignedIdentity (1361.49s)
=== RUN   TestAccKubernetesCluster_updateRoleBasedAccessControlAAD
=== PAUSE TestAccKubernetesCluster_updateRoleBasedAccessControlAAD
=== CONT  TestAccKubernetesCluster_updateRoleBasedAccessControlAAD
--- PASS: TestAccKubernetesCluster_updateRoleBasedAccessControlAAD (811.89s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingKubenet
=== PAUSE TestAccKubernetesCluster_advancedNetworkingKubenet
=== CONT  TestAccKubernetesCluster_advancedNetworkingKubenet
--- PASS: TestAccKubernetesCluster_advancedNetworkingKubenet (1093.72s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingKubenetComplete
=== PAUSE TestAccKubernetesCluster_advancedNetworkingKubenetComplete
=== CONT  TestAccKubernetesCluster_advancedNetworkingKubenetComplete
--- PASS: TestAccKubernetesCluster_advancedNetworkingKubenetComplete (1072.97s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzure
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzure
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzure
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzure (1012.60s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureComplete
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureComplete
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureComplete
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureComplete (1103.55s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicy
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicy
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicy
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicy (1158.87s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete (1218.91s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeTransparent
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeTransparent
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeTransparent
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeTransparent (1228.09s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicy
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicy
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicy
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicy (1102.50s)
=== RUN   TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicyComplete
=== PAUSE TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicyComplete
=== CONT  TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicyComplete
--- PASS: TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicyComplete (1171.73s)
=== RUN   TestAccKubernetesCluster_enableNodePublicIP
=== PAUSE TestAccKubernetesCluster_enableNodePublicIP
=== CONT  TestAccKubernetesCluster_enableNodePublicIP
--- PASS: TestAccKubernetesCluster_enableNodePublicIP (1180.76s)
=== RUN   TestAccKubernetesCluster_internalNetwork
=== PAUSE TestAccKubernetesCluster_internalNetwork
=== CONT  TestAccKubernetesCluster_internalNetwork
--- PASS: TestAccKubernetesCluster_internalNetwork (1165.52s)
=== RUN   TestAccKubernetesCluster_nodePublicIPPrefix
=== PAUSE TestAccKubernetesCluster_nodePublicIPPrefix
=== CONT  TestAccKubernetesCluster_nodePublicIPPrefix
--- PASS: TestAccKubernetesCluster_nodePublicIPPrefix (961.23s)
=== RUN   TestAccKubernetesCluster_outboundTypeLoadBalancer
=== PAUSE TestAccKubernetesCluster_outboundTypeLoadBalancer
=== CONT  TestAccKubernetesCluster_outboundTypeLoadBalancer
--- PASS: TestAccKubernetesCluster_outboundTypeLoadBalancer (971.09s)
=== RUN   TestAccKubernetesCluster_privateClusterOn
=== PAUSE TestAccKubernetesCluster_privateClusterOn
=== CONT  TestAccKubernetesCluster_privateClusterOn
--- PASS: TestAccKubernetesCluster_privateClusterOn (1129.76s)
=== RUN   TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZone
=== PAUSE TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZone
=== CONT  TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZone
--- PASS: TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZone (1207.29s)
=== RUN   TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneAndServicePrincipal
=== PAUSE TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneAndServicePrincipal
=== CONT  TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneAndServicePrincipal
--- PASS: TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneAndServicePrincipal (1068.48s)
=== RUN   TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSubDomain
=== PAUSE TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSubDomain
=== CONT  TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSubDomain
--- PASS: TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSubDomain (1184.09s)
=== RUN   TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSystem
=== PAUSE TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSystem
=== CONT  TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSystem
--- PASS: TestAccKubernetesCluster_privateClusterOnWithPrivateDNSZoneSystem (1187.66s)
=== RUN   TestAccKubernetesCluster_privateClusterOff
=== PAUSE TestAccKubernetesCluster_privateClusterOff
=== CONT  TestAccKubernetesCluster_privateClusterOff
--- PASS: TestAccKubernetesCluster_privateClusterOff (1082.70s)
=== RUN   TestAccKubernetesCluster_standardLoadBalancer
=== PAUSE TestAccKubernetesCluster_standardLoadBalancer
=== CONT  TestAccKubernetesCluster_standardLoadBalancer
--- PASS: TestAccKubernetesCluster_standardLoadBalancer (1181.34s)
=== RUN   TestAccKubernetesCluster_standardLoadBalancerComplete
=== PAUSE TestAccKubernetesCluster_standardLoadBalancerComplete
=== CONT  TestAccKubernetesCluster_standardLoadBalancerComplete
--- PASS: TestAccKubernetesCluster_standardLoadBalancerComplete (1130.26s)
=== RUN   TestAccKubernetesCluster_standardLoadBalancerProfile
=== PAUSE TestAccKubernetesCluster_standardLoadBalancerProfile
=== CONT  TestAccKubernetesCluster_standardLoadBalancerProfile
--- PASS: TestAccKubernetesCluster_standardLoadBalancerProfile (1018.16s)
=== RUN   TestAccKubernetesCluster_standardLoadBalancerProfileComplete
=== PAUSE TestAccKubernetesCluster_standardLoadBalancerProfileComplete
=== CONT  TestAccKubernetesCluster_standardLoadBalancerProfileComplete
--- PASS: TestAccKubernetesCluster_standardLoadBalancerProfileComplete (1140.96s)
=== RUN   TestAccKubernetesCluster_standardLoadBalancerProfileWithPortAndTimeout
=== PAUSE TestAccKubernetesCluster_standardLoadBalancerProfileWithPortAndTimeout
=== CONT  TestAccKubernetesCluster_standardLoadBalancerProfileWithPortAndTimeout
--- PASS: TestAccKubernetesCluster_standardLoadBalancerProfileWithPortAndTimeout (939.40s)
=== RUN   TestAccKubernetesCluster_basicLoadBalancerProfile
=== PAUSE TestAccKubernetesCluster_basicLoadBalancerProfile
=== CONT  TestAccKubernetesCluster_basicLoadBalancerProfile
--- PASS: TestAccKubernetesCluster_basicLoadBalancerProfile (238.41s)
=== RUN   TestAccKubernetesCluster_prefixedLoadBalancerProfile
=== PAUSE TestAccKubernetesCluster_prefixedLoadBalancerProfile
=== CONT  TestAccKubernetesCluster_prefixedLoadBalancerProfile
--- PASS: TestAccKubernetesCluster_prefixedLoadBalancerProfile (1073.55s)
=== RUN   TestAccKubernetesCluster_changingLoadBalancerProfile
=== PAUSE TestAccKubernetesCluster_changingLoadBalancerProfile
=== CONT  TestAccKubernetesCluster_changingLoadBalancerProfile
--- PASS: TestAccKubernetesCluster_changingLoadBalancerProfile (1819.10s)
=== RUN   TestAccKubernetesCluster_basicAvailabilitySet
=== PAUSE TestAccKubernetesCluster_basicAvailabilitySet
=== CONT  TestAccKubernetesCluster_basicAvailabilitySet
--- PASS: TestAccKubernetesCluster_basicAvailabilitySet (871.29s)
=== RUN   TestAccKubernetesCluster_sameSize
=== PAUSE TestAccKubernetesCluster_sameSize
=== CONT  TestAccKubernetesCluster_sameSize
--- PASS: TestAccKubernetesCluster_sameSize (878.18s)
=== RUN   TestAccKubernetesCluster_basicAvailabilitySetSensitive
=== PAUSE TestAccKubernetesCluster_basicAvailabilitySetSensitive
=== CONT  TestAccKubernetesCluster_basicAvailabilitySetSensitive
--- PASS: TestAccKubernetesCluster_basicAvailabilitySetSensitive (997.77s)
=== RUN   TestAccKubernetesCluster_basicVMSS
=== PAUSE TestAccKubernetesCluster_basicVMSS
=== CONT  TestAccKubernetesCluster_basicVMSS
--- PASS: TestAccKubernetesCluster_basicVMSS (903.59s)
=== RUN   TestAccKubernetesCluster_requiresImport
=== PAUSE TestAccKubernetesCluster_requiresImport
=== CONT  TestAccKubernetesCluster_requiresImport
--- PASS: TestAccKubernetesCluster_requiresImport (896.89s)
=== RUN   TestAccKubernetesCluster_criticalAddonsTaint
=== PAUSE TestAccKubernetesCluster_criticalAddonsTaint
=== CONT  TestAccKubernetesCluster_criticalAddonsTaint
--- PASS: TestAccKubernetesCluster_criticalAddonsTaint (904.45s)
=== RUN   TestAccKubernetesCluster_kubeletAndLinuxOSConfig
=== PAUSE TestAccKubernetesCluster_kubeletAndLinuxOSConfig
=== CONT  TestAccKubernetesCluster_kubeletAndLinuxOSConfig
--- PASS: TestAccKubernetesCluster_kubeletAndLinuxOSConfig (951.12s)
=== RUN   TestAccKubernetesCluster_kubeletAndLinuxOSConfigPartial
=== PAUSE TestAccKubernetesCluster_kubeletAndLinuxOSConfigPartial
=== CONT  TestAccKubernetesCluster_kubeletAndLinuxOSConfigPartial
--- PASS: TestAccKubernetesCluster_kubeletAndLinuxOSConfigPartial (860.21s)
=== RUN   TestAccKubernetesCluster_linuxProfile
=== PAUSE TestAccKubernetesCluster_linuxProfile
=== CONT  TestAccKubernetesCluster_linuxProfile
--- PASS: TestAccKubernetesCluster_linuxProfile (926.81s)
=== RUN   TestAccKubernetesCluster_nodeLabels
=== PAUSE TestAccKubernetesCluster_nodeLabels
=== CONT  TestAccKubernetesCluster_nodeLabels
--- PASS: TestAccKubernetesCluster_nodeLabels (2372.08s)
=== RUN   TestAccKubernetesCluster_nodeResourceGroup
=== PAUSE TestAccKubernetesCluster_nodeResourceGroup
=== CONT  TestAccKubernetesCluster_nodeResourceGroup
--- PASS: TestAccKubernetesCluster_nodeResourceGroup (870.43s)
=== RUN   TestAccKubernetesCluster_nodePoolOther
=== PAUSE TestAccKubernetesCluster_nodePoolOther
=== CONT  TestAccKubernetesCluster_nodePoolOther
--- PASS: TestAccKubernetesCluster_nodePoolOther (977.66s)
=== RUN   TestAccKubernetesCluster_upgradeSkuTier
=== PAUSE TestAccKubernetesCluster_upgradeSkuTier
=== CONT  TestAccKubernetesCluster_upgradeSkuTier
--- PASS: TestAccKubernetesCluster_upgradeSkuTier (1394.22s)
=== RUN   TestAccKubernetesCluster_paidSku
=== PAUSE TestAccKubernetesCluster_paidSku
=== CONT  TestAccKubernetesCluster_paidSku
--- PASS: TestAccKubernetesCluster_paidSku (939.06s)
=== RUN   TestAccKubernetesCluster_podSubnet
=== PAUSE TestAccKubernetesCluster_podSubnet
=== CONT  TestAccKubernetesCluster_podSubnet
--- PASS: TestAccKubernetesCluster_podSubnet (1119.77s)
=== RUN   TestAccKubernetesCluster_upgrade
=== PAUSE TestAccKubernetesCluster_upgrade
=== CONT  TestAccKubernetesCluster_upgrade
--- PASS: TestAccKubernetesCluster_upgrade (1205.00s)
=== RUN   TestAccKubernetesCluster_tags
=== PAUSE TestAccKubernetesCluster_tags
=== CONT  TestAccKubernetesCluster_tags
--- PASS: TestAccKubernetesCluster_tags (1207.27s)
=== RUN   TestAccKubernetesCluster_windowsProfile
=== PAUSE TestAccKubernetesCluster_windowsProfile
=== CONT  TestAccKubernetesCluster_windowsProfile
--- PASS: TestAccKubernetesCluster_windowsProfile (869.35s)
=== RUN   TestAccKubernetesCluster_windowsProfileLicense
=== PAUSE TestAccKubernetesCluster_windowsProfileLicense
=== CONT  TestAccKubernetesCluster_windowsProfileLicense
--- PASS: TestAccKubernetesCluster_windowsProfileLicense (938.29s)
=== RUN   TestAccKubernetesCluster_updateWindowsProfileLicense
=== PAUSE TestAccKubernetesCluster_updateWindowsProfileLicense
=== CONT  TestAccKubernetesCluster_updateWindowsProfileLicense
--- PASS: TestAccKubernetesCluster_updateWindowsProfileLicense (1406.57s)
=== RUN   TestAccKubernetesCluster_diskEncryption
=== PAUSE TestAccKubernetesCluster_diskEncryption
=== CONT  TestAccKubernetesCluster_diskEncryption
--- PASS: TestAccKubernetesCluster_diskEncryption (1218.75s)
=== RUN   TestAccKubernetesCluster_upgradeChannel
=== PAUSE TestAccKubernetesCluster_upgradeChannel
=== CONT  TestAccKubernetesCluster_upgradeChannel
--- PASS: TestAccKubernetesCluster_upgradeChannel (2032.50s)
=== RUN   TestAccKubernetesCluster_basicMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_basicMaintenanceConfig
=== CONT  TestAccKubernetesCluster_basicMaintenanceConfig
--- PASS: TestAccKubernetesCluster_basicMaintenanceConfig (871.00s)
=== RUN   TestAccKubernetesCluster_completeMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_completeMaintenanceConfig
=== CONT  TestAccKubernetesCluster_completeMaintenanceConfig
--- PASS: TestAccKubernetesCluster_completeMaintenanceConfig (897.11s)
=== RUN   TestAccKubernetesCluster_updateMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_updateMaintenanceConfig
=== CONT  TestAccKubernetesCluster_updateMaintenanceConfig
--- PASS: TestAccKubernetesCluster_updateMaintenanceConfig (1423.42s)
=== RUN   TestAccKubernetesCluster_ultraSSD
=== PAUSE TestAccKubernetesCluster_ultraSSD
=== CONT  TestAccKubernetesCluster_ultraSSD
=== CONT  TestAccKubernetesCluster_ultraSSD
    testcase.go:110: Step 5/6 error: Error running apply: exit status 1
        
        Error: waiting for creation of Managed Kubernetes Cluster "acctestaks211117214102337711" (Resource Group "acctestRG-aks-211117214102337711"): Code="ReconcileMSICredentialError" Message="AKS encountered an internal error while attempting the requested Creating operation. AKS will continuously retry the requested operation until successful or a retry timeout is hit. Check back to see if the operation requires resubmission. Correlation ID: 4aefc913-7075-31e0-ce3e-1502cd0431be, Operation ID: 8e6315d3-d705-4cf2-9613-0cdf6f7782e2, Timestamp: 2021-11-17T16:00:43Z."
        
          with azurerm_kubernetes_cluster.test,
          on terraform_plugin_test.tf line 9, in resource "azurerm_kubernetes_cluster" "test":
           9: resource "azurerm_kubernetes_cluster" "test" {
        
--- FAIL: TestAccKubernetesCluster_ultraSSD (1936.77s)

=== RUN   TestAccKubernetesCluster_privateClusterPublicFqdn
=== PAUSE TestAccKubernetesCluster_privateClusterPublicFqdn
=== CONT  TestAccKubernetesCluster_privateClusterPublicFqdn
--- PASS: TestAccKubernetesCluster_privateClusterPublicFqdn (1423.72s)
=== RUN   TestAccKubernetesCluster_osSku
=== PAUSE TestAccKubernetesCluster_osSku
=== CONT  TestAccKubernetesCluster_osSku
--- PASS: TestAccKubernetesCluster_osSku (936.02s)
=== RUN   TestAccKubernetesCluster_hostEncryption
=== PAUSE TestAccKubernetesCluster_hostEncryption
=== CONT  TestAccKubernetesCluster_hostEncryption
--- PASS: TestAccKubernetesCluster_hostEncryption (891.34s)
=== RUN   TestAccKubernetesCluster_addAgent
=== PAUSE TestAccKubernetesCluster_addAgent
=== CONT  TestAccKubernetesCluster_addAgent
--- PASS: TestAccKubernetesCluster_addAgent (1527.84s)
=== RUN   TestAccKubernetesCluster_manualScaleIgnoreChanges
=== PAUSE TestAccKubernetesCluster_manualScaleIgnoreChanges
=== CONT  TestAccKubernetesCluster_manualScaleIgnoreChanges
--- PASS: TestAccKubernetesCluster_manualScaleIgnoreChanges (1225.84s)
=== RUN   TestAccKubernetesCluster_removeAgent
=== PAUSE TestAccKubernetesCluster_removeAgent
=== CONT  TestAccKubernetesCluster_removeAgent
--- PASS: TestAccKubernetesCluster_removeAgent (1243.50s)
=== RUN   TestAccKubernetesCluster_autoScalingError
=== PAUSE TestAccKubernetesCluster_autoScalingError
=== CONT  TestAccKubernetesCluster_autoScalingError
--- PASS: TestAccKubernetesCluster_autoScalingError (996.85s)
=== RUN   TestAccKubernetesCluster_autoScalingErrorMax
=== PAUSE TestAccKubernetesCluster_autoScalingErrorMax
=== CONT  TestAccKubernetesCluster_autoScalingErrorMax
--- PASS: TestAccKubernetesCluster_autoScalingErrorMax (190.45s)
=== RUN   TestAccKubernetesCluster_autoScalingWithMaxCount
=== PAUSE TestAccKubernetesCluster_autoScalingWithMaxCount
=== CONT  TestAccKubernetesCluster_autoScalingWithMaxCount
--- PASS: TestAccKubernetesCluster_autoScalingWithMaxCount (946.97s)
=== RUN   TestAccKubernetesCluster_autoScalingErrorMin
=== PAUSE TestAccKubernetesCluster_autoScalingErrorMin
=== CONT  TestAccKubernetesCluster_autoScalingErrorMin
--- PASS: TestAccKubernetesCluster_autoScalingErrorMin (198.04s)
=== RUN   TestAccKubernetesCluster_autoScalingNodeCountUnset
=== PAUSE TestAccKubernetesCluster_autoScalingNodeCountUnset
=== CONT  TestAccKubernetesCluster_autoScalingNodeCountUnset
--- PASS: TestAccKubernetesCluster_autoScalingNodeCountUnset (887.69s)
=== RUN   TestAccKubernetesCluster_autoScalingNoAvailabilityZones
=== PAUSE TestAccKubernetesCluster_autoScalingNoAvailabilityZones
=== CONT  TestAccKubernetesCluster_autoScalingNoAvailabilityZones
--- PASS: TestAccKubernetesCluster_autoScalingNoAvailabilityZones (932.15s)
=== RUN   TestAccKubernetesCluster_autoScalingWithAvailabilityZones
=== PAUSE TestAccKubernetesCluster_autoScalingWithAvailabilityZones
=== CONT  TestAccKubernetesCluster_autoScalingWithAvailabilityZones
--- PASS: TestAccKubernetesCluster_autoScalingWithAvailabilityZones (910.73s)
=== RUN   TestAccKubernetesCluster_autoScalingProfile
=== PAUSE TestAccKubernetesCluster_autoScalingProfile
=== CONT  TestAccKubernetesCluster_autoScalingProfile
--- PASS: TestAccKubernetesCluster_autoScalingProfile (935.33s)
=== RUN   TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== PAUSE TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== CONT  TestAccKubernetesCluster_upgradeAutoScaleMinCount
--- PASS: TestAccKubernetesCluster_upgradeAutoScaleMinCount (1274.70s)
=== RUN   TestAccKubernetesCluster_upgradeControlPlane
=== PAUSE TestAccKubernetesCluster_upgradeControlPlane
=== CONT  TestAccKubernetesCluster_upgradeControlPlane
--- PASS: TestAccKubernetesCluster_upgradeControlPlane (1192.37s)
=== RUN   TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTogether
=== PAUSE TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTogether
=== CONT  TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTogether
--- PASS: TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTogether (1776.82s)
=== RUN   TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTwoPhase
=== PAUSE TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTwoPhase
=== CONT  TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTwoPhase
--- PASS: TestAccKubernetesCluster_upgradeControlPlaneAndDefaultNodePoolTwoPhase (1775.94s)
=== RUN   TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails
=== PAUSE TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails
=== CONT  TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails
--- PASS: TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails (1134.44s)
=== RUN   TestAccKubernetesCluster_upgradeCustomNodePoolAfterControlPlane
=== PAUSE TestAccKubernetesCluster_upgradeCustomNodePoolAfterControlPlane
=== CONT  TestAccKubernetesCluster_upgradeCustomNodePoolAfterControlPlane
--- PASS: TestAccKubernetesCluster_upgradeCustomNodePoolAfterControlPlane (2304.55s)
=== RUN   TestAccKubernetesCluster_upgradeCustomNodePoolBeforeControlPlaneFails
=== PAUSE TestAccKubernetesCluster_upgradeCustomNodePoolBeforeControlPlaneFails
=== CONT  TestAccKubernetesCluster_upgradeCustomNodePoolBeforeControlPlaneFails
--- PASS: TestAccKubernetesCluster_upgradeCustomNodePoolBeforeControlPlaneFails (1364.80s)
=== RUN   TestAccKubernetesCluster_upgradeSettings
=== PAUSE TestAccKubernetesCluster_upgradeSettings
=== CONT  TestAccKubernetesCluster_upgradeSettings
--- PASS: TestAccKubernetesCluster_upgradeSettings (1463.98s)
FAIL

Process finished with the exit code 1

The only one failed test also failed in main branch, so I guess it's ok for this patch.