### PR TITLE
Trim trailing slashes from ARM ids when using `terraform import`

### DIFF
--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -38,6 +39,10 @@ func ImporterValidatingResourceIdThen(validateFunc IDValidationFunc, thenFunc Im
 	return &schema.ResourceImporter{
 		StateContext: func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
+
+			// strip trailing slashes off the id
+			id := strings.TrimSuffix(d.Id(), "/")
+			d.SetId(id)
 
 			if err := validateFunc(d.Id()); err != nil {
 				return []*ResourceData{d}, fmt.Errorf("parsing Resource ID %q: %+v", d.Id(), err)


### PR DESCRIPTION
I'm a complete newbie to this project and the go language, so grateful for feedback on this change.