### PR TITLE
azurerm_key_vault_certificate - support versionless_id, versionless_secret_id

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -210,6 +210,11 @@ func dataSourceKeyVaultCertificate() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"certificate_data": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -289,6 +294,7 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
+	d.Set("versionless_id", id.VersionlessID())
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -290,11 +290,6 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	secretId, err := parse.ParseNestedItemID(*cert.Sid)
-	if err != nil {
-		return err
-	}
-
 	d.Set("name", id.Name)
 
 	certificatePolicy := flattenKeyVaultCertificatePolicyForDataSource(cert.Policy)
@@ -305,7 +300,14 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
 	d.Set("versionless_id", id.VersionlessID())
-	d.Set("versionless_secret_id", secretId.VersionlessID())
+
+	if cert.Sid != nil {
+		secretId, err := parse.ParseNestedItemID(*cert.Sid)
+		if err != nil {
+			return err
+		}
+		d.Set("versionless_secret_id", secretId.VersionlessID())
+	}
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -215,6 +215,11 @@ func dataSourceKeyVaultCertificate() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"versionless_secret_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"certificate_data": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -285,6 +290,11 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
+	secretId, err := parse.ParseNestedItemID(*cert.Sid)
+	if err != nil {
+		return err
+	}
+
 	d.Set("name", id.Name)
 
 	certificatePolicy := flattenKeyVaultCertificatePolicyForDataSource(cert.Policy)
@@ -295,6 +305,7 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
 	d.Set("versionless_id", id.VersionlessID())
+	d.Set("versionless_secret_id", secretId.VersionlessID())
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_data_source_test.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source_test.go
@@ -25,6 +25,8 @@ func TestAccDataSourceKeyVaultCertificate_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("RSA"),
 				check.That(data.ResourceName).Key("not_before").HasValue("2017-10-10T08:27:55Z"),
 				check.That(data.ResourceName).Key("expires").HasValue("2027-10-08T08:27:55Z"),
+				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkeyvault%s.vault.azure.net/certificates/acctestcert%s", data.RandomString, data.RandomString)),
+				check.That(data.ResourceName).Key("versionless_secret_id").HasValue(fmt.Sprintf("https://acctestkeyvault%s.vault.azure.net/secrets/acctestcert%s", data.RandomString, data.RandomString)),
 			),
 		},
 	})

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -616,11 +616,6 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("reading Key Vault Certificate: %+v", err)
 	}
 
-	secretId, err := parse.ParseNestedItemID(*cert.Sid)
-	if err != nil {
-		return err
-	}
-
 	d.Set("name", id.Name)
 
 	certificatePolicy := flattenKeyVaultCertificatePolicy(cert.Policy, cert.Cer)
@@ -636,7 +631,14 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
 	d.Set("versionless_id", id.VersionlessID())
-	d.Set("versionless_secret_id", secretId.VersionlessID())
+
+	if cert.Sid != nil {
+		secretId, err := parse.ParseNestedItemID(*cert.Sid)
+		if err != nil {
+			return err
+		}
+		d.Set("versionless_secret_id", secretId.VersionlessID())
+	}
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -385,6 +385,11 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"certificate_data": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -620,6 +625,7 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 	// Computed
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
+	d.Set("versionless_id", id.VersionlessID())
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -390,6 +390,11 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"versionless_secret_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"certificate_data": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -611,6 +616,11 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("reading Key Vault Certificate: %+v", err)
 	}
 
+	secretId, err := parse.ParseNestedItemID(*cert.Sid)
+	if err != nil {
+		return err
+	}
+
 	d.Set("name", id.Name)
 
 	certificatePolicy := flattenKeyVaultCertificatePolicy(cert.Policy, cert.Cer)
@@ -626,6 +636,7 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("version", id.Version)
 	d.Set("secret_id", cert.Sid)
 	d.Set("versionless_id", id.VersionlessID())
+	d.Set("versionless_secret_id", secretId.VersionlessID())
 
 	certificateData := ""
 	if contents := cert.Cer; contents != nil {

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -28,6 +28,8 @@ func TestAccKeyVaultCertificate_basicImportPFX(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate_data").Exists(),
 				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
 				check.That(data.ResourceName).Key("certificate_policy.0.secret_properties.0.content_type").HasValue("application/x-pkcs12"),
+				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkeyvault%s.vault.azure.net/certificates/acctestcert%s", data.RandomString, data.RandomString)),
+				check.That(data.ResourceName).Key("versionless_secret_id").HasValue(fmt.Sprintf("https://acctestkeyvault%s.vault.azure.net/secrets/acctestcert%s", data.RandomString, data.RandomString)),
 			),
 		},
 		data.ImportStep("certificate"),

--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -58,6 +58,8 @@ The following attributes are exported:
 
 * `versionless_id` - The Base ID of the Key Vault Certificate.
 
+* `versionless_secret_id` - The Base ID of the Key Vault Secret.
+
 * `certificate_data` - The raw Key Vault Certificate data represented as a hexadecimal string.
 
 * `certificate_data_base64` - The raw Key Vault Certificate data represented as a base64 string.

--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -56,6 +56,8 @@ The following attributes are exported:
 
 * `version` - The current version of the Key Vault Certificate.
 
+* `versionless_id` - The Base ID of the Key Vault Certificate.
+
 * `certificate_data` - The raw Key Vault Certificate data represented as a hexadecimal string.
 
 * `certificate_data_base64` - The raw Key Vault Certificate data represented as a base64 string.

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -301,6 +301,7 @@ The following attributes are exported:
 * `id` - The Key Vault Certificate ID.
 * `secret_id` - The ID of the associated Key Vault Secret.
 * `version` - The current version of the Key Vault Certificate.
+* `versionless_id` - The Base ID of the Key Vault Certificate.
 * `certificate_data` - The raw Key Vault Certificate data represented as a hexadecimal string.
 * `certificate_data_base64` - The Base64 encoded Key Vault Certificate data.
 * `thumbprint` - The X509 Thumbprint of the Key Vault Certificate represented as a hexadecimal string.

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -302,6 +302,7 @@ The following attributes are exported:
 * `secret_id` - The ID of the associated Key Vault Secret.
 * `version` - The current version of the Key Vault Certificate.
 * `versionless_id` - The Base ID of the Key Vault Certificate.
+* `versionless_secret_id` - The Base ID of the Key Vault Secret.
 * `certificate_data` - The raw Key Vault Certificate data represented as a hexadecimal string.
 * `certificate_data_base64` - The Base64 encoded Key Vault Certificate data.
 * `thumbprint` - The X509 Thumbprint of the Key Vault Certificate represented as a hexadecimal string.


### PR DESCRIPTION
Adds the `versionless_id` and `versionless_secret_id` for Key Vault certificates in the same vein as the `versionless_id` property on Secrets and Keys. Useful for API Management and Application Gateway.

 Resolves #13193.