### PR TITLE
`azurerm_web_application_firewall_policy` fix #14322 by change `policy_settings.max_request_body_size_in_kb` length limitation from [8, 128] to [8, 2000]

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -275,7 +275,7 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 						"max_request_body_size_in_kb": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(8, 128),
+							ValidateFunc: validation.IntBetween(8, 2000),
 							Default:      128,
 						},
 					},


### PR DESCRIPTION
According to #14322 `policy_settings.max_request_body_size_in_kb` length limitation should be [8, 2000] now.

Acc tests:

=== RUN   TestAccWebApplicationFirewallPolicy_basic
=== PAUSE TestAccWebApplicationFirewallPolicy_basic
=== CONT  TestAccWebApplicationFirewallPolicy_basic
--- PASS: TestAccWebApplicationFirewallPolicy_basic (345.95s)
=== RUN   TestAccWebApplicationFirewallPolicy_complete
=== PAUSE TestAccWebApplicationFirewallPolicy_complete
=== CONT  TestAccWebApplicationFirewallPolicy_complete
--- PASS: TestAccWebApplicationFirewallPolicy_complete (361.06s)
=== RUN   TestAccWebApplicationFirewallPolicy_update
=== PAUSE TestAccWebApplicationFirewallPolicy_update
=== CONT  TestAccWebApplicationFirewallPolicy_update
--- PASS: TestAccWebApplicationFirewallPolicy_update (481.80s)
PASS
