### PR TITLE
`r\iothub`: Support managed service identity

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -25,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+type iothubIdentity = identity.SystemAssignedUserAssigned
 
 // TODO: outside of this pr make this private
 
@@ -538,6 +542,8 @@ func resourceIotHub() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"identity": iothubIdentity{}.Schema(),
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -608,6 +614,12 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		cloudToDeviceProperties = expandIoTHubCloudToDevice(d)
 	}
 
+	identityRaw := d.Get("identity").([]interface{})
+	identity, err := expandIotHubIdentity(identityRaw)
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
+
 	props := devices.IotHubDescription{
 		Name:     utils.String(id.Name),
 		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
@@ -620,7 +632,8 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			EnableFileUploadNotifications: &enableFileUploadNotifications,
 			CloudToDevice:                 cloudToDeviceProperties,
 		},
-		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+		Identity: identity,
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	// nolint staticcheck
@@ -765,6 +778,14 @@ func resourceIotHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 
 		d.Set("min_tls_version", properties.MinTLSVersion)
+	}
+
+	identity, err := flattenIotHubIdentity(hub.Identity)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 
 	d.Set("name", id.Name)
@@ -1420,6 +1441,60 @@ func flattenIPFilterRules(in *[]devices.IPFilterRule) []interface{} {
 		rules = append(rules, rawRule)
 	}
 	return rules
+}
+
+func expandIotHubIdentity(input []interface{}) (*devices.ArmIdentity, error) {
+	config, err := iothubIdentity{}.Expand(input)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := devices.ArmIdentity{
+		Type: devices.ResourceIdentityType(config.Type),
+	}
+
+	if len(config.UserAssignedIdentityIds) != 0 {
+		identityIds := make(map[string]*devices.ArmUserIdentity, len(config.UserAssignedIdentityIds))
+		for _, id := range config.UserAssignedIdentityIds {
+			identityIds[id] = &devices.ArmUserIdentity{}
+		}
+		identity.UserAssignedIdentities = identityIds
+	}
+
+	return &identity, nil
+}
+
+func flattenIotHubIdentity(input *devices.ArmIdentity) ([]interface{}, error) {
+	var config *identity.ExpandedConfig
+
+	if input != nil {
+		var identityIds []string
+		for id := range input.UserAssignedIdentities {
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(id)
+			if err != nil {
+				return nil, err
+			}
+			identityIds = append(identityIds, parsedId.ID())
+		}
+
+		principalId := ""
+		if input.PrincipalID != nil {
+			principalId = *input.PrincipalID
+		}
+
+		tenantId := ""
+		if input.TenantID != nil {
+			tenantId = *input.TenantID
+		}
+
+		config = &identity.ExpandedConfig{
+			Type:                    identity.Type(string(input.Type)),
+			PrincipalId:             principalId,
+			TenantId:                tenantId,
+			UserAssignedIdentityIds: identityIds,
+		}
+	}
+	return iothubIdentity{}.Flatten(config), nil
 }
 
 func fileUploadConnectionStringDiffSuppress(k, old, new string, d *pluginsdk.ResourceData) bool {

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -152,6 +152,8 @@ The following arguments are supported:
 
 * `file_upload` - (Optional) A `file_upload` block as defined below.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `ip_filter_rule` - (Optional) One or more `ip_filter_rule` blocks as defined below.
 
 * `route` - (Optional) A `route` block as defined below.
@@ -197,6 +199,14 @@ An `endpoint` block supports the following:
 * `file_name_format` - (Optional) File name format for the blob. Default format is ``{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}``. All parameters are mandatory but can be reordered. This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`.
 
 * `resource_group_name` - (Optional) The resource group in which the endpoint will be created.
+
+---
+
+A `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Identity which should be assigned to the Iot Hub. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Iot Hub.
 
 ---
 
@@ -297,7 +307,17 @@ The following attributes are exported:
 
 * `hostname` - The hostname of the IotHub Resource.
 
+* `identity` - An `identity` block as documented below.
+
 * `shared_access_policy` - One or more `shared_access_policy` blocks as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The ID of the System Managed Service Principal.
+
+* `tenant_id` - The ID of the Tenant the System Managed Service Principal is assigned in.
 
 ---
 


### PR DESCRIPTION
Fix #9139
This is required when Iot Hub needs to talk to other resources on a private v-net. Support for `AuthenticatinType` in routing, file upload, device import/export will be added in following prs
Test result:
![image](https://user-images.githubusercontent.com/10579712/146703830-25604dc4-6c88-4ea1-bf05-2b5f7b0de459.png)
