### PR TITLE
`r\managed_disk`: Add support for purchase_plan

### DIFF
--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -155,6 +155,8 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether it is allowed to access the disk via public network. Defaults to `true`.
 
+* `purchase_plan` - (Optional) A `purchase_plan` block as defined below. Purchase Plan is used for establishing the purchase context of any 3rd Party artifact through Marketplace.
+
 For more information on managed disks, such as sizing options and pricing, please check out the [Azure Documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview).
 
 ---
@@ -182,6 +184,18 @@ The `key_encryption_key` block supports:
 * `key_url` - (Required) The URL to the Key Vault Key used as the Key Encryption Key. This can be found as `id` on the `azurerm_key_vault_key` resource.
 
 * `source_vault_id` - (Required) The ID of the source Key Vault.
+
+---
+
+A `purchase_plan` block supports:
+
+* `name` - (Required) The Purchase Plan Name.
+
+* `publisher` - (Required) The Purchase Plan Publisher.
+
+* `product` - (Required) The Purchase Plan Product.
+
+* `promotion_code` - (Optional) The Purchase Plan Promotion Code.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for PurchasePlan. This is auto-populated by server if a marketplace image used to create the disk has the info, and can be specified by user as well when image does not have it.

**Test result:**
$ TF_ACC=1 go test -v ./internal/services/compute -run=TestAccAzureRMManagedDisk_update_withPurchasePlan -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMManagedDisk_update_withPurchasePlan
=== PAUSE TestAccAzureRMManagedDisk_update_withPurchasePlan
=== CONT  TestAccAzureRMManagedDisk_update_withPurchasePlan
--- PASS: TestAccAzureRMManagedDisk_update_withPurchasePlan (549.10s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       549.778s
