### PR TITLE
add local json schema http server

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -129,9 +129,12 @@ teamcity-test:
 	@$(MAKE) -C .teamcity tools
 	@$(MAKE) -C .teamcity test
 
+serve-schema-api:
+	-go run ./internal/tools/schema-api/main.go || true
+
 validate-examples:
 	./scripts/validate-examples.sh
 
 pr-check: generate build test lint tflint website-lint
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck pr-check scaffold-website test-compile website website-test validate-examples
+.PHONY: build build-docker test test-docker testacc vet fmt fmtcheck errcheck scaffold-website test-compile website website-test validate-examples pr-check serve-schema-api

--- a/internal/tools/schema-api/main.go
+++ b/internal/tools/schema-api/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/schema-api/providerjson"
+)
+
+/*
+/docs/v1/data-sources - list of data sources
+/docs/v1/data-sources/{name} - info for a specific data source
+/docs/v1/resources - list of resources
+/docs/v1/resources/{name} - info for a specific resource
+*/
+
+var data providerjson.ProviderData
+
+func main() {
+	data.LoadData()
+
+	mux := http.NewServeMux()
+	// paths
+	mux.HandleFunc(providerjson.DataSourcesList, data.DataSourcesHandler)
+	mux.HandleFunc(providerjson.ResourcesList, data.ListResources)
+
+	mux.HandleFunc(providerjson.DataSourcesPath, data.DataSourcesHandler)
+	mux.HandleFunc(providerjson.ResourcesPath, data.ListResources)
+
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/internal/tools/schema-api/main.go
+++ b/internal/tools/schema-api/main.go
@@ -1,31 +1,51 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/schema-api/providerjson"
 )
 
-/*
-/docs/v1/data-sources - list of data sources
-/docs/v1/data-sources/{name} - info for a specific data source
-/docs/v1/resources - list of resources
-/docs/v1/resources/{name} - info for a specific resource
-*/
-
-var data providerjson.ProviderData
+var port = "8080"
 
 func main() {
-	data.LoadData()
+	data := providerjson.LoadData()
+
+	if userPort := os.Getenv("ARM_API_SERVER_PORT"); userPort != "" {
+		if portInt, err := strconv.Atoi(userPort); err != nil || (portInt < 1024 || portInt > 65534) {
+			if err == nil {
+				log.Fatal(fmt.Sprintf("invalid port specified, need a value between 1025 and 65534, got %q", userPort))
+			} else {
+				log.Fatal(fmt.Sprintf("invalid value for ARM_API_SERVER_PORT: %+v", err))
+			}
+		}
+		port = userPort
+	}
+
+	sig := make(chan os.Signal, 1)
+
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sig
+		log.Printf("%s signal received, closing provider API server on port %s", sig, port)
+		os.Exit(0)
+	}()
 
 	mux := http.NewServeMux()
 	// paths
-	mux.HandleFunc(providerjson.DataSourcesList, data.DataSourcesHandler)
+	mux.HandleFunc(providerjson.DataSourcesList, data.ListDataSources)
 	mux.HandleFunc(providerjson.ResourcesList, data.ListResources)
 
 	mux.HandleFunc(providerjson.DataSourcesPath, data.DataSourcesHandler)
-	mux.HandleFunc(providerjson.ResourcesPath, data.ListResources)
+	mux.HandleFunc(providerjson.ResourcesPath, data.ResourcesHandler)
 
-	log.Fatal(http.ListenAndServe(":8080", mux))
+	log.Printf("starting api service on localhost:%s", port)
+	log.Println(http.ListenAndServe(fmt.Sprintf(":%s", port), mux))
 }

--- a/internal/tools/schema-api/providerjson/handlers.go
+++ b/internal/tools/schema-api/providerjson/handlers.go
@@ -1,0 +1,60 @@
+package providerjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+const (
+	DataSourcesList = "/schema-data/v1/data-sources"  // Lists all data sources in the Provider
+	ResourcesList   = "/schema-data/v1/resources"     // Lists all Resources in the Provider
+	DataSourcesPath = "/schema-data/v1/data-sources/" // Gets all schema data for a data source
+	ResourcesPath   = "/schema-data/v1/resources/"    // Gets all schema data for a Resource
+)
+
+func (p ProviderJSON) DataSourcesHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	dsRaw := strings.Split(req.URL.RequestURI(), DataSourcesPath)
+	ds := strings.Split(dsRaw[1], "/")[0]
+	data, err := resourceFromRaw(p.DataSourcesMap[ds])
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		log.Println(w.Write([]byte(fmt.Sprintf("[{\"error\": \"Could not process schema for %q from provider: %+v\"}]", ds, err))))
+	} else if err := json.NewEncoder(w).Encode(data); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println(w.Write([]byte(fmt.Sprintf("Marshall error: %+v", err))))
+	}
+}
+
+func (p ProviderJSON) ResourcesHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	dsRaw := strings.Split(req.URL.RequestURI(), ResourcesPath)
+	ds := strings.Split(dsRaw[1], "/")[0]
+	data, err := resourceFromRaw(p.ResourcesMap[ds])
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		log.Println(w.Write([]byte(fmt.Sprintf("[{\"error\": \"Could not process schema for %q from provider: %+v\"}]", ds, err))))
+	} else if err := json.NewEncoder(w).Encode(data); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println(w.Write([]byte(fmt.Sprintf("Marshall error: %+v", err))))
+	}
+}
+
+func (p *ProviderJSON) ListResources(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if err := json.NewEncoder(w).Encode(p.Resources()); err != nil {
+		log.Println(w.Write([]byte(fmt.Sprintf("Marshall error: %+v", err))))
+	}
+}
+
+func (p *ProviderJSON) ListDataSources(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if err := json.NewEncoder(w).Encode(p.DataSources()); err != nil {
+		log.Println(w.Write([]byte(fmt.Sprintf("Marshall error: %+v", err))))
+	}
+}

--- a/internal/tools/schema-api/providerjson/helpers.go
+++ b/internal/tools/schema-api/providerjson/helpers.go
@@ -1,0 +1,16 @@
+package providerjson
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func (p *ProviderJSON) DataSources() []terraform.DataSource {
+	s := schema.Provider(*p)
+	return s.DataSources()
+}
+
+func (p *ProviderJSON) Resources() []terraform.ResourceType {
+	s := schema.Provider(*p)
+	return s.Resources()
+}

--- a/internal/tools/schema-api/providerjson/json.go
+++ b/internal/tools/schema-api/providerjson/json.go
@@ -1,0 +1,215 @@
+package providerjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
+)
+
+const (
+	DataSourcesPath = "/schema-data/v1/data-sources/"
+	ResourcesPath   = "/schema-data/v1/resources/"
+	DataSourcesList = "/schema-data/v1/data-sources"
+	ResourcesList   = "/schema-data/v1/resources"
+)
+
+type ProviderData struct {
+	*schema.Provider `json:"provider"`
+}
+
+type Provider schema.Provider
+type Schema schema.Schema
+type Resource schema.Resource
+
+func (p *Provider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Schema        map[string]*schema.Schema   `json:"schema"`
+		ResourceMap   map[string]*schema.Resource `json:"resource_map,omitempty"`
+		DataSourceMap map[string]*schema.Resource `json:"data_source_map,omitempty"`
+	}{
+		Schema:        p.Schema,
+		ResourceMap:   p.ResourcesMap,
+		DataSourceMap: p.DataSourcesMap,
+	})
+}
+
+func (s *Schema) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type          schema.ValueType        `json:"type"`
+		ConfigMode    schema.SchemaConfigMode `json:"config_mode,omitempty"`
+		Optional      bool                    `json:"optional,omitempty"`
+		Required      bool                    `json:"required,omitempty"`
+		Default       interface{}             `json:"default,omitempty"`
+		Description   string                  `json:"description,omitempty"`
+		InputDefault  string                  `json:"-"`
+		Computed      bool                    `json:"computed,omitempty"`
+		ForceNew      bool                    `json:"force_new,omitempty"`
+		Elem          interface{}             `json:"elem,omitempty"`
+		MaxItems      int                     `json:"max_items,omitempty"`
+		MinItems      int                     `json:"min_items,omitempty"`
+		Set           interface{}             `json:"-"`
+		ComputedWhen  []string                `json:"computed_when,omitempty"`
+		ConflictsWith []string                `json:"conflicts_with,omitempty"`
+		ExactlyOneOf  []string                `json:"exactly_one_of,omitempty"`
+		AtLeastOneOf  []string                `json:"at_least_one_of,omitempty"`
+		RequiredWith  []string                `json:"required_with,omitempty"`
+		Deprecated    string                  `json:"deprecated,omitempty"`
+		Sensitive     bool                    `json:"sensitive,omitempty"`
+	}{
+		Type:          s.Type,
+		ConfigMode:    s.ConfigMode,
+		Optional:      s.Optional,
+		Required:      s.Required,
+		Default:       s.Default,
+		Description:   s.Description,
+		Computed:      s.Computed,
+		ForceNew:      s.ForceNew,
+		Elem:          s.Elem,
+		MaxItems:      s.MaxItems,
+		MinItems:      s.MinItems,
+		ComputedWhen:  s.ComputedWhen,
+		ConflictsWith: s.ConflictsWith,
+		ExactlyOneOf:  s.ExactlyOneOf,
+		AtLeastOneOf:  s.AtLeastOneOf,
+		RequiredWith:  s.RequiredWith,
+		Deprecated:    s.Deprecated,
+		Sensitive:     s.Sensitive,
+	})
+}
+
+func (r *Resource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Schema        map[string]*schema.Schema `json:"schema,omitempty"`
+		SchemaVersion int                       `json:"schema_version,omitempty"`
+	}{
+		Schema:        r.Schema,
+		SchemaVersion: r.SchemaVersion,
+	})
+}
+
+type JsonSchema struct {
+	Type          interface{} `json:"type"`
+	ConfigMode    interface{} `json:"config_mode,omitempty"`
+	Optional      bool        `json:"optional,omitempty"`
+	Required      bool        `json:"required,omitempty"`
+	Default       interface{} `json:"default,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	InputDefault  string      `json:"-"`
+	Computed      bool        `json:"computed,omitempty"`
+	ForceNew      bool        `json:"force_new,omitempty"`
+	Elem          interface{} `json:"elem,omitempty"`
+	MaxItems      int         `json:"max_items,omitempty"`
+	MinItems      int         `json:"min_items,omitempty"`
+	Set           interface{} `json:"-"`
+	ComputedWhen  []string    `json:"computed_when,omitempty"`
+	ConflictsWith []string    `json:"conflicts_with,omitempty"`
+	ExactlyOneOf  []string    `json:"exactly_one_of,omitempty"`
+	AtLeastOneOf  []string    `json:"at_least_one_of,omitempty"`
+	RequiredWith  []string    `json:"required_with,omitempty"`
+	Deprecated    string      `json:"deprecated,omitempty"`
+	Sensitive     bool        `json:"sensitive,omitempty"`
+}
+
+type ResourceData struct {
+	Schema        map[string]JsonSchema `json:"schema,omitempty"`
+	SchemaVersion int                   `json:"schema_version,omitempty"`
+	//MigrateState         interface{}        `json:"-"`
+	//StateUpgraders       interface{}        `json:"-"`
+	//Create               interface{}        `json:"-"`
+	//Read                 interface{}        `json:"-"`
+	//Update               interface{}        `json:"-"`
+	//Delete               interface{}        `json:"-"`
+	//Exists               interface{}        `json:"-"`
+	//CreateContext        interface{}        `json:"-"`
+	//ReadContext          interface{}        `json:"-"`
+	//UpdateContext        interface{}        `json:"-"`
+	//DeleteContext        interface{}        `json:"-"`
+	//CreateWithoutTimeout interface{}        `json:"-"`
+	//ReadWithoutTimeout   interface{}        `json:"-"`
+	//UpdateWithoutTimeout interface{}        `json:"-"`
+	//DeleteWithoutTimeout interface{}        `json:"-"`
+	// CustomizeDiff        interface{}        `json:"-"`
+}
+
+func ResourceCopy(input *schema.Resource) (r ResourceData) {
+	if input == nil {
+		return r
+	}
+	r.Schema = schemaCopy(input.Schema)
+	r.SchemaVersion = input.SchemaVersion
+
+	return r
+}
+
+func schemaCopy(input map[string]*schema.Schema) map[string]JsonSchema {
+	s := make(map[string]JsonSchema, 0)
+	for k, p := range input {
+		v := *p
+		s[k] = JsonSchema{
+			Type:          v.Type,
+			ConfigMode:    v.ConfigMode,
+			Optional:      v.Optional,
+			Required:      v.Required,
+			Default:       v.Default,
+			Description:   v.Description,
+			InputDefault:  v.InputDefault,
+			Computed:      v.Computed,
+			ForceNew:      v.ForceNew,
+			Elem:          v.Elem,
+			MaxItems:      v.MaxItems,
+			MinItems:      v.MinItems,
+			Set:           v.Set,
+			ComputedWhen:  v.ComputedWhen,
+			ConflictsWith: v.ConflictsWith,
+			ExactlyOneOf:  v.ExactlyOneOf,
+			AtLeastOneOf:  v.AtLeastOneOf,
+			RequiredWith:  v.RequiredWith,
+			Deprecated:    v.Deprecated,
+			Sensitive:     v.Sensitive,
+		}
+	}
+
+	return s
+}
+
+func (p *ProviderData) LoadData() {
+	p.Provider = provider.AzureProvider()
+}
+
+func (p *ProviderData) DataSourcesHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	if path := req.URL; path != nil {
+		if strings.EqualFold(path.RequestURI(), DataSourcesList) {
+			if err := json.NewEncoder(w).Encode(p.Provider.DataSources()); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf("Failed to process provider data: %+v", err)))
+			}
+		} else {
+			dsRaw := strings.Split(path.RequestURI(), DataSourcesPath)
+			ds := strings.Split(dsRaw[1], "/")[0]
+			if len(ds) > 0 {
+				dsResource := ResourceCopy(p.Provider.DataSourcesMap[ds])
+				if err := json.NewEncoder(w).Encode(dsResource); err != nil {
+					w.Write([]byte(fmt.Sprintf("Failed to process provider data for data source %q: %+v", ds, err)))
+				}
+			}
+
+		}
+	}
+}
+
+func (p *ProviderData) ListResources(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if err := json.NewEncoder(w).Encode(p.Provider.Resources()); err != nil {
+		panic(err)
+	}
+}
+
+func (p *Provider) ShowResource(w http.ResponseWriter, _ *http.Request) {
+
+}

--- a/internal/tools/schema-api/providerjson/json.go
+++ b/internal/tools/schema-api/providerjson/json.go
@@ -1,215 +1,39 @@
 package providerjson
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
 )
 
-const (
-	DataSourcesPath = "/schema-data/v1/data-sources/"
-	ResourcesPath   = "/schema-data/v1/resources/"
-	DataSourcesList = "/schema-data/v1/data-sources"
-	ResourcesList   = "/schema-data/v1/resources"
-)
+type ProviderJSON schema.Provider
 
-type ProviderData struct {
-	*schema.Provider `json:"provider"`
+type SchemaJSON struct {
+	Type        string      `json:"type,omitempty"`
+	ConfigMode  string      `json:"config_mode,omitempty"`
+	Optional    bool        `json:"optional,omitempty"`
+	Required    bool        `json:"required,omitempty"`
+	Default     interface{} `json:"default,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Computed    bool        `json:"computed,omitempty"`
+	ForceNew    bool        `json:"force_new,omitempty"`
+	Elem        interface{} `json:"elem,omitempty"`
+	MaxItems    int         `json:"max_items,omitempty"`
+	MinItems    int         `json:"min_items,omitempty"`
 }
 
-type Provider schema.Provider
-type Schema schema.Schema
-type Resource schema.Resource
-
-func (p *Provider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Schema        map[string]*schema.Schema   `json:"schema"`
-		ResourceMap   map[string]*schema.Resource `json:"resource_map,omitempty"`
-		DataSourceMap map[string]*schema.Resource `json:"data_source_map,omitempty"`
-	}{
-		Schema:        p.Schema,
-		ResourceMap:   p.ResourcesMap,
-		DataSourceMap: p.DataSourcesMap,
-	})
+type ResourceJSON struct {
+	Schema   map[string]SchemaJSON `json:"schema"`
+	Timeouts *ResourceTimeoutJSON  `json:"timeouts,omitempty"`
 }
 
-func (s *Schema) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Type          schema.ValueType        `json:"type"`
-		ConfigMode    schema.SchemaConfigMode `json:"config_mode,omitempty"`
-		Optional      bool                    `json:"optional,omitempty"`
-		Required      bool                    `json:"required,omitempty"`
-		Default       interface{}             `json:"default,omitempty"`
-		Description   string                  `json:"description,omitempty"`
-		InputDefault  string                  `json:"-"`
-		Computed      bool                    `json:"computed,omitempty"`
-		ForceNew      bool                    `json:"force_new,omitempty"`
-		Elem          interface{}             `json:"elem,omitempty"`
-		MaxItems      int                     `json:"max_items,omitempty"`
-		MinItems      int                     `json:"min_items,omitempty"`
-		Set           interface{}             `json:"-"`
-		ComputedWhen  []string                `json:"computed_when,omitempty"`
-		ConflictsWith []string                `json:"conflicts_with,omitempty"`
-		ExactlyOneOf  []string                `json:"exactly_one_of,omitempty"`
-		AtLeastOneOf  []string                `json:"at_least_one_of,omitempty"`
-		RequiredWith  []string                `json:"required_with,omitempty"`
-		Deprecated    string                  `json:"deprecated,omitempty"`
-		Sensitive     bool                    `json:"sensitive,omitempty"`
-	}{
-		Type:          s.Type,
-		ConfigMode:    s.ConfigMode,
-		Optional:      s.Optional,
-		Required:      s.Required,
-		Default:       s.Default,
-		Description:   s.Description,
-		Computed:      s.Computed,
-		ForceNew:      s.ForceNew,
-		Elem:          s.Elem,
-		MaxItems:      s.MaxItems,
-		MinItems:      s.MinItems,
-		ComputedWhen:  s.ComputedWhen,
-		ConflictsWith: s.ConflictsWith,
-		ExactlyOneOf:  s.ExactlyOneOf,
-		AtLeastOneOf:  s.AtLeastOneOf,
-		RequiredWith:  s.RequiredWith,
-		Deprecated:    s.Deprecated,
-		Sensitive:     s.Sensitive,
-	})
+type ResourceTimeoutJSON struct {
+	Create int `json:"create,omitempty"`
+	Read   int `json:"read,omitempty"`
+	Delete int `json:"delete,omitempty"`
+	Update int `json:"update,omitempty"`
 }
 
-func (r *Resource) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Schema        map[string]*schema.Schema `json:"schema,omitempty"`
-		SchemaVersion int                       `json:"schema_version,omitempty"`
-	}{
-		Schema:        r.Schema,
-		SchemaVersion: r.SchemaVersion,
-	})
-}
-
-type JsonSchema struct {
-	Type          interface{} `json:"type"`
-	ConfigMode    interface{} `json:"config_mode,omitempty"`
-	Optional      bool        `json:"optional,omitempty"`
-	Required      bool        `json:"required,omitempty"`
-	Default       interface{} `json:"default,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	InputDefault  string      `json:"-"`
-	Computed      bool        `json:"computed,omitempty"`
-	ForceNew      bool        `json:"force_new,omitempty"`
-	Elem          interface{} `json:"elem,omitempty"`
-	MaxItems      int         `json:"max_items,omitempty"`
-	MinItems      int         `json:"min_items,omitempty"`
-	Set           interface{} `json:"-"`
-	ComputedWhen  []string    `json:"computed_when,omitempty"`
-	ConflictsWith []string    `json:"conflicts_with,omitempty"`
-	ExactlyOneOf  []string    `json:"exactly_one_of,omitempty"`
-	AtLeastOneOf  []string    `json:"at_least_one_of,omitempty"`
-	RequiredWith  []string    `json:"required_with,omitempty"`
-	Deprecated    string      `json:"deprecated,omitempty"`
-	Sensitive     bool        `json:"sensitive,omitempty"`
-}
-
-type ResourceData struct {
-	Schema        map[string]JsonSchema `json:"schema,omitempty"`
-	SchemaVersion int                   `json:"schema_version,omitempty"`
-	//MigrateState         interface{}        `json:"-"`
-	//StateUpgraders       interface{}        `json:"-"`
-	//Create               interface{}        `json:"-"`
-	//Read                 interface{}        `json:"-"`
-	//Update               interface{}        `json:"-"`
-	//Delete               interface{}        `json:"-"`
-	//Exists               interface{}        `json:"-"`
-	//CreateContext        interface{}        `json:"-"`
-	//ReadContext          interface{}        `json:"-"`
-	//UpdateContext        interface{}        `json:"-"`
-	//DeleteContext        interface{}        `json:"-"`
-	//CreateWithoutTimeout interface{}        `json:"-"`
-	//ReadWithoutTimeout   interface{}        `json:"-"`
-	//UpdateWithoutTimeout interface{}        `json:"-"`
-	//DeleteWithoutTimeout interface{}        `json:"-"`
-	// CustomizeDiff        interface{}        `json:"-"`
-}
-
-func ResourceCopy(input *schema.Resource) (r ResourceData) {
-	if input == nil {
-		return r
-	}
-	r.Schema = schemaCopy(input.Schema)
-	r.SchemaVersion = input.SchemaVersion
-
-	return r
-}
-
-func schemaCopy(input map[string]*schema.Schema) map[string]JsonSchema {
-	s := make(map[string]JsonSchema, 0)
-	for k, p := range input {
-		v := *p
-		s[k] = JsonSchema{
-			Type:          v.Type,
-			ConfigMode:    v.ConfigMode,
-			Optional:      v.Optional,
-			Required:      v.Required,
-			Default:       v.Default,
-			Description:   v.Description,
-			InputDefault:  v.InputDefault,
-			Computed:      v.Computed,
-			ForceNew:      v.ForceNew,
-			Elem:          v.Elem,
-			MaxItems:      v.MaxItems,
-			MinItems:      v.MinItems,
-			Set:           v.Set,
-			ComputedWhen:  v.ComputedWhen,
-			ConflictsWith: v.ConflictsWith,
-			ExactlyOneOf:  v.ExactlyOneOf,
-			AtLeastOneOf:  v.AtLeastOneOf,
-			RequiredWith:  v.RequiredWith,
-			Deprecated:    v.Deprecated,
-			Sensitive:     v.Sensitive,
-		}
-	}
-
-	return s
-}
-
-func (p *ProviderData) LoadData() {
-	p.Provider = provider.AzureProvider()
-}
-
-func (p *ProviderData) DataSourcesHandler(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-
-	if path := req.URL; path != nil {
-		if strings.EqualFold(path.RequestURI(), DataSourcesList) {
-			if err := json.NewEncoder(w).Encode(p.Provider.DataSources()); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("Failed to process provider data: %+v", err)))
-			}
-		} else {
-			dsRaw := strings.Split(path.RequestURI(), DataSourcesPath)
-			ds := strings.Split(dsRaw[1], "/")[0]
-			if len(ds) > 0 {
-				dsResource := ResourceCopy(p.Provider.DataSourcesMap[ds])
-				if err := json.NewEncoder(w).Encode(dsResource); err != nil {
-					w.Write([]byte(fmt.Sprintf("Failed to process provider data for data source %q: %+v", ds, err)))
-				}
-			}
-
-		}
-	}
-}
-
-func (p *ProviderData) ListResources(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	if err := json.NewEncoder(w).Encode(p.Provider.Resources()); err != nil {
-		panic(err)
-	}
-}
-
-func (p *Provider) ShowResource(w http.ResponseWriter, _ *http.Request) {
-
+func LoadData() *ProviderJSON {
+	p := provider.AzureProvider()
+	return (*ProviderJSON)(p)
 }

--- a/internal/tools/schema-api/providerjson/transform.go
+++ b/internal/tools/schema-api/providerjson/transform.go
@@ -20,11 +20,20 @@ func resourceFromRaw(input *schema.Resource) (*ResourceJSON, error) {
 	result.Schema = translatedSchema
 
 	if input.Timeouts != nil {
-		timeouts := &ResourceTimeoutJSON{
-			Create: int(input.Timeouts.Create.Minutes()),
-			Read:   int(input.Timeouts.Read.Minutes()),
-			Delete: int(input.Timeouts.Delete.Minutes()),
-			Update: int(input.Timeouts.Update.Minutes()),
+		timeouts := &ResourceTimeoutJSON{}
+		if t := input.Timeouts; t != nil {
+			if t.Create != nil {
+				timeouts.Create = int(t.Create.Minutes())
+			}
+			if t.Read != nil {
+				timeouts.Read = int(t.Read.Minutes())
+			}
+			if t.Delete != nil {
+				timeouts.Delete = int(t.Delete.Minutes())
+			}
+			if t.Update != nil {
+				timeouts.Update = int(t.Update.Minutes())
+			}
 		}
 		result.Timeouts = timeouts
 	}

--- a/internal/tools/schema-api/providerjson/transform.go
+++ b/internal/tools/schema-api/providerjson/transform.go
@@ -1,0 +1,81 @@
+package providerjson
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceFromRaw(input *schema.Resource) (*ResourceJSON, error) {
+	if input == nil {
+		return nil, fmt.Errorf("resource not found")
+	}
+
+	result := &ResourceJSON{}
+	translatedSchema := make(map[string]SchemaJSON)
+
+	for k, s := range input.Schema {
+		translatedSchema[k] = schemaFromRaw(s)
+	}
+	result.Schema = translatedSchema
+
+	if input.Timeouts != nil {
+		timeouts := &ResourceTimeoutJSON{
+			Create: int(input.Timeouts.Create.Minutes()),
+			Read:   int(input.Timeouts.Read.Minutes()),
+			Delete: int(input.Timeouts.Delete.Minutes()),
+			Update: int(input.Timeouts.Update.Minutes()),
+		}
+		result.Timeouts = timeouts
+	}
+
+	return result, nil
+}
+
+func schemaFromRaw(input *schema.Schema) SchemaJSON {
+
+	return SchemaJSON{
+		Type:        input.Type.String(),
+		ConfigMode:  decodeConfigMode(input.ConfigMode),
+		Optional:    input.Optional,
+		Required:    input.Required,
+		Default:     input.Default,
+		Description: input.Description,
+		Computed:    input.Computed,
+		ForceNew:    input.ForceNew,
+		Elem:        decodeElem(input.Elem),
+		MaxItems:    input.MaxItems,
+		MinItems:    input.MinItems,
+	}
+}
+
+func decodeConfigMode(input schema.SchemaConfigMode) (out string) {
+	switch input {
+	case 1:
+		out = "Auto"
+	case 2:
+		out = "Block"
+	case 4:
+		out = "Attribute"
+	}
+	return
+}
+
+func decodeElem(input interface{}) interface{} {
+	switch t := input.(type) {
+	case bool:
+		return t
+	case string:
+		return t
+	case int:
+		return t
+	case float32, float64:
+		return t
+	case *schema.Schema:
+		return schemaFromRaw(t)
+	case *schema.Resource:
+		r, _ := resourceFromRaw(t)
+		return r
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a simple HTTP server via `make serve-schema-api` that exposes the resources and data sources available. This is initially intended to form a base for document generation, but may have other applications in future. 

By default port `8080` is used, however, as this is a commonly used ad-hoc port, it can be changed by setting the env var `ARM_API_SERVER_PORT` to a value between 1025 and 65534, for example: 
```shell
ARM_API_SERVER_PORT=8081 make serve-schema-api
```

Note: Document generation will be based on the Schema defined in the resource or data source code, meaning that the `Description` property needs to be populated.

Examples: 
## Resources list
```shell
curl -s localhost:8081/schema-data/v1/resources | jq
[
  {
    "Name": "azurerm_active_directory_domain_service",
    "Importable": true,
    "SchemaAvailable": true
  },
  {
    "Name": "azurerm_active_directory_domain_service_replica_set",
    "Importable": true,
    "SchemaAvailable": true
  },
  {
    "Name": "azurerm_advanced_threat_protection",
    "Importable": true,
    "SchemaAvailable": true
  },
  {
    "Name": "azurerm_analysis_services_server",
    "Importable": true,
    "SchemaAvailable": true
  },
  {
    "Name": "azurerm_api_management",
    "Importable": true,
    "SchemaAvailable": true
  },

...
```

## Resource detail
```shell
curl -s localhost:8081/schema-data/v1/resources/azurerm_subscription | jq
{
  "schema": {
    "alias": {
      "type": "TypeString",
      "optional": true,
      "description": "The Alias Name of the subscription. If omitted a new UUID will be generated for this property.",
      "computed": true,
      "force_new": true
    },
    "billing_scope_id": {
      "type": "TypeString",
      "optional": true
    },
    "subscription_id": {
      "type": "TypeString",
      "optional": true,
      "description": "The GUID of the Subscription.",
      "computed": true,
      "force_new": true
    },
    "subscription_name": {
      "type": "TypeString",
      "required": true,
      "description": "The Display Name for the Subscription."
    },
    "tags": {
      "type": "TypeMap",
      "computed": true,
      "elem": {
        "type": "TypeString"
      }
    },
    "tenant_id": {
      "type": "TypeString",
      "description": "The Tenant ID to which the subscription belongs",
      "computed": true
    },
    "workload": {
      "type": "TypeString",
      "optional": true,
      "description": "The workload type for the Subscription. Possible values are `Production` (default) and `DevTest`.",
      "force_new": true
    }
  },
  "timeouts": {
    "create": 30,
    "read": 5,
    "delete": 30,
    "update": 30
  }
}
```

The following endpoints are made available:
`/schema-data/v1/data-sources`  - Lists all data sources in the Provider
`/schema-data/v1/resources` - Lists all Resources in the Provider
`/schema-data/v1/data-sources/{data_source_name}` - Gets all schema data for a data source
`/schema-data/v1/resources/{resource_name}` - Gets all schema data for a Resource

```