### PR TITLE
`azurerm_virtual_hub_ip` - Make `public_ip_address_id` required for new instance and ForceNew

### DIFF
--- a/internal/services/network/virtual_hub_ip_resource.go
+++ b/internal/services/network/virtual_hub_ip_resource.go
@@ -77,6 +77,7 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 			"public_ip_address_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: networkValidate.PublicIpAddressID,
 			},
 		},
@@ -108,6 +109,10 @@ func resourceVirtualHubIPCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 
 		if existing.ID != nil && *existing.ID != "" {
 			return tf.ImportAsExistsError("azurerm_virtual_hub_ip", *existing.ID)
+		}
+
+		if d.Get("public_ip_address_id").(string) == "" {
+			return fmt.Errorf("`public_ip_address_id` is required for new resources, created after September 1st 2021")
 		}
 	}
 

--- a/website/docs/r/virtual_hub_ip.html.markdown
+++ b/website/docs/r/virtual_hub_ip.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub_ip"
 description: |-
-  Manages a Virtual Hub IP.
+  Manages a Virtual Hub IP. This resource is also known as a Route Server.
 ---
 
 # azurerm_virtual_hub_ip
 
-Manages a Virtual Hub IP.
+Manages a Virtual Hub IP. This resource is also known as a Route Server.
 
 ~> **NOTE** Virtual Hub IP only supports Standard Virtual Hub without Virtual Wan.
 
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `private_ip_allocation_method` - (Optional) The private IP address allocation method. Possible values are `Static` and `Dynamic` is allowed. Defaults to `Dynamic`.
 
-* `public_ip_address_id` - (Optional) The ID of the Public IP Address.
+* `public_ip_address_id` - (Optional) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
When fixing tests in PR #14408 I didn't realise/include the changes due to GA in the resource itself, only in the tests:
- [x] Make `public_ip_address_id` required for new instance [as stated here](https://docs.microsoft.com/en-us/azure/route-server/overview) by throwing an error on create, but keep the option `Optional` to keep it backward compatible
- [x] Make `public_ip_address_id` ForceNew:
  - > If you have an Azure Route Server created before September 1st and it doesn't have a public IP address asssociated, you'll need to recreate the Route Server so it can obtain an IP address for management purpose.
  - `Error: Code="RouteServerPublicIpAddressCannotBeUpdated" Message="Route Server public ip address cannot be changed. This is not supported.`
- [x] Document that this resource is documented as [Route Server](https://docs.microsoft.com/en-us/azure/route-server/overview)

## Acceptance Tests
<img width="632" alt="Screenshot 2021-12-02 at 12 04 13" src="https://user-images.githubusercontent.com/8375124/144410436-652f7120-bee5-4430-95ed-7f9b0e33c9b1.png">

