### PR TITLE
docs: fix wrong documentation of max_pid featore of  azurerm_kubernetes_cluster_node_pool

### DIFF
--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -183,7 +183,7 @@ A `kubelet_config` block supports the following:
 
 * `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage lower than which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
-* `pod_max_pids` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
+* `pod_max_pid` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
 
 * `topology_manager_policy` - (Optional) Specifies the Topology Manager policy to use. Possible values are `none`, `best-effort`, `restricted` or `single-numa-node`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
# Motivation

While working with the nodepool resource, I encountered the following issue:
```
╷
│ Error: Unsupported argument
│ 
│   on ../../../../terraform/modules/tf-module-aks-nodegroup/main.tf line 76, in resource "azurerm_kubernetes_cluster_node_pool" "this":
│   76:     pod_max_pids               = lookup(jsondecode(random_string.id.keepers.kubelet_config), "pod_max_pids ", null)
│ 
│ An argument named "pod_max_pids" is not expected here. Did you mean "pod_max_pid"?
╵
```

Looking it up in the documentation - it is everywhere else referred as `pod_max_pid` without the leading `s`.

This PR updates the documentation accordingly