### PR TITLE
fix(firewall_policy): replace ip address range with cidr range as valid input for threat_intelligence_allowlist

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -129,7 +129,7 @@ func resourceFirewallPolicy() *pluginsdk.Resource {
 							Optional: true,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.Any(validation.IsIPv4Range, validation.IsIPv4Address),
+								ValidateFunc: validation.Any(validation.IsCIDR, validation.IsIPv4Address),
 							},
 							AtLeastOneOf: []string{"threat_intelligence_allowlist.0.ip_addresses", "threat_intelligence_allowlist.0.fqdns"},
 						},

--- a/internal/services/firewall/firewall_policy_resource_test.go
+++ b/internal/services/firewall/firewall_policy_resource_test.go
@@ -245,7 +245,7 @@ resource "azurerm_firewall_policy" "test" {
   location                 = azurerm_resource_group.test.location
   threat_intelligence_mode = "Off"
   threat_intelligence_allowlist {
-    ip_addresses = ["1.1.1.1", "2.2.2.2"]
+    ip_addresses = ["1.1.1.1", "2.2.2.2", "10.0.0.0/16"]
     fqdns        = ["foo.com", "bar.com"]
   }
   dns {
@@ -271,7 +271,7 @@ resource "azurerm_firewall_policy" "test" {
   sku                      = "Premium"
   threat_intelligence_mode = "Off"
   threat_intelligence_allowlist {
-    ip_addresses = ["1.1.1.1", "2.2.2.2"]
+    ip_addresses = ["1.1.1.1", "2.2.2.2", "10.0.0.0/16"]
     fqdns        = ["foo.com", "bar.com"]
   }
   dns {

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -116,7 +116,7 @@ A `threat_intelligence_allowlist` block supports the following:
 
 * `fqdns` - (Optional) A list of FQDNs that will be skipped for threat detection.
 
-* `ip_addresses` - (Optional) A list of IP addresses or IP address ranges that will be skipped for threat detection.
+* `ip_addresses` - (Optional) A list of IP addresses or CIDR ranges that will be skipped for threat detection.
 
 ---
 


### PR DESCRIPTION
This PR address #14339 by:

- removing IP address range as a valid input, as it's not supported
- adding the CIDR range as a valid input