### PR TITLE
Fix acctests for `azurerm_sentinel_alert_rule_tempalte` datasource

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -34,7 +34,7 @@ func TestAccSentinelAlertRuleTemplateDataSource_securityIncident(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.byDisplayName(data, "Create incidents based on Azure Security Center for IoT alerts"),
+			Config: r.byDisplayName(data, "Create incidents based on Azure Defender alerts"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("display_name").Exists(),
@@ -59,7 +59,6 @@ func TestAccSentinelAlertRuleTemplateDataSource_scheduled(t *testing.T) {
 				check.That(data.ResourceName).Key("display_name").Exists(),
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template.0.description").Exists(),
-				check.That(data.ResourceName).Key("scheduled_template.0.tactics.0").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template.0.severity").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template.0.query").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template.0.query_frequency").Exists(),


### PR DESCRIPTION
## Test

```shell
terraform-provider-azurerm on  fix_sentinel_alert_rule_template_test_failures via 🐹 v1.17.3 took 1m22s
💢 TF_ACC=1 go test -timeout=3h -v ./internal/services/sentinel -run='TestAccSentinelAlertRuleTemplateDataSource_scheduled'
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_scheduled
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_scheduled (179.94s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      179.971s

terraform-provider-azurerm on  fix_sentinel_alert_rule_template_test_failures via 🐹 v1.17.3 took 3m8s
💤 TF_ACC=1 go test -timeout=3h -v ./internal/services/sentinel -run='TestAccSentinelAlertRuleTemplateDataSource_securityIncident'
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_securityIncident
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_securityIncident (167.42s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      167.450s
```