### PR TITLE
azurerm_eventgrid_event_subscription - support queue_message_time_to_live_in_seconds and user_assigned_identity

### DIFF
--- a/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -205,7 +205,11 @@ func resourceEventGridEventSubscriptionCreateUpdate(d *pluginsdk.ResourceData, m
 
 	if v, ok := d.GetOk("delivery_identity"); ok {
 		deliveryIdentityRaw := v.([]interface{})
-		deliveryIdentity := expandEventGridEventSubscriptionIdentity(deliveryIdentityRaw)
+		deliveryIdentity, err := expandEventGridEventSubscriptionIdentity(deliveryIdentityRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `delivery_identity`: %+v", err)
+		}
+
 		eventSubscriptionProperties.DeliveryWithResourceIdentity = &eventgrid.DeliveryWithResourceIdentity{
 			Identity:    deliveryIdentity,
 			Destination: destination,
@@ -219,7 +223,11 @@ func resourceEventGridEventSubscriptionCreateUpdate(d *pluginsdk.ResourceData, m
 			return fmt.Errorf("`dead_letter_identity`: `storage_blob_dead_letter_destination` must be specified")
 		}
 		deadLetterIdentityRaw := v.([]interface{})
-		deadLetterIdentity := expandEventGridEventSubscriptionIdentity(deadLetterIdentityRaw)
+		deadLetterIdentity, err := expandEventGridEventSubscriptionIdentity(deadLetterIdentityRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `dead_letter_identity`: %+v", err)
+		}
+
 		eventSubscriptionProperties.DeadLetterWithResourceIdentity = &eventgrid.DeadLetterWithResourceIdentity{
 			Identity:              deadLetterIdentity,
 			DeadLetterDestination: deadLetterDestination,

--- a/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource.go
@@ -182,7 +182,11 @@ func resourceEventGridSystemTopicEventSubscriptionCreateUpdate(d *pluginsdk.Reso
 
 	if v, ok := d.GetOk("delivery_identity"); ok {
 		deliveryIdentityRaw := v.([]interface{})
-		deliveryIdentity := expandEventGridEventSubscriptionIdentity(deliveryIdentityRaw)
+		deliveryIdentity, err := expandEventGridEventSubscriptionIdentity(deliveryIdentityRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `delivery_identity`: %+v", err)
+		}
+
 		eventSubscriptionProperties.DeliveryWithResourceIdentity = &eventgrid.DeliveryWithResourceIdentity{
 			Identity:    deliveryIdentity,
 			Destination: destination,
@@ -196,7 +200,11 @@ func resourceEventGridSystemTopicEventSubscriptionCreateUpdate(d *pluginsdk.Reso
 			return fmt.Errorf("`dead_letter_identity`: `storage_blob_dead_letter_destination` must be specified")
 		}
 		deadLetterIdentityRaw := v.([]interface{})
-		deadLetterIdentity := expandEventGridEventSubscriptionIdentity(deadLetterIdentityRaw)
+		deadLetterIdentity, err := expandEventGridEventSubscriptionIdentity(deadLetterIdentityRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `dead_letter_identity`: %+v", err)
+		}
+
 		eventSubscriptionProperties.DeadLetterWithResourceIdentity = &eventgrid.DeadLetterWithResourceIdentity{
 			Identity:              deadLetterIdentity,
 			DeadLetterDestination: deadLetterDestination,

--- a/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -126,6 +126,7 @@ func TestAccEventGridSystemTopicEventSubscription_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("included_event_types.0").HasValue("Microsoft.Storage.BlobCreated"),
 				check.That(data.ResourceName).Key("included_event_types.1").HasValue("Microsoft.Storage.BlobDeleted"),
+				check.That(data.ResourceName).Key("storage_queue_endpoint.0.queue_message_time_to_live_in_seconds").HasValue("3600"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_ends_with").HasValue(".jpg"),
 				check.That(data.ResourceName).Key("subject_filter.0.subject_begins_with").HasValue("test/test"),
 				check.That(data.ResourceName).Key("retry_policy.0.max_delivery_attempts").HasValue("10"),
@@ -188,13 +189,13 @@ func TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems(t *test
 	})
 }
 
-func TestAccEventGridSystemTopicEventSubscription_identity(t *testing.T) {
+func TestAccEventGridSystemTopicEventSubscription_systemIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventgrid_system_topic_event_subscription", "test")
 	r := EventGridSystemTopicEventSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.identity(data),
+			Config: r.systemIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("delivery_identity.#").HasValue("1"),
@@ -214,13 +215,52 @@ func TestAccEventGridSystemTopicEventSubscription_identity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.identity(data),
+			Config: r.systemIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("delivery_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("delivery_identity.0.type").HasValue("SystemAssigned"),
 				check.That(data.ResourceName).Key("dead_letter_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("dead_letter_identity.0.type").HasValue("SystemAssigned"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccEventGridSystemTopicEventSubscription_userIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_system_topic_event_subscription", "test")
+	r := EventGridSystemTopicEventSubscriptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("delivery_identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("delivery_identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("dead_letter_identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("dead_letter_identity.0.type").HasValue("UserAssigned"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("delivery_identity.#").HasValue("0"),
+				check.That(data.ResourceName).Key("dead_letter_identity.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("delivery_identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("delivery_identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("dead_letter_identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("dead_letter_identity.0.type").HasValue("UserAssigned"),
 			),
 		},
 		data.ImportStep(),
@@ -389,8 +429,9 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   storage_queue_endpoint {
-    storage_account_id = azurerm_storage_account.test.id
-    queue_name         = azurerm_storage_queue.test.name
+    storage_account_id                    = azurerm_storage_account.test.id
+    queue_name                            = azurerm_storage_queue.test.name
+    queue_message_time_to_live_in_seconds = 3600
   }
 
   storage_blob_dead_letter_destination {
@@ -847,7 +888,7 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (EventGridSystemTopicEventSubscriptionResource) identity(data acceptance.TestData) string {
+func (EventGridSystemTopicEventSubscriptionResource) systemIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -910,6 +951,93 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
 
   dead_letter_identity {
     type = "SystemAssigned"
+  }
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.test.id
+    queue_name         = azurerm_storage_queue.test.name
+  }
+
+  storage_blob_dead_letter_destination {
+    storage_account_id          = azurerm_storage_account.test.id
+    storage_blob_container_name = azurerm_storage_container.test.name
+  }
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (EventGridSystemTopicEventSubscriptionResource) userIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "mysamplequeue-%[1]d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "test" {
+  name = "herpderp1.vhd"
+
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+
+  type = "Page"
+  size = 5120
+}
+
+resource "azurerm_eventgrid_system_topic" "test" {
+  name                   = "acctesteg-%[1]d"
+  location               = "Global"
+  resource_group_name    = azurerm_resource_group.test.name
+  source_arm_resource_id = azurerm_resource_group.test.id
+  topic_type             = "Microsoft.Resources.ResourceGroups"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
+  name                = "acctesteg-%[1]d"
+  system_topic        = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  delivery_identity {
+    type                   = "UserAssigned"
+    user_assigned_identity = azurerm_user_assigned_identity.test.id
+  }
+
+  dead_letter_identity {
+    type                   = "UserAssigned"
+    user_assigned_identity = azurerm_user_assigned_identity.test.id
   }
 
   storage_queue_endpoint {

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -109,6 +109,8 @@ A `storage_queue_endpoint` supports the following:
 
 * `queue_name` - (Required) Specifies the name of the storage queue where the Event Subscription will receive events.
 
+* `queue_message_time_to_live_in_seconds` - (Optional) Storage queue message time to live in seconds.
+
 ---
 
 An `azure_function_endpoint` supports the following:
@@ -197,8 +199,9 @@ Each nested block consists of a key and a value(s) element.
 
 A `delivery_identity` supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`, `UserAssigned`.
 
+* `userAssignedIdentity` - (Optional) The user identity associated with the resource.
 
 ---
 
@@ -218,7 +221,9 @@ A `delivery_property` supports the following:
 
 A `dead_letter_identity` supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`, `UserAssigned`.
+
+* `userAssignedIdentity` - (Optional) The user identity associated with the resource.
 
 ---
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -113,6 +113,8 @@ A `storage_queue_endpoint` supports the following:
 
 * `queue_name` - (Required) Specifies the name of the storage queue where the Event Subscription will receive events.
 
+* `queue_message_time_to_live_in_seconds` - (Optional) Storage queue message time to live in seconds.
+
 ---
 
 An `azure_function_endpoint` supports the following:
@@ -189,13 +191,17 @@ Each nested block consists of a key and a value(s) element.
 
 A `delivery_identity` supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`, `UserAssigned`.
+
+* `userAssignedIdentity` - (Optional) The user identity associated with the resource.
 
 ---
 
 A `dead_letter_identity` supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`, `UserAssigned`.
+
+* `userAssignedIdentity` - (Optional) The user identity associated with the resource.
 
 ---
 


### PR DESCRIPTION
https://ci-oss.hashicorp.engineering/buildConfiguration/TerraformOpenSource_TerraformProviders_AzureRMPublic_AZURERM_SERVICE_PUBLIC_EVENTGRID/223376?buildTab=tests&status=passed
![image](https://user-images.githubusercontent.com/76987228/143239536-93c156f2-d276-4106-b007-d64fdf70ac84.png)
https://ci-oss.hashicorp.engineering/buildConfiguration/TerraformOpenSource_TerraformProviders_AzureRMPublic_AZURERM_SERVICE_PUBLIC_EVENTGRID/223377?buildTab=tests&status=passed
![image](https://user-images.githubusercontent.com/76987228/143240109-7de73218-1668-4418-a217-cb80b0d041e5.png)
