### PR TITLE
`azurerm_elastic_pool` - Support for Fsv2 family

### DIFF
--- a/internal/services/mssql/helper/elasticpool.go
+++ b/internal/services/mssql/helper/elasticpool.go
@@ -137,6 +137,19 @@ var getvCoreMaxGB = map[string]map[string]map[int]float64{
 			40: 4096,
 			80: 4096,
 		},
+		"fsv2": {
+			8:  1024,
+			10: 1024,
+			12: 1024,
+			14: 1024,
+			16: 1536,
+			18: 1536,
+			20: 1536,
+			24: 1536,
+			32: 3072,
+			36: 3072,
+			72: 4096,
+		},
 	},
 	"businesscritical": {
 		"gen4": {
@@ -182,6 +195,7 @@ var getTierFromName = map[string]string{
 	"premiumpool":  "Premium",
 	"gp_gen4":      "GeneralPurpose",
 	"gp_gen5":      "GeneralPurpose",
+	"gp_fsv2":      "GeneralPurpose",
 	"bc_gen4":      "BusinessCritical",
 	"bc_gen5":      "BusinessCritical",
 }
@@ -270,6 +284,10 @@ func getFamilyFromName(s sku) string {
 
 	if strings.EqualFold(nameFamily, "Gen5") {
 		retFamily = "Gen5"
+	}
+
+	if strings.EqualFold(nameFamily, "Fsv2") {
+		retFamily = "Fsv2"
 	}
 
 	return retFamily

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -77,7 +77,7 @@ func resourceMsSqlElasticPool() *pluginsdk.Resource {
 								"GP_Gen5",
 								"BC_Gen4",
 								"BC_Gen5",
-								"GP_FSv2",
+								"GP_Fsv2",
 							}, true),
 							DiffSuppressFunc: suppress.CaseDifference,
 						},
@@ -107,6 +107,7 @@ func resourceMsSqlElasticPool() *pluginsdk.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								"Gen4",
 								"Gen5",
+								"Fsv2",
 							}, true),
 							DiffSuppressFunc: suppress.CaseDifference,
 						},

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -151,6 +151,21 @@ func TestAccMsSqlElasticPool_resizeVCore(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlElasticPool_fsv2FamilyVCore(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_elasticpool", "test")
+	r := MsSqlElasticPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fsv2VCore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("max_size_gb"),
+	})
+}
+
 func TestAccMsSqlElasticPool_licenseType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_elasticpool", "test")
 	r := MsSqlElasticPoolResource{}
@@ -235,6 +250,10 @@ func (r MsSqlElasticPoolResource) resizeDTU(data acceptance.TestData) string {
 
 func (r MsSqlElasticPoolResource) basicVCore(data acceptance.TestData) string {
 	return r.templateVCore(data, "GP_Gen5", "GeneralPurpose", 4, "Gen5", 0.25, 4)
+}
+
+func (r MsSqlElasticPoolResource) fsv2VCore(data acceptance.TestData) string {
+	return r.templateVCore(data, "GP_Fsv2", "GeneralPurpose", 8, "Fsv2", 0, 8)
 }
 
 func (r MsSqlElasticPoolResource) basicVCoreMaxSizeBytes(data acceptance.TestData) string {

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `tier` - (Required) The tier of the particular SKU. Possible values are `GeneralPurpose`, `BusinessCritical`, `Basic`, `Standard`, or `Premium`. For more information see the documentation for your Elasticpool configuration: [vCore-based](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-vcore-resource-limits-elastic-pools) or [DTU-based](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-dtu-resource-limits-elastic-pools).
 
-* `family` - (Optional) The `family` of hardware `Gen4` or `Gen5`.
+* `family` - (Optional) The `family` of hardware `Gen4`, `Gen5` or `Fsv2`.
 
 ---
 


### PR DESCRIPTION
Fixes #14203
Extends #13973

### Acceptance Tests
```bash
TF_ACC=1 go test -v ./internal/services/mssql -run=TestAccMsSqlElasticPool_fsv2FamilyVCore -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMsSqlElasticPool_fsv2FamilyVCore
=== PAUSE TestAccMsSqlElasticPool_fsv2FamilyVCore
=== CONT  TestAccMsSqlElasticPool_fsv2FamilyVCore
--- PASS: TestAccMsSqlElasticPool_fsv2FamilyVCore (553.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql   556.243s
```