### PR TITLE
scripts: adding an import-check for Track2 of the Azure SDK for Go

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -60,6 +60,8 @@ lint:
 	./scripts/run-lint.sh
 
 depscheck:
+	@echo "==> Checking dependencies.."
+	@./scripts/track2-check.sh
 	@echo "==> Checking source code with go mod tidy..."
 	@go mod tidy
 	@git diff --exit-code -- go.mod go.sum || \

--- a/scripts/track2-check.sh
+++ b/scripts/track2-check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+
+function checkForAzCoreUsages() {
+  result=$(grep -R "github.com/Azure/azure-sdk-for-go/sdk/azcore" go.mod go.sum)
+  if [ "$result" != "" ];
+  then
+    echo "Detected usages of AzCore of the Azure SDK for Go"
+    echo ""
+    echo "At this time Terraform makes use of both Track1 of the Azure SDK"
+    echo "for Go and some Embedded SDK's - however for various reasons we"
+    echo "do not make use of AzCore and Track2 of the Azure SDK for Go."
+    echo ""
+    echo "We've detected a usage of AzCore in the go.mod/go.sum with the"
+    echo "import path of github.com/Azure/azure-sdk-for-go/sdk/azcore"
+    echo "which is likely coming from a dependency, either from Track2 of"
+    echo "the Azure SDK for Go - or another Azure SDK library."
+    echo ""
+    echo "Rather than importing an SDK which has a reliance on the Track2"
+    echo "libraries, please use the Azure SDK for Go Track1 SDK at this time"
+    echo "or reach out to the Terraform Azure Provider Team if a Track1"
+    echo "SDK isn't available and we can add one in the interim."
+    exit 1
+  fi
+}
+
+function checkForAzIdentityUsages() {
+  result=$(grep -R "github.com/Azure/azure-sdk-for-go/sdk/azidentity" go.mod go.sum)
+  if [ "$result" != "" ];
+  then
+    echo "Detected usages of AzIdentity of the Azure SDK for Go"
+    echo ""
+    echo "At this time Terraform makes use of both Track1 of the Azure SDK"
+    echo "for Go and some Embedded SDK's - however for various reasons we"
+    echo "do not make use of AzIdentity and Track2 of the Azure SDK for Go."
+    echo ""
+    echo "We've detected a usage of AzIdentity in the go.mod/go.sum with the"
+    echo "import path of github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    echo "which is likely coming from a dependency, either from Track2 of"
+    echo "the Azure SDK for Go - or another Azure SDK library."
+    echo ""
+    echo "Rather than importing an SDK which has a reliance on the Track2"
+    echo "libraries, please use the Azure SDK for Go Track1 SDK at this time"
+    echo "or reach out to the Terraform Azure Provider Team if a Track1"
+    echo "SDK isn't available and we can add one in the interim."
+    exit 1
+  fi
+}
+
+function main {
+  checkForAzCoreUsages
+  checkForAzIdentityUsages
+}
+
+main


### PR DESCRIPTION
At this time we're intentionally not using Track2 of the Azure SDK for Go, so we should raise an error if usages are detected so that committers are aware of this.