### PR TITLE
New Resource: `azurerm_consumption_budget_management_group`

### DIFF
--- a/internal/services/consumption/consumption_budget_common.go
+++ b/internal/services/consumption/consumption_budget_common.go
@@ -12,7 +12,10 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func resourceArmConsumptionBudgetRead(d *pluginsdk.ResourceData, meta interface{}, scope, name string) error {
+type schemaNotificationElementFunc func() *pluginsdk.Resource
+type flattenNotificationElementFunc func(input map[string]*consumption.Notification) []interface{}
+
+func resourceArmConsumptionBudgetRead(d *pluginsdk.ResourceData, meta interface{}, scope, name string, schemaFunc schemaNotificationElementFunc, flattenFunc flattenNotificationElementFunc) error {
 	client := meta.(*clients.Client).Consumption.BudgetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -34,7 +37,7 @@ func resourceArmConsumptionBudgetRead(d *pluginsdk.ResourceData, meta interface{
 	d.Set("etag", resp.ETag)
 	d.Set("time_grain", string(resp.TimeGrain))
 	d.Set("time_period", FlattenConsumptionBudgetTimePeriod(resp.TimePeriod))
-	d.Set("notification", pluginsdk.NewSet(pluginsdk.HashResource(SchemaConsumptionBudgetNotificationElement()), FlattenConsumptionBudgetNotifications(resp.Notifications)))
+	d.Set("notification", pluginsdk.NewSet(pluginsdk.HashResource(schemaFunc()), flattenFunc(resp.Notifications)))
 	d.Set("filter", FlattenConsumptionBudgetFilter(resp.Filter))
 
 	return nil

--- a/internal/services/consumption/consumption_budget_management_group_resource.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource.go
@@ -33,10 +33,13 @@ func resourceArmConsumptionBudgetManagementGroup() *pluginsdk.Resource {
 }
 
 func resourceArmConsumptionBudgetManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	managementGroupId := managementGroupParse.NewManagementGroupId(d.Get("management_group_name").(string))
+	managementGroupId, err := managementGroupParse.ManagementGroupID(d.Get("management_group_id").(string))
+	if err != nil {
+		return err
+	}
 	id := parse.NewConsumptionBudgetManagementGroupID(managementGroupId.Name, d.Get("name").(string))
 
-	err := resourceArmConsumptionBudgetCreateUpdate(d, meta, consumptionBudgetManagementGroupName, managementGroupId.ID())
+	err = resourceArmConsumptionBudgetCreateUpdate(d, meta, consumptionBudgetManagementGroupName, managementGroupId.ID())
 	if err != nil {
 		return err
 	}
@@ -59,7 +62,7 @@ func resourceArmConsumptionBudgetManagementGroupRead(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	d.Set("management_group_name", consumptionBudgetId.ManagementGroupName)
+	d.Set("management_group_id", managementGroupId.ID())
 
 	return nil
 }

--- a/internal/services/consumption/consumption_budget_management_group_resource.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource.go
@@ -1,0 +1,101 @@
+package consumption
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/parse"
+	managementGroupParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceArmConsumptionBudgetManagementGroup() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceArmConsumptionBudgetManagementGroupCreateUpdate,
+		Read:   resourceArmConsumptionBudgetManagementGroupRead,
+		Update: resourceArmConsumptionBudgetManagementGroupCreateUpdate,
+		Delete: resourceArmConsumptionBudgetManagementGroupDelete,
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ConsumptionBudgetManagementGroupID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: SchemaConsumptionBudgetManagementGroupResource(),
+	}
+}
+
+func resourceArmConsumptionBudgetManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	managementGroupId := managementGroupParse.NewManagementGroupId(d.Get("management_group_name").(string))
+	id := parse.NewConsumptionBudgetManagementGroupID(managementGroupId.Name, d.Get("name").(string))
+
+	err := resourceArmConsumptionBudgetCreateUpdate(d, meta, consumptionBudgetManagementGroupName, managementGroupId.ID())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
+
+	return resourceArmConsumptionBudgetManagementGroupRead(d, meta)
+}
+
+func resourceArmConsumptionBudgetManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	consumptionBudgetId, err := parse.ConsumptionBudgetManagementGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	managementGroupId := managementGroupParse.NewManagementGroupId(consumptionBudgetId.ManagementGroupName)
+
+	err = resourceArmConsumptionBudgetRead(d, meta, managementGroupId.ID(), consumptionBudgetId.BudgetName, SchemaConsumptionBudgetNotificationManagementGroupElement, flattenConsumptionBudgetManagementGroupNotifications)
+	if err != nil {
+		return err
+	}
+
+	d.Set("management_group_name", consumptionBudgetId.ManagementGroupName)
+
+	return nil
+}
+
+func resourceArmConsumptionBudgetManagementGroupDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	consumptionBudgetId, err := parse.ConsumptionBudgetManagementGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	managementGroupId := managementGroupParse.NewManagementGroupId(consumptionBudgetId.ManagementGroupName)
+
+	return resourceArmConsumptionBudgetDelete(d, meta, managementGroupId.ID())
+}
+
+func flattenConsumptionBudgetManagementGroupNotifications(input map[string]*consumption.Notification) []interface{} {
+	notifications := make([]interface{}, 0)
+
+	if input == nil {
+		return notifications
+	}
+
+	for _, v := range input {
+		if v != nil {
+			notificationBlock := make(map[string]interface{})
+
+			notificationBlock["enabled"] = *v.Enabled
+			notificationBlock["operator"] = string(v.Operator)
+			threshold, _ := v.Threshold.Float64()
+			notificationBlock["threshold"] = int(threshold)
+			notificationBlock["threshold_type"] = string(v.ThresholdType)
+			notificationBlock["contact_emails"] = utils.FlattenStringSlice(v.ContactEmails)
+
+			notifications = append(notifications, notificationBlock)
+		}
+	}
+
+	return notifications
+}

--- a/internal/services/consumption/consumption_budget_management_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource_test.go
@@ -1,0 +1,433 @@
+package consumption_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ConsumptionBudgetManagementGroupResource struct{}
+
+func TestAccConsumptionBudgetManagementGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccConsumptionBudgetManagementGroup_basicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccConsumptionBudgetManagementGroup_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_consumption_budget_management_group"),
+		},
+	})
+}
+
+func TestAccConsumptionBudgetManagementGroup_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+func TestAccConsumptionBudgetManagementGroup_completeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (ConsumptionBudgetManagementGroupResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.ConsumptionBudgetManagementGroupID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := fmt.Sprintf("/providers/Microsoft.Management/managementGroups/%s", id.ManagementGroupName)
+	resp, err := clients.Consumption.BudgetsClient.Get(ctx, scope, id.BudgetName)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	return utils.Bool(resp.BudgetProperties != nil), nil
+}
+
+func (ConsumptionBudgetManagementGroupResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_management_group" "tenant_root" {
+  name = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azurerm_consumption_budget_management_group" "test" {
+  name                  = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_name = data.azurerm_management_group.tenant_root.name
+
+  amount     = 1000
+  time_grain = "Monthly"
+
+  time_period {
+    start_date = "%s"
+  }
+
+  filter {
+    tag {
+      name = "foo"
+      values = [
+        "bar"
+      ]
+    }
+  }
+
+  notification {
+    enabled   = true
+    threshold = 90.0
+    operator  = "EqualTo"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+`, data.RandomInteger, consumptionBudgetTestStartDate().Format(time.RFC3339))
+}
+
+func (ConsumptionBudgetManagementGroupResource) basicUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_management_group" "tenant_root" {
+  name = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azurerm_consumption_budget_management_group" "test" {
+  name                  = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_name = data.azurerm_management_group.tenant_root.name
+
+  // Changed the amount from 1000 to 3000
+  amount     = 3000
+  time_grain = "Monthly"
+
+  // Add end_date
+  time_period {
+    start_date = "%s"
+    end_date   = "%s"
+  }
+
+  // Remove filter
+
+  // Changed threshold and operator
+  notification {
+    enabled        = true
+    threshold      = 95.0
+    threshold_type = "Forecasted"
+    operator       = "GreaterThan"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+`, data.RandomInteger, consumptionBudgetTestStartDate().Format(time.RFC3339), consumptionBudgetTestStartDate().AddDate(1, 1, 0).Format(time.RFC3339))
+}
+
+func (ConsumptionBudgetManagementGroupResource) requiresImport(data acceptance.TestData) string {
+	template := ConsumptionBudgetManagementGroupResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_consumption_budget_management_group" "import" {
+  name                  = azurerm_consumption_budget_management_group.test.name
+  management_group_name = azurerm_consumption_budget_management_group.test.management_group_name
+
+  amount     = azurerm_consumption_budget_management_group.test.amount
+  time_grain = azurerm_consumption_budget_management_group.test.time_grain
+
+  time_period {
+    start_date = "%s"
+  }
+
+  notification {
+    enabled   = true
+    threshold = 90.0
+    operator  = "EqualTo"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+`, template, consumptionBudgetTestStartDate().Format(time.RFC3339))
+}
+
+func (ConsumptionBudgetManagementGroupResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_management_group" "tenant_root" {
+  name = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestAG-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  short_name          = "acctestAG"
+}
+
+resource "azurerm_consumption_budget_management_group" "test" {
+  name                  = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_name = data.azurerm_management_group.tenant_root.name
+
+  amount     = 1000
+  time_grain = "Monthly"
+
+  time_period {
+    start_date = "%s"
+    end_date   = "%s"
+  }
+
+  filter {
+    dimension {
+      name = "ResourceGroupName"
+      values = [
+        azurerm_resource_group.test.name,
+      ]
+    }
+
+    dimension {
+      name = "ResourceId"
+      values = [
+        azurerm_monitor_action_group.test.id,
+      ]
+    }
+
+    tag {
+      name = "foo"
+      values = [
+        "bar",
+        "baz",
+      ]
+    }
+
+    not {
+      tag {
+        name = "zip"
+        values = [
+          "zap",
+          "zop"
+        ]
+      }
+    }
+  }
+
+  notification {
+    enabled   = true
+    threshold = 90.0
+    operator  = "EqualTo"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+
+  notification {
+    enabled        = false
+    threshold      = 100.0
+    operator       = "GreaterThan"
+    threshold_type = "Forecasted"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, consumptionBudgetTestStartDate().Format(time.RFC3339), consumptionBudgetTestStartDate().AddDate(1, 1, 0).Format(time.RFC3339))
+}
+
+func (ConsumptionBudgetManagementGroupResource) completeUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_management_group" "tenant_root" {
+  name = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestAG-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  short_name          = "acctestAG"
+}
+
+resource "azurerm_consumption_budget_management_group" "test" {
+  name                  = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_name = data.azurerm_management_group.tenant_root.name
+
+  // Changed the amount from 1000 to 2000
+  amount     = 2000
+  time_grain = "Monthly"
+
+  // Removed end_date
+  time_period {
+    start_date = "%s"
+  }
+
+  filter {
+    dimension {
+      name = "ResourceGroupName"
+      values = [
+        azurerm_resource_group.test.name,
+      ]
+    }
+
+    tag {
+      name = "foo"
+      values = [
+        "bar",
+        "baz",
+      ]
+    }
+
+    // Added tag: zip
+    tag {
+      name = "zip"
+      values = [
+        "zap",
+        "zop",
+      ]
+    }
+
+    // Removed not block 
+  }
+
+  notification {
+    enabled        = true
+    threshold      = 90.0
+    operator       = "EqualTo"
+    threshold_type = "Actual"
+
+    contact_emails = [
+      // Added baz@example.com
+      "baz@example.com",
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+
+  notification {
+    // Set enabled to true
+    enabled        = true
+    threshold      = 100.0
+    threshold_type = "Forecasted"
+    // Changed from EqualTo to GreaterThanOrEqualTo 
+    operator = "GreaterThanOrEqualTo"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, consumptionBudgetTestStartDate().Format(time.RFC3339))
+}

--- a/internal/services/consumption/consumption_budget_management_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource_test.go
@@ -135,8 +135,8 @@ data "azurerm_management_group" "tenant_root" {
 }
 
 resource "azurerm_consumption_budget_management_group" "test" {
-  name                  = "acctestconsumptionbudgetManagementGroup-%d"
-  management_group_name = data.azurerm_management_group.tenant_root.name
+  name                = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_id = data.azurerm_management_group.tenant_root.id
 
   amount     = 1000
   time_grain = "Monthly"
@@ -181,8 +181,8 @@ data "azurerm_management_group" "tenant_root" {
 }
 
 resource "azurerm_consumption_budget_management_group" "test" {
-  name                  = "acctestconsumptionbudgetManagementGroup-%d"
-  management_group_name = data.azurerm_management_group.tenant_root.name
+  name                = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_id = data.azurerm_management_group.tenant_root.id
 
   // Changed the amount from 1000 to 3000
   amount     = 3000
@@ -218,8 +218,8 @@ func (ConsumptionBudgetManagementGroupResource) requiresImport(data acceptance.T
 %s
 
 resource "azurerm_consumption_budget_management_group" "import" {
-  name                  = azurerm_consumption_budget_management_group.test.name
-  management_group_name = azurerm_consumption_budget_management_group.test.management_group_name
+  name                = azurerm_consumption_budget_management_group.test.name
+  management_group_id = azurerm_consumption_budget_management_group.test.management_group_id
 
   amount     = azurerm_consumption_budget_management_group.test.amount
   time_grain = azurerm_consumption_budget_management_group.test.time_grain
@@ -266,8 +266,8 @@ resource "azurerm_monitor_action_group" "test" {
 }
 
 resource "azurerm_consumption_budget_management_group" "test" {
-  name                  = "acctestconsumptionbudgetManagementGroup-%d"
-  management_group_name = data.azurerm_management_group.tenant_root.name
+  name                = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_id = data.azurerm_management_group.tenant_root.id
 
   amount     = 1000
   time_grain = "Monthly"
@@ -361,8 +361,8 @@ resource "azurerm_monitor_action_group" "test" {
 }
 
 resource "azurerm_consumption_budget_management_group" "test" {
-  name                  = "acctestconsumptionbudgetManagementGroup-%d"
-  management_group_name = data.azurerm_management_group.tenant_root.name
+  name                = "acctestconsumptionbudgetManagementGroup-%d"
+  management_group_id = data.azurerm_management_group.tenant_root.id
 
   // Changed the amount from 1000 to 2000
   amount     = 2000

--- a/internal/services/consumption/consumption_budget_resource_group_resource.go
+++ b/internal/services/consumption/consumption_budget_resource_group_resource.go
@@ -55,7 +55,7 @@ func resourceArmConsumptionBudgetResourceGroupRead(d *pluginsdk.ResourceData, me
 
 	resourceGroupId := resourceParse.NewResourceGroupID(consumptionBudgetId.SubscriptionId, consumptionBudgetId.ResourceGroup)
 
-	err = resourceArmConsumptionBudgetRead(d, meta, resourceGroupId.ID(), consumptionBudgetId.BudgetName)
+	err = resourceArmConsumptionBudgetRead(d, meta, resourceGroupId.ID(), consumptionBudgetId.BudgetName, SchemaConsumptionBudgetNotificationElement, FlattenConsumptionBudgetNotifications)
 	if err != nil {
 		return err
 	}

--- a/internal/services/consumption/consumption_budget_subscription_resource.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource.go
@@ -52,7 +52,7 @@ func resourceArmConsumptionBudgetSubscriptionRead(d *pluginsdk.ResourceData, met
 
 	subscriptionId := subscriptionParse.NewSubscriptionId(consumptionBudgetId.SubscriptionId)
 
-	err = resourceArmConsumptionBudgetRead(d, meta, subscriptionId.ID(), consumptionBudgetId.BudgetName)
+	err = resourceArmConsumptionBudgetRead(d, meta, subscriptionId.ID(), consumptionBudgetId.BudgetName, SchemaConsumptionBudgetNotificationElement, FlattenConsumptionBudgetNotifications)
 	if err != nil {
 		return err
 	}

--- a/internal/services/consumption/helpers.go
+++ b/internal/services/consumption/helpers.go
@@ -83,8 +83,16 @@ func ExpandConsumptionBudgetNotifications(input []interface{}) map[string]*consu
 			notification.ThresholdType = consumption.ThresholdType(notificationRaw["threshold_type"].(string))
 
 			notification.ContactEmails = utils.ExpandStringSlice(notificationRaw["contact_emails"].([]interface{}))
-			notification.ContactRoles = utils.ExpandStringSlice(notificationRaw["contact_roles"].([]interface{}))
-			notification.ContactGroups = utils.ExpandStringSlice(notificationRaw["contact_groups"].([]interface{}))
+
+			// contact_roles cannot be set on consumption budgets for management groups
+			if _, ok := notificationRaw["contact_roles"]; ok {
+				notification.ContactRoles = utils.ExpandStringSlice(notificationRaw["contact_roles"].([]interface{}))
+			}
+
+			// contact_groups cannot be set on consumption budgets for management groups
+			if _, ok := notificationRaw["contact_groups"]; ok {
+				notification.ContactGroups = utils.ExpandStringSlice(notificationRaw["contact_groups"].([]interface{}))
+			}
 
 			notificationKey := fmt.Sprintf("actual_%s_%s_Percent", string(notification.Operator), notification.Threshold.StringFixed(0))
 			notifications[notificationKey] = &notification

--- a/internal/services/consumption/parse/consumption_budget_management_group.go
+++ b/internal/services/consumption/parse/consumption_budget_management_group.go
@@ -1,0 +1,58 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type ConsumptionBudgetManagementGroupId struct {
+	ManagementGroupName string
+	BudgetName          string
+}
+
+func NewConsumptionBudgetManagementGroupID(managementGroupName, budgetName string) ConsumptionBudgetManagementGroupId {
+	return ConsumptionBudgetManagementGroupId{
+		ManagementGroupName: managementGroupName,
+		BudgetName:          budgetName,
+	}
+}
+
+func (id ConsumptionBudgetManagementGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Budget Name %q", id.BudgetName),
+		fmt.Sprintf("Management Group Name %q", id.ManagementGroupName),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Consumption Budget Management Group", segmentsStr)
+}
+
+func (id ConsumptionBudgetManagementGroupId) ID() string {
+	fmtString := "/providers/Microsoft.Management/managementGroups/%s/providers/Microsoft.Consumption/budgets/%s"
+	return fmt.Sprintf(fmtString, id.ManagementGroupName, id.BudgetName)
+}
+
+// ConsumptionBudgetManagementGroupID parses a ConsumptionBudgetManagementGroup ID into an ConsumptionBudgetManagementGroupId struct
+func ConsumptionBudgetManagementGroupID(input string) (*ConsumptionBudgetManagementGroupId, error) {
+	id, err := azure.ParseAzureResourceIDWithoutSubscription(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ConsumptionBudgetManagementGroupId{}
+
+	if resourceId.ManagementGroupName, err = id.PopSegment("managementGroups"); err != nil {
+		return nil, err
+	}
+
+	if resourceId.BudgetName, err = id.PopSegment("budgets"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/consumption/parse/consumption_budget_management_group_test.go
+++ b/internal/services/consumption/parse/consumption_budget_management_group_test.go
@@ -1,0 +1,94 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = ConsumptionBudgetManagementGroupId{}
+
+func TestConsumptionBudgetManagementGroupIDFormatter(t *testing.T) {
+	actual := NewConsumptionBudgetManagementGroupID("12345678-1234-9876-4563-123456789012", "budget1").ID()
+	expected := "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/budgets/budget1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestConsumptionBudgetManagementGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConsumptionBudgetManagementGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing ManagementGroupName
+			Input: "/providers/Microsoft.Management/",
+			Error: true,
+		},
+
+		{
+			// missing value for ManagementGroupName
+			Input: "/providers/Microsoft.Management/managementGroups/",
+			Error: true,
+		},
+
+		{
+			// missing BudgetName
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/",
+			Error: true,
+		},
+
+		{
+			// missing value for BudgetName
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/budgets/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/budgets/budget1",
+			Expected: &ConsumptionBudgetManagementGroupId{
+				ManagementGroupName: "12345678-1234-9876-4563-123456789012",
+				BudgetName:          "budget1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/PROVIDERS/MICROSOFT.MANAGEMENT/MANAGEMENTGROUPS/12345678-1234-9876-4563-123456789012/PROVIDERS/MICROSOFT.CONSUMPTION/BUDGETS/BUDGET1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ConsumptionBudgetManagementGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ManagementGroupName != v.Expected.ManagementGroupName {
+			t.Fatalf("Expected %q but got %q for ManagementGroupName", v.Expected.ManagementGroupName, actual.ManagementGroupName)
+		}
+		if actual.BudgetName != v.Expected.BudgetName {
+			t.Fatalf("Expected %q but got %q for BudgetName", v.Expected.BudgetName, actual.BudgetName)
+		}
+	}
+}

--- a/internal/services/consumption/registration.go
+++ b/internal/services/consumption/registration.go
@@ -11,6 +11,7 @@ const (
 	// used when the generic Consumption Budget functions require a resource name.
 	consumptionBudgetResourceGroupName           = "azurerm_consumption_budget_resource_group"
 	consumptionBudgetSubscriptionName            = "azurerm_consumption_budget_subscription"
+	consumptionBudgetManagementGroupName         = "azurerm_consumption_budget_management_group"
 	consumptionBudgetResourceGroupDataSourceName = "azurerm_consumption_budget_resource_group"
 	consumptionBudgetSubscriptionDataSourceName  = "azurerm_consumption_budget_subscription"
 )
@@ -40,7 +41,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		consumptionBudgetResourceGroupName: resourceArmConsumptionBudgetResourceGroup(),
-		consumptionBudgetSubscriptionName:  resourceArmConsumptionBudgetSubscription(),
+		consumptionBudgetResourceGroupName:   resourceArmConsumptionBudgetResourceGroup(),
+		consumptionBudgetSubscriptionName:    resourceArmConsumptionBudgetSubscription(),
+		consumptionBudgetManagementGroupName: resourceArmConsumptionBudgetManagementGroup(),
 	}
 }

--- a/internal/services/consumption/schema.go
+++ b/internal/services/consumption/schema.go
@@ -308,11 +308,11 @@ func SchemaConsumptionBudgetManagementGroupResource() map[string]*pluginsdk.Sche
 			ValidateFunc: validate.ConsumptionBudgetName(),
 		},
 
-		"management_group_name": {
+		"management_group_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validateManagementGroup.ManagementGroupName,
+			ValidateFunc: validateManagementGroup.ManagementGroupID,
 		},
 
 		"etag": {

--- a/internal/services/consumption/schema.go
+++ b/internal/services/consumption/schema.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/validate"
+	validateManagementGroup "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -292,6 +293,180 @@ func SchemaConsumptionBudgetCommonResource() map[string]*pluginsdk.Schema {
 						Computed:     true,
 						ValidateFunc: validation.IsRFC3339Time,
 					},
+				},
+			},
+		},
+	}
+}
+
+func SchemaConsumptionBudgetManagementGroupResource() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ConsumptionBudgetName(),
+		},
+
+		"management_group_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validateManagementGroup.ManagementGroupName,
+		},
+
+		"etag": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+
+		"amount": {
+			Type:         pluginsdk.TypeFloat,
+			Required:     true,
+			ValidateFunc: validation.FloatAtLeast(1.0),
+		},
+
+		"filter": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"dimension": {
+						Type:         pluginsdk.TypeSet,
+						Optional:     true,
+						Set:          pluginsdk.HashResource(SchemaConsumptionBudgetFilterDimensionElement()),
+						Elem:         SchemaConsumptionBudgetFilterDimensionElement(),
+						AtLeastOneOf: []string{"filter.0.dimension", "filter.0.tag", "filter.0.not"},
+					},
+					"tag": {
+						Type:         pluginsdk.TypeSet,
+						Optional:     true,
+						Set:          pluginsdk.HashResource(SchemaConsumptionBudgetFilterTagElement()),
+						Elem:         SchemaConsumptionBudgetFilterTagElement(),
+						AtLeastOneOf: []string{"filter.0.dimension", "filter.0.tag", "filter.0.not"},
+					},
+					"not": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"dimension": {
+									Type:         pluginsdk.TypeList,
+									MaxItems:     1,
+									Optional:     true,
+									ExactlyOneOf: []string{"filter.0.not.0.tag"},
+									Elem:         SchemaConsumptionBudgetFilterDimensionElement(),
+								},
+								"tag": {
+									Type:         pluginsdk.TypeList,
+									MaxItems:     1,
+									Optional:     true,
+									ExactlyOneOf: []string{"filter.0.not.0.dimension"},
+									Elem:         SchemaConsumptionBudgetFilterTagElement(),
+								},
+							},
+						},
+						AtLeastOneOf: []string{"filter.0.dimension", "filter.0.tag", "filter.0.not"},
+					},
+				},
+			},
+		},
+
+		"notification": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 5,
+			Set:      pluginsdk.HashResource(SchemaConsumptionBudgetNotificationManagementGroupElement()),
+			Elem:     SchemaConsumptionBudgetNotificationManagementGroupElement(),
+		},
+
+		"time_grain": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(consumption.TimeGrainTypeMonthly),
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(consumption.TimeGrainTypeBillingAnnual),
+				string(consumption.TimeGrainTypeBillingMonth),
+				string(consumption.TimeGrainTypeBillingQuarter),
+				string(consumption.TimeGrainTypeAnnually),
+				string(consumption.TimeGrainTypeMonthly),
+				string(consumption.TimeGrainTypeQuarterly),
+			}, false),
+		},
+
+		"time_period": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"start_date": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validate.ConsumptionBudgetTimePeriodStartDate,
+						ForceNew:     true,
+					},
+					"end_date": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ValidateFunc: validation.IsRFC3339Time,
+					},
+				},
+			},
+		},
+	}
+}
+
+func SchemaConsumptionBudgetNotificationManagementGroupElement() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"threshold": {
+				Type:         pluginsdk.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(0, 1000),
+			},
+			// Issue: https://github.com/Azure/azure-rest-api-specs/issues/16240
+			// Toggling between these two values doesn't work at the moment and also doesn't throw an error
+			// but it seems unlikely that a user would switch the threshold_type of their budgets frequently
+			"threshold_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(consumption.ThresholdTypeActual),
+				ForceNew: true, // todo: remove this when the above issue is fixed
+				ValidateFunc: validation.StringInSlice([]string{
+					string(consumption.ThresholdTypeActual),
+					"Forecasted",
+				}, false),
+			},
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(consumption.OperatorTypeEqualTo),
+					string(consumption.OperatorTypeGreaterThan),
+					string(consumption.OperatorTypeGreaterThanOrEqualTo),
+				}, false),
+			},
+
+			"contact_emails": {
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 		},

--- a/internal/services/consumption/validate/consumption_budget_management_group_id.go
+++ b/internal/services/consumption/validate/consumption_budget_management_group_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/parse"
+)
+
+func ConsumptionBudgetManagementGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.ConsumptionBudgetManagementGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/consumption/validate/consumption_budget_management_group_id_test.go
+++ b/internal/services/consumption/validate/consumption_budget_management_group_id_test.go
@@ -1,0 +1,64 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestConsumptionBudgetManagementGroupID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing ManagementGroupName
+			Input: "/providers/Microsoft.Management/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ManagementGroupName
+			Input: "/providers/Microsoft.Management/managementGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing BudgetName
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/",
+			Valid: false,
+		},
+
+		{
+			// missing value for BudgetName
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/budgets/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Consumption/budgets/budget1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/PROVIDERS/MICROSOFT.MANAGEMENT/MANAGEMENTGROUPS/12345678-1234-9876-4563-123456789012/PROVIDERS/MICROSOFT.CONSUMPTION/BUDGETS/BUDGET1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ConsumptionBudgetManagementGroupID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/consumption_budget_management_group.html.markdown
+++ b/website/docs/r/consumption_budget_management_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Consumption"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_consumption_budget_management_group"
 description: |-
-  Manages a Management Group Consumption Budget.
+  Manages a Consumption Budget for a Management Group.
 ---
 
 # azurerm_consumption_budget_management_group
 
-Manages a Management Group Consumption Budget.
+Manages a Consumption Budget for a Management Group.
 
 ## Example Usage
 
@@ -23,8 +23,8 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_consumption_budget_management_group" "example" {
-  name                  = "example"
-  management_group_name = azurerm_management_group.example.name
+  name                = "example"
+  management_group_id = azurerm_management_group.example.id
 
   amount     = 1000
   time_grain = "Monthly"
@@ -80,9 +80,9 @@ resource "azurerm_consumption_budget_management_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Subscription Consumption Budget. Changing this forces a new Subscription Consumption Budget to be created.
+* `name` - (Required) The name which should be used for this Management Group Consumption Budget. Changing this forces a new resource to be created.
 
-* `subscription_id` - (Required) The ID of the Consumption Budget. Changing this forces a new Subscription Consumption Budget to be created.
+* `management_group_id` - (Required) The ID of the Management Group. Changing this forces a new resource to be created.
 
 * `amount` - (Required) The total amount of cost to track with the budget.
 
@@ -150,7 +150,7 @@ A `tag` block supports the following:
 
 A `time_period` block supports the following:
 
-* `start_date` - (Required) The start date for the budget. The start date must be first of the month and should be less than the end date. Budget start date must be on or after June 1, 2017. Future start date should not be more than twelve months. Past start date should be selected within the timegrain period. Changing this forces a new Subscription Consumption Budget to be created.
+* `start_date` - (Required) The start date for the budget. The start date must be first of the month and should be less than the end date. Budget start date must be on or after June 1, 2017. Future start date should not be more than twelve months. Past start date should be selected within the timegrain period. Changing this forces a new resource to be created.
 
 * `end_date` - (Optional) The end date for the budget. If not set this will be 10 years after the start date.
 
@@ -158,22 +158,22 @@ A `time_period` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Subscription Consumption Budget.
+* `id` - The ID of the Management Group Consumption Budget.
 
-* `etag` - The ETag of the Subscription Consumption Budget.
+* `etag` - The ETag of the Management Group Consumption Budget.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Subscription Consumption Budget.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Subscription Consumption Budget.
-* `update` - (Defaults to 30 minutes) Used when updating the Subscription Consumption Budget.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Subscription Consumption Budget.
+* `create` - (Defaults to 30 minutes) Used when creating the Management Group Consumption Budget.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Management Group Consumption Budget.
+* `update` - (Defaults to 30 minutes) Used when updating the Management Group Consumption Budget.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Management Group Consumption Budget.
 
 ## Import
 
-Subscription Consumption Budgets can be imported using the `resource id`, e.g.
+Management Group Consumption Budgets can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_consumption_budget_management_group.example /providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/budgets/budget1

--- a/website/docs/r/consumption_budget_management_group.html.markdown
+++ b/website/docs/r/consumption_budget_management_group.html.markdown
@@ -1,0 +1,180 @@
+---
+subcategory: "Consumption"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_consumption_budget_management_group"
+description: |-
+  Manages a Management Group Consumption Budget.
+---
+
+# azurerm_consumption_budget_management_group
+
+Manages a Management Group Consumption Budget.
+
+## Example Usage
+
+```hcl
+resource "azurerm_management_group" "example" {
+  display_name = "example"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "eastus"
+}
+
+resource "azurerm_consumption_budget_management_group" "example" {
+  name                  = "example"
+  management_group_name = azurerm_management_group.example.name
+
+  amount     = 1000
+  time_grain = "Monthly"
+
+  time_period {
+    start_date = "2022-06-01T00:00:00Z"
+    end_date   = "2022-07-01T00:00:00Z"
+  }
+
+  filter {
+    dimension {
+      name = "ResourceGroupName"
+      values = [
+        azurerm_resource_group.example.name,
+      ]
+    }
+
+    tag {
+      name = "foo"
+      values = [
+        "bar",
+        "baz",
+      ]
+    }
+  }
+
+  notification {
+    enabled   = true
+    threshold = 90.0
+    operator  = "EqualTo"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+
+  notification {
+    enabled        = false
+    threshold      = 100.0
+    operator       = "GreaterThan"
+    threshold_type = "Forecasted"
+
+    contact_emails = [
+      "foo@example.com",
+      "bar@example.com",
+    ]
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Subscription Consumption Budget. Changing this forces a new Subscription Consumption Budget to be created.
+
+* `subscription_id` - (Required) The ID of the Consumption Budget. Changing this forces a new Subscription Consumption Budget to be created.
+
+* `amount` - (Required) The total amount of cost to track with the budget.
+
+* `time_grain` - (Required) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `Monthly`, `Quarterly`, `Annually`, `BillingMonth`, `BillingQuarter`, or `BillingYear`. Defaults to `Monthly`.
+
+* `time_period` - (Required) A `time_period` block as defined below.
+
+* `notification` - (Required) One or more `notification` blocks as defined below.
+
+* `filter` - (Optional) A `filter` block as defined below.
+
+---
+
+A `filter` block supports the following:
+
+* `dimension` - (Optional) One or more `dimension` blocks as defined below to filter the budget on.
+
+* `tag` - (Optional) One or more `tag` blocks as defined below to filter the budget on.
+
+* `not` - (Optional) A `not` block as defined below to filter the budget on.
+
+---
+
+A `not` block supports the following:
+
+* `dimension` - (Optional) One `dimension` block as defined below to filter the budget on. Conflicts with `tag`.
+
+* `tag` - (Optional) One `tag` block as defined below to filter the budget on. Conflicts with `dimension`.
+
+---
+
+A `notification` block supports the following:
+
+* `operator` - (Required) The comparison operator for the notification. Must be one of `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`.
+
+* `threshold` - (Required) Threshold value associated with a notification. Notification is sent when the cost exceeded the threshold. It is always percent and has to be between 0 and 1000.
+
+* `contact_emails` - (Required) Specifies a list of email addresses to send the budget notification to when the threshold is exceeded.
+
+* `threshold_type` - (Optional) The type of threshold for the notification. This determines whether the notification is triggered by forecasted costs or actual costs. The allowed values are `Actual` and `Forecasted`. Default is `Actual`. Changing this forces a new resource to be created.
+
+* `enabled` - (Optional) Should the notification be enabled?
+
+---
+
+A `dimension` block supports the following:
+
+* `name` - (Required) The name of the column to use for the filter. The allowed values are `ChargeType`, `Frequency`, `InvoiceId`, `Meter`, `MeterCategory`, `MeterSubCategory`, `PartNumber`, `PricingModel`, `Product`, `ProductOrderId`, `ProductOrderName`, `PublisherType`, `ReservationId`, `ReservationName`, `ResourceGroupName`, `ResourceGuid`, `ResourceId`, `ResourceLocation`, `ResourceType`, `ServiceFamily`, `ServiceName`, `UnitOfMeasure`.
+
+* `operator` - (Optional) The operator to use for comparison. The allowed values are `In`.
+
+* `values` - (Required) Specifies a list of values for the column.
+
+---
+
+A `tag` block supports the following:
+
+* `name` - (Required) The name of the tag to use for the filter.
+
+* `operator` - (Optional) The operator to use for comparison. The allowed values are `In`.
+
+* `values` - (Required) Specifies a list of values for the tag.
+
+---
+
+A `time_period` block supports the following:
+
+* `start_date` - (Required) The start date for the budget. The start date must be first of the month and should be less than the end date. Budget start date must be on or after June 1, 2017. Future start date should not be more than twelve months. Past start date should be selected within the timegrain period. Changing this forces a new Subscription Consumption Budget to be created.
+
+* `end_date` - (Optional) The end date for the budget. If not set this will be 10 years after the start date.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Subscription Consumption Budget.
+
+* `etag` - The ETag of the Subscription Consumption Budget.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Subscription Consumption Budget.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Subscription Consumption Budget.
+* `update` - (Defaults to 30 minutes) Used when updating the Subscription Consumption Budget.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Subscription Consumption Budget.
+
+## Import
+
+Subscription Consumption Budgets can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_consumption_budget_management_group.example /providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/budgets/budget1
+```


### PR DESCRIPTION
This PR creates a new resources for the managing a consumption budget for management groups.

Whilst developing this I found that the schema is slightly different to resource groups and subscriptions.
- `contact_roles` are not supported
- `contact_groups` are not supported

This then changes the requirements for `contact_emails` making them mandatory and a minimum of 1 element.

I used go-generate to help create the initial outline for the ID resources, but as management group IDs do not have a subscription, I had to use `ParseAzureResourceIDWithoutSubscription`.

Addresses #13112