### PR TITLE
add azurerm_app_service_certificate_binding to example

### DIFF
--- a/website/docs/r/app_service_managed_certificate.html.markdown
+++ b/website/docs/r/app_service_managed_certificate.html.markdown
@@ -66,6 +66,12 @@ resource "azurerm_app_service_custom_hostname_binding" "example" {
 resource "azurerm_app_service_managed_certificate" "example" {
   custom_hostname_binding_id = azurerm_app_service_custom_hostname_binding.example.id
 }
+
+resource "azurerm_app_service_certificate_binding" "example" {
+  hostname_binding_id = azurerm_app_service_custom_hostname_binding.example.id
+  certificate_id      = azurerm_app_service_managed_certificate.example.id
+  ssl_state           = "SniEnabled"
+}
 ```
 
 ## Arguments Reference


### PR DESCRIPTION
Adding `azurerm_app_service_certificate_binding` to the example will make this an actual working example. Without it, it is not apparent why the App Service fails to bind the certificate.