### PR TITLE
FIX: `azurerm_storage_account` - Do not initialise `{table|queue}_encryption_key_type` with default

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -258,11 +258,13 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 			"queue_encryption_key_type": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 
 			"table_encryption_key_type": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 
 			"tags": tags.SchemaDataSource(),
@@ -379,22 +381,20 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 			d.Set("secondary_blob_connection_string", secondaryBlobConnectStr)
 		}
 
-		// Setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response.
-		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response. Also, define the default value as "Service" in the schema.
-		var (
-			queueEncryptionKeyType = string(storage.KeyTypeService)
-			tableEncryptionKeyType = string(storage.KeyTypeService)
-		)
 		if encryption := props.Encryption; encryption != nil && encryption.Services != nil {
 			if encryption.Services.Queue != nil {
 				queueEncryptionKeyType = string(encryption.Services.Queue.KeyType)
+				if err := d.Set("queue_encryption_key_type", queueEncryptionKeyType); err != nil {
+					return fmt.Errorf("setting `queue_encryption_key_type`: %+v", err)
+				}
 			}
 			if encryption.Services.Table != nil {
 				tableEncryptionKeyType = string(encryption.Services.Table.KeyType)
+				if err := d.Set("table_encryption_key_type", tableEncryptionKeyType); err != nil {
+					return fmt.Errorf("setting `table_encryption_key_type`: %+v", err)
+				}
 			}
 		}
-		d.Set("table_encryption_key_type", tableEncryptionKeyType)
-		d.Set("queue_encryption_key_type", queueEncryptionKeyType)
 	}
 
 	if accessKeys := accountKeys; accessKeys != nil {

--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -382,6 +382,10 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		if encryption := props.Encryption; encryption != nil && encryption.Services != nil {
+			var (
+				queueEncryptionKeyType = string
+				tableEncryptionKeyType = string
+			)
 			if encryption.Services.Queue != nil {
 				queueEncryptionKeyType = string(encryption.Services.Queue.KeyType)
 				if err := d.Set("queue_encryption_key_type", queueEncryptionKeyType); err != nil {

--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -382,10 +382,8 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		if encryption := props.Encryption; encryption != nil && encryption.Services != nil {
-			var (
-				queueEncryptionKeyType = string
-				tableEncryptionKeyType = string
-			)
+			var queueEncryptionKeyType string
+			var tableEncryptionKeyType string
 			if encryption.Services.Queue != nil {
 				queueEncryptionKeyType = string(encryption.Services.Queue.KeyType)
 				if err := d.Set("queue_encryption_key_type", queueEncryptionKeyType); err != nil {

--- a/internal/services/storage/storage_account_data_source_test.go
+++ b/internal/services/storage/storage_account_data_source_test.go
@@ -194,9 +194,9 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                  = azurerm_resource_group.test.location
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 data "azurerm_storage_account" "test" {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1766,10 +1766,8 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		d.Set("shared_access_key_enabled", allowSharedKeyAccess)
 
 		if encryption := props.Encryption; encryption != nil && encryption.Services != nil {
-			var (
-				queueEncryptionKeyType = string
-				tableEncryptionKeyType = string
-			)
+			var queueEncryptionKeyType string
+			var tableEncryptionKeyType string
 			if encryption.Services.Queue != nil {
 				queueEncryptionKeyType = string(encryption.Services.Queue.KeyType)
 				if err := d.Set("queue_encryption_key_type", queueEncryptionKeyType); err != nil {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1766,6 +1766,10 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		d.Set("shared_access_key_enabled", allowSharedKeyAccess)
 
 		if encryption := props.Encryption; encryption != nil && encryption.Services != nil {
+			var (
+				queueEncryptionKeyType = string
+				tableEncryptionKeyType = string
+			)
 			if encryption.Services.Queue != nil {
 				queueEncryptionKeyType = string(encryption.Services.Queue.KeyType)
 				if err := d.Set("queue_encryption_key_type", queueEncryptionKeyType); err != nil {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3188,9 +3188,9 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                  = azurerm_resource_group.test.location
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -139,8 +139,8 @@ The following arguments are supported:
 
 * `routing` - (Optional) A `routing` block as defined below.
 
-* `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
-* `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
+* `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created.
+* `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created.
 
 ~> **NOTE**: For  the `queue_encryption_key_type` and `table_encryption_key_type`, the `Account` key type is only allowed when the `account_kind` is set to `StorageV2`
 


### PR DESCRIPTION
The addition of `{table|queue}_encryption_key_type`  fields has meant that terraform 2.86.0 is not back-compatible with previous versions. 
(Feature addition made in [this PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/14080/files))

This MR fixes that by removing the defaulting behaviour and keeping the ForceNew behaviour because these fields are READ ONLY.

