### PR TITLE
Move virtual machine extension snippet in docs to example

### DIFF
--- a/examples/virtual-machines/windows/vm-custom-extension/README.md
+++ b/examples/virtual-machines/windows/vm-custom-extension/README.md
@@ -1,0 +1,11 @@
+## Example: Virtual Machine with Custom Script Extension
+
+This example is used to demonstrate how to create a custom script extension for a Windows Virtual Machine. In this particular example the custom extension configures the Windows Virtual Machine to be discoverable and accessible by ansible.
+
+This example provisions:
+- Windows Virtual Machine
+- A Virtual Machine Extension
+
+### Variables
+
+- `location` - (Required) Azure Region in which all resources in this example should be provisioned

--- a/examples/virtual-machines/windows/vm-custom-extension/main.tf
+++ b/examples/virtual-machines/windows/vm-custom-extension/main.tf
@@ -1,0 +1,75 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = var.location
+}
+
+# Virtual Machine Resources
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes       = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "example" {
+  name                = "example-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  ip_configuration {
+    name                          = "example-ip"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "example" {
+  name                = "example-vm"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.example.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "example" {
+  name                 = "ansible_windows_winrm"
+  virtual_machine_id   = azurerm_windows_virtual_machine.example.id
+  publisher            = "Microsoft.Compute"
+  type                 = "CustomScriptExtension"
+  type_handler_version = "1.9"
+
+  settings = <<SETTINGS
+    {
+        "fileUris": ["https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"],
+        "commandToExecute": "powershell -ExecutionPolicy Unrestricted -file ConfigureRemotingForAnsible.ps1 -EnableCredSSP -DisableBasicAuth"
+    }
+SETTINGS
+}

--- a/examples/virtual-machines/windows/vm-custom-extension/vars.tf
+++ b/examples/virtual-machines/windows/vm-custom-extension/vars.tf
@@ -1,0 +1,4 @@
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be provisioned"
+  default = "West US"
+}

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -122,24 +122,6 @@ SETTINGS
     environment = "Production"
   }
 }
-
-resource "azurerm_virtual_machine_extension" "hello_world" {
-  name                 = "ansible_windows_winrm"
-  virtual_machine_id   = azurerm_windows_virtual_machine.example.id
-  publisher            = "Microsoft.Compute"
-  type                 = "CustomScriptExtension"
-  type_handler_version = "1.9"
-  tags = {
-    environment = "Production"
-  }
-
-  settings = <<SETTINGS
-    {
-        "fileUris": ["https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"],
-        "commandToExecute": "powershell -ExecutionPolicy Unrestricted -file ConfigureRemotingForAnsible.ps1 -EnableCredSSP -DisableBasicAuth"
-    }
-SETTINGS
-}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
Fixing an oversight from the merge of #14443 (which accidentally merged #14425 before the code snippet in there could be moved to the examples folder)