### PR TITLE
Add twitter block info to function_app{_slot} documentation.

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -345,6 +345,14 @@ A `microsoft` block supports the following:
 
 ---
 
+A `twitter` block supports the following:
+
+* `consumer_key` - The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret` - The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+---
+
 A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -252,7 +252,7 @@ A `twitter` block supports the following:
 
 * `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
 
-* `consumer_secret` - (Optional) The OAuth 1.0a consumer secret of the Twitter application used for sign-in. Cannot be specified with `consumer_secret_setting_name`.
+* `consumer_secret` - (Optional) The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
 
 ---
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -248,6 +248,14 @@ A `microsoft` block supports the following:
 
 ---
 
+A `twitter` block supports the following:
+
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret` - (Optional) The OAuth 1.0a consumer secret of the Twitter application used for sign-in. Cannot be specified with `consumer_secret_setting_name`.
+
+---
+
 A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.


### PR DESCRIPTION
Fixes #11224 It's missing in both `function_app` and `function_app_slot`.