### PR TITLE
[docs] Remove unsupported argument "tier" from iothub examples.

### DIFF
--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -53,7 +53,6 @@ resource "azurerm_iothub" "example" {
 
   sku {
     name     = "B1"
-    tier     = "Basic"
     capacity = "1"
   }
 

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -53,7 +53,6 @@ resource "azurerm_iothub" "example" {
 
   sku {
     name     = "B1"
-    tier     = "Basic"
     capacity = "1"
   }
 

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -51,7 +51,6 @@ resource "azurerm_iothub" "example" {
 
   sku {
     name     = "B1"
-    tier     = "Basic"
     capacity = "1"
   }
 


### PR DESCRIPTION
The iothub examples where changed back in #5790 but eventhub examples missed
the change.

Signed-off-by: Matthias Schmitz <matthias@sigxcpu.org>