### PR TITLE
Public IP Document bug fix for issue #12979

### DIFF
--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `ip_version` - (Optional) The IP Version to use, IPv6 or IPv4.
 
--> **Note** Only `dynamic` IP address allocation is supported for IPv6.
+-> **Note** Only `static` IP address allocation is supported for IPv6.
 
 * `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes.
 


### PR DESCRIPTION
Fixed issue  #12979
Changed the note in Public IP Documentation for ip_version property saying "Only dynamic IP address allocation is supported for IPv6." to "Only static IP address allocation is supported for IPv6."