### PR TITLE
Add support for public_ip_configuration.sku in azurerm_virtual_machin…

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -455,6 +455,10 @@ output "principal_id" {
 * `name` - (Required) The name of the public ip address configuration
 * `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 30.
 * `domain_name_label` - (Required) The domain name label for the dns settings.
+* `sku` - (Optional) Describes the public IP Sku. Consists of two entities:
+
+* - `name` (Optional) One of `Basic` or `Standard`.
+* - `tier` (Optional) One of `Global` or `Regional`. 
 
 `storage_profile_os_disk` supports the following:
 


### PR DESCRIPTION
…e_scale_set

This fixes GH #13250

```
        Error: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestFormat" Message="Cannot parse the request." Details=[{"code":"InvalidJson","message":"Could not find member 'sku' on object of type 'VMScaleSetPublicIPAddressConfiguration'. Path 'Properties.UpdateGroups[0].NetworkProfile.networkInterfaceConfigurations[0].properties.ipConfigurations[0].properties.publicIPAddressConfiguration.sku', line 1, position 1038."}] InnerError={"errorDetail":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidRequestFormat\",\r\n    \"message\": \"Cannot parse the request.\",\r\n    \"details\": [\r\n      {\r\n        \"code\": \"InvalidJson\",\r\n        \"message\": \"Could not find member 'sku' on object of type 'VMScaleSetPublicIPAddressConfiguration'. Path 'Properties.UpdateGroups[0].NetworkProfile.networkInterfaceConfigurations[0].properties.ipConfigurations[0].properties.publicIPAddressConfiguration.sku', line 1, position 1038.\"\r\n      }\r\n    ]\r\n  }\r\n}"}
```