### PR TITLE
`azrurerm_storage_account`: Make `{queue|table}_encryption_key_type` backward compatible

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -380,7 +380,7 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		// Setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response.
-		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response. Also, define the default value as "Service" in the schema.
+		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response.
 		var (
 			queueEncryptionKeyType = string(storage.KeyTypeService)
 			tableEncryptionKeyType = string(storage.KeyTypeService)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1737,7 +1737,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		d.Set("shared_access_key_enabled", allowSharedKeyAccess)
 
 		// Setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response.
-		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response. Also, define the default value as "Service" in the schema.
+		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response.
 		var (
 			queueEncryptionKeyType = string(storage.KeyTypeService)
 			tableEncryptionKeyType = string(storage.KeyTypeService)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -688,23 +688,23 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			"queue_encryption_key_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(storage.KeyTypeService),
 					string(storage.KeyTypeAccount),
 				}, false),
-				Default: string(storage.KeyTypeService),
 			},
 
 			"table_encryption_key_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(storage.KeyTypeService),
 					string(storage.KeyTypeAccount),
 				}, false),
-				Default: string(storage.KeyTypeService),
 			},
 
 			"large_file_share_enabled": {

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -139,8 +139,8 @@ The following arguments are supported:
 
 * `routing` - (Optional) A `routing` block as defined below.
 
-* `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
-* `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
+* `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created.
+* `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created.
 
 ~> **NOTE**: For  the `queue_encryption_key_type` and `table_encryption_key_type`, the `Account` key type is only allowed when the `account_kind` is set to `StorageV2`
 


### PR DESCRIPTION
Since setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response. In order to not show plan diff in this case, [we are defaults to setting the encryption key type to "Service" if it is absent in the GET response in read](https://github.com/hashicorp/terraform-provider-azurerm/blob/fa3edbf67bda6f0b7520bd7cccc4354f3399cc3a/internal/services/storage/storage_account_resource.go#L1744). Also, *define the default value as "Service" in the schema.*

In this case, either users specify them to `Service` or leave them empty (which will then default to be `Service`), in the read we will always set it to be `Service`, ends up to no plan diff.

The #14279 raised that after upgrading to the v2.86.0, there will be a plan diff on an existing storage account. I've tested locally: I first checkout `dbde9ecab252eba42d54e9e8bd442b389226ef22` (without the #14080) and provision a storage account. Then I checkout `b758504702c00452402f191492970277089a37ff` (with #14080) and run `terraform plan` on it. There is no plan diff, as long as I didn't skip the `refresh` (i.e. not using the `terraform plan -refresh=false`). So I'm not sure how the issue #14279 is reproduced, while this PR should fix #14279 anyway by making it O+C and removing the default value.
