### PR TITLE
`azurerm_automation_rule` - add supports for `expiration`

### DIFF
--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -139,22 +139,13 @@ func (r SentinelAutomationRuleResource) complete(data acceptance.TestData) strin
 
 data "azurerm_client_config" "current" {}
 
-data "azuread_service_principal" "securityinsights" {
-  display_name = "Azure Security Insights"
-}
-
-resource "azurerm_role_assignment" "sentinel" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "Azure Sentinel Automation Contributor"
-  principal_id         = data.azuread_service_principal.securityinsights.object_id
-}
-
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
+  expiration                 = "2022-11-20T15:44:52Z"
   condition {
     property = "IncidentTitle"
     operator = "Contains"
@@ -188,8 +179,6 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order    = 4
     owner_id = data.azurerm_client_config.current.object_id
   }
-
-  depends_on = [azurerm_role_assignment.sentinel]
 }
 `, template, r.uuid, data.RandomInteger)
 }

--- a/website/docs/r/sentinel_automation_rule.html.markdown
+++ b/website/docs/r/sentinel_automation_rule.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Whether this Sentinel Automation Rule is enabled? Defaults to `true`.
 
+* `expiration` - (Optional) The time in RFC3339 format of kind "UTC" that determines when this Automation Rule should expire and be disabled.
+
 ---
 
 A `action_incident` block supports the following:

--- a/website/docs/r/sentinel_automation_rule.html.markdown
+++ b/website/docs/r/sentinel_automation_rule.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Whether this Sentinel Automation Rule is enabled? Defaults to `true`.
 
-* `expiration` - (Optional) The time in RFC3339 format of kind "UTC" that determines when this Automation Rule should expire and be disabled.
+* `expiration` - (Optional) The time in RFC3339 format of kind `UTC` that determines when this Automation Rule should expire and be disabled.
 
 ---
 


### PR DESCRIPTION
## Test

```shell
💢 TF_ACC=1 go test -timeout=3h -v ./internal/services/sentinel -run='TestAccSentinelAutomationRule_complete'
=== RUN   TestAccSentinelAutomationRule_complete
=== PAUSE TestAccSentinelAutomationRule_complete
=== CONT  TestAccSentinelAutomationRule_complete
--- PASS: TestAccSentinelAutomationRule_complete (97.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      97.816s
```