### PR TITLE
`azurerm_batch_pool` deprecate `max_task_retry_count` and `environment` as well as fix tests

### DIFF
--- a/internal/services/batch/batch_job_resource_test.go
+++ b/internal/services/batch/batch_job_resource_test.go
@@ -188,7 +188,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -198,7 +198,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 }

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -110,7 +110,7 @@ func flattenBatchPoolStartTask(startTask *batch.StartTask) []interface{} {
 	result["wait_for_success"] = waitForSuccess
 
 	maxTaskRetryCount := int32(0)
-	if startTask.MaxTaskRetryCount != nil  {
+	if startTask.MaxTaskRetryCount != nil {
 		maxTaskRetryCount = *startTask.MaxTaskRetryCount
 	}
 

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -2,13 +2,13 @@ package batch
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/parse"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -161,32 +161,26 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 			},
 			"certificate": {
 				Type:     pluginsdk.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							Computed: true,
 						},
 						"store_location": {
 							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"CurrentUser",
-								"LocalMachine",
-							}, false),
+							Computed: true,
 						},
 						"store_name": {
 							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Computed: true,
 						},
 						"visibility": {
 							Type:     pluginsdk.TypeSet,
-							Optional: true,
+							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
+								Type:     pluginsdk.TypeString,
 							},
 						},
 					},
@@ -194,30 +188,44 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 			},
 			"start_task": {
 				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"command_line": {
 							Type:     pluginsdk.TypeString,
-							Required: true,
+							Computed: true,
 						},
 
+						// TODO: Remove in 3.0
 						"max_task_retry_count": {
 							Type:     pluginsdk.TypeInt,
-							Optional: true,
-							Default:  1,
+							Computed: true,
+						},
+
+						"task_retry_maximum": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
 						},
 
 						"wait_for_success": {
 							Type:     pluginsdk.TypeBool,
-							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 
+						// TODO: Remove in 3.0
 						"environment": {
 							Type:     pluginsdk.TypeMap,
 							Optional: true,
+							//Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"common_environment_properties": {
+							Type:     pluginsdk.TypeMap,
+							Optional: true,
+							//Computed: true,
 							Elem: &pluginsdk.Schema{
 								Type: pluginsdk.TypeString,
 							},
@@ -356,26 +364,25 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 
 func dataSourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Batch.PoolClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	accountName := d.Get("account_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
+	id := parse.NewPoolID(subscriptionId, d.Get("resource_group_name").(string), d.Get("account_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, resourceGroup, accountName, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: Batch pool %q in account %q (Resource Group %q) was not found", name, accountName, resourceGroup)
+			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("making Read request on AzureRM Batch pool %q: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.SetId(*resp.ID)
+	d.SetId(id.ID())
 
-	d.Set("name", name)
-	d.Set("account_name", accountName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("account_name", id.BatchAccountName)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	if props := resp.PoolProperties; props != nil {
 		d.Set("vm_size", props.VMSize)

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -2,11 +2,11 @@ package batch
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/parse"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -165,7 +165,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:         pluginsdk.TypeString,
+							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
 						"store_location": {
@@ -173,14 +173,14 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 							Computed: true,
 						},
 						"store_name": {
-							Type:         pluginsdk.TypeString,
+							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
 						"visibility": {
 							Type:     pluginsdk.TypeSet,
 							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type:     pluginsdk.TypeString,
+								Type: pluginsdk.TypeString,
 							},
 						},
 					},

--- a/internal/services/batch/batch_pool_data_source_test.go
+++ b/internal/services/batch/batch_pool_data_source_test.go
@@ -31,7 +31,7 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 20.04"),
 				check.That(data.ResourceName).Key("max_tasks_per_node").HasValue("2"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.task_retry_maximum").HasValue("1"),
+				check.That(data.ResourceName).Key("start_task.0.task_retry_maximum").HasValue("5"),
 				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.#").HasValue("1"),
@@ -132,7 +132,7 @@ resource "azurerm_batch_pool" "test" {
 
   start_task {
     command_line         = "echo 'Hello World from $env'"
-    task_retry_maximum   = 1
+    task_retry_maximum   = 5
     wait_for_success     = true
 
     common_environment_properties = {

--- a/internal/services/batch/batch_pool_data_source_test.go
+++ b/internal/services/batch/batch_pool_data_source_test.go
@@ -131,9 +131,9 @@ resource "azurerm_batch_pool" "test" {
   }
 
   start_task {
-    command_line         = "echo 'Hello World from $env'"
-    task_retry_maximum   = 5
-    wait_for_success     = true
+    command_line       = "echo 'Hello World from $env'"
+    task_retry_maximum = 5
+    wait_for_success   = true
 
     common_environment_properties = {
       env = "TEST"

--- a/internal/services/batch/batch_pool_data_source_test.go
+++ b/internal/services/batch/batch_pool_data_source_test.go
@@ -22,18 +22,18 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("microsoft-azure-batch"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16-04-lts"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("20-04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("ubuntu-server-container"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("2"),
 				check.That(data.ResourceName).Key("fixed_scale.0.resize_timeout").HasValue("PT15M"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_low_priority_nodes").HasValue("0"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 20.04"),
 				check.That(data.ResourceName).Key("max_tasks_per_node").HasValue("2"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.max_task_retry_count").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.environment.%").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.environment.env").HasValue("TEST"),
+				check.That(data.ResourceName).Key("start_task.0.task_retry_maximum").HasValue("1"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("1"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.0.scope").HasValue("Task"),
@@ -100,7 +100,7 @@ resource "azurerm_batch_pool" "test" {
   account_name        = azurerm_batch_account.test.name
   display_name        = "Test Acc Pool"
   vm_size             = "Standard_A1"
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 20.04"
   max_tasks_per_node  = 2
 
   fixed_scale {
@@ -111,7 +111,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "microsoft-azure-batch"
     offer     = "ubuntu-server-container"
-    sku       = "16-04-lts"
+    sku       = "20-04-lts"
     version   = "latest"
   }
 
@@ -132,10 +132,10 @@ resource "azurerm_batch_pool" "test" {
 
   start_task {
     command_line         = "echo 'Hello World from $env'"
-    max_task_retry_count = 1
+    task_retry_maximum   = 1
     wait_for_success     = true
 
-    environment = {
+    common_environment_properties = {
       env = "TEST"
     }
 

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -52,9 +52,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 				ValidateFunc: validate.PoolName,
 			},
 
-			// TODO: make this case sensitive once this API bug has been fixed:
-			// https://github.com/Azure/azure-rest-api-specs/issues/5574
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"account_name": {
 				Type:         pluginsdk.TypeString,
@@ -301,11 +299,22 @@ func resourceBatchPool() *pluginsdk.Resource {
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
-						// TODO 3.0 - rename to task_retry_maximum to be consistent with azurerm_batch_job
+						// TODO: Remove in 3.0
 						"max_task_retry_count": {
+							Type:       pluginsdk.TypeInt,
+							Optional:   true,
+							Deprecated: "Deprecated in favour of `task_retry_maximum`",
+							ConflictsWith: []string{
+								"start_task.0.task_retry_maximum",
+							},
+						},
+
+						"task_retry_maximum": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
-							Default:  1,
+							ConflictsWith: []string{
+								"start_task.0.max_task_retry_count",
+							},
 						},
 
 						"wait_for_success": {
@@ -314,12 +323,27 @@ func resourceBatchPool() *pluginsdk.Resource {
 							Default:  false,
 						},
 
-						// TODO 3.0 - rename to common_environment_properties to be consistent with azurerm_batch_job
+						// TODO: Remove in 3.0
 						"environment": {
 							Type:     pluginsdk.TypeMap,
 							Optional: true,
 							Elem: &pluginsdk.Schema{
 								Type: pluginsdk.TypeString,
+							},
+							Deprecated: "Deprecated in favour of `common_environment_properties`",
+							ConflictsWith: []string{
+								"start_task.0.common_environment_properties",
+							},
+						},
+
+						"common_environment_properties": {
+							Type:     pluginsdk.TypeMap,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+							ConflictsWith: []string{
+								"start_task.0.environment",
 							},
 						},
 
@@ -519,36 +543,30 @@ func resourceBatchPool() *pluginsdk.Resource {
 
 func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Batch.PoolClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Batch pool creation.")
-
-	resourceGroup := d.Get("resource_group_name").(string)
-	accountName := d.Get("account_name").(string)
-	poolName := d.Get("name").(string)
-	displayName := d.Get("display_name").(string)
-	vmSize := d.Get("vm_size").(string)
-	maxTasksPerNode := int32(d.Get("max_tasks_per_node").(int))
+	id := parse.NewPoolID(subscriptionId, d.Get("resource_group_name").(string), d.Get("account_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, accountName, poolName)
+		existing, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Batch Pool %q (Account %q / Resource Group %q): %+v", poolName, accountName, resourceGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_batch_pool", *existing.ID)
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_batch_pool", id.ID())
 		}
 	}
 
 	parameters := batch.Pool{
 		PoolProperties: &batch.PoolProperties{
-			VMSize:           &vmSize,
-			DisplayName:      &displayName,
-			TaskSlotsPerNode: &maxTasksPerNode,
+			VMSize:           utils.String(d.Get("vm_size").(string)),
+			DisplayName:      utils.String(d.Get("display_name").(string)),
+			TaskSlotsPerNode: utils.Int32(int32(d.Get("max_tasks_per_node").(int))),
 		},
 	}
 
@@ -570,18 +588,18 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 	storageImageReferenceSet := d.Get("storage_image_reference").([]interface{})
 	imageReference, err := ExpandBatchPoolImageReference(storageImageReferenceSet)
 	if err != nil {
-		return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if imageReference != nil {
 		// if an image reference ID is specified, the user wants use a custom image. This property is mutually exclusive with other properties.
 		if imageReference.ID != nil && (imageReference.Offer != nil || imageReference.Publisher != nil || imageReference.Sku != nil || imageReference.Version != nil) {
-			return fmt.Errorf("creating Batch pool %q (Resource Group %q): Properties version, offer, publish cannot be defined when using a custom image id", poolName, resourceGroup)
+			return fmt.Errorf("creating %s: Properties version, offer, publish cannot be defined when using a custom image id", id)
 		} else if imageReference.ID == nil && (imageReference.Offer == nil || imageReference.Publisher == nil || imageReference.Sku == nil || imageReference.Version == nil) {
-			return fmt.Errorf("creating Batch pool %q (Resource Group %q): Properties version, offer, publish and sku are mandatory when not using a custom image", poolName, resourceGroup)
+			return fmt.Errorf("creating %s: Properties version, offer, publish and sku are mandatory when not using a custom image", id)
 		}
 	} else {
-		return fmt.Errorf("creating Batch pool %q (Resource Group %q): image reference property can not be empty", poolName, resourceGroup)
+		return fmt.Errorf("creating %s: image reference property can not be empty", id)
 	}
 
 	if startTaskValue, startTaskOk := d.GetOk("start_task"); startTaskOk {
@@ -589,13 +607,13 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 		startTask, startTaskErr := ExpandBatchPoolStartTask(startTaskList)
 
 		if startTaskErr != nil {
-			return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, startTaskErr)
+			return fmt.Errorf("creating %s: %+v", id, startTaskErr)
 		}
 
 		// start task should have a user identity defined
 		userIdentity := startTask.UserIdentity
 		if userIdentityError := validateUserIdentity(userIdentity); userIdentityError != nil {
-			return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, userIdentityError)
+			return fmt.Errorf("creating %s: %+v", id, userIdentityError)
 		}
 
 		parameters.PoolProperties.StartTask = startTask
@@ -603,7 +621,7 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	containerConfiguration, err := ExpandBatchPoolContainerConfiguration(d.Get("container_configuration").([]interface{}))
 	if err != nil {
-		return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	parameters.PoolProperties.DeploymentConfiguration = &batch.DeploymentConfiguration{
@@ -634,26 +652,22 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 		return fmt.Errorf("expanding `network_configuration`: %+v", err)
 	}
 
-	_, err = client.Create(ctx, resourceGroup, accountName, poolName, parameters, "", "")
+	_, err = client.Create(ctx, id.ResourceGroup, id.BatchAccountName, id.Name, parameters, "", "")
 	if err != nil {
-		return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroup, accountName, poolName)
+	read, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return fmt.Errorf("retrieving Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read Batch pool %q (resource group %q) ID", poolName, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
+	d.SetId(id.ID())
 
 	// if the pool is not Steady after the create operation, wait for it to be Steady
 	if props := read.PoolProperties; props != nil && props.AllocationState != batch.AllocationStateSteady {
-		if err = waitForBatchPoolPendingResizeOperation(ctx, client, resourceGroup, accountName, poolName); err != nil {
-			return fmt.Errorf("waiting for Batch pool %q (resource group %q) being ready", poolName, resourceGroup)
+		if err = waitForBatchPoolPendingResizeOperation(ctx, client, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
+			return fmt.Errorf("waiting for %s", id)
 		}
 	}
 
@@ -672,24 +686,24 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return fmt.Errorf("retrieving the Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
 	if resp.PoolProperties.AllocationState != batch.AllocationStateSteady {
 		log.Printf("[INFO] there is a pending resize operation on this pool...")
 		stopPendingResizeOperation := d.Get("stop_pending_resize_operation").(bool)
 		if !stopPendingResizeOperation {
-			return fmt.Errorf("updating the Batch pool %q (Resource Group %q) because of pending resize operation. Set flag `stop_pending_resize_operation` to true to force update", id.Name, id.ResourceGroup)
+			return fmt.Errorf("updating %s because of pending resize operation. Set flag `stop_pending_resize_operation` to true to force update", *id)
 		}
 
 		log.Printf("[INFO] stopping the pending resize operation on this pool...")
 		if _, err = client.StopResize(ctx, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
-			return fmt.Errorf("stopping resize operation for Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			return fmt.Errorf("stopping resize operation for %s: %+v", *id, err)
 		}
 
 		// waiting for the pool to be in steady state
 		if err = waitForBatchPoolPendingResizeOperation(ctx, client, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
-			return fmt.Errorf("waiting for Batch pool %q (resource group %q) being ready", id.Name, id.ResourceGroup)
+			return fmt.Errorf("waiting for %s", *id)
 		}
 	}
 
@@ -715,13 +729,13 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 		startTask, startTaskErr := ExpandBatchPoolStartTask(startTaskList)
 
 		if startTaskErr != nil {
-			return fmt.Errorf("updating Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, startTaskErr)
+			return fmt.Errorf("updating %s: %+v", *id, startTaskErr)
 		}
 
 		// start task should have a user identity defined
 		userIdentity := startTask.UserIdentity
 		if userIdentityError := validateUserIdentity(userIdentity); userIdentityError != nil {
-			return fmt.Errorf("creating Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, userIdentityError)
+			return fmt.Errorf("creating %s: %+v", *id, userIdentityError)
 		}
 
 		parameters.PoolProperties.StartTask = startTask
@@ -738,7 +752,7 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 	}
 
 	if d.HasChange("metadata") {
-		log.Printf("[DEBUG] Updating the MetaData for Batch pool %q (Account name %q / Resource Group %q)..", id.Name, id.BatchAccountName, id.ResourceGroup)
+		log.Printf("[DEBUG] Updating the MetaData for %s", *id)
 		metaDataRaw := d.Get("metadata").(map[string]interface{})
 
 		parameters.PoolProperties.Metadata = ExpandBatchMetaData(metaDataRaw)
@@ -746,13 +760,13 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	result, err := client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.Name, parameters, "")
 	if err != nil {
-		return fmt.Errorf("updating Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
 	// if the pool is not Steady after the update, wait for it to be Steady
 	if props := result.PoolProperties; props != nil && props.AllocationState != batch.AllocationStateSteady {
 		if err := waitForBatchPoolPendingResizeOperation(ctx, client, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
-			return fmt.Errorf("waiting for Batch pool %q (resource group %q) being ready", id.Name, id.ResourceGroup)
+			return fmt.Errorf("waiting for %s", *id)
 		}
 	}
 
@@ -772,9 +786,9 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: Batch pool %q in account %q (Resource Group %q) was not found", id.Name, id.BatchAccountName, id.ResourceGroup)
+			return fmt.Errorf("%s was not found", *id)
 		}
-		return fmt.Errorf("making Read request on AzureRM Batch pool %q: %+v", id.Name, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
 	d.Set("name", id.Name)
@@ -846,12 +860,12 @@ func resourceBatchPoolDelete(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return fmt.Errorf("deleting Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("waiting for deletion of Batch pool %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 		}
 	}
 	return nil
@@ -864,17 +878,17 @@ func expandBatchPoolScaleSettings(d *pluginsdk.ResourceData) (*batch.ScaleSettin
 	fixedScaleValue, fixedScaleOk := d.GetOk("fixed_scale")
 
 	if !autoScaleOk && !fixedScaleOk {
-		return nil, fmt.Errorf("Error: auto_scale block or fixed_scale block need to be specified")
+		return nil, fmt.Errorf("auto_scale block or fixed_scale block need to be specified")
 	}
 
 	if autoScaleOk && fixedScaleOk {
-		return nil, fmt.Errorf("Error: auto_scale and fixed_scale blocks cannot be specified at the same time")
+		return nil, fmt.Errorf("auto_scale and fixed_scale blocks cannot be specified at the same time")
 	}
 
 	if autoScaleOk {
 		autoScale := autoScaleValue.([]interface{})
 		if len(autoScale) == 0 {
-			return nil, fmt.Errorf("Error: when scale mode is Auto, auto_scale block is required")
+			return nil, fmt.Errorf("when scale mode is Auto, auto_scale block is required")
 		}
 
 		autoScaleSettings := autoScale[0].(map[string]interface{})
@@ -889,7 +903,7 @@ func expandBatchPoolScaleSettings(d *pluginsdk.ResourceData) (*batch.ScaleSettin
 	} else if fixedScaleOk {
 		fixedScale := fixedScaleValue.([]interface{})
 		if len(fixedScale) == 0 {
-			return nil, fmt.Errorf("Error: when scale mode is Fixed, fixed_scale block is required")
+			return nil, fmt.Errorf("when scale mode is Fixed, fixed_scale block is required")
 		}
 
 		fixedScaleSettings := fixedScale[0].(map[string]interface{})
@@ -963,7 +977,7 @@ func validateBatchPoolCrossFieldRules(pool *batch.Pool) error {
 					sourceCount++
 				}
 				if sourceCount != 1 {
-					return fmt.Errorf("Exactly one of auto_storage_container_name, storage_container_url and http_url must be specified")
+					return fmt.Errorf("exactly one of auto_storage_container_name, storage_container_url and http_url must be specified")
 				}
 
 				if referenceFile.BlobPrefix != nil {

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -303,6 +303,8 @@ func resourceBatchPool() *pluginsdk.Resource {
 						"max_task_retry_count": {
 							Type:       pluginsdk.TypeInt,
 							Optional:   true,
+							Computed:	true, // Remove in 3.0
+							// Need to default this in the expand function for this block for the deprecation
 							Deprecated: "Deprecated in favour of `task_retry_maximum`",
 							ConflictsWith: []string{
 								"start_task.0.task_retry_maximum",
@@ -312,6 +314,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 						"task_retry_maximum": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
+							Computed: true, // Remove in 3.0
 							ConflictsWith: []string{
 								"start_task.0.max_task_retry_count",
 							},
@@ -327,6 +330,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 						"environment": {
 							Type:     pluginsdk.TypeMap,
 							Optional: true,
+							Computed: true, // Remove in 3.0
 							Elem: &pluginsdk.Schema{
 								Type: pluginsdk.TypeString,
 							},
@@ -339,6 +343,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 						"common_environment_properties": {
 							Type:     pluginsdk.TypeMap,
 							Optional: true,
+							Computed: true, // Remove in 3.0
 							Elem: &pluginsdk.Schema{
 								Type: pluginsdk.TypeString,
 							},
@@ -538,6 +543,17 @@ func resourceBatchPool() *pluginsdk.Resource {
 				},
 			},
 		},
+
+		// TODO: Remove in 3.0
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+			if d.HasChange("start_task.0.max_task_retry_count") || d.HasChange("start_task.0.task_retry_maximum") {
+				_, newMax := d.GetChange("start_task.0.task_retry_maximum")
+				d.SetNew("start_task.0.max_task_retry_count", newMax)
+				d.SetNew("start_task.0.task_retry_maximum", newMax)
+			}
+
+			return nil
+		}),
 	}
 }
 

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -301,9 +301,9 @@ func resourceBatchPool() *pluginsdk.Resource {
 
 						// TODO: Remove in 3.0
 						"max_task_retry_count": {
-							Type:       pluginsdk.TypeInt,
-							Optional:   true,
-							Computed:	true, // Remove in 3.0
+							Type:     pluginsdk.TypeInt,
+							Optional: true,
+							Computed: true, // Remove in 3.0
 							// Need to default this in the expand function for this block for the deprecation
 							Deprecated: "Deprecated in favour of `task_retry_maximum`",
 							ConflictsWith: []string{

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -250,9 +250,12 @@ func TestAccBatchPool_startTask_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("fixed_scale.0.target_low_priority_nodes").HasValue("0"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.max_task_retry_count").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("2"),
-				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
-				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.bu").HasValue("Research&Dev"),
+				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("2"),
+				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
+				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.bu").HasValue("Research&Dev"),
+				check.That(data.ResourceName).Key("start_task.0.environment.%").HasValue("2"),
+				check.That(data.ResourceName).Key("start_task.0.environment.env").HasValue("TEST"),
+				check.That(data.ResourceName).Key("start_task.0.environment.bu").HasValue("Research&Dev"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.0.scope").HasValue("Task"),
@@ -300,7 +303,7 @@ func TestAccBatchPool_validateResourceFileWithoutSource(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.validateResourceFileWithoutSource(data),
-			ExpectError: regexp.MustCompile("Exactly one of auto_storage_container_name, storage_container_url and http_url must be specified"),
+			ExpectError: regexp.MustCompile("exactly one of auto_storage_container_name, storage_container_url and http_url must be specified"),
 		},
 	})
 }
@@ -336,7 +339,7 @@ func TestAccBatchPool_validateResourceFileWithMultipleSources(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.validateResourceFileWithMultipleSources(data),
-			ExpectError: regexp.MustCompile("Exactly one of auto_storage_container_name, storage_container_url and http_url must be specified"),
+			ExpectError: regexp.MustCompile("exactly one of auto_storage_container_name, storage_container_url and http_url must be specified"),
 		},
 	})
 }
@@ -783,7 +786,7 @@ resource "azurerm_batch_pool" "test" {
     task_retry_maximum = 1
     wait_for_success   = true
 
-    common_environment_properties = {
+    environment = {
       env = "TEST"
       bu  = "Research&Dev"
     }
@@ -1148,7 +1151,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  node_agent_sku_id   = "batch.node.ubuntu 20.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -1158,7 +1161,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "microsoft-azure-batch"
     offer     = "ubuntu-server-container"
-    sku       = "16-04-lts"
+    sku       = "20-04-lts"
     version   = "latest"
   }
 

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -31,7 +31,7 @@ func TestAccBatchPool_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("1"),
@@ -70,7 +70,7 @@ func TestAccBatchPool_identityUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("1"),
@@ -93,7 +93,7 @@ func TestAccBatchPool_identityUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("1"),
@@ -117,7 +117,7 @@ func TestAccBatchPool_requiresImport(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("1"),
@@ -145,7 +145,7 @@ func TestAccBatchPool_fixedScale_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
@@ -172,7 +172,7 @@ func TestAccBatchPool_autoScale_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("1"),
@@ -197,7 +197,7 @@ func TestAccBatchPool_completeUpdated(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
@@ -216,7 +216,7 @@ func TestAccBatchPool_completeUpdated(t *testing.T) {
 				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("1"),
@@ -1251,7 +1251,7 @@ resource "azurerm_virtual_machine" "testsource" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -781,7 +781,7 @@ resource "azurerm_batch_pool" "test" {
   start_task {
     command_line       = "echo 'Hello World from $env'"
     wait_for_success   = true
-	task_retry_maximum = 5
+    task_retry_maximum = 5
     common_environment_properties = {
       env = "TEST"
       bu  = "Research&Dev"

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -28,7 +28,7 @@ func TestAccBatchPool_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -67,7 +67,7 @@ func TestAccBatchPool_identityUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -90,7 +90,7 @@ func TestAccBatchPool_identityUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -114,7 +114,7 @@ func TestAccBatchPool_requiresImport(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -142,7 +142,7 @@ func TestAccBatchPool_fixedScale_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
 				check.That(data.ResourceName).Key("max_tasks_per_node").HasValue("2"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -169,7 +169,7 @@ func TestAccBatchPool_autoScale_complete(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -194,7 +194,7 @@ func TestAccBatchPool_completeUpdated(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -213,7 +213,7 @@ func TestAccBatchPool_completeUpdated(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
@@ -238,10 +238,10 @@ func TestAccBatchPool_startTask_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
@@ -250,9 +250,9 @@ func TestAccBatchPool_startTask_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("fixed_scale.0.target_low_priority_nodes").HasValue("0"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.max_task_retry_count").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.environment.%").HasValue("2"),
-				check.That(data.ResourceName).Key("start_task.0.environment.env").HasValue("TEST"),
-				check.That(data.ResourceName).Key("start_task.0.environment.bu").HasValue("Research&Dev"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("2"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.bu").HasValue("Research&Dev"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.0.scope").HasValue("Task"),
@@ -277,7 +277,7 @@ func TestAccBatchPool_certificates(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("certificate.#").HasValue("2"),
 				check.That(data.ResourceName).Key("certificate.0.id").HasValue(certificate0ID),
 				check.That(data.ResourceName).Key("certificate.0.store_location").HasValue("CurrentUser"),
@@ -376,7 +376,7 @@ func TestAccBatchPool_customImage(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
 				check.That(data.ResourceName).Key("max_tasks_per_node").HasValue("2"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("2"),
@@ -399,10 +399,10 @@ func TestAccBatchPool_frontEndPortRanges(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vm_size").HasValue("STANDARD_A1"),
-				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 16.04"),
+				check.That(data.ResourceName).Key("node_agent_sku_id").HasValue("batch.node.ubuntu 18.04"),
 				check.That(data.ResourceName).Key("storage_image_reference.#").HasValue("1"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.publisher").HasValue("Canonical"),
-				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("16.04.0-LTS"),
+				check.That(data.ResourceName).Key("storage_image_reference.0.sku").HasValue("18.04-lts"),
 				check.That(data.ResourceName).Key("storage_image_reference.0.offer").HasValue("UbuntuServer"),
 				check.That(data.ResourceName).Key("auto_scale.#").HasValue("0"),
 				check.That(data.ResourceName).Key("fixed_scale.#").HasValue("1"),
@@ -447,7 +447,7 @@ func (t BatchPoolResource) Exists(ctx context.Context, clients *clients.Client, 
 
 	resp, err := clients.Batch.PoolClient.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Batch Pool %q (Account Name %q / Resource Group %q) does not exist", id.Name, id.BatchAccountName, id.ResourceGroup)
+		return nil, fmt.Errorf("retrieving %s", *id)
 	}
 
 	return utils.Bool(resp.PoolProperties != nil), nil
@@ -491,7 +491,7 @@ resource "azurerm_batch_pool" "test" {
   display_name        = "Test Acc Pool"
   vm_size             = "Standard_A1"
   max_tasks_per_node  = 2
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
 
   fixed_scale {
     target_dedicated_nodes = 2
@@ -500,7 +500,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -549,7 +549,7 @@ resource "azurerm_batch_pool" "test" {
   display_name        = "Test Acc Pool"
   vm_size             = "Standard_A1"
   max_tasks_per_node  = 2
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
 
   fixed_scale {
     target_dedicated_nodes = 3
@@ -558,7 +558,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -606,7 +606,7 @@ resource "azurerm_batch_pool" "test" {
   account_name                  = azurerm_batch_account.test.name
   display_name                  = "Test Acc Pool"
   vm_size                       = "Standard_A1"
-  node_agent_sku_id             = "batch.node.ubuntu 16.04"
+  node_agent_sku_id             = "batch.node.ubuntu 18.04"
   stop_pending_resize_operation = true
 
   auto_scale {
@@ -625,7 +625,7 @@ EOF
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 }
@@ -653,7 +653,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -663,7 +663,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 }
@@ -697,7 +697,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
   identity {
     type         = "UserAssigned"
@@ -711,7 +711,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 }
@@ -736,7 +736,7 @@ resource "azurerm_batch_pool" "import" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 }
@@ -764,7 +764,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -774,16 +774,16 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
   start_task {
-    command_line         = "echo 'Hello World from $env'"
-    max_task_retry_count = 1
-    wait_for_success     = true
+    command_line       = "echo 'Hello World from $env'"
+    task_retry_maximum = 1
+    wait_for_success   = true
 
-    environment = {
+    common_environment_properties = {
       env = "TEST"
       bu  = "Research&Dev"
     }
@@ -825,7 +825,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -835,7 +835,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -887,7 +887,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -897,7 +897,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -949,7 +949,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -959,7 +959,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -1011,7 +1011,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -1021,7 +1021,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -1091,7 +1091,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -1101,7 +1101,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 
@@ -1148,7 +1148,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%s"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_batch_account.test.name
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -1336,7 +1336,7 @@ resource "azurerm_batch_pool" "test" {
   display_name        = "Test Acc Pool"
   vm_size             = "Standard_A1"
   max_tasks_per_node  = 2
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
 
   fixed_scale {
     target_dedicated_nodes = 2
@@ -1389,7 +1389,7 @@ resource "azurerm_batch_pool" "test" {
   name                = "testaccpool%[3]s"
   resource_group_name = "${azurerm_resource_group.test.name}"
   account_name        = "${azurerm_batch_account.test.name}"
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
 
   fixed_scale {
@@ -1399,7 +1399,7 @@ resource "azurerm_batch_pool" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    sku       = "18.04-lts"
     version   = "latest"
   }
 

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -249,13 +249,10 @@ func TestAccBatchPool_startTask_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("fixed_scale.0.resize_timeout").HasValue("PT15M"),
 				check.That(data.ResourceName).Key("fixed_scale.0.target_low_priority_nodes").HasValue("0"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("1"),
-				check.That(data.ResourceName).Key("start_task.0.max_task_retry_count").HasValue("1"),
-				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("2"),
-				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
-				//check.That(data.ResourceName).Key("start_task.0.common_environment_properties.bu").HasValue("Research&Dev"),
-				check.That(data.ResourceName).Key("start_task.0.environment.%").HasValue("2"),
-				check.That(data.ResourceName).Key("start_task.0.environment.env").HasValue("TEST"),
-				check.That(data.ResourceName).Key("start_task.0.environment.bu").HasValue("Research&Dev"),
+				check.That(data.ResourceName).Key("start_task.0.task_retry_maximum").HasValue("5"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.%").HasValue("2"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.env").HasValue("TEST"),
+				check.That(data.ResourceName).Key("start_task.0.common_environment_properties.bu").HasValue("Research&Dev"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.#").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.0.user_identity.0.auto_user.0.scope").HasValue("Task"),
@@ -783,10 +780,9 @@ resource "azurerm_batch_pool" "test" {
 
   start_task {
     command_line       = "echo 'Hello World from $env'"
-    task_retry_maximum = 1
     wait_for_success   = true
-
-    environment = {
+	task_retry_maximum = 5
+    common_environment_properties = {
       env = "TEST"
       bu  = "Research&Dev"
     }

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -75,9 +75,17 @@ A `start_task` block exports the following:
 
 * `max_task_retry_count` - The number of retry count.
 
+-> **Note:** This property has been deprecated in favour of the `task_retry_maximum` property and will be removed in version 3.0 of the provider.
+
+* `task_retry_maximum` - The number of retry count
+
 * `wait_for_success` - A flag that indicates if the Batch pool should wait for the start task to be completed.
 
 * `environment` - A map of strings (key,value) that represents the environment variables to set in the start task.
+
+-> **Note:** This property has been deprecated in favour of the `common_environment_properties` property and will be removed in version 3.0 of the provider.
+
+* `common_environment_properties` - A map of strings (key,value) that represents the environment variables to set in the start task.
 
 * `user_identity` - A `user_identity` block that describes the user identity under which the start task runs.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_batch_pool" "example" {
   account_name        = azurerm_batch_account.example.name
   display_name        = "Test Acc Pool Auto"
   vm_size             = "Standard_A1"
-  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  node_agent_sku_id   = "batch.node.ubuntu 20.04"
 
   auto_scale {
     evaluation_interval = "PT15M"
@@ -72,7 +72,7 @@ EOF
   storage_image_reference {
     publisher = "microsoft-azure-batch"
     offer     = "ubuntu-server-container"
-    sku       = "16-04-lts"
+    sku       = "20-04-lts"
     version   = "latest"
   }
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -86,11 +86,11 @@ EOF
   }
 
   start_task {
-    command_line         = "echo 'Hello World from $env'"
-    max_task_retry_count = 1
-    wait_for_success     = true
+    command_line       = "echo 'Hello World from $env'"
+    task_retry_maximum = 1
+    wait_for_success   = true
 
-    environment = {
+    common_environment_properties = {
       env = "TEST"
     }
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_batch_pool" "example" {
   account_name        = azurerm_batch_account.example.name
   display_name        = "Test Acc Pool Auto"
   vm_size             = "Standard_A1"
-  node_agent_sku_id   = "batch.node.ubuntu 16.04"
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
 
   auto_scale {
     evaluation_interval = "PT15M"
@@ -116,8 +116,6 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Batch pool. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Batch pool. Changing this forces a new resource to be created.
-
-~> **NOTE:** To work around [a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/5574) this property is currently treated as case-insensitive. A future version of Terraform will require that the casing is correct.
 
 * `account_name` - (Required) Specifies the name of the Batch account in which the pool will be created. Changing this forces a new resource to be created.
 
@@ -204,9 +202,17 @@ A `start_task` block supports the following:
 
 * `max_task_retry_count` - (Optional) The number of retry count. Defaults to `1`.
 
+-> **Note:** This property has been deprecated in favour of the `task_retry_maximum` property and will be removed in version 3.0 of the provider.
+
+* `task_retry_maximum` - (Optional) The number of retry count. Defaults to `1`.
+
 * `wait_for_success` - (Optional) A flag that indicates if the Batch pool should wait for the start task to be completed. Default to `false`.
 
 * `environment` - (Optional) A map of strings (key,value) that represents the environment variables to set in the start task.
+
+-> **Note:** This property has been deprecated in favour of the `common_environment_properties` property and will be removed in version 3.0 of the provider.
+
+* `common_environment_properties` - (Optional) A map of strings (key,value) that represents the environment variables to set in the start task.
 
 * `user_identity` - (Required) A `user_identity` block that describes the user identity under which the start task runs.
 


### PR DESCRIPTION
This PR contains the following:
- Deprecates `max_task_retry_count` and `environment`
- Refactor and clean up for id parsers in batch pool resource and data source
- Fix the failing tests for `azurerm_batch_pool` (resource and data source) and `azurerm_batch_job`

![image](https://user-images.githubusercontent.com/25562180/144079818-427b1c1f-137b-4df3-96d3-a23de78c1d8a.png)
