### PR TITLE
`azurerm_kubernetes_node_pool` remove Computed on `node_taints` and `eviction_policy`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -180,6 +180,8 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				RequiredWith: []string{"enable_node_public_ip"},
 			},
 
+			// Node Taints control the behaviour of the Node Pool, as such they should not be computed and
+			// must be specified/reconciled as required
 			"node_taints": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -108,7 +108,6 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.ScaleSetEvictionPolicyDelete),
 					string(containerservice.ScaleSetEvictionPolicyDeallocate),
@@ -185,7 +184,6 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -683,23 +683,6 @@ func testAccKubernetesClusterNodePool_spot(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t *testing.T) {
-	checkIfShouldRunTestsIndividually(t)
-	testAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t)
-}
-
-func testAccKubernetesClusterNodePool_spot_without_taints_and_eviction_policy(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
-	r := KubernetesClusterNodePoolResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.spotConfigWithoutEvictionPolicyAndTaints(data),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
 	testAccKubernetesClusterNodePool_upgradeSettings(t)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1760,25 +1760,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
 `, r.templateConfig(data))
 }
 
-func (r KubernetesClusterNodePoolResource) spotConfigWithoutEvictionPolicyAndTaints(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_DS2_v2"
-  node_count            = 1
-  priority              = "Spot"
-  spot_max_price        = 0.5 # high, but this is a maximum (we pay less) so ensures this won't fail
-}
-`, r.templateConfig(data))
-}
-
 func (r KubernetesClusterNodePoolResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string) string {
 	template := r.templateConfig(data)
 	if maxSurge != "" {

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -105,8 +105,6 @@ The following arguments are supported:
 
 * `node_taints` - (Optional) A list of Kubernetes taints which should be applied to nodes in the agent pool (e.g `key=value:NoSchedule`). Changing this forces a new resource to be created.
 
-~> **Note:** Node Taints control the behaviour of the Node Pool, as such they must be specified and reconciled as required.
-
 * `orchestrator_version` - (Optional) Version of Kubernetes used for the Agents. If not specified, the latest recommended version will be used at provisioning time (but won't auto-upgrade)
 
 -> **Note:** This version must be supported by the Kubernetes Cluster - as such the version of Kubernetes used on the Cluster/Control Plane may need to be upgraded first.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `eviction_policy` - (Optional) The Eviction Policy which should be used for Virtual Machines within the Virtual Machine Scale Set powering this Node Pool. Possible values are `Deallocate` and `Delete`. Changing this forces a new resource to be created.
 
--> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot`.
+~> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot` and will default to `Delete` unless otherwise specified. 
 
 * `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
 
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
 
-~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
+~> **Note:** FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible Values are `OS`.
 
@@ -104,6 +104,8 @@ The following arguments are supported:
 * `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
 
 * `node_taints` - (Optional) A list of Kubernetes taints which should be applied to nodes in the agent pool (e.g `key=value:NoSchedule`). Changing this forces a new resource to be created.
+
+~> **Note:** Node Taints control the behaviour of the Node Pool, as such they must be specified and reconciled as required.
 
 * `orchestrator_version` - (Optional) Version of Kubernetes used for the Agents. If not specified, the latest recommended version will be used at provisioning time (but won't auto-upgrade)
 


### PR DESCRIPTION
Reverting #14030.

After an internal discussion the conclusion was reached that these two fields should not be set to `Computed`. Since `node_taints` play a pivotal role in how a cluster behaves and functions and the behaviour set by `eviction_policy` has a direct effect on billing and any persistent data used within the cluster, these should be explicitly set and reconciled by the user to avoid any unpleasant surprises and potentially obscure behaviour of the cluster.