### PR TITLE
`azurerm_data_fatory_trigger_schedule` - Fix `schedule` for `frequency = "Month/Week"`

### DIFF
--- a/internal/services/datafactory/data_factory_trigger_schedule_resource.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource.go
@@ -138,6 +138,8 @@ func resourceDataFactoryTriggerSchedule() *pluginsdk.Resource {
 			},
 
 			// This time can only be  represented in UTC.
+			// An issue has been filed in the SDK for the timezone attribute that doesn't seem to work
+			// https://github.com/Azure/azure-sdk-for-go/issues/6244
 			"start_time": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,
@@ -147,6 +149,8 @@ func resourceDataFactoryTriggerSchedule() *pluginsdk.Resource {
 			},
 
 			// This time can only be  represented in UTC.
+			// An issue has been filed in the SDK for the timezone attribute that doesn't seem to work
+			// https://github.com/Azure/azure-sdk-for-go/issues/6244
 			"end_time": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,

--- a/internal/services/datafactory/data_factory_trigger_schedule_resource.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource.go
@@ -244,7 +244,8 @@ func resourceDataFactoryTriggerScheduleCreateUpdate(d *pluginsdk.ResourceData, m
 		t, _ := time.Parse(time.RFC3339, v.(string)) // should be validated by the schema
 		props.Recurrence.StartTime = &date.Time{Time: t}
 	} else {
-		props.Recurrence.StartTime = &date.Time{Time: time.Now()}
+		t, _ := time.Parse(time.RFC3339, time.Now().UTC().Format(time.RFC3339))
+		props.Recurrence.StartTime = &date.Time{Time: t}
 	}
 
 	if v, ok := d.GetOk("end_time"); ok {

--- a/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
@@ -53,13 +53,28 @@ func TestAccDataFactoryTriggerSchedule_complete(t *testing.T) {
 	})
 }
 
-func TestAccDataFactoryTriggerSchedule_schedule(t *testing.T) {
+func TestAccDataFactoryTriggerSchedule_scheduleWeekly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_trigger_schedule", "test")
 	r := TriggerScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.schedule(data),
+			Config: r.scheduleWeekly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactoryTriggerSchedule_scheduleMonthly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_trigger_schedule", "test")
+	r := TriggerScheduleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scheduleMonthly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -167,7 +182,7 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (TriggerScheduleResource) schedule(data acceptance.TestData) string {
+func (TriggerScheduleResource) scheduleWeekly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -201,12 +216,64 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
   pipeline_name       = azurerm_data_factory_pipeline.test.name
 
   annotations = ["test1", "test2", "test3"]
+  activated   = true
+  frequency   = "Week"
+  end_time    = "2022-09-22T00:00:00Z"
+  start_time  = "2022-09-21T00:00:00Z"
 
   schedule {
+    minutes      = [0, 30, 59]
+    hours        = [0, 12, 23]
+    days_of_week = ["Monday", "Tuesday"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (TriggerScheduleResource) scheduleMonthly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name                = "acctest%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+
+  parameters = {
+    test = "testparameter"
+  }
+}
+
+resource "azurerm_data_factory_trigger_schedule" "test" {
+  name                = "acctestdf%d"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  pipeline_name       = azurerm_data_factory_pipeline.test.name
+
+  annotations = ["test1", "test2", "test3"]
+  frequency   = "Month"
+  interval    = 1
+  activated   = true
+  end_time    = "2022-09-22T00:00:00Z"
+  start_time  = "2022-09-21T00:00:00Z"
+
+  schedule {
+    hours         = [0, 12, 23]
+    minutes       = [0, 30, 59]
     days_of_month = [1, 2, 3]
-    days_of_week  = ["Monday", "Tuesday"]
-    hours         = [0, 12, 24]
-    minutes       = [0, 30, 60]
     monthly {
       weekday = "Monday"
       week    = 1

--- a/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
+++ b/internal/services/datafactory/data_factory_trigger_schedule_resource_test.go
@@ -218,8 +218,6 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
   annotations = ["test1", "test2", "test3"]
   activated   = true
   frequency   = "Week"
-  end_time    = "2022-09-22T00:00:00Z"
-  start_time  = "2022-09-21T00:00:00Z"
 
   schedule {
     minutes      = [0, 30, 59]
@@ -267,8 +265,6 @@ resource "azurerm_data_factory_trigger_schedule" "test" {
   frequency   = "Month"
   interval    = 1
   activated   = true
-  end_time    = "2022-09-22T00:00:00Z"
-  start_time  = "2022-09-21T00:00:00Z"
 
   schedule {
     hours         = [0, 12, 23]


### PR DESCRIPTION
Fixes #14384

## Acceptance tests
- [x] Passing
![Screenshot 2021-11-30 at 11 39 08](https://user-images.githubusercontent.com/8375124/144032172-fa8c5dba-61ce-4156-8d8e-b88b45cf8706.png)

## Extra
- [x] Fix for `start_time`, the fallback when `start_time` was empty produced an invalid time value