### PR TITLE
Changing Postgres instance type from Default to Replica forces a new resource to be created

### DIFF
--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -447,8 +447,8 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 				return false
 			}),
 			pluginsdk.ForceNewIfChange("create_mode", func(ctx context.Context, old, new, meta interface{}) bool {
-				oldMode := old.(postgresql.CreateMode)
-				newMode := new.(postgresql.CreateMode)
+				oldMode := postgresql.CreateMode(old.(string))
+				newMode := postgresql.CreateMode(new.(string))
 				// Instance could not be changed from Default to Replica
 				if oldMode == postgresql.CreateModeDefault && newMode == postgresql.CreateModeReplica {
 					return true

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -446,6 +446,15 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 				}
 				return false
 			}),
+			pluginsdk.ForceNewIfChange("create_mode", func(ctx context.Context, old, new, meta interface{}) bool {
+				oldMode := old.(postgresql.CreateMode)
+				newMode := new.(postgresql.CreateMode)
+				// Instance could not be changed from Default to Replica
+				if oldMode == postgresql.CreateModeDefault && newMode == postgresql.CreateModeReplica {
+					return true
+				}
+				return false
+			}),
 		),
 	}
 }


### PR DESCRIPTION
According to the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/postgresql/concepts-read-replicas)
> The standalone server can't be made into a replica again.

So changing instance type from Default to Replica should lead to resource re-creation.