### PR TITLE
docs: backup_instance_disk: fix example

### DIFF
--- a/website/docs/r/data_protection_backup_instance_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_disk.html.markdown
@@ -49,8 +49,8 @@ resource "azurerm_role_assignment" "example2" {
 
 
 resource "azurerm_data_protection_backup_policy_disk" "example" {
-  name                = "example-backup-policy"
-  vault_id            = azurerm_data_protection_backup_vault.example.id
+  name     = "example-backup-policy"
+  vault_id = azurerm_data_protection_backup_vault.example.id
 
   backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
   default_retention_duration      = "P7D"

--- a/website/docs/r/data_protection_backup_instance_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_disk.html.markdown
@@ -50,8 +50,7 @@ resource "azurerm_role_assignment" "example2" {
 
 resource "azurerm_data_protection_backup_policy_disk" "example" {
   name                = "example-backup-policy"
-  resource_group_name = azurerm_resource_group.rg.name
-  vault_name          = azurerm_data_protection_backup_vault.example.name
+  vault_id            = azurerm_data_protection_backup_vault.example.id
 
   backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
   default_retention_duration      = "P7D"


### PR DESCRIPTION
As per documentation and `terraform validate` output, the correct argument is `vault_id`, not `vault_name`:

> * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Instance Disk should exist. Changing this forces a new Backup Instance Disk to be created.

Additionally, `resource_group_name` is not an expected argument.