### PR TITLE
`azurerm_kusto_cluster` - Fix `trusted_external_tenant` for MyTenantOnly incl default change for 3.0

### DIFF
--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2021-01-01/kusto"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
 	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -123,6 +124,10 @@ func expandTrustedExternalTenants(input []interface{}) *[]kusto.TrustedExternalT
 	output := make([]kusto.TrustedExternalTenant, 0)
 
 	for _, v := range input {
+		// TODO 3.0: remove MyTenantOnly
+		if v.(string) == "MyTenantOnly" {
+			return &[]kusto.TrustedExternalTenant{}
+		}
 		output = append(output, kusto.TrustedExternalTenant{
 			Value: utils.String(v.(string)),
 		})
@@ -137,6 +142,10 @@ func flattenTrustedExternalTenants(input *[]kusto.TrustedExternalTenant) []inter
 	}
 
 	output := make([]interface{}, 0)
+
+	if !features.ThreePointOh() && len(*input) == 0 {
+		return append(output, "MyTenantOnly")
+	}
 
 	for _, v := range *input {
 		if v.Value == nil {

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -298,6 +299,72 @@ func TestAccKustoCluster_engineV3(t *testing.T) {
 	})
 }
 
+func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
+
+	if features.ThreePointOh() {
+		t.Skip("Skipping since 3.0 mode is enabled")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.trustedExternalTenants(data, "[\"*\"]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[\"MyTenantOnly\"]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[data.azurerm_client_config.current.tenant_id]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoCluster_trustedExternalTenantsThreePointOh(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
+
+	if !features.ThreePointOh() {
+		t.Skip("Skipping since 3.0 mode is disabled")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.trustedExternalTenants(data, "[\"*\"]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[data.azurerm_client_config.current.tenant_id]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KustoClusterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ClusterID(state.ID)
 	if err != nil {
@@ -334,6 +401,35 @@ resource "azurerm_kusto_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (KustoClusterResource) trustedExternalTenants(data acceptance.TestData, tenantConfig string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  trusted_external_tenants = %s
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantConfig)
 }
 
 func (KustoClusterResource) doubleEncryption(data acceptance.TestData) string {

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -300,14 +300,20 @@ func TestAccKustoCluster_engineV3(t *testing.T) {
 }
 
 func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
-	r := KustoClusterResource{}
-
 	if features.ThreePointOh() {
 		t.Skip("Skipping since 3.0 mode is enabled")
 	}
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("trusted_external_tenants"),
 		{
 			Config: r.trustedExternalTenants(data, "[\"*\"]"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -333,14 +339,20 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 }
 
 func TestAccKustoCluster_trustedExternalTenantsThreePointOh(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
-	r := KustoClusterResource{}
-
 	if !features.ThreePointOh() {
 		t.Skip("Skipping since 3.0 mode is disabled")
 	}
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.trustedExternalTenants(data, "[\"*\"]"),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -64,7 +64,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `trusted_external_tenants` - (Optional) Specifies a list of tenant IDs that are trusted by the cluster.
+* `trusted_external_tenants` - (Optional) Specifies a list of tenant IDs that are trusted by the cluster. Default setting trusts all other tenants. Use `trusted_external_tenants = ["*"]` to explicitly allow all other tenants, `trusted_external_tenants = ["MyTentantOnly"]` for only your tenant or `trusted_external_tenants = ["<tenantId1>", "<tenantIdx>"]` to allow specific other tenants.
+
+~> **NOTE:** In v3.0 of `azurerm` a new or updated Kusto Cluster will only allow your own tenant by default. Explicit configuration of this setting will change from `trusted_external_tenants = ["MyTentantOnly"]` to `trusted_external_tenants = []`.
 
 * `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fixes #14234

## Explanation for `azurerm` 2.x
For an empty `trusted_external_tenant`, whether it is not set or `[]`, current situation resolves that in the API/Azure backend to `[*]`. This conflicts upon 2nd `apply`, which can only be resolved manually. It is impossible in current situation to send an empty `[]` to the API, as this is noticed as `null` in Terraform and thus leaving the config for `trustedExternalTenants` out towards the API, resolving in `[*]`.

- Solved: By adding a `MyTenantOnly` as a config option, we resolve that in `azurerm` to a `[]` value towards the API, and reverse it upon read back to `[MyTenantOnly]`.
- To be solved: Explicit`[]` configuration results in `[*]` in the API upon update as it is today, creating the same situation (`[*]` from the API becomes `[*]` as read value, while config is `[]`). This is easily solved by the user to specify `[*]` or remove config as it is Computed anyway, not sure if a better solution could be applied. We could require minimum of 1 item, but this is a breaking change.

## Change for `azurerm` 3.0
Turn behaviour around by having `[]` as a 'default'  when config not set or `[]` .

Default send `[]` to the API, remove `MyTenantOnly` option. This is a breaking change, thus not in 2.x already. `[*]` resolves to `[*]` in the API, `[ "<tenantIdx>" ]` works like before.

## ToDo
- [x] AccTests for 2.x

```bash
TF_ACC=1 go test -v ./internal/services/kusto -run=TestAccKustoCluster_trustedExternalTenants -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKustoCluster_trustedExternalTenants
=== PAUSE TestAccKustoCluster_trustedExternalTenants
=== RUN   TestAccKustoCluster_trustedExternalTenantsThreePointOh
    kusto_cluster_resource_test.go:340: Skipping since 3.0 mode is disabled
--- SKIP: TestAccKustoCluster_trustedExternalTenantsThreePointOh (0.00s)
=== CONT  TestAccKustoCluster_trustedExternalTenants
--- PASS: TestAccKustoCluster_trustedExternalTenants (1639.41s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto1641.065s
```
- [x] AccTests for 3.0
```bash
TF_ACC=1 go test -v ./internal/services/kusto -run=TestAccKustoCluster_trustedExternalTenants -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKustoCluster_trustedExternalTenants
    kusto_cluster_resource_test.go:304: Skipping since 3.0 mode is enabled
--- SKIP: TestAccKustoCluster_trustedExternalTenants (0.00s)
=== RUN   TestAccKustoCluster_trustedExternalTenantsThreePointOh
=== PAUSE TestAccKustoCluster_trustedExternalTenantsThreePointOh
=== CONT  TestAccKustoCluster_trustedExternalTenantsThreePointOh
--- PASS: TestAccKustoCluster_trustedExternalTenantsThreePointOh (1629.42s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto1637.045s
```
