### PR TITLE
`azurerm_recovery_services_vault` Update doc modify example code to meet service side's constraint, update `name` field description

### DIFF
--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -19,7 +19,7 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_recovery_services_vault" "vault" {
-  name                = "example_recovery_vault"
+  name                = "example-recovery-vault"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   sku                 = "Standard"
@@ -32,7 +32,7 @@ resource "azurerm_recovery_services_vault" "vault" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Recovery Services Vault. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Recovery Services Vault. Recovery Service Vault name must be 2 - 50 characters long, start with a letter, contain only letters, numbers and hyphens. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Recovery Services Vault. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Origin example code would complain an error: invalid value for name (Recovery Service Vault name must be 2 - 50 characters long, start with a letter, contain only letters, numbers and hyphens.)

This patch update doc and example to meet service side constraint.