### PR TITLE
docs: backup_instance_disk: add necessary identity block

### DIFF
--- a/website/docs/r/data_protection_backup_instance_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_disk.html.markdown
@@ -33,6 +33,9 @@ resource "azurerm_data_protection_backup_vault" "example" {
   location            = azurerm_resource_group.rg.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_role_assignment" "example1" {


### PR DESCRIPTION
The identity block in `azurerm_data_protection_backup_vault.example` is necessary
because we're trying to access index 0 in the two role assignments