### PR TITLE
Add 'optional' keyword to aks->aad->managed bool in the Docs

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -277,7 +277,7 @@ An `auto_scaler_profile` block supports the following:
 
 A `azure_active_directory` block supports the following:
 
-* `managed` - Is the Azure Active Directory integration Managed, meaning that Azure will create/manage the Service Principal used for integration.
+* `managed` - (Optional) Is the Azure Active Directory integration Managed, meaning that Azure will create/manage the Service Principal used for integration.
 
 * `tenant_id` - (Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used.
 


### PR DESCRIPTION
Hello,

I'm currently spending some time reading the Terraform docs and noticed one little oversight in the kubernetes_cluster docs.
I figured I would make its tiny PR  (I won't ask for a hacktoberfest shirt hahaha)

I found the code responsible for the implementation of the azure_active_directory block and azure_active_directory->managed specifically in https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/containers/kubernetes_cluster_resource.go#L713.

Excerpt:
```go
	"managed": {
		Type:     pluginsdk.TypeBool,
		Optional: true,
		AtLeastOneOf: []string{"role_based_access_control.0.azure_active_directory.0.client_app_id", "role_based_access_control.0.azure_active_directory.0.server_app_id",
			"role_based_access_control.0.azure_active_directory.0.server_app_secret", "role_based_access_control.0.azure_active_directory.0.tenant_id",
			"role_based_access_control.0.azure_active_directory.0.managed", "role_based_access_control.0.azure_active_directory.0.admin_group_object_ids",
		},
	},
```

Have a good day,

Loris