### PR TITLE
`azurerm_container_group` Fix #9831 by change `dns_config.search_domains` and `dns_config.options` from `Required` to `Optional`

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -515,7 +515,7 @@ func resourceContainerGroup() *pluginsdk.Resource {
 						},
 						"search_domains": {
 							Type:     pluginsdk.TypeSet,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
@@ -524,7 +524,7 @@ func resourceContainerGroup() *pluginsdk.Resource {
 						},
 						"options": {
 							Type:     pluginsdk.TypeSet,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -280,9 +280,9 @@ The `dns_config` block supports:
 
 * `nameservers` - (Required) A list of nameservers the containers will search out to resolve requests.
 
-* `search_domains` - (Required) A list of search domains that DNS requests will search along.
+* `search_domains` - (Optional) A list of search domains that DNS requests will search along.
 
-* `options` - (Required) A list of [resolver configuration options](https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
+* `options` - (Optional) A list of [resolver configuration options](https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
As #9831 requested, this patch change `dns_config.search_domains` and `dns_config.options` from `Required` to `Optional`. As I cannot find `dns_config` setting while creating container group via portal, I just guess that these two fields are optional on service side. I tested this patch on my machine with the following code:

```hcl
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "example" {
  name     = "zjhe-f9831"
  location = "West Europe"
}

resource "azurerm_virtual_network" "example" {
  name                = "zjhe-f9831"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.1.0.0/16"]
}

resource "azurerm_subnet" "example" {
  name                 = "zjhe-f9831"
  resource_group_name  = azurerm_resource_group.example.name
  virtual_network_name = azurerm_virtual_network.example.name
  address_prefixes     = ["10.1.0.0/24"]

  delegation {
    name = "delegation"

    service_delegation {
      name    = "Microsoft.ContainerInstance/containerGroups"
      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
    }
  }
}

resource "azurerm_network_profile" "example" {
  name                = "zjhe-f9831"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name

  container_network_interface {
    name = "examplecnic"

    ip_configuration {
      name      = "exampleipconfig"
      subnet_id = azurerm_subnet.example.id
    }
  }
}

resource "azurerm_container_group" "example" {
  name                = "zjhe-f9831"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  ip_address_type     = "private"
  os_type             = "Linux"

  container {
    name   = "hello-world"
    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
    cpu    = "0.5"
    memory = "1.5"

    ports {
      port     = 443
      protocol = "TCP"
    }
  }

  container {
    name   = "sidecar"
    image  = "mcr.microsoft.com/azuredocs/aci-tutorial-sidecar"
    cpu    = "0.5"
    memory = "1.5"
  }
  network_profile_id = azurerm_network_profile.example.id

  dns_config {
    nameservers = ["8.8.8.8"]
  }

  tags = {
    environment = "testing"
  }
}
```

The test provision ran successfully with following outputs:

```shell
azurerm_container_group.example: Still creating... [2m30s elapsed]
azurerm_container_group.example: Still creating... [2m40s elapsed]
azurerm_container_group.example: Creation complete after 2m45s [id=/subscriptions/#############/resourceGroups/zjhe-f9831/provide
rs/Microsoft.ContainerInstance/containerGroups/zjhe-f9831]
```

I have no idea whether I should add an acc test for this scenario, if it was required, I would like to add one.

Current acc tests:

=== RUN   TestAccContainerGroup_SystemAssignedIdentity
=== PAUSE TestAccContainerGroup_SystemAssignedIdentity
=== CONT  TestAccContainerGroup_SystemAssignedIdentity
--- PASS: TestAccContainerGroup_SystemAssignedIdentity (382.17s)
=== RUN   TestAccContainerGroup_UserAssignedIdentity
=== PAUSE TestAccContainerGroup_UserAssignedIdentity
=== CONT  TestAccContainerGroup_UserAssignedIdentity
--- PASS: TestAccContainerGroup_UserAssignedIdentity (386.68s)
=== RUN   TestAccContainerGroup_multipleAssignedIdentities
=== PAUSE TestAccContainerGroup_multipleAssignedIdentities
=== CONT  TestAccContainerGroup_multipleAssignedIdentities
--- PASS: TestAccContainerGroup_multipleAssignedIdentities (391.87s)
=== RUN   TestAccContainerGroup_imageRegistryCredentials
=== PAUSE TestAccContainerGroup_imageRegistryCredentials
=== CONT  TestAccContainerGroup_imageRegistryCredentials
--- PASS: TestAccContainerGroup_imageRegistryCredentials (367.28s)
=== RUN   TestAccContainerGroup_imageRegistryCredentialsUpdate
=== PAUSE TestAccContainerGroup_imageRegistryCredentialsUpdate
=== CONT  TestAccContainerGroup_imageRegistryCredentialsUpdate
--- PASS: TestAccContainerGroup_imageRegistryCredentialsUpdate (516.79s)
=== RUN   TestAccContainerGroup_logTypeUnset
=== PAUSE TestAccContainerGroup_logTypeUnset
=== CONT  TestAccContainerGroup_logTypeUnset
--- PASS: TestAccContainerGroup_logTypeUnset (314.00s)
=== RUN   TestAccContainerGroup_linuxBasic
=== PAUSE TestAccContainerGroup_linuxBasic
=== CONT  TestAccContainerGroup_linuxBasic
--- PASS: TestAccContainerGroup_linuxBasic (305.25s)
=== RUN   TestAccContainerGroup_exposedPort
=== PAUSE TestAccContainerGroup_exposedPort
=== CONT  TestAccContainerGroup_exposedPort
--- PASS: TestAccContainerGroup_exposedPort (373.26s)
=== RUN   TestAccContainerGroup_requiresImport
=== PAUSE TestAccContainerGroup_requiresImport
=== CONT  TestAccContainerGroup_requiresImport
--- PASS: TestAccContainerGroup_requiresImport (392.99s)
=== RUN   TestAccContainerGroup_linuxBasicUpdate
=== PAUSE TestAccContainerGroup_linuxBasicUpdate
=== CONT  TestAccContainerGroup_linuxBasicUpdate
--- PASS: TestAccContainerGroup_linuxBasicUpdate (513.36s)
=== RUN   TestAccContainerGroup_exposedPortUpdate
=== PAUSE TestAccContainerGroup_exposedPortUpdate
=== CONT  TestAccContainerGroup_exposedPortUpdate
--- PASS: TestAccContainerGroup_exposedPortUpdate (439.58s)
=== RUN   TestAccContainerGroup_linuxBasicTagsUpdate
=== PAUSE TestAccContainerGroup_linuxBasicTagsUpdate
=== CONT  TestAccContainerGroup_linuxBasicTagsUpdate
--- PASS: TestAccContainerGroup_linuxBasicTagsUpdate (482.56s)
=== RUN   TestAccContainerGroup_linuxComplete
=== PAUSE TestAccContainerGroup_linuxComplete
=== CONT  TestAccContainerGroup_linuxComplete
--- PASS: TestAccContainerGroup_linuxComplete (1081.00s)
=== RUN   TestAccContainerGroup_virtualNetwork
=== PAUSE TestAccContainerGroup_virtualNetwork
=== CONT  TestAccContainerGroup_virtualNetwork
--- PASS: TestAccContainerGroup_virtualNetwork (539.40s)
=== RUN   TestAccContainerGroup_windowsBasic
=== PAUSE TestAccContainerGroup_windowsBasic
=== CONT  TestAccContainerGroup_windowsBasic
--- PASS: TestAccContainerGroup_windowsBasic (713.56s)
=== RUN   TestAccContainerGroup_windowsComplete
=== PAUSE TestAccContainerGroup_windowsComplete
=== CONT  TestAccContainerGroup_windowsComplete
--- PASS: TestAccContainerGroup_windowsComplete (1049.58s)
=== RUN   TestAccContainerGroup_withPrivateEmpty
=== PAUSE TestAccContainerGroup_withPrivateEmpty
=== CONT  TestAccContainerGroup_withPrivateEmpty
--- PASS: TestAccContainerGroup_withPrivateEmpty (382.38s)
=== RUN   TestAccContainerGroup_gitRepoVolume
=== PAUSE TestAccContainerGroup_gitRepoVolume
=== CONT  TestAccContainerGroup_gitRepoVolume
--- PASS: TestAccContainerGroup_gitRepoVolume (384.20s)
=== RUN   TestAccContainerGroup_emptyDirVolume
=== PAUSE TestAccContainerGroup_emptyDirVolume
=== CONT  TestAccContainerGroup_emptyDirVolume
--- PASS: TestAccContainerGroup_emptyDirVolume (320.29s)
=== RUN   TestAccContainerGroup_emptyDirVolumeShared
=== PAUSE TestAccContainerGroup_emptyDirVolumeShared
=== CONT  TestAccContainerGroup_emptyDirVolumeShared
--- PASS: TestAccContainerGroup_emptyDirVolumeShared (382.99s)
=== RUN   TestAccContainerGroup_secretVolume
=== PAUSE TestAccContainerGroup_secretVolume
=== CONT  TestAccContainerGroup_secretVolume
--- PASS: TestAccContainerGroup_secretVolume (382.86s)
PASS