### PR TITLE
`r/azurerm_app_service`: Add support for `client_cert_mode` parameter

### DIFF
--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -77,10 +77,9 @@ func resourceAppService() *pluginsdk.Resource {
 			},
 
 			"client_cert_enabled": {
-				Type:         pluginsdk.TypeBool,
-				Optional:     true,
-				Default:      false,
-				RequiredWith: []string{"client_cert_mode"},
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 
 			"client_cert_mode": {

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -86,6 +86,7 @@ func resourceAppService() *pluginsdk.Resource {
 			"client_cert_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(web.ClientCertModeOptional),
 					string(web.ClientCertModeRequired),

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -77,9 +77,20 @@ func resourceAppService() *pluginsdk.Resource {
 			},
 
 			"client_cert_enabled": {
-				Type:     pluginsdk.TypeBool,
+				Type:         pluginsdk.TypeBool,
+				Optional:     true,
+				Default:      false,
+				RequiredWith: []string{"client_cert_mode"},
+			},
+
+			"client_cert_mode": {
+				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  false,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(web.ClientCertModeOptional),
+					string(web.ClientCertModeRequired),
+					string(web.ClientCertModeOptionalInteractiveUser),
+				}, false),
 			},
 
 			"connection_string": {
@@ -295,6 +306,11 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(d.Get("client_affinity_enabled").(bool))
 
 	siteEnvelope.SiteProperties.ClientCertEnabled = utils.Bool(d.Get("client_cert_enabled").(bool))
+	if *siteEnvelope.SiteProperties.ClientCertEnabled {
+		if clientCertMode, ok := d.GetOk("client_cert_mode"); ok {
+			siteEnvelope.SiteProperties.ClientCertMode = web.ClientCertMode(clientCertMode.(string))
+		}
+	}
 
 	createFuture, err := client.CreateOrUpdate(ctx, resourceGroup, name, siteEnvelope)
 	if err != nil {
@@ -415,6 +431,12 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 
 	siteEnvelope.SiteProperties.ClientCertEnabled = utils.Bool(d.Get("client_cert_enabled").(bool))
+
+	if *siteEnvelope.SiteProperties.ClientCertEnabled {
+		if clientCertMode, ok := d.GetOk("client_cert_mode"); ok {
+			siteEnvelope.SiteProperties.ClientCertMode = web.ClientCertMode(clientCertMode.(string))
+		}
+	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
 	if err != nil {
@@ -690,6 +712,7 @@ func resourceAppServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("enabled", props.Enabled)
 		d.Set("https_only", props.HTTPSOnly)
 		d.Set("client_cert_enabled", props.ClientCertEnabled)
+		d.Set("client_cert_mode", props.ClientCertMode)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		if props.OutboundIPAddresses != nil {

--- a/internal/services/web/app_service_resource_test.go
+++ b/internal/services/web/app_service_resource_test.go
@@ -250,6 +250,23 @@ func TestAccAppService_clientCertEnabled(t *testing.T) {
 	})
 }
 
+func TestAccAppService_clientCertEnabledWithMode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	r := AppServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.clientCertEnabledWithMode(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Optional"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppService_appSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
@@ -2252,6 +2269,39 @@ resource "azurerm_app_service" "test" {
   resource_group_name = azurerm_resource_group.test.name
   app_service_plan_id = azurerm_app_service_plan.test.id
   client_cert_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r AppServiceResource) clientCertEnabledWithMode(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  client_cert_enabled = true
+  client_cert_mode    = "Optional"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `client_cert_enabled` - (Optional) Does the App Service require client certificates for incoming requests? Defaults to `false`.
 
-* `client_cert_mode` - (Optional) Mode of client certificates for this App Service. Possible values are `Requred`, `Optional` and `OptionalInteractiveUser`. If this parameter is set, `client_cert_enabled` must be set to `true`, otherwise this parameter is ignored.
+* `client_cert_mode` - (Optional) Mode of client certificates for this App Service. Possible values are `Required`, `Optional` and `OptionalInteractiveUser`. If this parameter is set, `client_cert_enabled` must be set to `true`, otherwise this parameter is ignored.
 
 * `enabled` - (Optional) Is the App Service Enabled?
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -81,6 +81,8 @@ The following arguments are supported:
 
 * `client_cert_enabled` - (Optional) Does the App Service require client certificates for incoming requests? Defaults to `false`.
 
+* `client_cert_mode` - (Optional) Mode of client certificates for this App Service. Possible values are `Requred`, `Optional` and `OptionalInteractiveUser`. If this parameter is set, `client_cert_enabled` must be set to `true`, otherwise this parameter is ignored.
+
 * `enabled` - (Optional) Is the App Service Enabled?
 
 * `identity` - (Optional) An `identity` block as defined below.


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./internal/services/web -timeout=1000m -run='TestAccAppService_clientCertEnabledWithMode'
=== RUN   TestAccAppService_clientCertEnabledWithMode
=== PAUSE TestAccAppService_clientCertEnabledWithMode
=== CONT  TestAccAppService_clientCertEnabledWithMode
--- PASS: TestAccAppService_clientCertEnabledWithMode (213.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/web	215.565s
```

Fixes #14393