### PR TITLE
azurerm_cosmosdb_account: Remove the invalid validation and update TF doc for cosmos DB account resource

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -52,27 +52,6 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				// backup type can only change from Periodic to Continuous
 				return old.(string) == string(documentdb.TypeContinuous) && new.(string) == string(documentdb.TypePeriodic)
 			}),
-
-			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
-				caps := diff.Get("capabilities")
-				mongo34found := false
-				enableMongo := false
-				for _, cap := range caps.(*pluginsdk.Set).List() {
-					m := cap.(map[string]interface{})
-					if v, ok := m["name"].(string); ok {
-						if v == "MongoDBv3.4" {
-							mongo34found = true
-						} else if v == "EnableMongo" {
-							enableMongo = true
-						}
-					}
-				}
-
-				if mongo34found && !enableMongo {
-					return fmt.Errorf("capability EnableMongo must be enabled if MongoDBv3.4 is also enabled")
-				}
-				return nil
-			}),
 		),
 
 		// TODO: replace this with an importer which validates the ID during import

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -3,7 +3,6 @@ package cosmos_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"testing"
 
@@ -472,17 +471,6 @@ func TestAccCosmosDBAccount_capabilities_EnableMongo(t *testing.T) {
 
 func TestAccCosmosDBAccount_capabilities_MongoDBv34(t *testing.T) {
 	testAccCosmosDBAccount_capabilitiesWith(t, documentdb.DatabaseAccountKindMongoDB, []string{"EnableMongo", "MongoDBv3.4"})
-}
-
-func TestAccCosmosDBAccount_capabilities_MongoDBv34_NoEnableMongo(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
-	r := CosmosDBAccountResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.capabilities(data, documentdb.DatabaseAccountKindMongoDB, []string{"MongoDBv3.4"}),
-			ExpectError: regexp.MustCompile("capability EnableMongo must be enabled if MongoDBv3.4 is also enabled"),
-		},
-	})
 }
 
 func TestAccCosmosDBAccount_capabilities_mongoEnableDocLevelTTL(t *testing.T) {

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a CosmosDB (formally DocumentDB) Account.
 
-## Example Usage
+## Example Usage (GlobalDocumentDB)
 
 ```hcl
 resource "azurerm_resource_group" "rg" {
@@ -32,22 +32,6 @@ resource "azurerm_cosmosdb_account" "db" {
 
   enable_automatic_failover = true
 
-  capabilities {
-    name = "EnableAggregationPipeline"
-  }
-
-  capabilities {
-    name = "mongoEnableDocLevelTTL"
-  }
-
-  capabilities {
-    name = "MongoDBv3.4"
-  }
-
-  capabilities {
-    name = "EnableMongo"
-  }
-
   consistency_policy {
     consistency_level       = "BoundedStaleness"
     max_interval_in_seconds = 10
@@ -57,6 +41,75 @@ resource "azurerm_cosmosdb_account" "db" {
   geo_location {
     location          = var.failover_location
     failover_priority = 1
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.rg.location
+    failover_priority = 0
+  }
+}
+```
+
+## Example Usage (MongoDB)
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.resource_group_location
+}
+
+resource "random_integer" "ri" {
+  min = 10000
+  max = 99999
+}
+
+resource "azurerm_cosmosdb_account" "db" {
+  name                 = "tfex-cosmos-db-${random_integer.ri.result}"
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  offer_type           = "Standard"
+  kind                 = "MongoDB"
+  mongo_server_version = "3.6"
+
+  public_network_access_enabled = true
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "Strong"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.rg.location
+    failover_priority = 0
+  }
+}
+```
+
+## Example Usage (Parse)
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.resource_group_location
+}
+
+resource "random_integer" "ri" {
+  min = 10000
+  max = 99999
+}
+
+resource "azurerm_cosmosdb_account" "db" {
+  name                = "tfex-cosmos-db-${random_integer.ri.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  offer_type          = "Standard"
+  kind                = "Parse"
+
+  consistency_policy {
+    consistency_level = "Strong"
   }
 
   geo_location {
@@ -149,9 +202,7 @@ The following arguments are supported:
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 
-* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`. 
-
-**NOTE:**  Setting `MongoDBv3.4` also requires setting `EnableMongo`.
+* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`.
 
 **NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
 


### PR DESCRIPTION
The purposes of this PR:

- The validation of "capability EnableMongo must be enabled if MongoDBv3.4 is also enabled." was added to Terraform In PR [#13757](https://github.com/hashicorp/terraform-provider-azurerm/pull/13757). We received a request from service team to remove this validation because this is an incorrect validation. In fact it’s the exact opposite, MongoDBv3.4 is meaningless if EnableMongo is also specified in API. Therefore, remove the invalid validation in Terraform.

- Update the TF doc:

    1. Remove capabilities in existing TF doc because the kind is GlobalDocumentDB . The ca

  pabilities should not be specified in this kind.

    2. Add new example to the TF doc to introduce the kinds of Parse and MongoDB.

**Related issues** : [#14039](https://github.com/hashicorp/terraform-provider-azurerm/issues/14039), [#14116](https://github.com/hashicorp/terraform-provider-azurerm/issues/14116)

****Test Results** (The failed testcase report the same error before modification):**
PASS: TestAccCosmosDBAccount_mongoVersion32 (1177.29s)
PASS: TestAccCosmosDBAccount_mongoVersion36 (1240.95s)
PASS: TestAccCosmosDBAccount_failover_boundedStaleness (1317.57s)
PASS: TestAccCosmosDBAccount_capabilities_EnableServerless (1453.88s)
PASS: TestAccCosmosDBAccount_localAuthenticationDisabled (1463.08s)
PASS: TestAccCosmosDBAccount_backupContinuous (1520.82s)
PASS: TestAccCosmosDBAccount_mongoVersion40 (1594.67s)
PASS: TestAccCosmosDBAccount_backupPeriodicToContinuous (1808.14s)
PASS: TestAccCosmosDBAccount_networkBypass (1969.15s)
PASS: TestAccCosmosDBAccount_capabilities_EnableTable (1459.64s)
PASS: TestAccCosmosDBAccount_capabilities_EnableAggregationPipeline (1343.42s)
PASS: TestAccCosmosDBAccount_capabilities_EnableCassandra (1360.13s)
PASS: TestAccCosmosDBAccount_capabilities_EnableGremlin (1561.95s)
PASS: TestAccCosmosDBAccount_mongoVersionUpdate (2900.83s)
PASS: TestAccCosmosDBAccount_basic_mongo_session (1630.26s)
PASS: TestAccCosmosDBAccount_basic_parse_strong (1204.16s)
PASS: TestAccCosmosDBAccount_requiresImport (1346.28s)
PASS: TestAccCosmosDBAccount_basic_parse_session (1317.86s)
PASS: TestAccCosmosDBAccount_basic_parse_eventual (1373.08s)
PASS: TestAccCosmosDBAccount_complete_mongo (4368.53s)
PASS: TestAccCosmosDBAccount_basic_parse_consistentPrefix (1276.77s)
PASS: TestAccCosmosDBAccount_updateConsistency_mongo (2758.33s)
PASS: TestAccCosmosDBAccount_updateConsistency_global (2476.24s)
PASS: TestAccCosmosDBAccount_basic_parse_boundedStaleness (1206.19s)
PASS: TestAccCosmosDBAccount_basic_mongo_strong (1337.05s)
PASS: TestAccCosmosDBAccount_basic_mongo_strong_without_capability (1520.42s)
PASS: TestAccCosmosDBAccount_update_global (5465.89s)
PASS: TestAccCosmosDBAccount_capabilities_AllowSelfServeUpgradeToMongo36 (1532.30s)
PASS: TestAccCosmosDBAccount_backup (1905.93s)
PASS: TestAccCosmosDBAccount_capabilities_mongoEnableDocLevelTTL (1351.58s)
PASS: TestAccCosmosDBAccount_update_parse (5594.33s)
PASS: TestAccCosmosDBAccount_capabilities_DisableRateLimitingResponses (1500.52s)
PASS: TestAccCosmosDBAccount_capabilitiesUpdate (2778.28s)
PASS: TestAccCosmosDBAccount_update_mongo (6527.73s)
PASS: TestAccCosmosDBAccount_vNetFilters (1647.01s)
PASS: TestAccCosmosDBAccount_capabilitiesAdd (2824.56s)
PASS: TestAccCosmosDBAccount_analyticalStorage (1216.96s)
PASS: TestAccCosmosDBAccount_identity (2196.70s)
PASS: TestAccCosmosDBAccount_capabilities_EnableMongo (1334.12s)
PASS: TestAccCosmosDBAccount_capabilities_MongoDBv34 (1543.99s)
PASS: TestAccCosmosDBAccount_basic_global_consistentPrefix (1452.07s)
PASS: TestAccCosmosDBAccount_basic_mongo_boundedStaleness (1381.83s)
PASS: TestAccCosmosDBAccount_basic_mongo_eventual (1371.73s)
PASS: TestAccCosmosDBAccount_geoLocationsUpdate (2583.37s)
PASS: TestAccCosmosDBAccount_basic_global_strong (1472.82s)
PASS: TestAccCosmosDBAccount_failover_session (1369.97s)
PASS: TestAccCosmosDBAccount_basic_mongo_consistentPrefix (1516.84s)
PASS: TestAccCosmosDBAccount_basic_global_session (1334.89s)
PASS: TestAccCosmosDBAccount_basic_global_boundedStaleness (1191.61s)
PASS: TestAccCosmosDBAccount_complete_parse (3210.30s)
PASS: TestAccCosmosDBAccount_basic_global_eventual (1472.35s)
PASS: TestAccCosmosDBAccount_failover_strong (1174.84s)
PASS: TestAccCosmosDBAccount_complete_global (3593.57s)
PASS: TestAccCosmosDBAccount_failover_eventualConsistency (1388.50s)
PASS: TestAccCosmosDBAccount_failover_mongoDB (1308.17s)
PASS: TestAccCosmosDBAccount_failover_boundedStalenessComplete (1469.10s)
PASS: TestAccCosmosDBAccount_failover_geoReplicated (2234.54s)
PASS: TestAccCosmosDBAccount_public_network_access_enabled (1654.77s)

FAIL: TestAccCosmosDBAccount_keyVaultUriUpdateConsistancy (15.01s)
FAIL: TestAccCosmosDBAccount_keyVaultUri (13.69s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_global (1463.84s)
FAIL: TestAccCosmosDBAccount_zoneRedundant_update_mongo (1725.12s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_parse (1461.12s)
FAIL: TestAccCosmosDBAccount_freeTier (143.65s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_mongo (1612.80s)