### PR TITLE
tools/generator-resource-id: refactoring to use the Go Azure Helpers ID Parser

### DIFF
--- a/internal/services/apimanagement/parse/api.go
+++ b/internal/services/apimanagement/parse/api.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiId struct {
@@ -42,7 +42,7 @@ func (id ApiId) ID() string {
 
 // ApiID parses a Api ID into an ApiId struct
 func ApiID(input string) (*ApiId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_diagnostic.go
+++ b/internal/services/apimanagement/parse/api_diagnostic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiDiagnosticId struct {
@@ -45,7 +45,7 @@ func (id ApiDiagnosticId) ID() string {
 
 // ApiDiagnosticID parses a ApiDiagnostic ID into an ApiDiagnosticId struct
 func ApiDiagnosticID(input string) (*ApiDiagnosticId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_management.go
+++ b/internal/services/apimanagement/parse/api_management.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiManagementId struct {
@@ -39,7 +39,7 @@ func (id ApiManagementId) ID() string {
 
 // ApiManagementID parses a ApiManagement ID into an ApiManagementId struct
 func ApiManagementID(input string) (*ApiManagementId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_operation.go
+++ b/internal/services/apimanagement/parse/api_operation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiOperationId struct {
@@ -45,7 +45,7 @@ func (id ApiOperationId) ID() string {
 
 // ApiOperationID parses a ApiOperation ID into an ApiOperationId struct
 func ApiOperationID(input string) (*ApiOperationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_operation_policy.go
+++ b/internal/services/apimanagement/parse/api_operation_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiOperationPolicyId struct {
@@ -48,7 +48,7 @@ func (id ApiOperationPolicyId) ID() string {
 
 // ApiOperationPolicyID parses a ApiOperationPolicy ID into an ApiOperationPolicyId struct
 func ApiOperationPolicyID(input string) (*ApiOperationPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_policy.go
+++ b/internal/services/apimanagement/parse/api_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiPolicyId struct {
@@ -45,7 +45,7 @@ func (id ApiPolicyId) ID() string {
 
 // ApiPolicyID parses a ApiPolicy ID into an ApiPolicyId struct
 func ApiPolicyID(input string) (*ApiPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_release.go
+++ b/internal/services/apimanagement/parse/api_release.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiReleaseId struct {
@@ -45,7 +45,7 @@ func (id ApiReleaseId) ID() string {
 
 // ApiReleaseID parses a ApiRelease ID into an ApiReleaseId struct
 func ApiReleaseID(input string) (*ApiReleaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_schema.go
+++ b/internal/services/apimanagement/parse/api_schema.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiSchemaId struct {
@@ -45,7 +45,7 @@ func (id ApiSchemaId) ID() string {
 
 // ApiSchemaID parses a ApiSchema ID into an ApiSchemaId struct
 func ApiSchemaID(input string) (*ApiSchemaId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/api_version_set.go
+++ b/internal/services/apimanagement/parse/api_version_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiVersionSetId struct {
@@ -42,7 +42,7 @@ func (id ApiVersionSetId) ID() string {
 
 // ApiVersionSetID parses a ApiVersionSet ID into an ApiVersionSetId struct
 func ApiVersionSetID(input string) (*ApiVersionSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/authorization_server.go
+++ b/internal/services/apimanagement/parse/authorization_server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AuthorizationServerId struct {
@@ -42,7 +42,7 @@ func (id AuthorizationServerId) ID() string {
 
 // AuthorizationServerID parses a AuthorizationServer ID into an AuthorizationServerId struct
 func AuthorizationServerID(input string) (*AuthorizationServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/backend.go
+++ b/internal/services/apimanagement/parse/backend.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackendId struct {
@@ -42,7 +42,7 @@ func (id BackendId) ID() string {
 
 // BackendID parses a Backend ID into an BackendId struct
 func BackendID(input string) (*BackendId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/certificate.go
+++ b/internal/services/apimanagement/parse/certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CertificateId struct {
@@ -42,7 +42,7 @@ func (id CertificateId) ID() string {
 
 // CertificateID parses a Certificate ID into an CertificateId struct
 func CertificateID(input string) (*CertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/custom_domain.go
+++ b/internal/services/apimanagement/parse/custom_domain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CustomDomainId struct {
@@ -42,7 +42,7 @@ func (id CustomDomainId) ID() string {
 
 // CustomDomainID parses a CustomDomain ID into an CustomDomainId struct
 func CustomDomainID(input string) (*CustomDomainId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/diagnostic.go
+++ b/internal/services/apimanagement/parse/diagnostic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DiagnosticId struct {
@@ -42,7 +42,7 @@ func (id DiagnosticId) ID() string {
 
 // DiagnosticID parses a Diagnostic ID into an DiagnosticId struct
 func DiagnosticID(input string) (*DiagnosticId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/email_template.go
+++ b/internal/services/apimanagement/parse/email_template.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EmailTemplateId struct {
@@ -42,7 +42,7 @@ func (id EmailTemplateId) ID() string {
 
 // EmailTemplateID parses a EmailTemplate ID into an EmailTemplateId struct
 func EmailTemplateID(input string) (*EmailTemplateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/gateway.go
+++ b/internal/services/apimanagement/parse/gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GatewayId struct {
@@ -42,7 +42,7 @@ func (id GatewayId) ID() string {
 
 // GatewayID parses a Gateway ID into an GatewayId struct
 func GatewayID(input string) (*GatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/gateway_api.go
+++ b/internal/services/apimanagement/parse/gateway_api.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GatewayApiId struct {
@@ -45,7 +45,7 @@ func (id GatewayApiId) ID() string {
 
 // GatewayApiID parses a GatewayApi ID into an GatewayApiId struct
 func GatewayApiID(input string) (*GatewayApiId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/group.go
+++ b/internal/services/apimanagement/parse/group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GroupId struct {
@@ -42,7 +42,7 @@ func (id GroupId) ID() string {
 
 // GroupID parses a Group ID into an GroupId struct
 func GroupID(input string) (*GroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/group_user.go
+++ b/internal/services/apimanagement/parse/group_user.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GroupUserId struct {
@@ -45,7 +45,7 @@ func (id GroupUserId) ID() string {
 
 // GroupUserID parses a GroupUser ID into an GroupUserId struct
 func GroupUserID(input string) (*GroupUserId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/identity_provider.go
+++ b/internal/services/apimanagement/parse/identity_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IdentityProviderId struct {
@@ -42,7 +42,7 @@ func (id IdentityProviderId) ID() string {
 
 // IdentityProviderID parses a IdentityProvider ID into an IdentityProviderId struct
 func IdentityProviderID(input string) (*IdentityProviderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/logger.go
+++ b/internal/services/apimanagement/parse/logger.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoggerId struct {
@@ -42,7 +42,7 @@ func (id LoggerId) ID() string {
 
 // LoggerID parses a Logger ID into an LoggerId struct
 func LoggerID(input string) (*LoggerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/named_value.go
+++ b/internal/services/apimanagement/parse/named_value.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamedValueId struct {
@@ -42,7 +42,7 @@ func (id NamedValueId) ID() string {
 
 // NamedValueID parses a NamedValue ID into an NamedValueId struct
 func NamedValueID(input string) (*NamedValueId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/notification_recipient_email.go
+++ b/internal/services/apimanagement/parse/notification_recipient_email.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NotificationRecipientEmailId struct {
@@ -45,7 +45,7 @@ func (id NotificationRecipientEmailId) ID() string {
 
 // NotificationRecipientEmailID parses a NotificationRecipientEmail ID into an NotificationRecipientEmailId struct
 func NotificationRecipientEmailID(input string) (*NotificationRecipientEmailId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/open_id_connect_provider.go
+++ b/internal/services/apimanagement/parse/open_id_connect_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type OpenIDConnectProviderId struct {
@@ -42,7 +42,7 @@ func (id OpenIDConnectProviderId) ID() string {
 
 // OpenIDConnectProviderID parses a OpenIDConnectProvider ID into an OpenIDConnectProviderId struct
 func OpenIDConnectProviderID(input string) (*OpenIDConnectProviderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/operation_tag.go
+++ b/internal/services/apimanagement/parse/operation_tag.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type OperationTagId struct {
@@ -48,7 +48,7 @@ func (id OperationTagId) ID() string {
 
 // OperationTagID parses a OperationTag ID into an OperationTagId struct
 func OperationTagID(input string) (*OperationTagId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/policy.go
+++ b/internal/services/apimanagement/parse/policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PolicyId struct {
@@ -42,7 +42,7 @@ func (id PolicyId) ID() string {
 
 // PolicyID parses a Policy ID into an PolicyId struct
 func PolicyID(input string) (*PolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/product.go
+++ b/internal/services/apimanagement/parse/product.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProductId struct {
@@ -42,7 +42,7 @@ func (id ProductId) ID() string {
 
 // ProductID parses a Product ID into an ProductId struct
 func ProductID(input string) (*ProductId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/product_api.go
+++ b/internal/services/apimanagement/parse/product_api.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProductApiId struct {
@@ -45,7 +45,7 @@ func (id ProductApiId) ID() string {
 
 // ProductApiID parses a ProductApi ID into an ProductApiId struct
 func ProductApiID(input string) (*ProductApiId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/product_group.go
+++ b/internal/services/apimanagement/parse/product_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProductGroupId struct {
@@ -45,7 +45,7 @@ func (id ProductGroupId) ID() string {
 
 // ProductGroupID parses a ProductGroup ID into an ProductGroupId struct
 func ProductGroupID(input string) (*ProductGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/product_policy.go
+++ b/internal/services/apimanagement/parse/product_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProductPolicyId struct {
@@ -45,7 +45,7 @@ func (id ProductPolicyId) ID() string {
 
 // ProductPolicyID parses a ProductPolicy ID into an ProductPolicyId struct
 func ProductPolicyID(input string) (*ProductPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/property.go
+++ b/internal/services/apimanagement/parse/property.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PropertyId struct {
@@ -42,7 +42,7 @@ func (id PropertyId) ID() string {
 
 // PropertyID parses a Property ID into an PropertyId struct
 func PropertyID(input string) (*PropertyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/redis_cache.go
+++ b/internal/services/apimanagement/parse/redis_cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RedisCacheId struct {
@@ -42,7 +42,7 @@ func (id RedisCacheId) ID() string {
 
 // RedisCacheID parses a RedisCache ID into an RedisCacheId struct
 func RedisCacheID(input string) (*RedisCacheId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/subscription.go
+++ b/internal/services/apimanagement/parse/subscription.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionId struct {
@@ -42,7 +42,7 @@ func (id SubscriptionId) ID() string {
 
 // SubscriptionID parses a Subscription ID into an SubscriptionId struct
 func SubscriptionID(input string) (*SubscriptionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/tag.go
+++ b/internal/services/apimanagement/parse/tag.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TagId struct {
@@ -42,7 +42,7 @@ func (id TagId) ID() string {
 
 // TagID parses a Tag ID into an TagId struct
 func TagID(input string) (*TagId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/apimanagement/parse/user.go
+++ b/internal/services/apimanagement/parse/user.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type UserId struct {
@@ -42,7 +42,7 @@ func (id UserId) ID() string {
 
 // UserID parses a User ID into an UserId struct
 func UserID(input string) (*UserId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/analytics_shared_item.go
+++ b/internal/services/applicationinsights/parse/analytics_shared_item.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AnalyticsSharedItemId struct {
@@ -42,7 +42,7 @@ func (id AnalyticsSharedItemId) ID() string {
 
 // AnalyticsSharedItemID parses a AnalyticsSharedItem ID into an AnalyticsSharedItemId struct
 func AnalyticsSharedItemID(input string) (*AnalyticsSharedItemId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/analytics_user_item.go
+++ b/internal/services/applicationinsights/parse/analytics_user_item.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AnalyticsUserItemId struct {
@@ -42,7 +42,7 @@ func (id AnalyticsUserItemId) ID() string {
 
 // AnalyticsUserItemID parses a AnalyticsUserItem ID into an AnalyticsUserItemId struct
 func AnalyticsUserItemID(input string) (*AnalyticsUserItemId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/api_key.go
+++ b/internal/services/applicationinsights/parse/api_key.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApiKeyId struct {
@@ -42,7 +42,7 @@ func (id ApiKeyId) ID() string {
 
 // ApiKeyID parses a ApiKey ID into an ApiKeyId struct
 func ApiKeyID(input string) (*ApiKeyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/component.go
+++ b/internal/services/applicationinsights/parse/component.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ComponentId struct {
@@ -39,7 +39,7 @@ func (id ComponentId) ID() string {
 
 // ComponentID parses a Component ID into an ComponentId struct
 func ComponentID(input string) (*ComponentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/smart_detection_rule.go
+++ b/internal/services/applicationinsights/parse/smart_detection_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SmartDetectionRuleId struct {
@@ -42,7 +42,7 @@ func (id SmartDetectionRuleId) ID() string {
 
 // SmartDetectionRuleID parses a SmartDetectionRule ID into an SmartDetectionRuleId struct
 func SmartDetectionRuleID(input string) (*SmartDetectionRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/applicationinsights/parse/web_test_id.go
+++ b/internal/services/applicationinsights/parse/web_test_id.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WebTestId struct {
@@ -39,7 +39,7 @@ func (id WebTestId) ID() string {
 
 // WebTestID parses a WebTest ID into an WebTestId struct
 func WebTestID(input string) (*WebTestId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/appservice/parse/app_service_environment.go
+++ b/internal/services/appservice/parse/app_service_environment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServiceEnvironmentId struct {
@@ -39,7 +39,7 @@ func (id AppServiceEnvironmentId) ID() string {
 
 // AppServiceEnvironmentID parses a AppServiceEnvironment ID into an AppServiceEnvironmentId struct
 func AppServiceEnvironmentID(input string) (*AppServiceEnvironmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/appservice/parse/function_app.go
+++ b/internal/services/appservice/parse/function_app.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FunctionAppId struct {
@@ -39,7 +39,7 @@ func (id FunctionAppId) ID() string {
 
 // FunctionAppID parses a FunctionApp ID into an FunctionAppId struct
 func FunctionAppID(input string) (*FunctionAppId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/appservice/parse/service_plan.go
+++ b/internal/services/appservice/parse/service_plan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServicePlanId struct {
@@ -39,7 +39,7 @@ func (id ServicePlanId) ID() string {
 
 // ServicePlanID parses a ServicePlan ID into an ServicePlanId struct
 func ServicePlanID(input string) (*ServicePlanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/appservice/parse/web_app.go
+++ b/internal/services/appservice/parse/web_app.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WebAppId struct {
@@ -39,7 +39,7 @@ func (id WebAppId) ID() string {
 
 // WebAppID parses a WebApp ID into an WebAppId struct
 func WebAppID(input string) (*WebAppId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/attestation/parse/provider.go
+++ b/internal/services/attestation/parse/provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProviderId struct {
@@ -39,7 +39,7 @@ func (id ProviderId) ID() string {
 
 // ProviderID parses a Provider ID into an ProviderId struct
 func ProviderID(input string) (*ProviderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/automation_account.go
+++ b/internal/services/automation/parse/automation_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AutomationAccountId struct {
@@ -39,7 +39,7 @@ func (id AutomationAccountId) ID() string {
 
 // AutomationAccountID parses a AutomationAccount ID into an AutomationAccountId struct
 func AutomationAccountID(input string) (*AutomationAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/certificate.go
+++ b/internal/services/automation/parse/certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CertificateId struct {
@@ -42,7 +42,7 @@ func (id CertificateId) ID() string {
 
 // CertificateID parses a Certificate ID into an CertificateId struct
 func CertificateID(input string) (*CertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/configuration.go
+++ b/internal/services/automation/parse/configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConfigurationId struct {
@@ -42,7 +42,7 @@ func (id ConfigurationId) ID() string {
 
 // ConfigurationID parses a Configuration ID into an ConfigurationId struct
 func ConfigurationID(input string) (*ConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/connection.go
+++ b/internal/services/automation/parse/connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConnectionId struct {
@@ -42,7 +42,7 @@ func (id ConnectionId) ID() string {
 
 // ConnectionID parses a Connection ID into an ConnectionId struct
 func ConnectionID(input string) (*ConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/credential.go
+++ b/internal/services/automation/parse/credential.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CredentialId struct {
@@ -42,7 +42,7 @@ func (id CredentialId) ID() string {
 
 // CredentialID parses a Credential ID into an CredentialId struct
 func CredentialID(input string) (*CredentialId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/job_schedule.go
+++ b/internal/services/automation/parse/job_schedule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type JobScheduleId struct {
@@ -42,7 +42,7 @@ func (id JobScheduleId) ID() string {
 
 // JobScheduleID parses a JobSchedule ID into an JobScheduleId struct
 func JobScheduleID(input string) (*JobScheduleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/module.go
+++ b/internal/services/automation/parse/module.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ModuleId struct {
@@ -42,7 +42,7 @@ func (id ModuleId) ID() string {
 
 // ModuleID parses a Module ID into an ModuleId struct
 func ModuleID(input string) (*ModuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/node_configuration.go
+++ b/internal/services/automation/parse/node_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NodeConfigurationId struct {
@@ -42,7 +42,7 @@ func (id NodeConfigurationId) ID() string {
 
 // NodeConfigurationID parses a NodeConfiguration ID into an NodeConfigurationId struct
 func NodeConfigurationID(input string) (*NodeConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/runbook.go
+++ b/internal/services/automation/parse/runbook.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RunbookId struct {
@@ -42,7 +42,7 @@ func (id RunbookId) ID() string {
 
 // RunbookID parses a Runbook ID into an RunbookId struct
 func RunbookID(input string) (*RunbookId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/schedule.go
+++ b/internal/services/automation/parse/schedule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ScheduleId struct {
@@ -42,7 +42,7 @@ func (id ScheduleId) ID() string {
 
 // ScheduleID parses a Schedule ID into an ScheduleId struct
 func ScheduleID(input string) (*ScheduleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/variable.go
+++ b/internal/services/automation/parse/variable.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VariableId struct {
@@ -42,7 +42,7 @@ func (id VariableId) ID() string {
 
 // VariableID parses a Variable ID into an VariableId struct
 func VariableID(input string) (*VariableId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/automation/parse/webhook.go
+++ b/internal/services/automation/parse/webhook.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WebhookId struct {
@@ -42,7 +42,7 @@ func (id WebhookId) ID() string {
 
 // WebhookID parses a Webhook ID into an WebhookId struct
 func WebhookID(input string) (*WebhookId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/azurestackhci/parse/cluster.go
+++ b/internal/services/azurestackhci/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/batch/parse/account.go
+++ b/internal/services/batch/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/batch/parse/application.go
+++ b/internal/services/batch/parse/application.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationId struct {
@@ -42,7 +42,7 @@ func (id ApplicationId) ID() string {
 
 // ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/batch/parse/certificate.go
+++ b/internal/services/batch/parse/certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CertificateId struct {
@@ -42,7 +42,7 @@ func (id CertificateId) ID() string {
 
 // CertificateID parses a Certificate ID into an CertificateId struct
 func CertificateID(input string) (*CertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/batch/parse/job.go
+++ b/internal/services/batch/parse/job.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type JobId struct {
@@ -45,7 +45,7 @@ func (id JobId) ID() string {
 
 // JobID parses a Job ID into an JobId struct
 func JobID(input string) (*JobId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/batch/parse/pool.go
+++ b/internal/services/batch/parse/pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PoolId struct {
@@ -42,7 +42,7 @@ func (id PoolId) ID() string {
 
 // PoolID parses a Pool ID into an PoolId struct
 func PoolID(input string) (*PoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/bot/parse/bot_channel.go
+++ b/internal/services/bot/parse/bot_channel.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BotChannelId struct {
@@ -42,7 +42,7 @@ func (id BotChannelId) ID() string {
 
 // BotChannelID parses a BotChannel ID into an BotChannelId struct
 func BotChannelID(input string) (*BotChannelId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/bot/parse/bot_connection.go
+++ b/internal/services/bot/parse/bot_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BotConnectionId struct {
@@ -42,7 +42,7 @@ func (id BotConnectionId) ID() string {
 
 // BotConnectionID parses a BotConnection ID into an BotConnectionId struct
 func BotConnectionID(input string) (*BotConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/bot/parse/bot_healthbot.go
+++ b/internal/services/bot/parse/bot_healthbot.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BotHealthbotId struct {
@@ -39,7 +39,7 @@ func (id BotHealthbotId) ID() string {
 
 // BotHealthbotID parses a BotHealthbot ID into an BotHealthbotId struct
 func BotHealthbotID(input string) (*BotHealthbotId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/bot/parse/bot_service.go
+++ b/internal/services/bot/parse/bot_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BotServiceId struct {
@@ -39,7 +39,7 @@ func (id BotServiceId) ID() string {
 
 // BotServiceID parses a BotService ID into an BotServiceId struct
 func BotServiceID(input string) (*BotServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cdn/parse/custom_domain.go
+++ b/internal/services/cdn/parse/custom_domain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CustomDomainId struct {
@@ -45,7 +45,7 @@ func (id CustomDomainId) ID() string {
 
 // CustomDomainID parses a CustomDomain ID into an CustomDomainId struct
 func CustomDomainID(input string) (*CustomDomainId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cdn/parse/endpoint.go
+++ b/internal/services/cdn/parse/endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EndpointId struct {
@@ -42,7 +42,7 @@ func (id EndpointId) ID() string {
 
 // EndpointID parses a Endpoint ID into an EndpointId struct
 func EndpointID(input string) (*EndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cdn/parse/profile.go
+++ b/internal/services/cdn/parse/profile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProfileId struct {
@@ -39,7 +39,7 @@ func (id ProfileId) ID() string {
 
 // ProfileID parses a Profile ID into an ProfileId struct
 func ProfileID(input string) (*ProfileId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cognitive/parse/account.go
+++ b/internal/services/cognitive/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/communication/parse/communication_service.go
+++ b/internal/services/communication/parse/communication_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CommunicationServiceId struct {
@@ -39,7 +39,7 @@ func (id CommunicationServiceId) ID() string {
 
 // CommunicationServiceID parses a CommunicationService ID into an CommunicationServiceId struct
 func CommunicationServiceID(input string) (*CommunicationServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/availability_set.go
+++ b/internal/services/compute/parse/availability_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AvailabilitySetId struct {
@@ -39,7 +39,7 @@ func (id AvailabilitySetId) ID() string {
 
 // AvailabilitySetID parses a AvailabilitySet ID into an AvailabilitySetId struct
 func AvailabilitySetID(input string) (*AvailabilitySetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/data_disk.go
+++ b/internal/services/compute/parse/data_disk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataDiskId struct {
@@ -42,7 +42,7 @@ func (id DataDiskId) ID() string {
 
 // DataDiskID parses a DataDisk ID into an DataDiskId struct
 func DataDiskID(input string) (*DataDiskId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/dedicated_host.go
+++ b/internal/services/compute/parse/dedicated_host.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DedicatedHostId struct {
@@ -42,7 +42,7 @@ func (id DedicatedHostId) ID() string {
 
 // DedicatedHostID parses a DedicatedHost ID into an DedicatedHostId struct
 func DedicatedHostID(input string) (*DedicatedHostId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/dedicated_host_group.go
+++ b/internal/services/compute/parse/dedicated_host_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DedicatedHostGroupId struct {
@@ -39,7 +39,7 @@ func (id DedicatedHostGroupId) ID() string {
 
 // DedicatedHostGroupID parses a DedicatedHostGroup ID into an DedicatedHostGroupId struct
 func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/disk_access.go
+++ b/internal/services/compute/parse/disk_access.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DiskAccessId struct {
@@ -39,7 +39,7 @@ func (id DiskAccessId) ID() string {
 
 // DiskAccessID parses a DiskAccess ID into an DiskAccessId struct
 func DiskAccessID(input string) (*DiskAccessId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/disk_encryption_set.go
+++ b/internal/services/compute/parse/disk_encryption_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DiskEncryptionSetId struct {
@@ -39,7 +39,7 @@ func (id DiskEncryptionSetId) ID() string {
 
 // DiskEncryptionSetID parses a DiskEncryptionSet ID into an DiskEncryptionSetId struct
 func DiskEncryptionSetID(input string) (*DiskEncryptionSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/host_group.go
+++ b/internal/services/compute/parse/host_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HostGroupId struct {
@@ -39,7 +39,7 @@ func (id HostGroupId) ID() string {
 
 // HostGroupID parses a HostGroup ID into an HostGroupId struct
 func HostGroupID(input string) (*HostGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/hybrid_machine.go
+++ b/internal/services/compute/parse/hybrid_machine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HybridMachineId struct {
@@ -39,7 +39,7 @@ func (id HybridMachineId) ID() string {
 
 // HybridMachineID parses a HybridMachine ID into an HybridMachineId struct
 func HybridMachineID(input string) (*HybridMachineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/image.go
+++ b/internal/services/compute/parse/image.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ImageId struct {
@@ -39,7 +39,7 @@ func (id ImageId) ID() string {
 
 // ImageID parses a Image ID into an ImageId struct
 func ImageID(input string) (*ImageId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/managed_disk.go
+++ b/internal/services/compute/parse/managed_disk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedDiskId struct {
@@ -39,7 +39,7 @@ func (id ManagedDiskId) ID() string {
 
 // ManagedDiskID parses a ManagedDisk ID into an ManagedDiskId struct
 func ManagedDiskID(input string) (*ManagedDiskId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/plan.go
+++ b/internal/services/compute/parse/plan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PlanId struct {
@@ -42,7 +42,7 @@ func (id PlanId) ID() string {
 
 // PlanID parses a Plan ID into an PlanId struct
 func PlanID(input string) (*PlanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/proximity_placement_group.go
+++ b/internal/services/compute/parse/proximity_placement_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProximityPlacementGroupId struct {
@@ -39,7 +39,7 @@ func (id ProximityPlacementGroupId) ID() string {
 
 // ProximityPlacementGroupID parses a ProximityPlacementGroup ID into an ProximityPlacementGroupId struct
 func ProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/shared_image.go
+++ b/internal/services/compute/parse/shared_image.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SharedImageId struct {
@@ -42,7 +42,7 @@ func (id SharedImageId) ID() string {
 
 // SharedImageID parses a SharedImage ID into an SharedImageId struct
 func SharedImageID(input string) (*SharedImageId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/shared_image_gallery.go
+++ b/internal/services/compute/parse/shared_image_gallery.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SharedImageGalleryId struct {
@@ -39,7 +39,7 @@ func (id SharedImageGalleryId) ID() string {
 
 // SharedImageGalleryID parses a SharedImageGallery ID into an SharedImageGalleryId struct
 func SharedImageGalleryID(input string) (*SharedImageGalleryId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/shared_image_version.go
+++ b/internal/services/compute/parse/shared_image_version.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SharedImageVersionId struct {
@@ -45,7 +45,7 @@ func (id SharedImageVersionId) ID() string {
 
 // SharedImageVersionID parses a SharedImageVersion ID into an SharedImageVersionId struct
 func SharedImageVersionID(input string) (*SharedImageVersionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/snapshot.go
+++ b/internal/services/compute/parse/snapshot.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SnapshotId struct {
@@ -39,7 +39,7 @@ func (id SnapshotId) ID() string {
 
 // SnapshotID parses a Snapshot ID into an SnapshotId struct
 func SnapshotID(input string) (*SnapshotId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/ssh_public_key.go
+++ b/internal/services/compute/parse/ssh_public_key.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SSHPublicKeyId struct {
@@ -39,7 +39,7 @@ func (id SSHPublicKeyId) ID() string {
 
 // SSHPublicKeyID parses a SSHPublicKey ID into an SSHPublicKeyId struct
 func SSHPublicKeyID(input string) (*SSHPublicKeyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/virtual_machine.go
+++ b/internal/services/compute/parse/virtual_machine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineId struct {
@@ -39,7 +39,7 @@ func (id VirtualMachineId) ID() string {
 
 // VirtualMachineID parses a VirtualMachine ID into an VirtualMachineId struct
 func VirtualMachineID(input string) (*VirtualMachineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/virtual_machine_extension.go
+++ b/internal/services/compute/parse/virtual_machine_extension.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineExtensionId struct {
@@ -42,7 +42,7 @@ func (id VirtualMachineExtensionId) ID() string {
 
 // VirtualMachineExtensionID parses a VirtualMachineExtension ID into an VirtualMachineExtensionId struct
 func VirtualMachineExtensionID(input string) (*VirtualMachineExtensionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/virtual_machine_scale_set.go
+++ b/internal/services/compute/parse/virtual_machine_scale_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineScaleSetId struct {
@@ -39,7 +39,7 @@ func (id VirtualMachineScaleSetId) ID() string {
 
 // VirtualMachineScaleSetID parses a VirtualMachineScaleSet ID into an VirtualMachineScaleSetId struct
 func VirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/compute/parse/virtual_machine_scale_set_extension.go
+++ b/internal/services/compute/parse/virtual_machine_scale_set_extension.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineScaleSetExtensionId struct {
@@ -42,7 +42,7 @@ func (id VirtualMachineScaleSetExtensionId) ID() string {
 
 // VirtualMachineScaleSetExtensionID parses a VirtualMachineScaleSetExtension ID into an VirtualMachineScaleSetExtensionId struct
 func VirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleSetExtensionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/consumption/parse/consumption_budget_resource_group.go
+++ b/internal/services/consumption/parse/consumption_budget_resource_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConsumptionBudgetResourceGroupId struct {
@@ -39,7 +39,7 @@ func (id ConsumptionBudgetResourceGroupId) ID() string {
 
 // ConsumptionBudgetResourceGroupID parses a ConsumptionBudgetResourceGroup ID into an ConsumptionBudgetResourceGroupId struct
 func ConsumptionBudgetResourceGroupID(input string) (*ConsumptionBudgetResourceGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/consumption/parse/consumption_budget_subscription.go
+++ b/internal/services/consumption/parse/consumption_budget_subscription.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConsumptionBudgetSubscriptionId struct {
@@ -36,7 +36,7 @@ func (id ConsumptionBudgetSubscriptionId) ID() string {
 
 // ConsumptionBudgetSubscriptionID parses a ConsumptionBudgetSubscription ID into an ConsumptionBudgetSubscriptionId struct
 func ConsumptionBudgetSubscriptionID(input string) (*ConsumptionBudgetSubscriptionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/cluster.go
+++ b/internal/services/containers/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/container_group.go
+++ b/internal/services/containers/parse/container_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ContainerGroupId struct {
@@ -39,7 +39,7 @@ func (id ContainerGroupId) ID() string {
 
 // ContainerGroupID parses a ContainerGroup ID into an ContainerGroupId struct
 func ContainerGroupID(input string) (*ContainerGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/container_registry_scope_map.go
+++ b/internal/services/containers/parse/container_registry_scope_map.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ContainerRegistryScopeMapId struct {
@@ -42,7 +42,7 @@ func (id ContainerRegistryScopeMapId) ID() string {
 
 // ContainerRegistryScopeMapID parses a ContainerRegistryScopeMap ID into an ContainerRegistryScopeMapId struct
 func ContainerRegistryScopeMapID(input string) (*ContainerRegistryScopeMapId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/container_registry_token.go
+++ b/internal/services/containers/parse/container_registry_token.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ContainerRegistryTokenId struct {
@@ -42,7 +42,7 @@ func (id ContainerRegistryTokenId) ID() string {
 
 // ContainerRegistryTokenID parses a ContainerRegistryToken ID into an ContainerRegistryTokenId struct
 func ContainerRegistryTokenID(input string) (*ContainerRegistryTokenId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/node_pool.go
+++ b/internal/services/containers/parse/node_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NodePoolId struct {
@@ -42,7 +42,7 @@ func (id NodePoolId) ID() string {
 
 // NodePoolID parses a NodePool ID into an NodePoolId struct
 func NodePoolID(input string) (*NodePoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/registry.go
+++ b/internal/services/containers/parse/registry.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RegistryId struct {
@@ -39,7 +39,7 @@ func (id RegistryId) ID() string {
 
 // RegistryID parses a Registry ID into an RegistryId struct
 func RegistryID(input string) (*RegistryId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/containers/parse/webhook.go
+++ b/internal/services/containers/parse/webhook.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WebhookId struct {
@@ -42,7 +42,7 @@ func (id WebhookId) ID() string {
 
 // WebhookID parses a Webhook ID into an WebhookId struct
 func WebhookID(input string) (*WebhookId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/cassandra_cluster.go
+++ b/internal/services/cosmos/parse/cassandra_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CassandraClusterId struct {
@@ -39,7 +39,7 @@ func (id CassandraClusterId) ID() string {
 
 // CassandraClusterID parses a CassandraCluster ID into an CassandraClusterId struct
 func CassandraClusterID(input string) (*CassandraClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/cassandra_datacenter.go
+++ b/internal/services/cosmos/parse/cassandra_datacenter.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CassandraDatacenterId struct {
@@ -42,7 +42,7 @@ func (id CassandraDatacenterId) ID() string {
 
 // CassandraDatacenterID parses a CassandraDatacenter ID into an CassandraDatacenterId struct
 func CassandraDatacenterID(input string) (*CassandraDatacenterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/cassandra_keyspace.go
+++ b/internal/services/cosmos/parse/cassandra_keyspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CassandraKeyspaceId struct {
@@ -42,7 +42,7 @@ func (id CassandraKeyspaceId) ID() string {
 
 // CassandraKeyspaceID parses a CassandraKeyspace ID into an CassandraKeyspaceId struct
 func CassandraKeyspaceID(input string) (*CassandraKeyspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/cassandra_table.go
+++ b/internal/services/cosmos/parse/cassandra_table.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CassandraTableId struct {
@@ -45,7 +45,7 @@ func (id CassandraTableId) ID() string {
 
 // CassandraTableID parses a CassandraTable ID into an CassandraTableId struct
 func CassandraTableID(input string) (*CassandraTableId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/database_account.go
+++ b/internal/services/cosmos/parse/database_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseAccountId struct {
@@ -39,7 +39,7 @@ func (id DatabaseAccountId) ID() string {
 
 // DatabaseAccountID parses a DatabaseAccount ID into an DatabaseAccountId struct
 func DatabaseAccountID(input string) (*DatabaseAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/gremlin_database.go
+++ b/internal/services/cosmos/parse/gremlin_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GremlinDatabaseId struct {
@@ -42,7 +42,7 @@ func (id GremlinDatabaseId) ID() string {
 
 // GremlinDatabaseID parses a GremlinDatabase ID into an GremlinDatabaseId struct
 func GremlinDatabaseID(input string) (*GremlinDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/gremlin_graph.go
+++ b/internal/services/cosmos/parse/gremlin_graph.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type GremlinGraphId struct {
@@ -45,7 +45,7 @@ func (id GremlinGraphId) ID() string {
 
 // GremlinGraphID parses a GremlinGraph ID into an GremlinGraphId struct
 func GremlinGraphID(input string) (*GremlinGraphId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/mongodb_collection.go
+++ b/internal/services/cosmos/parse/mongodb_collection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MongodbCollectionId struct {
@@ -45,7 +45,7 @@ func (id MongodbCollectionId) ID() string {
 
 // MongodbCollectionID parses a MongodbCollection ID into an MongodbCollectionId struct
 func MongodbCollectionID(input string) (*MongodbCollectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/mongodb_database.go
+++ b/internal/services/cosmos/parse/mongodb_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MongodbDatabaseId struct {
@@ -42,7 +42,7 @@ func (id MongodbDatabaseId) ID() string {
 
 // MongodbDatabaseID parses a MongodbDatabase ID into an MongodbDatabaseId struct
 func MongodbDatabaseID(input string) (*MongodbDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/notebook_workspace.go
+++ b/internal/services/cosmos/parse/notebook_workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NotebookWorkspaceId struct {
@@ -42,7 +42,7 @@ func (id NotebookWorkspaceId) ID() string {
 
 // NotebookWorkspaceID parses a NotebookWorkspace ID into an NotebookWorkspaceId struct
 func NotebookWorkspaceID(input string) (*NotebookWorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/sql_container.go
+++ b/internal/services/cosmos/parse/sql_container.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlContainerId struct {
@@ -45,7 +45,7 @@ func (id SqlContainerId) ID() string {
 
 // SqlContainerID parses a SqlContainer ID into an SqlContainerId struct
 func SqlContainerID(input string) (*SqlContainerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/sql_database.go
+++ b/internal/services/cosmos/parse/sql_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlDatabaseId struct {
@@ -42,7 +42,7 @@ func (id SqlDatabaseId) ID() string {
 
 // SqlDatabaseID parses a SqlDatabase ID into an SqlDatabaseId struct
 func SqlDatabaseID(input string) (*SqlDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/sql_function.go
+++ b/internal/services/cosmos/parse/sql_function.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlFunctionId struct {
@@ -48,7 +48,7 @@ func (id SqlFunctionId) ID() string {
 
 // SqlFunctionID parses a SqlFunction ID into an SqlFunctionId struct
 func SqlFunctionID(input string) (*SqlFunctionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/sql_stored_procedure.go
+++ b/internal/services/cosmos/parse/sql_stored_procedure.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlStoredProcedureId struct {
@@ -48,7 +48,7 @@ func (id SqlStoredProcedureId) ID() string {
 
 // SqlStoredProcedureID parses a SqlStoredProcedure ID into an SqlStoredProcedureId struct
 func SqlStoredProcedureID(input string) (*SqlStoredProcedureId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/sql_trigger.go
+++ b/internal/services/cosmos/parse/sql_trigger.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlTriggerId struct {
@@ -48,7 +48,7 @@ func (id SqlTriggerId) ID() string {
 
 // SqlTriggerID parses a SqlTrigger ID into an SqlTriggerId struct
 func SqlTriggerID(input string) (*SqlTriggerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/parse/table.go
+++ b/internal/services/cosmos/parse/table.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TableId struct {
@@ -42,7 +42,7 @@ func (id TableId) ID() string {
 
 // TableID parses a Table ID into an TableId struct
 func TableID(input string) (*TableId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/cosmos/validate/cassandra_cluster_id_test.go
+++ b/internal/services/cosmos/validate/cassandra_cluster_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCassandraClusterID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/cluster1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.DOCUMENTDB/CASSANDRACLUSTERS/CLUSTER1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CassandraClusterID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/cosmos/validate/cassandra_datacenter_id.go
+++ b/internal/services/cosmos/validate/cassandra_datacenter_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
+)
+
+func CassandraDatacenterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.CassandraDatacenterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/cosmos/validate/cassandra_datacenter_id_test.go
+++ b/internal/services/cosmos/validate/cassandra_datacenter_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCassandraDatacenterID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing CassandraClusterName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CassandraClusterName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/",
+			Valid: false,
+		},
+
+		{
+			// missing DataCenterName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/cluster1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for DataCenterName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/cluster1/dataCenters/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DocumentDB/cassandraClusters/cluster1/dataCenters/dc1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.DOCUMENTDB/CASSANDRACLUSTERS/CLUSTER1/DATACENTERS/DC1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CassandraDatacenterID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/costmanagement/parse/resource_group_cost_management_export.go
+++ b/internal/services/costmanagement/parse/resource_group_cost_management_export.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ResourceGroupCostManagementExportId struct {
@@ -39,7 +39,7 @@ func (id ResourceGroupCostManagementExportId) ID() string {
 
 // ResourceGroupCostManagementExportID parses a ResourceGroupCostManagementExport ID into an ResourceGroupCostManagementExportId struct
 func ResourceGroupCostManagementExportID(input string) (*ResourceGroupCostManagementExportId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/costmanagement/parse/subscription_cost_management_export.go
+++ b/internal/services/costmanagement/parse/subscription_cost_management_export.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionCostManagementExportId struct {
@@ -36,7 +36,7 @@ func (id SubscriptionCostManagementExportId) ID() string {
 
 // SubscriptionCostManagementExportID parses a SubscriptionCostManagementExport ID into an SubscriptionCostManagementExportId struct
 func SubscriptionCostManagementExportID(input string) (*SubscriptionCostManagementExportId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/customproviders/parse/resource_provider.go
+++ b/internal/services/customproviders/parse/resource_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ResourceProviderId struct {
@@ -39,7 +39,7 @@ func (id ResourceProviderId) ID() string {
 
 // ResourceProviderID parses a ResourceProvider ID into an ResourceProviderId struct
 func ResourceProviderID(input string) (*ResourceProviderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/databasemigration/parse/project.go
+++ b/internal/services/databasemigration/parse/project.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProjectId struct {
@@ -42,7 +42,7 @@ func (id ProjectId) ID() string {
 
 // ProjectID parses a Project ID into an ProjectId struct
 func ProjectID(input string) (*ProjectId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/databasemigration/parse/service.go
+++ b/internal/services/databasemigration/parse/service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServiceId struct {
@@ -39,7 +39,7 @@ func (id ServiceId) ID() string {
 
 // ServiceID parses a Service ID into an ServiceId struct
 func ServiceID(input string) (*ServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/databricks/parse/customer_managed_key.go
+++ b/internal/services/databricks/parse/customer_managed_key.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CustomerManagedKeyId struct {
@@ -39,7 +39,7 @@ func (id CustomerManagedKeyId) ID() string {
 
 // CustomerManagedKeyID parses a CustomerManagedKey ID into an CustomerManagedKeyId struct
 func CustomerManagedKeyID(input string) (*CustomerManagedKeyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/databricks/parse/workspace.go
+++ b/internal/services/databricks/parse/workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceId struct {
@@ -39,7 +39,7 @@ func (id WorkspaceId) ID() string {
 
 // WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/data_factory.go
+++ b/internal/services/datafactory/parse/data_factory.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataFactoryId struct {
@@ -39,7 +39,7 @@ func (id DataFactoryId) ID() string {
 
 // DataFactoryID parses a DataFactory ID into an DataFactoryId struct
 func DataFactoryID(input string) (*DataFactoryId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/data_flow.go
+++ b/internal/services/datafactory/parse/data_flow.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataFlowId struct {
@@ -42,7 +42,7 @@ func (id DataFlowId) ID() string {
 
 // DataFlowID parses a DataFlow ID into an DataFlowId struct
 func DataFlowID(input string) (*DataFlowId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/data_set.go
+++ b/internal/services/datafactory/parse/data_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataSetId struct {
@@ -42,7 +42,7 @@ func (id DataSetId) ID() string {
 
 // DataSetID parses a DataSet ID into an DataSetId struct
 func DataSetID(input string) (*DataSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/integration_runtime.go
+++ b/internal/services/datafactory/parse/integration_runtime.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationRuntimeId struct {
@@ -42,7 +42,7 @@ func (id IntegrationRuntimeId) ID() string {
 
 // IntegrationRuntimeID parses a IntegrationRuntime ID into an IntegrationRuntimeId struct
 func IntegrationRuntimeID(input string) (*IntegrationRuntimeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/linked_service.go
+++ b/internal/services/datafactory/parse/linked_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LinkedServiceId struct {
@@ -42,7 +42,7 @@ func (id LinkedServiceId) ID() string {
 
 // LinkedServiceID parses a LinkedService ID into an LinkedServiceId struct
 func LinkedServiceID(input string) (*LinkedServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/managed_private_endpoint.go
+++ b/internal/services/datafactory/parse/managed_private_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedPrivateEndpointId struct {
@@ -45,7 +45,7 @@ func (id ManagedPrivateEndpointId) ID() string {
 
 // ManagedPrivateEndpointID parses a ManagedPrivateEndpoint ID into an ManagedPrivateEndpointId struct
 func ManagedPrivateEndpointID(input string) (*ManagedPrivateEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/pipeline.go
+++ b/internal/services/datafactory/parse/pipeline.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PipelineId struct {
@@ -42,7 +42,7 @@ func (id PipelineId) ID() string {
 
 // PipelineID parses a Pipeline ID into an PipelineId struct
 func PipelineID(input string) (*PipelineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datafactory/parse/trigger.go
+++ b/internal/services/datafactory/parse/trigger.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TriggerId struct {
@@ -42,7 +42,7 @@ func (id TriggerId) ID() string {
 
 // TriggerID parses a Trigger ID into an TriggerId struct
 func TriggerID(input string) (*TriggerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datalake/parse/account.go
+++ b/internal/services/datalake/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datalake/parse/analytics_account.go
+++ b/internal/services/datalake/parse/analytics_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AnalyticsAccountId struct {
@@ -39,7 +39,7 @@ func (id AnalyticsAccountId) ID() string {
 
 // AnalyticsAccountID parses a AnalyticsAccount ID into an AnalyticsAccountId struct
 func AnalyticsAccountID(input string) (*AnalyticsAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datalake/parse/analytics_firewall_rule.go
+++ b/internal/services/datalake/parse/analytics_firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AnalyticsFirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id AnalyticsFirewallRuleId) ID() string {
 
 // AnalyticsFirewallRuleID parses a AnalyticsFirewallRule ID into an AnalyticsFirewallRuleId struct
 func AnalyticsFirewallRuleID(input string) (*AnalyticsFirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datalake/parse/firewall_rule.go
+++ b/internal/services/datalake/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datalake/parse/virtual_network_rule.go
+++ b/internal/services/datalake/parse/virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkRuleId) ID() string {
 
 // VirtualNetworkRuleID parses a VirtualNetworkRule ID into an VirtualNetworkRuleId struct
 func VirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dataprotection/parse/backup_instance.go
+++ b/internal/services/dataprotection/parse/backup_instance.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackupInstanceId struct {
@@ -42,7 +42,7 @@ func (id BackupInstanceId) ID() string {
 
 // BackupInstanceID parses a BackupInstance ID into an BackupInstanceId struct
 func BackupInstanceID(input string) (*BackupInstanceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dataprotection/parse/backup_policy.go
+++ b/internal/services/dataprotection/parse/backup_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackupPolicyId struct {
@@ -42,7 +42,7 @@ func (id BackupPolicyId) ID() string {
 
 // BackupPolicyID parses a BackupPolicy ID into an BackupPolicyId struct
 func BackupPolicyID(input string) (*BackupPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dataprotection/parse/backup_vault.go
+++ b/internal/services/dataprotection/parse/backup_vault.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackupVaultId struct {
@@ -39,7 +39,7 @@ func (id BackupVaultId) ID() string {
 
 // BackupVaultID parses a BackupVault ID into an BackupVaultId struct
 func BackupVaultID(input string) (*BackupVaultId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datashare/parse/account.go
+++ b/internal/services/datashare/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datashare/parse/data_set.go
+++ b/internal/services/datashare/parse/data_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataSetId struct {
@@ -45,7 +45,7 @@ func (id DataSetId) ID() string {
 
 // DataSetID parses a DataSet ID into an DataSetId struct
 func DataSetID(input string) (*DataSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/datashare/parse/share.go
+++ b/internal/services/datashare/parse/share.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ShareId struct {
@@ -42,7 +42,7 @@ func (id ShareId) ID() string {
 
 // ShareID parses a Share ID into an ShareId struct
 func ShareID(input string) (*ShareId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/desktopvirtualization/parse/application.go
+++ b/internal/services/desktopvirtualization/parse/application.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationId struct {
@@ -42,7 +42,7 @@ func (id ApplicationId) ID() string {
 
 // ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func ApplicationID(input string) (*ApplicationId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func ApplicationIDInsensitively(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/desktopvirtualization/parse/application_group.go
+++ b/internal/services/desktopvirtualization/parse/application_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationGroupId struct {
@@ -39,7 +39,7 @@ func (id ApplicationGroupId) ID() string {
 
 // ApplicationGroupID parses a ApplicationGroup ID into an ApplicationGroupId struct
 func ApplicationGroupID(input string) (*ApplicationGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ApplicationGroupID(input string) (*ApplicationGroupId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func ApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/desktopvirtualization/parse/host_pool.go
+++ b/internal/services/desktopvirtualization/parse/host_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HostPoolId struct {
@@ -39,7 +39,7 @@ func (id HostPoolId) ID() string {
 
 // HostPoolID parses a HostPool ID into an HostPoolId struct
 func HostPoolID(input string) (*HostPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func HostPoolID(input string) (*HostPoolId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func HostPoolIDInsensitively(input string) (*HostPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/desktopvirtualization/parse/workspace.go
+++ b/internal/services/desktopvirtualization/parse/workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceId struct {
@@ -39,7 +39,7 @@ func (id WorkspaceId) ID() string {
 
 // WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devspace/parse/controller.go
+++ b/internal/services/devspace/parse/controller.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ControllerId struct {
@@ -39,7 +39,7 @@ func (id ControllerId) ID() string {
 
 // ControllerID parses a Controller ID into an ControllerId struct
 func ControllerID(input string) (*ControllerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/dev_test_lab.go
+++ b/internal/services/devtestlabs/parse/dev_test_lab.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DevTestLabId struct {
@@ -39,7 +39,7 @@ func (id DevTestLabId) ID() string {
 
 // DevTestLabID parses a DevTestLab ID into an DevTestLabId struct
 func DevTestLabID(input string) (*DevTestLabId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/dev_test_lab_policy.go
+++ b/internal/services/devtestlabs/parse/dev_test_lab_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DevTestLabPolicyId struct {
@@ -45,7 +45,7 @@ func (id DevTestLabPolicyId) ID() string {
 
 // DevTestLabPolicyID parses a DevTestLabPolicy ID into an DevTestLabPolicyId struct
 func DevTestLabPolicyID(input string) (*DevTestLabPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/dev_test_lab_schedule.go
+++ b/internal/services/devtestlabs/parse/dev_test_lab_schedule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DevTestLabScheduleId struct {
@@ -42,7 +42,7 @@ func (id DevTestLabScheduleId) ID() string {
 
 // DevTestLabScheduleID parses a DevTestLabSchedule ID into an DevTestLabScheduleId struct
 func DevTestLabScheduleID(input string) (*DevTestLabScheduleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/dev_test_virtual_machine.go
+++ b/internal/services/devtestlabs/parse/dev_test_virtual_machine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DevTestVirtualMachineId struct {
@@ -42,7 +42,7 @@ func (id DevTestVirtualMachineId) ID() string {
 
 // DevTestVirtualMachineID parses a DevTestVirtualMachine ID into an DevTestVirtualMachineId struct
 func DevTestVirtualMachineID(input string) (*DevTestVirtualMachineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/dev_test_virtual_network.go
+++ b/internal/services/devtestlabs/parse/dev_test_virtual_network.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DevTestVirtualNetworkId struct {
@@ -42,7 +42,7 @@ func (id DevTestVirtualNetworkId) ID() string {
 
 // DevTestVirtualNetworkID parses a DevTestVirtualNetwork ID into an DevTestVirtualNetworkId struct
 func DevTestVirtualNetworkID(input string) (*DevTestVirtualNetworkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/devtestlabs/parse/schedule.go
+++ b/internal/services/devtestlabs/parse/schedule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ScheduleId struct {
@@ -39,7 +39,7 @@ func (id ScheduleId) ID() string {
 
 // ScheduleID parses a Schedule ID into an ScheduleId struct
 func ScheduleID(input string) (*ScheduleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/digitaltwins/parse/digital_twins_endpoint.go
+++ b/internal/services/digitaltwins/parse/digital_twins_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DigitalTwinsEndpointId struct {
@@ -42,7 +42,7 @@ func (id DigitalTwinsEndpointId) ID() string {
 
 // DigitalTwinsEndpointID parses a DigitalTwinsEndpoint ID into an DigitalTwinsEndpointId struct
 func DigitalTwinsEndpointID(input string) (*DigitalTwinsEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/digitaltwins/parse/digital_twins_instance.go
+++ b/internal/services/digitaltwins/parse/digital_twins_instance.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DigitalTwinsInstanceId struct {
@@ -39,7 +39,7 @@ func (id DigitalTwinsInstanceId) ID() string {
 
 // DigitalTwinsInstanceID parses a DigitalTwinsInstance ID into an DigitalTwinsInstanceId struct
 func DigitalTwinsInstanceID(input string) (*DigitalTwinsInstanceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/a_record.go
+++ b/internal/services/dns/parse/a_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ARecordId struct {
@@ -42,7 +42,7 @@ func (id ARecordId) ID() string {
 
 // ARecordID parses a ARecord ID into an ARecordId struct
 func ARecordID(input string) (*ARecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/aaaa_record.go
+++ b/internal/services/dns/parse/aaaa_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AaaaRecordId struct {
@@ -42,7 +42,7 @@ func (id AaaaRecordId) ID() string {
 
 // AaaaRecordID parses a AaaaRecord ID into an AaaaRecordId struct
 func AaaaRecordID(input string) (*AaaaRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/caa_record.go
+++ b/internal/services/dns/parse/caa_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CaaRecordId struct {
@@ -42,7 +42,7 @@ func (id CaaRecordId) ID() string {
 
 // CaaRecordID parses a CaaRecord ID into an CaaRecordId struct
 func CaaRecordID(input string) (*CaaRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/cname_record.go
+++ b/internal/services/dns/parse/cname_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CnameRecordId struct {
@@ -42,7 +42,7 @@ func (id CnameRecordId) ID() string {
 
 // CnameRecordID parses a CnameRecord ID into an CnameRecordId struct
 func CnameRecordID(input string) (*CnameRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/dns_zone.go
+++ b/internal/services/dns/parse/dns_zone.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DnsZoneId struct {
@@ -39,7 +39,7 @@ func (id DnsZoneId) ID() string {
 
 // DnsZoneID parses a DnsZone ID into an DnsZoneId struct
 func DnsZoneID(input string) (*DnsZoneId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/mx_record.go
+++ b/internal/services/dns/parse/mx_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MxRecordId struct {
@@ -42,7 +42,7 @@ func (id MxRecordId) ID() string {
 
 // MxRecordID parses a MxRecord ID into an MxRecordId struct
 func MxRecordID(input string) (*MxRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/ns_record.go
+++ b/internal/services/dns/parse/ns_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NsRecordId struct {
@@ -42,7 +42,7 @@ func (id NsRecordId) ID() string {
 
 // NsRecordID parses a NsRecord ID into an NsRecordId struct
 func NsRecordID(input string) (*NsRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/ptr_record.go
+++ b/internal/services/dns/parse/ptr_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PtrRecordId struct {
@@ -42,7 +42,7 @@ func (id PtrRecordId) ID() string {
 
 // PtrRecordID parses a PtrRecord ID into an PtrRecordId struct
 func PtrRecordID(input string) (*PtrRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/srv_record.go
+++ b/internal/services/dns/parse/srv_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SrvRecordId struct {
@@ -42,7 +42,7 @@ func (id SrvRecordId) ID() string {
 
 // SrvRecordID parses a SrvRecord ID into an SrvRecordId struct
 func SrvRecordID(input string) (*SrvRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/dns/parse/txt_record.go
+++ b/internal/services/dns/parse/txt_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TxtRecordId struct {
@@ -42,7 +42,7 @@ func (id TxtRecordId) ID() string {
 
 // TxtRecordID parses a TxtRecord ID into an TxtRecordId struct
 func TxtRecordID(input string) (*TxtRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/domainservices/parse/domain_service.go
+++ b/internal/services/domainservices/parse/domain_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DomainServiceId struct {
@@ -42,7 +42,7 @@ func (id DomainServiceId) ID() string {
 
 // DomainServiceID parses a DomainService ID into an DomainServiceId struct
 func DomainServiceID(input string) (*DomainServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/domainservices/parse/domain_service_replica_set.go
+++ b/internal/services/domainservices/parse/domain_service_replica_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DomainServiceReplicaSetId struct {
@@ -42,7 +42,7 @@ func (id DomainServiceReplicaSetId) ID() string {
 
 // DomainServiceReplicaSetID parses a DomainServiceReplicaSet ID into an DomainServiceReplicaSetId struct
 func DomainServiceReplicaSetID(input string) (*DomainServiceReplicaSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/eventgrid/parse/domain.go
+++ b/internal/services/eventgrid/parse/domain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DomainId struct {
@@ -39,7 +39,7 @@ func (id DomainId) ID() string {
 
 // DomainID parses a Domain ID into an DomainId struct
 func DomainID(input string) (*DomainId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/eventgrid/parse/domain_topic.go
+++ b/internal/services/eventgrid/parse/domain_topic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DomainTopicId struct {
@@ -42,7 +42,7 @@ func (id DomainTopicId) ID() string {
 
 // DomainTopicID parses a DomainTopic ID into an DomainTopicId struct
 func DomainTopicID(input string) (*DomainTopicId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/eventgrid/parse/system_topic.go
+++ b/internal/services/eventgrid/parse/system_topic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SystemTopicId struct {
@@ -39,7 +39,7 @@ func (id SystemTopicId) ID() string {
 
 // SystemTopicID parses a SystemTopic ID into an SystemTopicId struct
 func SystemTopicID(input string) (*SystemTopicId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/eventgrid/parse/topic.go
+++ b/internal/services/eventgrid/parse/topic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TopicId struct {
@@ -39,7 +39,7 @@ func (id TopicId) ID() string {
 
 // TopicID parses a Topic ID into an TopicId struct
 func TopicID(input string) (*TopicId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall.go
+++ b/internal/services/firewall/parse/firewall.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallId struct {
@@ -39,7 +39,7 @@ func (id FirewallId) ID() string {
 
 // FirewallID parses a Firewall ID into an FirewallId struct
 func FirewallID(input string) (*FirewallId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall_application_rule_collection.go
+++ b/internal/services/firewall/parse/firewall_application_rule_collection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallApplicationRuleCollectionId struct {
@@ -42,7 +42,7 @@ func (id FirewallApplicationRuleCollectionId) ID() string {
 
 // FirewallApplicationRuleCollectionID parses a FirewallApplicationRuleCollection ID into an FirewallApplicationRuleCollectionId struct
 func FirewallApplicationRuleCollectionID(input string) (*FirewallApplicationRuleCollectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall_nat_rule_collection.go
+++ b/internal/services/firewall/parse/firewall_nat_rule_collection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallNatRuleCollectionId struct {
@@ -42,7 +42,7 @@ func (id FirewallNatRuleCollectionId) ID() string {
 
 // FirewallNatRuleCollectionID parses a FirewallNatRuleCollection ID into an FirewallNatRuleCollectionId struct
 func FirewallNatRuleCollectionID(input string) (*FirewallNatRuleCollectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall_network_rule_collection.go
+++ b/internal/services/firewall/parse/firewall_network_rule_collection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallNetworkRuleCollectionId struct {
@@ -42,7 +42,7 @@ func (id FirewallNetworkRuleCollectionId) ID() string {
 
 // FirewallNetworkRuleCollectionID parses a FirewallNetworkRuleCollection ID into an FirewallNetworkRuleCollectionId struct
 func FirewallNetworkRuleCollectionID(input string) (*FirewallNetworkRuleCollectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall_policy.go
+++ b/internal/services/firewall/parse/firewall_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallPolicyId struct {
@@ -39,7 +39,7 @@ func (id FirewallPolicyId) ID() string {
 
 // FirewallPolicyID parses a FirewallPolicy ID into an FirewallPolicyId struct
 func FirewallPolicyID(input string) (*FirewallPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/firewall/parse/firewall_policy_rule_collection_group.go
+++ b/internal/services/firewall/parse/firewall_policy_rule_collection_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallPolicyRuleCollectionGroupId struct {
@@ -42,7 +42,7 @@ func (id FirewallPolicyRuleCollectionGroupId) ID() string {
 
 // FirewallPolicyRuleCollectionGroupID parses a FirewallPolicyRuleCollectionGroup ID into an FirewallPolicyRuleCollectionGroupId struct
 func FirewallPolicyRuleCollectionGroupID(input string) (*FirewallPolicyRuleCollectionGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/backend_pool.go
+++ b/internal/services/frontdoor/parse/backend_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackendPoolId struct {
@@ -42,7 +42,7 @@ func (id BackendPoolId) ID() string {
 
 // BackendPoolID parses a BackendPool ID into an BackendPoolId struct
 func BackendPoolID(input string) (*BackendPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func BackendPoolID(input string) (*BackendPoolId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func BackendPoolIDInsensitively(input string) (*BackendPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/custom_https_configuration.go
+++ b/internal/services/frontdoor/parse/custom_https_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CustomHttpsConfigurationId struct {
@@ -42,7 +42,7 @@ func (id CustomHttpsConfigurationId) ID() string {
 
 // CustomHttpsConfigurationID parses a CustomHttpsConfiguration ID into an CustomHttpsConfigurationId struct
 func CustomHttpsConfigurationID(input string) (*CustomHttpsConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func CustomHttpsConfigurationID(input string) (*CustomHttpsConfigurationId, erro
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func CustomHttpsConfigurationIDInsensitively(input string) (*CustomHttpsConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/front_door.go
+++ b/internal/services/frontdoor/parse/front_door.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FrontDoorId struct {
@@ -39,7 +39,7 @@ func (id FrontDoorId) ID() string {
 
 // FrontDoorID parses a FrontDoor ID into an FrontDoorId struct
 func FrontDoorID(input string) (*FrontDoorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func FrontDoorID(input string) (*FrontDoorId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func FrontDoorIDInsensitively(input string) (*FrontDoorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/frontend_endpoint.go
+++ b/internal/services/frontdoor/parse/frontend_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FrontendEndpointId struct {
@@ -42,7 +42,7 @@ func (id FrontendEndpointId) ID() string {
 
 // FrontendEndpointID parses a FrontendEndpoint ID into an FrontendEndpointId struct
 func FrontendEndpointID(input string) (*FrontendEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func FrontendEndpointID(input string) (*FrontendEndpointId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func FrontendEndpointIDInsensitively(input string) (*FrontendEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/health_probe.go
+++ b/internal/services/frontdoor/parse/health_probe.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HealthProbeId struct {
@@ -42,7 +42,7 @@ func (id HealthProbeId) ID() string {
 
 // HealthProbeID parses a HealthProbe ID into an HealthProbeId struct
 func HealthProbeID(input string) (*HealthProbeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func HealthProbeID(input string) (*HealthProbeId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func HealthProbeIDInsensitively(input string) (*HealthProbeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/load_balancing.go
+++ b/internal/services/frontdoor/parse/load_balancing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancingId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancingId) ID() string {
 
 // LoadBalancingID parses a LoadBalancing ID into an LoadBalancingId struct
 func LoadBalancingID(input string) (*LoadBalancingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func LoadBalancingID(input string) (*LoadBalancingId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func LoadBalancingIDInsensitively(input string) (*LoadBalancingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/load_balancing_rule.go
+++ b/internal/services/frontdoor/parse/load_balancing_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancingRuleId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancingRuleId) ID() string {
 
 // LoadBalancingRuleID parses a LoadBalancingRule ID into an LoadBalancingRuleId struct
 func LoadBalancingRuleID(input string) (*LoadBalancingRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/routing_rule.go
+++ b/internal/services/frontdoor/parse/routing_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RoutingRuleId struct {
@@ -42,7 +42,7 @@ func (id RoutingRuleId) ID() string {
 
 // RoutingRuleID parses a RoutingRule ID into an RoutingRuleId struct
 func RoutingRuleID(input string) (*RoutingRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func RoutingRuleID(input string) (*RoutingRuleId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func RoutingRuleIDInsensitively(input string) (*RoutingRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/rules_engine.go
+++ b/internal/services/frontdoor/parse/rules_engine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RulesEngineId struct {
@@ -42,7 +42,7 @@ func (id RulesEngineId) ID() string {
 
 // RulesEngineID parses a RulesEngine ID into an RulesEngineId struct
 func RulesEngineID(input string) (*RulesEngineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func RulesEngineID(input string) (*RulesEngineId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func RulesEngineIDInsensitively(input string) (*RulesEngineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/frontdoor/parse/web_application_firewall_policy.go
+++ b/internal/services/frontdoor/parse/web_application_firewall_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WebApplicationFirewallPolicyId struct {
@@ -39,7 +39,7 @@ func (id WebApplicationFirewallPolicyId) ID() string {
 
 // WebApplicationFirewallPolicyID parses a WebApplicationFirewallPolicy ID into an WebApplicationFirewallPolicyId struct
 func WebApplicationFirewallPolicyID(input string) (*WebApplicationFirewallPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func WebApplicationFirewallPolicyID(input string) (*WebApplicationFirewallPolicy
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func WebApplicationFirewallPolicyIDInsensitively(input string) (*WebApplicationFirewallPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/hdinsight/parse/cluster.go
+++ b/internal/services/hdinsight/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/healthcare/parse/service.go
+++ b/internal/services/healthcare/parse/service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServiceId struct {
@@ -39,7 +39,7 @@ func (id ServiceId) ID() string {
 
 // ServiceID parses a Service ID into an ServiceId struct
 func ServiceID(input string) (*ServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/hpccache/parse/cache.go
+++ b/internal/services/hpccache/parse/cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CacheId struct {
@@ -39,7 +39,7 @@ func (id CacheId) ID() string {
 
 // CacheID parses a Cache ID into an CacheId struct
 func CacheID(input string) (*CacheId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/hpccache/parse/cache_access_policy.go
+++ b/internal/services/hpccache/parse/cache_access_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CacheAccessPolicyId struct {
@@ -42,7 +42,7 @@ func (id CacheAccessPolicyId) ID() string {
 
 // CacheAccessPolicyID parses a CacheAccessPolicy ID into an CacheAccessPolicyId struct
 func CacheAccessPolicyID(input string) (*CacheAccessPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/hpccache/parse/storage_target.go
+++ b/internal/services/hpccache/parse/storage_target.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageTargetId struct {
@@ -42,7 +42,7 @@ func (id StorageTargetId) ID() string {
 
 // StorageTargetID parses a StorageTarget ID into an StorageTargetId struct
 func StorageTargetID(input string) (*StorageTargetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/hsm/parse/dedicated_hardware_security_module.go
+++ b/internal/services/hsm/parse/dedicated_hardware_security_module.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DedicatedHardwareSecurityModuleId struct {
@@ -39,7 +39,7 @@ func (id DedicatedHardwareSecurityModuleId) ID() string {
 
 // DedicatedHardwareSecurityModuleID parses a DedicatedHardwareSecurityModule ID into an DedicatedHardwareSecurityModuleId struct
 func DedicatedHardwareSecurityModuleID(input string) (*DedicatedHardwareSecurityModuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iotcentral/parse/application.go
+++ b/internal/services/iotcentral/parse/application.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationId struct {
@@ -39,7 +39,7 @@ func (id ApplicationId) ID() string {
 
 // ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ApplicationID(input string) (*ApplicationId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func ApplicationIDInsensitively(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/consumer_group.go
+++ b/internal/services/iothub/parse/consumer_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConsumerGroupId struct {
@@ -45,7 +45,7 @@ func (id ConsumerGroupId) ID() string {
 
 // ConsumerGroupID parses a ConsumerGroup ID into an ConsumerGroupId struct
 func ConsumerGroupID(input string) (*ConsumerGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/dps_certificate.go
+++ b/internal/services/iothub/parse/dps_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DpsCertificateId struct {
@@ -42,7 +42,7 @@ func (id DpsCertificateId) ID() string {
 
 // DpsCertificateID parses a DpsCertificate ID into an DpsCertificateId struct
 func DpsCertificateID(input string) (*DpsCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/dps_shared_access_policy.go
+++ b/internal/services/iothub/parse/dps_shared_access_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DpsSharedAccessPolicyId struct {
@@ -42,7 +42,7 @@ func (id DpsSharedAccessPolicyId) ID() string {
 
 // DpsSharedAccessPolicyID parses a DpsSharedAccessPolicy ID into an DpsSharedAccessPolicyId struct
 func DpsSharedAccessPolicyID(input string) (*DpsSharedAccessPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/endpoint_eventhub.go
+++ b/internal/services/iothub/parse/endpoint_eventhub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EndpointEventhubId struct {
@@ -42,7 +42,7 @@ func (id EndpointEventhubId) ID() string {
 
 // EndpointEventhubID parses a EndpointEventhub ID into an EndpointEventhubId struct
 func EndpointEventhubID(input string) (*EndpointEventhubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/endpoint_service_bus_queue.go
+++ b/internal/services/iothub/parse/endpoint_service_bus_queue.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EndpointServiceBusQueueId struct {
@@ -42,7 +42,7 @@ func (id EndpointServiceBusQueueId) ID() string {
 
 // EndpointServiceBusQueueID parses a EndpointServiceBusQueue ID into an EndpointServiceBusQueueId struct
 func EndpointServiceBusQueueID(input string) (*EndpointServiceBusQueueId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/endpoint_service_bus_topic.go
+++ b/internal/services/iothub/parse/endpoint_service_bus_topic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EndpointServiceBusTopicId struct {
@@ -42,7 +42,7 @@ func (id EndpointServiceBusTopicId) ID() string {
 
 // EndpointServiceBusTopicID parses a EndpointServiceBusTopic ID into an EndpointServiceBusTopicId struct
 func EndpointServiceBusTopicID(input string) (*EndpointServiceBusTopicId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/endpoint_storage_container.go
+++ b/internal/services/iothub/parse/endpoint_storage_container.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EndpointStorageContainerId struct {
@@ -42,7 +42,7 @@ func (id EndpointStorageContainerId) ID() string {
 
 // EndpointStorageContainerID parses a EndpointStorageContainer ID into an EndpointStorageContainerId struct
 func EndpointStorageContainerID(input string) (*EndpointStorageContainerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/enrichment.go
+++ b/internal/services/iothub/parse/enrichment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EnrichmentId struct {
@@ -42,7 +42,7 @@ func (id EnrichmentId) ID() string {
 
 // EnrichmentID parses a Enrichment ID into an EnrichmentId struct
 func EnrichmentID(input string) (*EnrichmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/fallback_route.go
+++ b/internal/services/iothub/parse/fallback_route.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FallbackRouteId struct {
@@ -42,7 +42,7 @@ func (id FallbackRouteId) ID() string {
 
 // FallbackRouteID parses a FallbackRoute ID into an FallbackRouteId struct
 func FallbackRouteID(input string) (*FallbackRouteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/iot_hub.go
+++ b/internal/services/iothub/parse/iot_hub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IotHubId struct {
@@ -39,7 +39,7 @@ func (id IotHubId) ID() string {
 
 // IotHubID parses a IotHub ID into an IotHubId struct
 func IotHubID(input string) (*IotHubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/iot_hub_dps.go
+++ b/internal/services/iothub/parse/iot_hub_dps.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IotHubDpsId struct {
@@ -39,7 +39,7 @@ func (id IotHubDpsId) ID() string {
 
 // IotHubDpsID parses a IotHubDps ID into an IotHubDpsId struct
 func IotHubDpsID(input string) (*IotHubDpsId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/route.go
+++ b/internal/services/iothub/parse/route.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RouteId struct {
@@ -42,7 +42,7 @@ func (id RouteId) ID() string {
 
 // RouteID parses a Route ID into an RouteId struct
 func RouteID(input string) (*RouteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iothub/parse/shared_access_policy.go
+++ b/internal/services/iothub/parse/shared_access_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SharedAccessPolicyId struct {
@@ -42,7 +42,7 @@ func (id SharedAccessPolicyId) ID() string {
 
 // SharedAccessPolicyID parses a SharedAccessPolicy ID into an SharedAccessPolicyId struct
 func SharedAccessPolicyID(input string) (*SharedAccessPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iottimeseriesinsights/parse/access_policy.go
+++ b/internal/services/iottimeseriesinsights/parse/access_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccessPolicyId struct {
@@ -42,7 +42,7 @@ func (id AccessPolicyId) ID() string {
 
 // AccessPolicyID parses a AccessPolicy ID into an AccessPolicyId struct
 func AccessPolicyID(input string) (*AccessPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iottimeseriesinsights/parse/environment.go
+++ b/internal/services/iottimeseriesinsights/parse/environment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EnvironmentId struct {
@@ -39,7 +39,7 @@ func (id EnvironmentId) ID() string {
 
 // EnvironmentID parses a Environment ID into an EnvironmentId struct
 func EnvironmentID(input string) (*EnvironmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iottimeseriesinsights/parse/event_source.go
+++ b/internal/services/iottimeseriesinsights/parse/event_source.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EventSourceId struct {
@@ -42,7 +42,7 @@ func (id EventSourceId) ID() string {
 
 // EventSourceID parses a EventSource ID into an EventSourceId struct
 func EventSourceID(input string) (*EventSourceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/iottimeseriesinsights/parse/reference_data_set.go
+++ b/internal/services/iottimeseriesinsights/parse/reference_data_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReferenceDataSetId struct {
@@ -42,7 +42,7 @@ func (id ReferenceDataSetId) ID() string {
 
 // ReferenceDataSetID parses a ReferenceDataSet ID into an ReferenceDataSetId struct
 func ReferenceDataSetID(input string) (*ReferenceDataSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/keyvault/parse/managed_hsm.go
+++ b/internal/services/keyvault/parse/managed_hsm.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedHSMId struct {
@@ -39,7 +39,7 @@ func (id ManagedHSMId) ID() string {
 
 // ManagedHSMID parses a ManagedHSM ID into an ManagedHSMId struct
 func ManagedHSMID(input string) (*ManagedHSMId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/keyvault/parse/vault.go
+++ b/internal/services/keyvault/parse/vault.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VaultId struct {
@@ -39,7 +39,7 @@ func (id VaultId) ID() string {
 
 // VaultID parses a Vault ID into an VaultId struct
 func VaultID(input string) (*VaultId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/attached_database_configuration.go
+++ b/internal/services/kusto/parse/attached_database_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AttachedDatabaseConfigurationId struct {
@@ -42,7 +42,7 @@ func (id AttachedDatabaseConfigurationId) ID() string {
 
 // AttachedDatabaseConfigurationID parses a AttachedDatabaseConfiguration ID into an AttachedDatabaseConfigurationId struct
 func AttachedDatabaseConfigurationID(input string) (*AttachedDatabaseConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/cluster.go
+++ b/internal/services/kusto/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/cluster_principal_assignment.go
+++ b/internal/services/kusto/parse/cluster_principal_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterPrincipalAssignmentId struct {
@@ -42,7 +42,7 @@ func (id ClusterPrincipalAssignmentId) ID() string {
 
 // ClusterPrincipalAssignmentID parses a ClusterPrincipalAssignment ID into an ClusterPrincipalAssignmentId struct
 func ClusterPrincipalAssignmentID(input string) (*ClusterPrincipalAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/data_connection.go
+++ b/internal/services/kusto/parse/data_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataConnectionId struct {
@@ -45,7 +45,7 @@ func (id DataConnectionId) ID() string {
 
 // DataConnectionID parses a DataConnection ID into an DataConnectionId struct
 func DataConnectionID(input string) (*DataConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/database.go
+++ b/internal/services/kusto/parse/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseId struct {
@@ -42,7 +42,7 @@ func (id DatabaseId) ID() string {
 
 // DatabaseID parses a Database ID into an DatabaseId struct
 func DatabaseID(input string) (*DatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/database_principal.go
+++ b/internal/services/kusto/parse/database_principal.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabasePrincipalId struct {
@@ -48,7 +48,7 @@ func (id DatabasePrincipalId) ID() string {
 
 // DatabasePrincipalID parses a DatabasePrincipal ID into an DatabasePrincipalId struct
 func DatabasePrincipalID(input string) (*DatabasePrincipalId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/database_principal_assignment.go
+++ b/internal/services/kusto/parse/database_principal_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabasePrincipalAssignmentId struct {
@@ -45,7 +45,7 @@ func (id DatabasePrincipalAssignmentId) ID() string {
 
 // DatabasePrincipalAssignmentID parses a DatabasePrincipalAssignment ID into an DatabasePrincipalAssignmentId struct
 func DatabasePrincipalAssignmentID(input string) (*DatabasePrincipalAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/kusto/parse/script.go
+++ b/internal/services/kusto/parse/script.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ScriptId struct {
@@ -45,7 +45,7 @@ func (id ScriptId) ID() string {
 
 // ScriptID parses a Script ID into an ScriptId struct
 func ScriptID(input string) (*ScriptId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/backend_address_pool_address.go
+++ b/internal/services/loadbalancer/parse/backend_address_pool_address.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackendAddressPoolAddressId struct {
@@ -45,7 +45,7 @@ func (id BackendAddressPoolAddressId) ID() string {
 
 // BackendAddressPoolAddressID parses a BackendAddressPoolAddress ID into an BackendAddressPoolAddressId struct
 func BackendAddressPoolAddressID(input string) (*BackendAddressPoolAddressId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer.go
+++ b/internal/services/loadbalancer/parse/load_balancer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerId struct {
@@ -39,7 +39,7 @@ func (id LoadBalancerId) ID() string {
 
 // LoadBalancerID parses a LoadBalancer ID into an LoadBalancerId struct
 func LoadBalancerID(input string) (*LoadBalancerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_backend_address_pool.go
+++ b/internal/services/loadbalancer/parse/load_balancer_backend_address_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerBackendAddressPoolId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerBackendAddressPoolId) ID() string {
 
 // LoadBalancerBackendAddressPoolID parses a LoadBalancerBackendAddressPool ID into an LoadBalancerBackendAddressPoolId struct
 func LoadBalancerBackendAddressPoolID(input string) (*LoadBalancerBackendAddressPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_frontend_ip_configuration.go
+++ b/internal/services/loadbalancer/parse/load_balancer_frontend_ip_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerFrontendIpConfigurationId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerFrontendIpConfigurationId) ID() string {
 
 // LoadBalancerFrontendIpConfigurationID parses a LoadBalancerFrontendIpConfiguration ID into an LoadBalancerFrontendIpConfigurationId struct
 func LoadBalancerFrontendIpConfigurationID(input string) (*LoadBalancerFrontendIpConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_inbound_nat_pool.go
+++ b/internal/services/loadbalancer/parse/load_balancer_inbound_nat_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerInboundNatPoolId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerInboundNatPoolId) ID() string {
 
 // LoadBalancerInboundNatPoolID parses a LoadBalancerInboundNatPool ID into an LoadBalancerInboundNatPoolId struct
 func LoadBalancerInboundNatPoolID(input string) (*LoadBalancerInboundNatPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_inbound_nat_rule.go
+++ b/internal/services/loadbalancer/parse/load_balancer_inbound_nat_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerInboundNatRuleId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerInboundNatRuleId) ID() string {
 
 // LoadBalancerInboundNatRuleID parses a LoadBalancerInboundNatRule ID into an LoadBalancerInboundNatRuleId struct
 func LoadBalancerInboundNatRuleID(input string) (*LoadBalancerInboundNatRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_outbound_rule.go
+++ b/internal/services/loadbalancer/parse/load_balancer_outbound_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerOutboundRuleId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerOutboundRuleId) ID() string {
 
 // LoadBalancerOutboundRuleID parses a LoadBalancerOutboundRule ID into an LoadBalancerOutboundRuleId struct
 func LoadBalancerOutboundRuleID(input string) (*LoadBalancerOutboundRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancer_probe.go
+++ b/internal/services/loadbalancer/parse/load_balancer_probe.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerProbeId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerProbeId) ID() string {
 
 // LoadBalancerProbeID parses a LoadBalancerProbe ID into an LoadBalancerProbeId struct
 func LoadBalancerProbeID(input string) (*LoadBalancerProbeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loadbalancer/parse/load_balancing_rule.go
+++ b/internal/services/loadbalancer/parse/load_balancing_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancingRuleId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancingRuleId) ID() string {
 
 // LoadBalancingRuleID parses a LoadBalancingRule ID into an LoadBalancingRuleId struct
 func LoadBalancingRuleID(input string) (*LoadBalancingRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_cluster.go
+++ b/internal/services/loganalytics/parse/log_analytics_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsClusterId struct {
@@ -39,7 +39,7 @@ func (id LogAnalyticsClusterId) ID() string {
 
 // LogAnalyticsClusterID parses a LogAnalyticsCluster ID into an LogAnalyticsClusterId struct
 func LogAnalyticsClusterID(input string) (*LogAnalyticsClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_data_export.go
+++ b/internal/services/loganalytics/parse/log_analytics_data_export.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsDataExportId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsDataExportId) ID() string {
 
 // LogAnalyticsDataExportID parses a LogAnalyticsDataExport ID into an LogAnalyticsDataExportId struct
 func LogAnalyticsDataExportID(input string) (*LogAnalyticsDataExportId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_data_source_windows_event.go
+++ b/internal/services/loganalytics/parse/log_analytics_data_source_windows_event.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsDataSourceWindowsEventId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsDataSourceWindowsEventId) ID() string {
 
 // LogAnalyticsDataSourceWindowsEventID parses a LogAnalyticsDataSourceWindowsEvent ID into an LogAnalyticsDataSourceWindowsEventId struct
 func LogAnalyticsDataSourceWindowsEventID(input string) (*LogAnalyticsDataSourceWindowsEventId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_linked_service.go
+++ b/internal/services/loganalytics/parse/log_analytics_linked_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsLinkedServiceId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsLinkedServiceId) ID() string {
 
 // LogAnalyticsLinkedServiceID parses a LogAnalyticsLinkedService ID into an LogAnalyticsLinkedServiceId struct
 func LogAnalyticsLinkedServiceID(input string) (*LogAnalyticsLinkedServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_linked_storage_account.go
+++ b/internal/services/loganalytics/parse/log_analytics_linked_storage_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsLinkedStorageAccountId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsLinkedStorageAccountId) ID() string {
 
 // LogAnalyticsLinkedStorageAccountID parses a LogAnalyticsLinkedStorageAccount ID into an LogAnalyticsLinkedStorageAccountId struct
 func LogAnalyticsLinkedStorageAccountID(input string) (*LogAnalyticsLinkedStorageAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_saved_search.go
+++ b/internal/services/loganalytics/parse/log_analytics_saved_search.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsSavedSearchId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsSavedSearchId) ID() string {
 
 // LogAnalyticsSavedSearchID parses a LogAnalyticsSavedSearch ID into an LogAnalyticsSavedSearchId struct
 func LogAnalyticsSavedSearchID(input string) (*LogAnalyticsSavedSearchId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_solution.go
+++ b/internal/services/loganalytics/parse/log_analytics_solution.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsSolutionId struct {
@@ -39,7 +39,7 @@ func (id LogAnalyticsSolutionId) ID() string {
 
 // LogAnalyticsSolutionID parses a LogAnalyticsSolution ID into an LogAnalyticsSolutionId struct
 func LogAnalyticsSolutionID(input string) (*LogAnalyticsSolutionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_storage_insights.go
+++ b/internal/services/loganalytics/parse/log_analytics_storage_insights.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsStorageInsightsId struct {
@@ -42,7 +42,7 @@ func (id LogAnalyticsStorageInsightsId) ID() string {
 
 // LogAnalyticsStorageInsightsID parses a LogAnalyticsStorageInsights ID into an LogAnalyticsStorageInsightsId struct
 func LogAnalyticsStorageInsightsID(input string) (*LogAnalyticsStorageInsightsId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/loganalytics/parse/log_analytics_workspace.go
+++ b/internal/services/loganalytics/parse/log_analytics_workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogAnalyticsWorkspaceId struct {
@@ -39,7 +39,7 @@ func (id LogAnalyticsWorkspaceId) ID() string {
 
 // LogAnalyticsWorkspaceID parses a LogAnalyticsWorkspace ID into an LogAnalyticsWorkspaceId struct
 func LogAnalyticsWorkspaceID(input string) (*LogAnalyticsWorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/action.go
+++ b/internal/services/logic/parse/action.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ActionId struct {
@@ -42,7 +42,7 @@ func (id ActionId) ID() string {
 
 // ActionID parses a Action ID into an ActionId struct
 func ActionID(input string) (*ActionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account.go
+++ b/internal/services/logic/parse/integration_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountId struct {
@@ -39,7 +39,7 @@ func (id IntegrationAccountId) ID() string {
 
 // IntegrationAccountID parses a IntegrationAccount ID into an IntegrationAccountId struct
 func IntegrationAccountID(input string) (*IntegrationAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_agreement.go
+++ b/internal/services/logic/parse/integration_account_agreement.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountAgreementId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountAgreementId) ID() string {
 
 // IntegrationAccountAgreementID parses a IntegrationAccountAgreement ID into an IntegrationAccountAgreementId struct
 func IntegrationAccountAgreementID(input string) (*IntegrationAccountAgreementId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_assembly.go
+++ b/internal/services/logic/parse/integration_account_assembly.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountAssemblyId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountAssemblyId) ID() string {
 
 // IntegrationAccountAssemblyID parses a IntegrationAccountAssembly ID into an IntegrationAccountAssemblyId struct
 func IntegrationAccountAssemblyID(input string) (*IntegrationAccountAssemblyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_batch_configuration.go
+++ b/internal/services/logic/parse/integration_account_batch_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountBatchConfigurationId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountBatchConfigurationId) ID() string {
 
 // IntegrationAccountBatchConfigurationID parses a IntegrationAccountBatchConfiguration ID into an IntegrationAccountBatchConfigurationId struct
 func IntegrationAccountBatchConfigurationID(input string) (*IntegrationAccountBatchConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_certificate.go
+++ b/internal/services/logic/parse/integration_account_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountCertificateId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountCertificateId) ID() string {
 
 // IntegrationAccountCertificateID parses a IntegrationAccountCertificate ID into an IntegrationAccountCertificateId struct
 func IntegrationAccountCertificateID(input string) (*IntegrationAccountCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_map.go
+++ b/internal/services/logic/parse/integration_account_map.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountMapId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountMapId) ID() string {
 
 // IntegrationAccountMapID parses a IntegrationAccountMap ID into an IntegrationAccountMapId struct
 func IntegrationAccountMapID(input string) (*IntegrationAccountMapId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_partner.go
+++ b/internal/services/logic/parse/integration_account_partner.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountPartnerId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountPartnerId) ID() string {
 
 // IntegrationAccountPartnerID parses a IntegrationAccountPartner ID into an IntegrationAccountPartnerId struct
 func IntegrationAccountPartnerID(input string) (*IntegrationAccountPartnerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_schema.go
+++ b/internal/services/logic/parse/integration_account_schema.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountSchemaId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountSchemaId) ID() string {
 
 // IntegrationAccountSchemaID parses a IntegrationAccountSchema ID into an IntegrationAccountSchemaId struct
 func IntegrationAccountSchemaID(input string) (*IntegrationAccountSchemaId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_account_session.go
+++ b/internal/services/logic/parse/integration_account_session.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationAccountSessionId struct {
@@ -42,7 +42,7 @@ func (id IntegrationAccountSessionId) ID() string {
 
 // IntegrationAccountSessionID parses a IntegrationAccountSession ID into an IntegrationAccountSessionId struct
 func IntegrationAccountSessionID(input string) (*IntegrationAccountSessionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/integration_service_environment.go
+++ b/internal/services/logic/parse/integration_service_environment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationServiceEnvironmentId struct {
@@ -39,7 +39,7 @@ func (id IntegrationServiceEnvironmentId) ID() string {
 
 // IntegrationServiceEnvironmentID parses a IntegrationServiceEnvironment ID into an IntegrationServiceEnvironmentId struct
 func IntegrationServiceEnvironmentID(input string) (*IntegrationServiceEnvironmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/logic_app_standard.go
+++ b/internal/services/logic/parse/logic_app_standard.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogicAppStandardId struct {
@@ -39,7 +39,7 @@ func (id LogicAppStandardId) ID() string {
 
 // LogicAppStandardID parses a LogicAppStandard ID into an LogicAppStandardId struct
 func LogicAppStandardID(input string) (*LogicAppStandardId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/trigger.go
+++ b/internal/services/logic/parse/trigger.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TriggerId struct {
@@ -42,7 +42,7 @@ func (id TriggerId) ID() string {
 
 // TriggerID parses a Trigger ID into an TriggerId struct
 func TriggerID(input string) (*TriggerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logic/parse/workflow.go
+++ b/internal/services/logic/parse/workflow.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkflowId struct {
@@ -39,7 +39,7 @@ func (id WorkflowId) ID() string {
 
 // WorkflowID parses a Workflow ID into an WorkflowId struct
 func WorkflowID(input string) (*WorkflowId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logz/parse/logz_monitor.go
+++ b/internal/services/logz/parse/logz_monitor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogzMonitorId struct {
@@ -39,7 +39,7 @@ func (id LogzMonitorId) ID() string {
 
 // LogzMonitorID parses a LogzMonitor ID into an LogzMonitorId struct
 func LogzMonitorID(input string) (*LogzMonitorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/logz/parse/logz_tag_rule.go
+++ b/internal/services/logz/parse/logz_tag_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogzTagRuleId struct {
@@ -42,7 +42,7 @@ func (id LogzTagRuleId) ID() string {
 
 // LogzTagRuleID parses a LogzTagRule ID into an LogzTagRuleId struct
 func LogzTagRuleID(input string) (*LogzTagRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/machinelearning/parse/compute.go
+++ b/internal/services/machinelearning/parse/compute.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ComputeId struct {
@@ -42,7 +42,7 @@ func (id ComputeId) ID() string {
 
 // ComputeID parses a Compute ID into an ComputeId struct
 func ComputeID(input string) (*ComputeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/machinelearning/parse/compute_cluster.go
+++ b/internal/services/machinelearning/parse/compute_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ComputeClusterId struct {
@@ -42,7 +42,7 @@ func (id ComputeClusterId) ID() string {
 
 // ComputeClusterID parses a ComputeCluster ID into an ComputeClusterId struct
 func ComputeClusterID(input string) (*ComputeClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/machinelearning/parse/inference_cluster.go
+++ b/internal/services/machinelearning/parse/inference_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type InferenceClusterId struct {
@@ -42,7 +42,7 @@ func (id InferenceClusterId) ID() string {
 
 // InferenceClusterID parses a InferenceCluster ID into an InferenceClusterId struct
 func InferenceClusterID(input string) (*InferenceClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/machinelearning/parse/kubernetes_cluster.go
+++ b/internal/services/machinelearning/parse/kubernetes_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type KubernetesClusterId struct {
@@ -39,7 +39,7 @@ func (id KubernetesClusterId) ID() string {
 
 // KubernetesClusterID parses a KubernetesCluster ID into an KubernetesClusterId struct
 func KubernetesClusterID(input string) (*KubernetesClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/machinelearning/parse/workspace.go
+++ b/internal/services/machinelearning/parse/workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceId struct {
@@ -39,7 +39,7 @@ func (id WorkspaceId) ID() string {
 
 // WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/maintenance/parse/maintenance_configuration.go
+++ b/internal/services/maintenance/parse/maintenance_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MaintenanceConfigurationId struct {
@@ -39,7 +39,7 @@ func (id MaintenanceConfigurationId) ID() string {
 
 // MaintenanceConfigurationID parses a MaintenanceConfiguration ID into an MaintenanceConfigurationId struct
 func MaintenanceConfigurationID(input string) (*MaintenanceConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func MaintenanceConfigurationID(input string) (*MaintenanceConfigurationId, erro
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func MaintenanceConfigurationIDInsensitively(input string) (*MaintenanceConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/managedapplications/parse/application.go
+++ b/internal/services/managedapplications/parse/application.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationId struct {
@@ -39,7 +39,7 @@ func (id ApplicationId) ID() string {
 
 // ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/managedapplications/parse/application_definition.go
+++ b/internal/services/managedapplications/parse/application_definition.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationDefinitionId struct {
@@ -39,7 +39,7 @@ func (id ApplicationDefinitionId) ID() string {
 
 // ApplicationDefinitionID parses a ApplicationDefinition ID into an ApplicationDefinitionId struct
 func ApplicationDefinitionID(input string) (*ApplicationDefinitionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mariadb/parse/maria_db_configuration.go
+++ b/internal/services/mariadb/parse/maria_db_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MariaDBConfigurationId struct {
@@ -42,7 +42,7 @@ func (id MariaDBConfigurationId) ID() string {
 
 // MariaDBConfigurationID parses a MariaDBConfiguration ID into an MariaDBConfigurationId struct
 func MariaDBConfigurationID(input string) (*MariaDBConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mariadb/parse/maria_db_database.go
+++ b/internal/services/mariadb/parse/maria_db_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MariaDBDatabaseId struct {
@@ -42,7 +42,7 @@ func (id MariaDBDatabaseId) ID() string {
 
 // MariaDBDatabaseID parses a MariaDBDatabase ID into an MariaDBDatabaseId struct
 func MariaDBDatabaseID(input string) (*MariaDBDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mariadb/parse/maria_db_firewall_rule.go
+++ b/internal/services/mariadb/parse/maria_db_firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MariaDBFirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id MariaDBFirewallRuleId) ID() string {
 
 // MariaDBFirewallRuleID parses a MariaDBFirewallRule ID into an MariaDBFirewallRuleId struct
 func MariaDBFirewallRuleID(input string) (*MariaDBFirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mariadb/parse/maria_db_virtual_network_rule.go
+++ b/internal/services/mariadb/parse/maria_db_virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MariaDBVirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id MariaDBVirtualNetworkRuleId) ID() string {
 
 // MariaDBVirtualNetworkRuleID parses a MariaDBVirtualNetworkRule ID into an MariaDBVirtualNetworkRuleId struct
 func MariaDBVirtualNetworkRuleID(input string) (*MariaDBVirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mariadb/parse/server.go
+++ b/internal/services/mariadb/parse/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerId struct {
@@ -39,7 +39,7 @@ func (id ServerId) ID() string {
 
 // ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/asset.go
+++ b/internal/services/media/parse/asset.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AssetId struct {
@@ -42,7 +42,7 @@ func (id AssetId) ID() string {
 
 // AssetID parses a Asset ID into an AssetId struct
 func AssetID(input string) (*AssetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/asset_filter.go
+++ b/internal/services/media/parse/asset_filter.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AssetFilterId struct {
@@ -45,7 +45,7 @@ func (id AssetFilterId) ID() string {
 
 // AssetFilterID parses a AssetFilter ID into an AssetFilterId struct
 func AssetFilterID(input string) (*AssetFilterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/content_key_policy.go
+++ b/internal/services/media/parse/content_key_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ContentKeyPolicyId struct {
@@ -42,7 +42,7 @@ func (id ContentKeyPolicyId) ID() string {
 
 // ContentKeyPolicyID parses a ContentKeyPolicy ID into an ContentKeyPolicyId struct
 func ContentKeyPolicyID(input string) (*ContentKeyPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/job.go
+++ b/internal/services/media/parse/job.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type JobId struct {
@@ -45,7 +45,7 @@ func (id JobId) ID() string {
 
 // JobID parses a Job ID into an JobId struct
 func JobID(input string) (*JobId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/live_event.go
+++ b/internal/services/media/parse/live_event.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LiveEventId struct {
@@ -42,7 +42,7 @@ func (id LiveEventId) ID() string {
 
 // LiveEventID parses a LiveEvent ID into an LiveEventId struct
 func LiveEventID(input string) (*LiveEventId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/live_output.go
+++ b/internal/services/media/parse/live_output.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LiveOutputId struct {
@@ -45,7 +45,7 @@ func (id LiveOutputId) ID() string {
 
 // LiveOutputID parses a LiveOutput ID into an LiveOutputId struct
 func LiveOutputID(input string) (*LiveOutputId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/media_service.go
+++ b/internal/services/media/parse/media_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MediaServiceId struct {
@@ -39,7 +39,7 @@ func (id MediaServiceId) ID() string {
 
 // MediaServiceID parses a MediaService ID into an MediaServiceId struct
 func MediaServiceID(input string) (*MediaServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/streaming_endpoint.go
+++ b/internal/services/media/parse/streaming_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StreamingEndpointId struct {
@@ -42,7 +42,7 @@ func (id StreamingEndpointId) ID() string {
 
 // StreamingEndpointID parses a StreamingEndpoint ID into an StreamingEndpointId struct
 func StreamingEndpointID(input string) (*StreamingEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/streaming_locator.go
+++ b/internal/services/media/parse/streaming_locator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StreamingLocatorId struct {
@@ -42,7 +42,7 @@ func (id StreamingLocatorId) ID() string {
 
 // StreamingLocatorID parses a StreamingLocator ID into an StreamingLocatorId struct
 func StreamingLocatorID(input string) (*StreamingLocatorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/streaming_policy.go
+++ b/internal/services/media/parse/streaming_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StreamingPolicyId struct {
@@ -42,7 +42,7 @@ func (id StreamingPolicyId) ID() string {
 
 // StreamingPolicyID parses a StreamingPolicy ID into an StreamingPolicyId struct
 func StreamingPolicyID(input string) (*StreamingPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/media/parse/transform.go
+++ b/internal/services/media/parse/transform.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TransformId struct {
@@ -42,7 +42,7 @@ func (id TransformId) ID() string {
 
 // TransformID parses a Transform ID into an TransformId struct
 func TransformID(input string) (*TransformId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mixedreality/parse/spatial_anchors_account.go
+++ b/internal/services/mixedreality/parse/spatial_anchors_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpatialAnchorsAccountId struct {
@@ -39,7 +39,7 @@ func (id SpatialAnchorsAccountId) ID() string {
 
 // SpatialAnchorsAccountID parses a SpatialAnchorsAccount ID into an SpatialAnchorsAccountId struct
 func SpatialAnchorsAccountID(input string) (*SpatialAnchorsAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/action_group.go
+++ b/internal/services/monitor/parse/action_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ActionGroupId struct {
@@ -39,7 +39,7 @@ func (id ActionGroupId) ID() string {
 
 // ActionGroupID parses a ActionGroup ID into an ActionGroupId struct
 func ActionGroupID(input string) (*ActionGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/action_rule.go
+++ b/internal/services/monitor/parse/action_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ActionRuleId struct {
@@ -39,7 +39,7 @@ func (id ActionRuleId) ID() string {
 
 // ActionRuleID parses a ActionRule ID into an ActionRuleId struct
 func ActionRuleID(input string) (*ActionRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/activity_log_alert.go
+++ b/internal/services/monitor/parse/activity_log_alert.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ActivityLogAlertId struct {
@@ -39,7 +39,7 @@ func (id ActivityLogAlertId) ID() string {
 
 // ActivityLogAlertID parses a ActivityLogAlert ID into an ActivityLogAlertId struct
 func ActivityLogAlertID(input string) (*ActivityLogAlertId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/autoscale_setting.go
+++ b/internal/services/monitor/parse/autoscale_setting.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AutoscaleSettingId struct {
@@ -39,7 +39,7 @@ func (id AutoscaleSettingId) ID() string {
 
 // AutoscaleSettingID parses a AutoscaleSetting ID into an AutoscaleSettingId struct
 func AutoscaleSettingID(input string) (*AutoscaleSettingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/log_profile.go
+++ b/internal/services/monitor/parse/log_profile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LogProfileId struct {
@@ -36,7 +36,7 @@ func (id LogProfileId) ID() string {
 
 // LogProfileID parses a LogProfile ID into an LogProfileId struct
 func LogProfileID(input string) (*LogProfileId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/metric_alert.go
+++ b/internal/services/monitor/parse/metric_alert.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MetricAlertId struct {
@@ -39,7 +39,7 @@ func (id MetricAlertId) ID() string {
 
 // MetricAlertID parses a MetricAlert ID into an MetricAlertId struct
 func MetricAlertID(input string) (*MetricAlertId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/private_link_scope.go
+++ b/internal/services/monitor/parse/private_link_scope.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateLinkScopeId struct {
@@ -39,7 +39,7 @@ func (id PrivateLinkScopeId) ID() string {
 
 // PrivateLinkScopeID parses a PrivateLinkScope ID into an PrivateLinkScopeId struct
 func PrivateLinkScopeID(input string) (*PrivateLinkScopeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/private_link_scoped_service.go
+++ b/internal/services/monitor/parse/private_link_scoped_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateLinkScopedServiceId struct {
@@ -42,7 +42,7 @@ func (id PrivateLinkScopedServiceId) ID() string {
 
 // PrivateLinkScopedServiceID parses a PrivateLinkScopedService ID into an PrivateLinkScopedServiceId struct
 func PrivateLinkScopedServiceID(input string) (*PrivateLinkScopedServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/scheduled_query_rules.go
+++ b/internal/services/monitor/parse/scheduled_query_rules.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ScheduledQueryRulesId struct {
@@ -39,7 +39,7 @@ func (id ScheduledQueryRulesId) ID() string {
 
 // ScheduledQueryRulesID parses a ScheduledQueryRules ID into an ScheduledQueryRulesId struct
 func ScheduledQueryRulesID(input string) (*ScheduledQueryRulesId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/monitor/parse/smart_detector_alert_rule.go
+++ b/internal/services/monitor/parse/smart_detector_alert_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SmartDetectorAlertRuleId struct {
@@ -39,7 +39,7 @@ func (id SmartDetectorAlertRuleId) ID() string {
 
 // SmartDetectorAlertRuleID parses a SmartDetectorAlertRule ID into an SmartDetectorAlertRuleId struct
 func SmartDetectorAlertRuleID(input string) (*SmartDetectorAlertRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/database.go
+++ b/internal/services/mssql/parse/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseId struct {
@@ -42,7 +42,7 @@ func (id DatabaseId) ID() string {
 
 // DatabaseID parses a Database ID into an DatabaseId struct
 func DatabaseID(input string) (*DatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/database_extended_auditing_policy.go
+++ b/internal/services/mssql/parse/database_extended_auditing_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseExtendedAuditingPolicyId struct {
@@ -45,7 +45,7 @@ func (id DatabaseExtendedAuditingPolicyId) ID() string {
 
 // DatabaseExtendedAuditingPolicyID parses a DatabaseExtendedAuditingPolicy ID into an DatabaseExtendedAuditingPolicyId struct
 func DatabaseExtendedAuditingPolicyID(input string) (*DatabaseExtendedAuditingPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/database_vulnerability_assessment_rule_baseline.go
+++ b/internal/services/mssql/parse/database_vulnerability_assessment_rule_baseline.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseVulnerabilityAssessmentRuleBaselineId struct {
@@ -51,7 +51,7 @@ func (id DatabaseVulnerabilityAssessmentRuleBaselineId) ID() string {
 
 // DatabaseVulnerabilityAssessmentRuleBaselineID parses a DatabaseVulnerabilityAssessmentRuleBaseline ID into an DatabaseVulnerabilityAssessmentRuleBaselineId struct
 func DatabaseVulnerabilityAssessmentRuleBaselineID(input string) (*DatabaseVulnerabilityAssessmentRuleBaselineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/elastic_pool.go
+++ b/internal/services/mssql/parse/elastic_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ElasticPoolId struct {
@@ -42,7 +42,7 @@ func (id ElasticPoolId) ID() string {
 
 // ElasticPoolID parses a ElasticPool ID into an ElasticPoolId struct
 func ElasticPoolID(input string) (*ElasticPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/encryption_protector.go
+++ b/internal/services/mssql/parse/encryption_protector.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EncryptionProtectorId struct {
@@ -42,7 +42,7 @@ func (id EncryptionProtectorId) ID() string {
 
 // EncryptionProtectorID parses a EncryptionProtector ID into an EncryptionProtectorId struct
 func EncryptionProtectorID(input string) (*EncryptionProtectorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/failover_group.go
+++ b/internal/services/mssql/parse/failover_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FailoverGroupId struct {
@@ -42,7 +42,7 @@ func (id FailoverGroupId) ID() string {
 
 // FailoverGroupID parses a FailoverGroup ID into an FailoverGroupId struct
 func FailoverGroupID(input string) (*FailoverGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/firewall_rule.go
+++ b/internal/services/mssql/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/job_agent.go
+++ b/internal/services/mssql/parse/job_agent.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type JobAgentId struct {
@@ -42,7 +42,7 @@ func (id JobAgentId) ID() string {
 
 // JobAgentID parses a JobAgent ID into an JobAgentId struct
 func JobAgentID(input string) (*JobAgentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/job_credential.go
+++ b/internal/services/mssql/parse/job_credential.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type JobCredentialId struct {
@@ -45,7 +45,7 @@ func (id JobCredentialId) ID() string {
 
 // JobCredentialID parses a JobCredential ID into an JobCredentialId struct
 func JobCredentialID(input string) (*JobCredentialId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/recoverable_database.go
+++ b/internal/services/mssql/parse/recoverable_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RecoverableDatabaseId struct {
@@ -42,7 +42,7 @@ func (id RecoverableDatabaseId) ID() string {
 
 // RecoverableDatabaseID parses a RecoverableDatabase ID into an RecoverableDatabaseId struct
 func RecoverableDatabaseID(input string) (*RecoverableDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/server.go
+++ b/internal/services/mssql/parse/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerId struct {
@@ -39,7 +39,7 @@ func (id ServerId) ID() string {
 
 // ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/server_extended_auditing_policy.go
+++ b/internal/services/mssql/parse/server_extended_auditing_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerExtendedAuditingPolicyId struct {
@@ -42,7 +42,7 @@ func (id ServerExtendedAuditingPolicyId) ID() string {
 
 // ServerExtendedAuditingPolicyID parses a ServerExtendedAuditingPolicy ID into an ServerExtendedAuditingPolicyId struct
 func ServerExtendedAuditingPolicyID(input string) (*ServerExtendedAuditingPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/server_security_alert_policy.go
+++ b/internal/services/mssql/parse/server_security_alert_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerSecurityAlertPolicyId struct {
@@ -42,7 +42,7 @@ func (id ServerSecurityAlertPolicyId) ID() string {
 
 // ServerSecurityAlertPolicyID parses a ServerSecurityAlertPolicy ID into an ServerSecurityAlertPolicyId struct
 func ServerSecurityAlertPolicyID(input string) (*ServerSecurityAlertPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/server_vulnerability_assessment.go
+++ b/internal/services/mssql/parse/server_vulnerability_assessment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerVulnerabilityAssessmentId struct {
@@ -42,7 +42,7 @@ func (id ServerVulnerabilityAssessmentId) ID() string {
 
 // ServerVulnerabilityAssessmentID parses a ServerVulnerabilityAssessment ID into an ServerVulnerabilityAssessmentId struct
 func ServerVulnerabilityAssessmentID(input string) (*ServerVulnerabilityAssessmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/sql_virtual_machine.go
+++ b/internal/services/mssql/parse/sql_virtual_machine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlVirtualMachineId struct {
@@ -39,7 +39,7 @@ func (id SqlVirtualMachineId) ID() string {
 
 // SqlVirtualMachineID parses a SqlVirtualMachine ID into an SqlVirtualMachineId struct
 func SqlVirtualMachineID(input string) (*SqlVirtualMachineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mssql/parse/virtual_network_rule.go
+++ b/internal/services/mssql/parse/virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkRuleId) ID() string {
 
 // VirtualNetworkRuleID parses a VirtualNetworkRule ID into an VirtualNetworkRuleId struct
 func VirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/azure_active_directory_administrator.go
+++ b/internal/services/mysql/parse/azure_active_directory_administrator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AzureActiveDirectoryAdministratorId struct {
@@ -42,7 +42,7 @@ func (id AzureActiveDirectoryAdministratorId) ID() string {
 
 // AzureActiveDirectoryAdministratorID parses a AzureActiveDirectoryAdministrator ID into an AzureActiveDirectoryAdministratorId struct
 func AzureActiveDirectoryAdministratorID(input string) (*AzureActiveDirectoryAdministratorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/configuration.go
+++ b/internal/services/mysql/parse/configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConfigurationId struct {
@@ -42,7 +42,7 @@ func (id ConfigurationId) ID() string {
 
 // ConfigurationID parses a Configuration ID into an ConfigurationId struct
 func ConfigurationID(input string) (*ConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/database.go
+++ b/internal/services/mysql/parse/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseId struct {
@@ -42,7 +42,7 @@ func (id DatabaseId) ID() string {
 
 // DatabaseID parses a Database ID into an DatabaseId struct
 func DatabaseID(input string) (*DatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/firewall_rule.go
+++ b/internal/services/mysql/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/flexible_database.go
+++ b/internal/services/mysql/parse/flexible_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleDatabaseId struct {
@@ -42,7 +42,7 @@ func (id FlexibleDatabaseId) ID() string {
 
 // FlexibleDatabaseID parses a FlexibleDatabase ID into an FlexibleDatabaseId struct
 func FlexibleDatabaseID(input string) (*FlexibleDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/flexible_server.go
+++ b/internal/services/mysql/parse/flexible_server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerId struct {
@@ -39,7 +39,7 @@ func (id FlexibleServerId) ID() string {
 
 // FlexibleServerID parses a FlexibleServer ID into an FlexibleServerId struct
 func FlexibleServerID(input string) (*FlexibleServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/flexible_server_configuration.go
+++ b/internal/services/mysql/parse/flexible_server_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerConfigurationId struct {
@@ -42,7 +42,7 @@ func (id FlexibleServerConfigurationId) ID() string {
 
 // FlexibleServerConfigurationID parses a FlexibleServerConfiguration ID into an FlexibleServerConfigurationId struct
 func FlexibleServerConfigurationID(input string) (*FlexibleServerConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/flexible_server_firewall_rule.go
+++ b/internal/services/mysql/parse/flexible_server_firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerFirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FlexibleServerFirewallRuleId) ID() string {
 
 // FlexibleServerFirewallRuleID parses a FlexibleServerFirewallRule ID into an FlexibleServerFirewallRuleId struct
 func FlexibleServerFirewallRuleID(input string) (*FlexibleServerFirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/key.go
+++ b/internal/services/mysql/parse/key.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type KeyId struct {
@@ -42,7 +42,7 @@ func (id KeyId) ID() string {
 
 // KeyID parses a Key ID into an KeyId struct
 func KeyID(input string) (*KeyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/server.go
+++ b/internal/services/mysql/parse/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerId struct {
@@ -39,7 +39,7 @@ func (id ServerId) ID() string {
 
 // ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/mysql/parse/virtual_network_rule.go
+++ b/internal/services/mysql/parse/virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkRuleId) ID() string {
 
 // VirtualNetworkRuleID parses a VirtualNetworkRule ID into an VirtualNetworkRuleId struct
 func VirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/netapp/parse/account.go
+++ b/internal/services/netapp/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/netapp/parse/capacity_pool.go
+++ b/internal/services/netapp/parse/capacity_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CapacityPoolId struct {
@@ -42,7 +42,7 @@ func (id CapacityPoolId) ID() string {
 
 // CapacityPoolID parses a CapacityPool ID into an CapacityPoolId struct
 func CapacityPoolID(input string) (*CapacityPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/netapp/parse/snapshot.go
+++ b/internal/services/netapp/parse/snapshot.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SnapshotId struct {
@@ -48,7 +48,7 @@ func (id SnapshotId) ID() string {
 
 // SnapshotID parses a Snapshot ID into an SnapshotId struct
 func SnapshotID(input string) (*SnapshotId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/netapp/parse/volume.go
+++ b/internal/services/netapp/parse/volume.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VolumeId struct {
@@ -45,7 +45,7 @@ func (id VolumeId) ID() string {
 
 // VolumeID parses a Volume ID into an VolumeId struct
 func VolumeID(input string) (*VolumeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/application_gateway.go
+++ b/internal/services/network/parse/application_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationGatewayId struct {
@@ -39,7 +39,7 @@ func (id ApplicationGatewayId) ID() string {
 
 // ApplicationGatewayID parses a ApplicationGateway ID into an ApplicationGatewayId struct
 func ApplicationGatewayID(input string) (*ApplicationGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/application_gateway_http_listener.go
+++ b/internal/services/network/parse/application_gateway_http_listener.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationGatewayHTTPListenerId struct {
@@ -42,7 +42,7 @@ func (id ApplicationGatewayHTTPListenerId) ID() string {
 
 // ApplicationGatewayHTTPListenerID parses a ApplicationGatewayHTTPListener ID into an ApplicationGatewayHTTPListenerId struct
 func ApplicationGatewayHTTPListenerID(input string) (*ApplicationGatewayHTTPListenerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/application_gateway_url_path_map_path_rule.go
+++ b/internal/services/network/parse/application_gateway_url_path_map_path_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationGatewayURLPathMapPathRuleId struct {
@@ -45,7 +45,7 @@ func (id ApplicationGatewayURLPathMapPathRuleId) ID() string {
 
 // ApplicationGatewayURLPathMapPathRuleID parses a ApplicationGatewayURLPathMapPathRule ID into an ApplicationGatewayURLPathMapPathRuleId struct
 func ApplicationGatewayURLPathMapPathRuleID(input string) (*ApplicationGatewayURLPathMapPathRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/application_gateway_web_application_firewall_policy.go
+++ b/internal/services/network/parse/application_gateway_web_application_firewall_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationGatewayWebApplicationFirewallPolicyId struct {
@@ -39,7 +39,7 @@ func (id ApplicationGatewayWebApplicationFirewallPolicyId) ID() string {
 
 // ApplicationGatewayWebApplicationFirewallPolicyID parses a ApplicationGatewayWebApplicationFirewallPolicy ID into an ApplicationGatewayWebApplicationFirewallPolicyId struct
 func ApplicationGatewayWebApplicationFirewallPolicyID(input string) (*ApplicationGatewayWebApplicationFirewallPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/application_security_group.go
+++ b/internal/services/network/parse/application_security_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationSecurityGroupId struct {
@@ -39,7 +39,7 @@ func (id ApplicationSecurityGroupId) ID() string {
 
 // ApplicationSecurityGroupID parses a ApplicationSecurityGroup ID into an ApplicationSecurityGroupId struct
 func ApplicationSecurityGroupID(input string) (*ApplicationSecurityGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/authentication_certificate.go
+++ b/internal/services/network/parse/authentication_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AuthenticationCertificateId struct {
@@ -42,7 +42,7 @@ func (id AuthenticationCertificateId) ID() string {
 
 // AuthenticationCertificateID parses a AuthenticationCertificate ID into an AuthenticationCertificateId struct
 func AuthenticationCertificateID(input string) (*AuthenticationCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/backend_address_pool.go
+++ b/internal/services/network/parse/backend_address_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackendAddressPoolId struct {
@@ -42,7 +42,7 @@ func (id BackendAddressPoolId) ID() string {
 
 // BackendAddressPoolID parses a BackendAddressPool ID into an BackendAddressPoolId struct
 func BackendAddressPoolID(input string) (*BackendAddressPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/backend_http_settings_collection.go
+++ b/internal/services/network/parse/backend_http_settings_collection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackendHttpSettingsCollectionId struct {
@@ -42,7 +42,7 @@ func (id BackendHttpSettingsCollectionId) ID() string {
 
 // BackendHttpSettingsCollectionID parses a BackendHttpSettingsCollection ID into an BackendHttpSettingsCollectionId struct
 func BackendHttpSettingsCollectionID(input string) (*BackendHttpSettingsCollectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/bastion_host.go
+++ b/internal/services/network/parse/bastion_host.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BastionHostId struct {
@@ -39,7 +39,7 @@ func (id BastionHostId) ID() string {
 
 // BastionHostID parses a BastionHost ID into an BastionHostId struct
 func BastionHostID(input string) (*BastionHostId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/bgp_connection.go
+++ b/internal/services/network/parse/bgp_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BgpConnectionId struct {
@@ -42,7 +42,7 @@ func (id BgpConnectionId) ID() string {
 
 // BgpConnectionID parses a BgpConnection ID into an BgpConnectionId struct
 func BgpConnectionID(input string) (*BgpConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/connection_monitor.go
+++ b/internal/services/network/parse/connection_monitor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConnectionMonitorId struct {
@@ -42,7 +42,7 @@ func (id ConnectionMonitorId) ID() string {
 
 // ConnectionMonitorID parses a ConnectionMonitor ID into an ConnectionMonitorId struct
 func ConnectionMonitorID(input string) (*ConnectionMonitorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/ddos_protection_plan.go
+++ b/internal/services/network/parse/ddos_protection_plan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DdosProtectionPlanId struct {
@@ -39,7 +39,7 @@ func (id DdosProtectionPlanId) ID() string {
 
 // DdosProtectionPlanID parses a DdosProtectionPlan ID into an DdosProtectionPlanId struct
 func DdosProtectionPlanID(input string) (*DdosProtectionPlanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_circuit.go
+++ b/internal/services/network/parse/express_route_circuit.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteCircuitId struct {
@@ -39,7 +39,7 @@ func (id ExpressRouteCircuitId) ID() string {
 
 // ExpressRouteCircuitID parses a ExpressRouteCircuit ID into an ExpressRouteCircuitId struct
 func ExpressRouteCircuitID(input string) (*ExpressRouteCircuitId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_circuit_authorization.go
+++ b/internal/services/network/parse/express_route_circuit_authorization.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteCircuitAuthorizationId struct {
@@ -42,7 +42,7 @@ func (id ExpressRouteCircuitAuthorizationId) ID() string {
 
 // ExpressRouteCircuitAuthorizationID parses a ExpressRouteCircuitAuthorization ID into an ExpressRouteCircuitAuthorizationId struct
 func ExpressRouteCircuitAuthorizationID(input string) (*ExpressRouteCircuitAuthorizationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_circuit_connection.go
+++ b/internal/services/network/parse/express_route_circuit_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteCircuitConnectionId struct {
@@ -45,7 +45,7 @@ func (id ExpressRouteCircuitConnectionId) ID() string {
 
 // ExpressRouteCircuitConnectionID parses a ExpressRouteCircuitConnection ID into an ExpressRouteCircuitConnectionId struct
 func ExpressRouteCircuitConnectionID(input string) (*ExpressRouteCircuitConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_circuit_peering.go
+++ b/internal/services/network/parse/express_route_circuit_peering.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteCircuitPeeringId struct {
@@ -42,7 +42,7 @@ func (id ExpressRouteCircuitPeeringId) ID() string {
 
 // ExpressRouteCircuitPeeringID parses a ExpressRouteCircuitPeering ID into an ExpressRouteCircuitPeeringId struct
 func ExpressRouteCircuitPeeringID(input string) (*ExpressRouteCircuitPeeringId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_connection.go
+++ b/internal/services/network/parse/express_route_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteConnectionId struct {
@@ -42,7 +42,7 @@ func (id ExpressRouteConnectionId) ID() string {
 
 // ExpressRouteConnectionID parses a ExpressRouteConnection ID into an ExpressRouteConnectionId struct
 func ExpressRouteConnectionID(input string) (*ExpressRouteConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_gateway.go
+++ b/internal/services/network/parse/express_route_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRouteGatewayId struct {
@@ -39,7 +39,7 @@ func (id ExpressRouteGatewayId) ID() string {
 
 // ExpressRouteGatewayID parses a ExpressRouteGateway ID into an ExpressRouteGatewayId struct
 func ExpressRouteGatewayID(input string) (*ExpressRouteGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/express_route_port.go
+++ b/internal/services/network/parse/express_route_port.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExpressRoutePortId struct {
@@ -39,7 +39,7 @@ func (id ExpressRoutePortId) ID() string {
 
 // ExpressRoutePortID parses a ExpressRoutePort ID into an ExpressRoutePortId struct
 func ExpressRoutePortID(input string) (*ExpressRoutePortId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/frontend_ip_configuration.go
+++ b/internal/services/network/parse/frontend_ip_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FrontendIPConfigurationId struct {
@@ -42,7 +42,7 @@ func (id FrontendIPConfigurationId) ID() string {
 
 // FrontendIPConfigurationID parses a FrontendIPConfiguration ID into an FrontendIPConfigurationId struct
 func FrontendIPConfigurationID(input string) (*FrontendIPConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/frontend_port.go
+++ b/internal/services/network/parse/frontend_port.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FrontendPortId struct {
@@ -42,7 +42,7 @@ func (id FrontendPortId) ID() string {
 
 // FrontendPortID parses a FrontendPort ID into an FrontendPortId struct
 func FrontendPortID(input string) (*FrontendPortId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/http_listener.go
+++ b/internal/services/network/parse/http_listener.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HttpListenerId struct {
@@ -42,7 +42,7 @@ func (id HttpListenerId) ID() string {
 
 // HttpListenerID parses a HttpListener ID into an HttpListenerId struct
 func HttpListenerID(input string) (*HttpListenerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/hub_route_table.go
+++ b/internal/services/network/parse/hub_route_table.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HubRouteTableId struct {
@@ -42,7 +42,7 @@ func (id HubRouteTableId) ID() string {
 
 // HubRouteTableID parses a HubRouteTable ID into an HubRouteTableId struct
 func HubRouteTableID(input string) (*HubRouteTableId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/hub_route_table_route.go
+++ b/internal/services/network/parse/hub_route_table_route.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HubRouteTableRouteId struct {
@@ -45,7 +45,7 @@ func (id HubRouteTableRouteId) ID() string {
 
 // HubRouteTableRouteID parses a HubRouteTableRoute ID into an HubRouteTableRouteId struct
 func HubRouteTableRouteID(input string) (*HubRouteTableRouteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/hub_virtual_network_connection.go
+++ b/internal/services/network/parse/hub_virtual_network_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HubVirtualNetworkConnectionId struct {
@@ -42,7 +42,7 @@ func (id HubVirtualNetworkConnectionId) ID() string {
 
 // HubVirtualNetworkConnectionID parses a HubVirtualNetworkConnection ID into an HubVirtualNetworkConnectionId struct
 func HubVirtualNetworkConnectionID(input string) (*HubVirtualNetworkConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/inbound_nat_rule.go
+++ b/internal/services/network/parse/inbound_nat_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type InboundNatRuleId struct {
@@ -42,7 +42,7 @@ func (id InboundNatRuleId) ID() string {
 
 // InboundNatRuleID parses a InboundNatRule ID into an InboundNatRuleId struct
 func InboundNatRuleID(input string) (*InboundNatRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/ip_group.go
+++ b/internal/services/network/parse/ip_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IpGroupId struct {
@@ -39,7 +39,7 @@ func (id IpGroupId) ID() string {
 
 // IpGroupID parses a IpGroup ID into an IpGroupId struct
 func IpGroupID(input string) (*IpGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/load_balancer_backend_address_pool.go
+++ b/internal/services/network/parse/load_balancer_backend_address_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LoadBalancerBackendAddressPoolId struct {
@@ -42,7 +42,7 @@ func (id LoadBalancerBackendAddressPoolId) ID() string {
 
 // LoadBalancerBackendAddressPoolID parses a LoadBalancerBackendAddressPool ID into an LoadBalancerBackendAddressPoolId struct
 func LoadBalancerBackendAddressPoolID(input string) (*LoadBalancerBackendAddressPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/local_network_gateway.go
+++ b/internal/services/network/parse/local_network_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LocalNetworkGatewayId struct {
@@ -39,7 +39,7 @@ func (id LocalNetworkGatewayId) ID() string {
 
 // LocalNetworkGatewayID parses a LocalNetworkGateway ID into an LocalNetworkGatewayId struct
 func LocalNetworkGatewayID(input string) (*LocalNetworkGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/nat_gateway.go
+++ b/internal/services/network/parse/nat_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NatGatewayId struct {
@@ -39,7 +39,7 @@ func (id NatGatewayId) ID() string {
 
 // NatGatewayID parses a NatGateway ID into an NatGatewayId struct
 func NatGatewayID(input string) (*NatGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_gateway_connection.go
+++ b/internal/services/network/parse/network_gateway_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkGatewayConnectionId struct {
@@ -39,7 +39,7 @@ func (id NetworkGatewayConnectionId) ID() string {
 
 // NetworkGatewayConnectionID parses a NetworkGatewayConnection ID into an NetworkGatewayConnectionId struct
 func NetworkGatewayConnectionID(input string) (*NetworkGatewayConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_interface.go
+++ b/internal/services/network/parse/network_interface.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkInterfaceId struct {
@@ -39,7 +39,7 @@ func (id NetworkInterfaceId) ID() string {
 
 // NetworkInterfaceID parses a NetworkInterface ID into an NetworkInterfaceId struct
 func NetworkInterfaceID(input string) (*NetworkInterfaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_interface_ip_configuration.go
+++ b/internal/services/network/parse/network_interface_ip_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkInterfaceIpConfigurationId struct {
@@ -42,7 +42,7 @@ func (id NetworkInterfaceIpConfigurationId) ID() string {
 
 // NetworkInterfaceIpConfigurationID parses a NetworkInterfaceIpConfiguration ID into an NetworkInterfaceIpConfigurationId struct
 func NetworkInterfaceIpConfigurationID(input string) (*NetworkInterfaceIpConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_profile.go
+++ b/internal/services/network/parse/network_profile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkProfileId struct {
@@ -39,7 +39,7 @@ func (id NetworkProfileId) ID() string {
 
 // NetworkProfileID parses a NetworkProfile ID into an NetworkProfileId struct
 func NetworkProfileID(input string) (*NetworkProfileId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_security_group.go
+++ b/internal/services/network/parse/network_security_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkSecurityGroupId struct {
@@ -39,7 +39,7 @@ func (id NetworkSecurityGroupId) ID() string {
 
 // NetworkSecurityGroupID parses a NetworkSecurityGroup ID into an NetworkSecurityGroupId struct
 func NetworkSecurityGroupID(input string) (*NetworkSecurityGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/network_watcher.go
+++ b/internal/services/network/parse/network_watcher.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkWatcherId struct {
@@ -39,7 +39,7 @@ func (id NetworkWatcherId) ID() string {
 
 // NetworkWatcherID parses a NetworkWatcher ID into an NetworkWatcherId struct
 func NetworkWatcherID(input string) (*NetworkWatcherId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/packet_capture.go
+++ b/internal/services/network/parse/packet_capture.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PacketCaptureId struct {
@@ -42,7 +42,7 @@ func (id PacketCaptureId) ID() string {
 
 // PacketCaptureID parses a PacketCapture ID into an PacketCaptureId struct
 func PacketCaptureID(input string) (*PacketCaptureId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/point_to_site_vpn_gateway.go
+++ b/internal/services/network/parse/point_to_site_vpn_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PointToSiteVpnGatewayId struct {
@@ -39,7 +39,7 @@ func (id PointToSiteVpnGatewayId) ID() string {
 
 // PointToSiteVpnGatewayID parses a PointToSiteVpnGateway ID into an PointToSiteVpnGatewayId struct
 func PointToSiteVpnGatewayID(input string) (*PointToSiteVpnGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/private_dns_zone_config.go
+++ b/internal/services/network/parse/private_dns_zone_config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateDnsZoneConfigId struct {
@@ -45,7 +45,7 @@ func (id PrivateDnsZoneConfigId) ID() string {
 
 // PrivateDnsZoneConfigID parses a PrivateDnsZoneConfig ID into an PrivateDnsZoneConfigId struct
 func PrivateDnsZoneConfigID(input string) (*PrivateDnsZoneConfigId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/private_dns_zone_group.go
+++ b/internal/services/network/parse/private_dns_zone_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateDnsZoneGroupId struct {
@@ -42,7 +42,7 @@ func (id PrivateDnsZoneGroupId) ID() string {
 
 // PrivateDnsZoneGroupID parses a PrivateDnsZoneGroup ID into an PrivateDnsZoneGroupId struct
 func PrivateDnsZoneGroupID(input string) (*PrivateDnsZoneGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/private_endpoint.go
+++ b/internal/services/network/parse/private_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateEndpointId struct {
@@ -39,7 +39,7 @@ func (id PrivateEndpointId) ID() string {
 
 // PrivateEndpointID parses a PrivateEndpoint ID into an PrivateEndpointId struct
 func PrivateEndpointID(input string) (*PrivateEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/private_link_service.go
+++ b/internal/services/network/parse/private_link_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateLinkServiceId struct {
@@ -39,7 +39,7 @@ func (id PrivateLinkServiceId) ID() string {
 
 // PrivateLinkServiceID parses a PrivateLinkService ID into an PrivateLinkServiceId struct
 func PrivateLinkServiceID(input string) (*PrivateLinkServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/probe.go
+++ b/internal/services/network/parse/probe.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProbeId struct {
@@ -42,7 +42,7 @@ func (id ProbeId) ID() string {
 
 // ProbeID parses a Probe ID into an ProbeId struct
 func ProbeID(input string) (*ProbeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/public_ip_address.go
+++ b/internal/services/network/parse/public_ip_address.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PublicIpAddressId struct {
@@ -39,7 +39,7 @@ func (id PublicIpAddressId) ID() string {
 
 // PublicIpAddressID parses a PublicIpAddress ID into an PublicIpAddressId struct
 func PublicIpAddressID(input string) (*PublicIpAddressId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/public_ip_prefix.go
+++ b/internal/services/network/parse/public_ip_prefix.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PublicIpPrefixId struct {
@@ -39,7 +39,7 @@ func (id PublicIpPrefixId) ID() string {
 
 // PublicIpPrefixID parses a PublicIpPrefix ID into an PublicIpPrefixId struct
 func PublicIpPrefixID(input string) (*PublicIpPrefixId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/redirect_configurations.go
+++ b/internal/services/network/parse/redirect_configurations.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RedirectConfigurationsId struct {
@@ -42,7 +42,7 @@ func (id RedirectConfigurationsId) ID() string {
 
 // RedirectConfigurationsID parses a RedirectConfigurations ID into an RedirectConfigurationsId struct
 func RedirectConfigurationsID(input string) (*RedirectConfigurationsId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/rewrite_rule_set.go
+++ b/internal/services/network/parse/rewrite_rule_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RewriteRuleSetId struct {
@@ -42,7 +42,7 @@ func (id RewriteRuleSetId) ID() string {
 
 // RewriteRuleSetID parses a RewriteRuleSet ID into an RewriteRuleSetId struct
 func RewriteRuleSetID(input string) (*RewriteRuleSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/route.go
+++ b/internal/services/network/parse/route.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RouteId struct {
@@ -42,7 +42,7 @@ func (id RouteId) ID() string {
 
 // RouteID parses a Route ID into an RouteId struct
 func RouteID(input string) (*RouteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/route_filter.go
+++ b/internal/services/network/parse/route_filter.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RouteFilterId struct {
@@ -39,7 +39,7 @@ func (id RouteFilterId) ID() string {
 
 // RouteFilterID parses a RouteFilter ID into an RouteFilterId struct
 func RouteFilterID(input string) (*RouteFilterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/route_table.go
+++ b/internal/services/network/parse/route_table.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RouteTableId struct {
@@ -39,7 +39,7 @@ func (id RouteTableId) ID() string {
 
 // RouteTableID parses a RouteTable ID into an RouteTableId struct
 func RouteTableID(input string) (*RouteTableId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/security_partner_provider.go
+++ b/internal/services/network/parse/security_partner_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SecurityPartnerProviderId struct {
@@ -39,7 +39,7 @@ func (id SecurityPartnerProviderId) ID() string {
 
 // SecurityPartnerProviderID parses a SecurityPartnerProvider ID into an SecurityPartnerProviderId struct
 func SecurityPartnerProviderID(input string) (*SecurityPartnerProviderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/security_rule.go
+++ b/internal/services/network/parse/security_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SecurityRuleId struct {
@@ -42,7 +42,7 @@ func (id SecurityRuleId) ID() string {
 
 // SecurityRuleID parses a SecurityRule ID into an SecurityRuleId struct
 func SecurityRuleID(input string) (*SecurityRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/ssl_certificate.go
+++ b/internal/services/network/parse/ssl_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SslCertificateId struct {
@@ -42,7 +42,7 @@ func (id SslCertificateId) ID() string {
 
 // SslCertificateID parses a SslCertificate ID into an SslCertificateId struct
 func SslCertificateID(input string) (*SslCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/ssl_profile.go
+++ b/internal/services/network/parse/ssl_profile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SslProfileId struct {
@@ -42,7 +42,7 @@ func (id SslProfileId) ID() string {
 
 // SslProfileID parses a SslProfile ID into an SslProfileId struct
 func SslProfileID(input string) (*SslProfileId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/subnet.go
+++ b/internal/services/network/parse/subnet.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubnetId struct {
@@ -42,7 +42,7 @@ func (id SubnetId) ID() string {
 
 // SubnetID parses a Subnet ID into an SubnetId struct
 func SubnetID(input string) (*SubnetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func SubnetID(input string) (*SubnetId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func SubnetIDInsensitively(input string) (*SubnetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/subnet_service_endpoint_storage_policy.go
+++ b/internal/services/network/parse/subnet_service_endpoint_storage_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubnetServiceEndpointStoragePolicyId struct {
@@ -39,7 +39,7 @@ func (id SubnetServiceEndpointStoragePolicyId) ID() string {
 
 // SubnetServiceEndpointStoragePolicyID parses a SubnetServiceEndpointStoragePolicy ID into an SubnetServiceEndpointStoragePolicyId struct
 func SubnetServiceEndpointStoragePolicyID(input string) (*SubnetServiceEndpointStoragePolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/trusted_client_certificate.go
+++ b/internal/services/network/parse/trusted_client_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TrustedClientCertificateId struct {
@@ -42,7 +42,7 @@ func (id TrustedClientCertificateId) ID() string {
 
 // TrustedClientCertificateID parses a TrustedClientCertificate ID into an TrustedClientCertificateId struct
 func TrustedClientCertificateID(input string) (*TrustedClientCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/trusted_root_certificate.go
+++ b/internal/services/network/parse/trusted_root_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TrustedRootCertificateId struct {
@@ -42,7 +42,7 @@ func (id TrustedRootCertificateId) ID() string {
 
 // TrustedRootCertificateID parses a TrustedRootCertificate ID into an TrustedRootCertificateId struct
 func TrustedRootCertificateID(input string) (*TrustedRootCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/url_path_map.go
+++ b/internal/services/network/parse/url_path_map.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type UrlPathMapId struct {
@@ -42,7 +42,7 @@ func (id UrlPathMapId) ID() string {
 
 // UrlPathMapID parses a UrlPathMap ID into an UrlPathMapId struct
 func UrlPathMapID(input string) (*UrlPathMapId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_hub.go
+++ b/internal/services/network/parse/virtual_hub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualHubId struct {
@@ -39,7 +39,7 @@ func (id VirtualHubId) ID() string {
 
 // VirtualHubID parses a VirtualHub ID into an VirtualHubId struct
 func VirtualHubID(input string) (*VirtualHubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_hub_ip_configuration.go
+++ b/internal/services/network/parse/virtual_hub_ip_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualHubIpConfigurationId struct {
@@ -42,7 +42,7 @@ func (id VirtualHubIpConfigurationId) ID() string {
 
 // VirtualHubIpConfigurationID parses a VirtualHubIpConfiguration ID into an VirtualHubIpConfigurationId struct
 func VirtualHubIpConfigurationID(input string) (*VirtualHubIpConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_network.go
+++ b/internal/services/network/parse/virtual_network.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkId struct {
@@ -39,7 +39,7 @@ func (id VirtualNetworkId) ID() string {
 
 // VirtualNetworkID parses a VirtualNetwork ID into an VirtualNetworkId struct
 func VirtualNetworkID(input string) (*VirtualNetworkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func VirtualNetworkID(input string) (*VirtualNetworkId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func VirtualNetworkIDInsensitively(input string) (*VirtualNetworkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_network_dns_servers.go
+++ b/internal/services/network/parse/virtual_network_dns_servers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkDnsServersId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkDnsServersId) ID() string {
 
 // VirtualNetworkDnsServersID parses a VirtualNetworkDnsServers ID into an VirtualNetworkDnsServersId struct
 func VirtualNetworkDnsServersID(input string) (*VirtualNetworkDnsServersId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func VirtualNetworkDnsServersID(input string) (*VirtualNetworkDnsServersId, erro
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func VirtualNetworkDnsServersIDInsensitively(input string) (*VirtualNetworkDnsServersId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_network_gateway.go
+++ b/internal/services/network/parse/virtual_network_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkGatewayId struct {
@@ -39,7 +39,7 @@ func (id VirtualNetworkGatewayId) ID() string {
 
 // VirtualNetworkGatewayID parses a VirtualNetworkGateway ID into an VirtualNetworkGatewayId struct
 func VirtualNetworkGatewayID(input string) (*VirtualNetworkGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_network_gateway_ip_configuration.go
+++ b/internal/services/network/parse/virtual_network_gateway_ip_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkGatewayIpConfigurationId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkGatewayIpConfigurationId) ID() string {
 
 // VirtualNetworkGatewayIpConfigurationID parses a VirtualNetworkGatewayIpConfiguration ID into an VirtualNetworkGatewayIpConfigurationId struct
 func VirtualNetworkGatewayIpConfigurationID(input string) (*VirtualNetworkGatewayIpConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_network_peering.go
+++ b/internal/services/network/parse/virtual_network_peering.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkPeeringId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkPeeringId) ID() string {
 
 // VirtualNetworkPeeringID parses a VirtualNetworkPeering ID into an VirtualNetworkPeeringId struct
 func VirtualNetworkPeeringID(input string) (*VirtualNetworkPeeringId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/virtual_wan.go
+++ b/internal/services/network/parse/virtual_wan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualWanId struct {
@@ -39,7 +39,7 @@ func (id VirtualWanId) ID() string {
 
 // VirtualWanID parses a VirtualWan ID into an VirtualWanId struct
 func VirtualWanID(input string) (*VirtualWanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/vpn_connection.go
+++ b/internal/services/network/parse/vpn_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VpnConnectionId struct {
@@ -42,7 +42,7 @@ func (id VpnConnectionId) ID() string {
 
 // VpnConnectionID parses a VpnConnection ID into an VpnConnectionId struct
 func VpnConnectionID(input string) (*VpnConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/vpn_gateway.go
+++ b/internal/services/network/parse/vpn_gateway.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VpnGatewayId struct {
@@ -39,7 +39,7 @@ func (id VpnGatewayId) ID() string {
 
 // VpnGatewayID parses a VpnGateway ID into an VpnGatewayId struct
 func VpnGatewayID(input string) (*VpnGatewayId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/vpn_server_configuration.go
+++ b/internal/services/network/parse/vpn_server_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VpnServerConfigurationId struct {
@@ -39,7 +39,7 @@ func (id VpnServerConfigurationId) ID() string {
 
 // VpnServerConfigurationID parses a VpnServerConfiguration ID into an VpnServerConfigurationId struct
 func VpnServerConfigurationID(input string) (*VpnServerConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/vpn_site.go
+++ b/internal/services/network/parse/vpn_site.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VpnSiteId struct {
@@ -39,7 +39,7 @@ func (id VpnSiteId) ID() string {
 
 // VpnSiteID parses a VpnSite ID into an VpnSiteId struct
 func VpnSiteID(input string) (*VpnSiteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/network/parse/vpn_site_link.go
+++ b/internal/services/network/parse/vpn_site_link.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VpnSiteLinkId struct {
@@ -42,7 +42,7 @@ func (id VpnSiteLinkId) ID() string {
 
 // VpnSiteLinkID parses a VpnSiteLink ID into an VpnSiteLinkId struct
 func VpnSiteLinkID(input string) (*VpnSiteLinkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/notificationhub/parse/namespace.go
+++ b/internal/services/notificationhub/parse/namespace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamespaceId struct {
@@ -39,7 +39,7 @@ func (id NamespaceId) ID() string {
 
 // NamespaceID parses a Namespace ID into an NamespaceId struct
 func NamespaceID(input string) (*NamespaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func NamespaceID(input string) (*NamespaceId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/notificationhub/parse/notification_hub.go
+++ b/internal/services/notificationhub/parse/notification_hub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NotificationHubId struct {
@@ -42,7 +42,7 @@ func (id NotificationHubId) ID() string {
 
 // NotificationHubID parses a NotificationHub ID into an NotificationHubId struct
 func NotificationHubID(input string) (*NotificationHubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func NotificationHubID(input string) (*NotificationHubId, error) {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func NotificationHubIDInsensitively(input string) (*NotificationHubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
+++ b/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NotificationHubAuthorizationRuleId struct {
@@ -45,7 +45,7 @@ func (id NotificationHubAuthorizationRuleId) ID() string {
 
 // NotificationHubAuthorizationRuleID parses a NotificationHubAuthorizationRule ID into an NotificationHubAuthorizationRuleId struct
 func NotificationHubAuthorizationRuleID(input string) (*NotificationHubAuthorizationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func NotificationHubAuthorizationRuleID(input string) (*NotificationHubAuthoriza
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func NotificationHubAuthorizationRuleIDInsensitively(input string) (*NotificationHubAuthorizationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/policy/parse/resource_group_assignment.go
+++ b/internal/services/policy/parse/resource_group_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ResourceGroupAssignmentId struct {
@@ -39,7 +39,7 @@ func (id ResourceGroupAssignmentId) ID() string {
 
 // ResourceGroupAssignmentID parses a ResourceGroupAssignment ID into an ResourceGroupAssignmentId struct
 func ResourceGroupAssignmentID(input string) (*ResourceGroupAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/policy/parse/subscription_assignment.go
+++ b/internal/services/policy/parse/subscription_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionAssignmentId struct {
@@ -36,7 +36,7 @@ func (id SubscriptionAssignmentId) ID() string {
 
 // SubscriptionAssignmentID parses a SubscriptionAssignment ID into an SubscriptionAssignmentId struct
 func SubscriptionAssignmentID(input string) (*SubscriptionAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/policy/parse/virtual_machine_configuration_assignment.go
+++ b/internal/services/policy/parse/virtual_machine_configuration_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineConfigurationAssignmentId struct {
@@ -42,7 +42,7 @@ func (id VirtualMachineConfigurationAssignmentId) ID() string {
 
 // VirtualMachineConfigurationAssignmentID parses a VirtualMachineConfigurationAssignment ID into an VirtualMachineConfigurationAssignmentId struct
 func VirtualMachineConfigurationAssignmentID(input string) (*VirtualMachineConfigurationAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func VirtualMachineConfigurationAssignmentID(input string) (*VirtualMachineConfi
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func VirtualMachineConfigurationAssignmentIDInsensitively(input string) (*VirtualMachineConfigurationAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/policy/parse/virtual_machine_configuration_policy_assignment.go
+++ b/internal/services/policy/parse/virtual_machine_configuration_policy_assignment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualMachineConfigurationPolicyAssignmentId struct {
@@ -42,7 +42,7 @@ func (id VirtualMachineConfigurationPolicyAssignmentId) ID() string {
 
 // VirtualMachineConfigurationPolicyAssignmentID parses a VirtualMachineConfigurationPolicyAssignment ID into an VirtualMachineConfigurationPolicyAssignmentId struct
 func VirtualMachineConfigurationPolicyAssignmentID(input string) (*VirtualMachineConfigurationPolicyAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func VirtualMachineConfigurationPolicyAssignmentID(input string) (*VirtualMachin
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func VirtualMachineConfigurationPolicyAssignmentIDInsensitively(input string) (*VirtualMachineConfigurationPolicyAssignmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/portal/parse/dashboard.go
+++ b/internal/services/portal/parse/dashboard.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DashboardId struct {
@@ -39,7 +39,7 @@ func (id DashboardId) ID() string {
 
 // DashboardID parses a Dashboard ID into an DashboardId struct
 func DashboardID(input string) (*DashboardId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/azure_active_directory_administrator.go
+++ b/internal/services/postgres/parse/azure_active_directory_administrator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AzureActiveDirectoryAdministratorId struct {
@@ -42,7 +42,7 @@ func (id AzureActiveDirectoryAdministratorId) ID() string {
 
 // AzureActiveDirectoryAdministratorID parses a AzureActiveDirectoryAdministrator ID into an AzureActiveDirectoryAdministratorId struct
 func AzureActiveDirectoryAdministratorID(input string) (*AzureActiveDirectoryAdministratorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/configuration.go
+++ b/internal/services/postgres/parse/configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ConfigurationId struct {
@@ -42,7 +42,7 @@ func (id ConfigurationId) ID() string {
 
 // ConfigurationID parses a Configuration ID into an ConfigurationId struct
 func ConfigurationID(input string) (*ConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/database.go
+++ b/internal/services/postgres/parse/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseId struct {
@@ -42,7 +42,7 @@ func (id DatabaseId) ID() string {
 
 // DatabaseID parses a Database ID into an DatabaseId struct
 func DatabaseID(input string) (*DatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/firewall_rule.go
+++ b/internal/services/postgres/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/flexible_server.go
+++ b/internal/services/postgres/parse/flexible_server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerId struct {
@@ -39,7 +39,7 @@ func (id FlexibleServerId) ID() string {
 
 // FlexibleServerID parses a FlexibleServer ID into an FlexibleServerId struct
 func FlexibleServerID(input string) (*FlexibleServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/flexible_server_configuration.go
+++ b/internal/services/postgres/parse/flexible_server_configuration.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerConfigurationId struct {
@@ -42,7 +42,7 @@ func (id FlexibleServerConfigurationId) ID() string {
 
 // FlexibleServerConfigurationID parses a FlexibleServerConfiguration ID into an FlexibleServerConfigurationId struct
 func FlexibleServerConfigurationID(input string) (*FlexibleServerConfigurationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/flexible_server_database.go
+++ b/internal/services/postgres/parse/flexible_server_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerDatabaseId struct {
@@ -42,7 +42,7 @@ func (id FlexibleServerDatabaseId) ID() string {
 
 // FlexibleServerDatabaseID parses a FlexibleServerDatabase ID into an FlexibleServerDatabaseId struct
 func FlexibleServerDatabaseID(input string) (*FlexibleServerDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/flexible_server_firewall_rule.go
+++ b/internal/services/postgres/parse/flexible_server_firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FlexibleServerFirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FlexibleServerFirewallRuleId) ID() string {
 
 // FlexibleServerFirewallRuleID parses a FlexibleServerFirewallRule ID into an FlexibleServerFirewallRuleId struct
 func FlexibleServerFirewallRuleID(input string) (*FlexibleServerFirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/server.go
+++ b/internal/services/postgres/parse/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerId struct {
@@ -39,7 +39,7 @@ func (id ServerId) ID() string {
 
 // ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/server_key.go
+++ b/internal/services/postgres/parse/server_key.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerKeyId struct {
@@ -42,7 +42,7 @@ func (id ServerKeyId) ID() string {
 
 // ServerKeyID parses a ServerKey ID into an ServerKeyId struct
 func ServerKeyID(input string) (*ServerKeyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/postgres/parse/virtual_network_rule.go
+++ b/internal/services/postgres/parse/virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkRuleId) ID() string {
 
 // VirtualNetworkRuleID parses a VirtualNetworkRule ID into an VirtualNetworkRuleId struct
 func VirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/a_record.go
+++ b/internal/services/privatedns/parse/a_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ARecordId struct {
@@ -42,7 +42,7 @@ func (id ARecordId) ID() string {
 
 // ARecordID parses a ARecord ID into an ARecordId struct
 func ARecordID(input string) (*ARecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/aaaa_record.go
+++ b/internal/services/privatedns/parse/aaaa_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AaaaRecordId struct {
@@ -42,7 +42,7 @@ func (id AaaaRecordId) ID() string {
 
 // AaaaRecordID parses a AaaaRecord ID into an AaaaRecordId struct
 func AaaaRecordID(input string) (*AaaaRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/cname_record.go
+++ b/internal/services/privatedns/parse/cname_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CnameRecordId struct {
@@ -42,7 +42,7 @@ func (id CnameRecordId) ID() string {
 
 // CnameRecordID parses a CnameRecord ID into an CnameRecordId struct
 func CnameRecordID(input string) (*CnameRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/mx_record.go
+++ b/internal/services/privatedns/parse/mx_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type MxRecordId struct {
@@ -42,7 +42,7 @@ func (id MxRecordId) ID() string {
 
 // MxRecordID parses a MxRecord ID into an MxRecordId struct
 func MxRecordID(input string) (*MxRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/private_dns_zone.go
+++ b/internal/services/privatedns/parse/private_dns_zone.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateDnsZoneId struct {
@@ -39,7 +39,7 @@ func (id PrivateDnsZoneId) ID() string {
 
 // PrivateDnsZoneID parses a PrivateDnsZone ID into an PrivateDnsZoneId struct
 func PrivateDnsZoneID(input string) (*PrivateDnsZoneId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/ptr_record.go
+++ b/internal/services/privatedns/parse/ptr_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PtrRecordId struct {
@@ -42,7 +42,7 @@ func (id PtrRecordId) ID() string {
 
 // PtrRecordID parses a PtrRecord ID into an PtrRecordId struct
 func PtrRecordID(input string) (*PtrRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/srv_record.go
+++ b/internal/services/privatedns/parse/srv_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SrvRecordId struct {
@@ -42,7 +42,7 @@ func (id SrvRecordId) ID() string {
 
 // SrvRecordID parses a SrvRecord ID into an SrvRecordId struct
 func SrvRecordID(input string) (*SrvRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/txt_record.go
+++ b/internal/services/privatedns/parse/txt_record.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TxtRecordId struct {
@@ -42,7 +42,7 @@ func (id TxtRecordId) ID() string {
 
 // TxtRecordID parses a TxtRecord ID into an TxtRecordId struct
 func TxtRecordID(input string) (*TxtRecordId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/privatedns/parse/virtual_network_link.go
+++ b/internal/services/privatedns/parse/virtual_network_link.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkLinkId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkLinkId) ID() string {
 
 // VirtualNetworkLinkID parses a VirtualNetworkLink ID into an VirtualNetworkLinkId struct
 func VirtualNetworkLinkID(input string) (*VirtualNetworkLinkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/purview/parse/account.go
+++ b/internal/services/purview/parse/account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AccountId struct {
@@ -39,7 +39,7 @@ func (id AccountId) ID() string {
 
 // AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/backup_policy.go
+++ b/internal/services/recoveryservices/parse/backup_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BackupPolicyId struct {
@@ -42,7 +42,7 @@ func (id BackupPolicyId) ID() string {
 
 // BackupPolicyID parses a BackupPolicy ID into an BackupPolicyId struct
 func BackupPolicyID(input string) (*BackupPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/protected_item.go
+++ b/internal/services/recoveryservices/parse/protected_item.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProtectedItemId struct {
@@ -48,7 +48,7 @@ func (id ProtectedItemId) ID() string {
 
 // ProtectedItemID parses a ProtectedItem ID into an ProtectedItemId struct
 func ProtectedItemID(input string) (*ProtectedItemId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/protection_container.go
+++ b/internal/services/recoveryservices/parse/protection_container.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ProtectionContainerId struct {
@@ -45,7 +45,7 @@ func (id ProtectionContainerId) ID() string {
 
 // ProtectionContainerID parses a ProtectionContainer ID into an ProtectionContainerId struct
 func ProtectionContainerID(input string) (*ProtectionContainerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_fabric.go
+++ b/internal/services/recoveryservices/parse/replication_fabric.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationFabricId struct {
@@ -42,7 +42,7 @@ func (id ReplicationFabricId) ID() string {
 
 // ReplicationFabricID parses a ReplicationFabric ID into an ReplicationFabricId struct
 func ReplicationFabricID(input string) (*ReplicationFabricId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_network_mapping.go
+++ b/internal/services/recoveryservices/parse/replication_network_mapping.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationNetworkMappingId struct {
@@ -48,7 +48,7 @@ func (id ReplicationNetworkMappingId) ID() string {
 
 // ReplicationNetworkMappingID parses a ReplicationNetworkMapping ID into an ReplicationNetworkMappingId struct
 func ReplicationNetworkMappingID(input string) (*ReplicationNetworkMappingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_policy.go
+++ b/internal/services/recoveryservices/parse/replication_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationPolicyId struct {
@@ -42,7 +42,7 @@ func (id ReplicationPolicyId) ID() string {
 
 // ReplicationPolicyID parses a ReplicationPolicy ID into an ReplicationPolicyId struct
 func ReplicationPolicyID(input string) (*ReplicationPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_protected_item.go
+++ b/internal/services/recoveryservices/parse/replication_protected_item.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationProtectedItemId struct {
@@ -48,7 +48,7 @@ func (id ReplicationProtectedItemId) ID() string {
 
 // ReplicationProtectedItemID parses a ReplicationProtectedItem ID into an ReplicationProtectedItemId struct
 func ReplicationProtectedItemID(input string) (*ReplicationProtectedItemId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_protection_container.go
+++ b/internal/services/recoveryservices/parse/replication_protection_container.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationProtectionContainerId struct {
@@ -45,7 +45,7 @@ func (id ReplicationProtectionContainerId) ID() string {
 
 // ReplicationProtectionContainerID parses a ReplicationProtectionContainer ID into an ReplicationProtectionContainerId struct
 func ReplicationProtectionContainerID(input string) (*ReplicationProtectionContainerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/replication_protection_container_mappings.go
+++ b/internal/services/recoveryservices/parse/replication_protection_container_mappings.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ReplicationProtectionContainerMappingsId struct {
@@ -48,7 +48,7 @@ func (id ReplicationProtectionContainerMappingsId) ID() string {
 
 // ReplicationProtectionContainerMappingsID parses a ReplicationProtectionContainerMappings ID into an ReplicationProtectionContainerMappingsId struct
 func ReplicationProtectionContainerMappingsID(input string) (*ReplicationProtectionContainerMappingsId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/recoveryservices/parse/vault.go
+++ b/internal/services/recoveryservices/parse/vault.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VaultId struct {
@@ -39,7 +39,7 @@ func (id VaultId) ID() string {
 
 // VaultID parses a Vault ID into an VaultId struct
 func VaultID(input string) (*VaultId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/redis/parse/cache.go
+++ b/internal/services/redis/parse/cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CacheId struct {
@@ -39,7 +39,7 @@ func (id CacheId) ID() string {
 
 // CacheID parses a Cache ID into an CacheId struct
 func CacheID(input string) (*CacheId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/redis/parse/firewall_rule.go
+++ b/internal/services/redis/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/redis/parse/linked_server.go
+++ b/internal/services/redis/parse/linked_server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LinkedServerId struct {
@@ -42,7 +42,7 @@ func (id LinkedServerId) ID() string {
 
 // LinkedServerID parses a LinkedServer ID into an LinkedServerId struct
 func LinkedServerID(input string) (*LinkedServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/redisenterprise/parse/redis_enterprise_cluster.go
+++ b/internal/services/redisenterprise/parse/redis_enterprise_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RedisEnterpriseClusterId struct {
@@ -39,7 +39,7 @@ func (id RedisEnterpriseClusterId) ID() string {
 
 // RedisEnterpriseClusterID parses a RedisEnterpriseCluster ID into an RedisEnterpriseClusterId struct
 func RedisEnterpriseClusterID(input string) (*RedisEnterpriseClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/redisenterprise/parse/redis_enterprise_database.go
+++ b/internal/services/redisenterprise/parse/redis_enterprise_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type RedisEnterpriseDatabaseId struct {
@@ -42,7 +42,7 @@ func (id RedisEnterpriseDatabaseId) ID() string {
 
 // RedisEnterpriseDatabaseID parses a RedisEnterpriseDatabase ID into an RedisEnterpriseDatabaseId struct
 func RedisEnterpriseDatabaseID(input string) (*RedisEnterpriseDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/resource/parse/resource_group.go
+++ b/internal/services/resource/parse/resource_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ResourceGroupId struct {
@@ -36,7 +36,7 @@ func (id ResourceGroupId) ID() string {
 
 // ResourceGroupID parses a ResourceGroup ID into an ResourceGroupId struct
 func ResourceGroupID(input string) (*ResourceGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/resource/parse/resource_group_template_deployment.go
+++ b/internal/services/resource/parse/resource_group_template_deployment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ResourceGroupTemplateDeploymentId struct {
@@ -39,7 +39,7 @@ func (id ResourceGroupTemplateDeploymentId) ID() string {
 
 // ResourceGroupTemplateDeploymentID parses a ResourceGroupTemplateDeployment ID into an ResourceGroupTemplateDeploymentId struct
 func ResourceGroupTemplateDeploymentID(input string) (*ResourceGroupTemplateDeploymentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ResourceGroupTemplateDeploymentID(input string) (*ResourceGroupTemplateDepl
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func ResourceGroupTemplateDeploymentIDInsensitively(input string) (*ResourceGroupTemplateDeploymentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/resource/parse/subscription_template_deployment.go
+++ b/internal/services/resource/parse/subscription_template_deployment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionTemplateDeploymentId struct {
@@ -36,7 +36,7 @@ func (id SubscriptionTemplateDeploymentId) ID() string {
 
 // SubscriptionTemplateDeploymentID parses a SubscriptionTemplateDeployment ID into an SubscriptionTemplateDeploymentId struct
 func SubscriptionTemplateDeploymentID(input string) (*SubscriptionTemplateDeploymentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/resource/parse/template_spec_version.go
+++ b/internal/services/resource/parse/template_spec_version.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TemplateSpecVersionId struct {
@@ -42,7 +42,7 @@ func (id TemplateSpecVersionId) ID() string {
 
 // TemplateSpecVersionID parses a TemplateSpecVersion ID into an TemplateSpecVersionId struct
 func TemplateSpecVersionID(input string) (*TemplateSpecVersionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/search/parse/search_service.go
+++ b/internal/services/search/parse/search_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SearchServiceId struct {
@@ -39,7 +39,7 @@ func (id SearchServiceId) ID() string {
 
 // SearchServiceID parses a SearchService ID into an SearchServiceId struct
 func SearchServiceID(input string) (*SearchServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/assessment_metadata.go
+++ b/internal/services/securitycenter/parse/assessment_metadata.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AssessmentMetadataId struct {
@@ -36,7 +36,7 @@ func (id AssessmentMetadataId) ID() string {
 
 // AssessmentMetadataID parses a AssessmentMetadata ID into an AssessmentMetadataId struct
 func AssessmentMetadataID(input string) (*AssessmentMetadataId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/automation.go
+++ b/internal/services/securitycenter/parse/automation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AutomationId struct {
@@ -39,7 +39,7 @@ func (id AutomationId) ID() string {
 
 // AutomationID parses a Automation ID into an AutomationId struct
 func AutomationID(input string) (*AutomationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/contact.go
+++ b/internal/services/securitycenter/parse/contact.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ContactId struct {
@@ -36,7 +36,7 @@ func (id ContactId) ID() string {
 
 // ContactID parses a Contact ID into an ContactId struct
 func ContactID(input string) (*ContactId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/iot_security_solution.go
+++ b/internal/services/securitycenter/parse/iot_security_solution.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IotSecuritySolutionId struct {
@@ -39,7 +39,7 @@ func (id IotSecuritySolutionId) ID() string {
 
 // IotSecuritySolutionID parses a IotSecuritySolution ID into an IotSecuritySolutionId struct
 func IotSecuritySolutionID(input string) (*IotSecuritySolutionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/pricing.go
+++ b/internal/services/securitycenter/parse/pricing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PricingId struct {
@@ -36,7 +36,7 @@ func (id PricingId) ID() string {
 
 // PricingID parses a Pricing ID into an PricingId struct
 func PricingID(input string) (*PricingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/setting.go
+++ b/internal/services/securitycenter/parse/setting.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SettingId struct {
@@ -36,7 +36,7 @@ func (id SettingId) ID() string {
 
 // SettingID parses a Setting ID into an SettingId struct
 func SettingID(input string) (*SettingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/securitycenter/parse/workspace.go
+++ b/internal/services/securitycenter/parse/workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceId struct {
@@ -36,7 +36,7 @@ func (id WorkspaceId) ID() string {
 
 // WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sentinel/parse/alert_rule.go
+++ b/internal/services/sentinel/parse/alert_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AlertRuleId struct {
@@ -42,7 +42,7 @@ func (id AlertRuleId) ID() string {
 
 // AlertRuleID parses a AlertRule ID into an AlertRuleId struct
 func AlertRuleID(input string) (*AlertRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sentinel/parse/automation_rule.go
+++ b/internal/services/sentinel/parse/automation_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AutomationRuleId struct {
@@ -42,7 +42,7 @@ func (id AutomationRuleId) ID() string {
 
 // AutomationRuleID parses a AutomationRule ID into an AutomationRuleId struct
 func AutomationRuleID(input string) (*AutomationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sentinel/parse/data_connector.go
+++ b/internal/services/sentinel/parse/data_connector.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DataConnectorId struct {
@@ -42,7 +42,7 @@ func (id DataConnectorId) ID() string {
 
 // DataConnectorID parses a DataConnector ID into an DataConnectorId struct
 func DataConnectorID(input string) (*DataConnectorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sentinel/parse/sentinel_alert_rule_template.go
+++ b/internal/services/sentinel/parse/sentinel_alert_rule_template.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SentinelAlertRuleTemplateId struct {
@@ -42,7 +42,7 @@ func (id SentinelAlertRuleTemplateId) ID() string {
 
 // SentinelAlertRuleTemplateID parses a SentinelAlertRuleTemplate ID into an SentinelAlertRuleTemplateId struct
 func SentinelAlertRuleTemplateID(input string) (*SentinelAlertRuleTemplateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sentinel/parse/watchlist.go
+++ b/internal/services/sentinel/parse/watchlist.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WatchlistId struct {
@@ -42,7 +42,7 @@ func (id WatchlistId) ID() string {
 
 // WatchlistID parses a Watchlist ID into an WatchlistId struct
 func WatchlistID(input string) (*WatchlistId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/namespace.go
+++ b/internal/services/servicebus/parse/namespace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamespaceId struct {
@@ -39,7 +39,7 @@ func (id NamespaceId) ID() string {
 
 // NamespaceID parses a Namespace ID into an NamespaceId struct
 func NamespaceID(input string) (*NamespaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/namespace_authorization_rule.go
+++ b/internal/services/servicebus/parse/namespace_authorization_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamespaceAuthorizationRuleId struct {
@@ -42,7 +42,7 @@ func (id NamespaceAuthorizationRuleId) ID() string {
 
 // NamespaceAuthorizationRuleID parses a NamespaceAuthorizationRule ID into an NamespaceAuthorizationRuleId struct
 func NamespaceAuthorizationRuleID(input string) (*NamespaceAuthorizationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/namespace_disaster_recovery_config.go
+++ b/internal/services/servicebus/parse/namespace_disaster_recovery_config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamespaceDisasterRecoveryConfigId struct {
@@ -42,7 +42,7 @@ func (id NamespaceDisasterRecoveryConfigId) ID() string {
 
 // NamespaceDisasterRecoveryConfigID parses a NamespaceDisasterRecoveryConfig ID into an NamespaceDisasterRecoveryConfigId struct
 func NamespaceDisasterRecoveryConfigID(input string) (*NamespaceDisasterRecoveryConfigId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/namespace_network_rule_set.go
+++ b/internal/services/servicebus/parse/namespace_network_rule_set.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NamespaceNetworkRuleSetId struct {
@@ -42,7 +42,7 @@ func (id NamespaceNetworkRuleSetId) ID() string {
 
 // NamespaceNetworkRuleSetID parses a NamespaceNetworkRuleSet ID into an NamespaceNetworkRuleSetId struct
 func NamespaceNetworkRuleSetID(input string) (*NamespaceNetworkRuleSetId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/queue.go
+++ b/internal/services/servicebus/parse/queue.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type QueueId struct {
@@ -42,7 +42,7 @@ func (id QueueId) ID() string {
 
 // QueueID parses a Queue ID into an QueueId struct
 func QueueID(input string) (*QueueId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/queue_authorization_rule.go
+++ b/internal/services/servicebus/parse/queue_authorization_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type QueueAuthorizationRuleId struct {
@@ -45,7 +45,7 @@ func (id QueueAuthorizationRuleId) ID() string {
 
 // QueueAuthorizationRuleID parses a QueueAuthorizationRule ID into an QueueAuthorizationRuleId struct
 func QueueAuthorizationRuleID(input string) (*QueueAuthorizationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/subscription.go
+++ b/internal/services/servicebus/parse/subscription.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionId struct {
@@ -45,7 +45,7 @@ func (id SubscriptionId) ID() string {
 
 // SubscriptionID parses a Subscription ID into an SubscriptionId struct
 func SubscriptionID(input string) (*SubscriptionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/subscription_rule.go
+++ b/internal/services/servicebus/parse/subscription_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SubscriptionRuleId struct {
@@ -48,7 +48,7 @@ func (id SubscriptionRuleId) ID() string {
 
 // SubscriptionRuleID parses a SubscriptionRule ID into an SubscriptionRuleId struct
 func SubscriptionRuleID(input string) (*SubscriptionRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/topic.go
+++ b/internal/services/servicebus/parse/topic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TopicId struct {
@@ -42,7 +42,7 @@ func (id TopicId) ID() string {
 
 // TopicID parses a Topic ID into an TopicId struct
 func TopicID(input string) (*TopicId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/parse/topic_authorization_rule.go
+++ b/internal/services/servicebus/parse/topic_authorization_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TopicAuthorizationRuleId struct {
@@ -45,7 +45,7 @@ func (id TopicAuthorizationRuleId) ID() string {
 
 // TopicAuthorizationRuleID parses a TopicAuthorizationRule ID into an TopicAuthorizationRuleId struct
 func TopicAuthorizationRuleID(input string) (*TopicAuthorizationRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabric/parse/cluster.go
+++ b/internal/services/servicefabric/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabricmanaged/parse/service_fabric_managed_cluster.go
+++ b/internal/services/servicefabricmanaged/parse/service_fabric_managed_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServiceFabricManagedClusterId struct {
@@ -39,7 +39,7 @@ func (id ServiceFabricManagedClusterId) ID() string {
 
 // ServiceFabricManagedClusterID parses a ServiceFabricManagedCluster ID into an ServiceFabricManagedClusterId struct
 func ServiceFabricManagedClusterID(input string) (*ServiceFabricManagedClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabricmesh/parse/application.go
+++ b/internal/services/servicefabricmesh/parse/application.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ApplicationId struct {
@@ -39,7 +39,7 @@ func (id ApplicationId) ID() string {
 
 // ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabricmesh/parse/network.go
+++ b/internal/services/servicefabricmesh/parse/network.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NetworkId struct {
@@ -39,7 +39,7 @@ func (id NetworkId) ID() string {
 
 // NetworkID parses a Network ID into an NetworkId struct
 func NetworkID(input string) (*NetworkId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabricmesh/parse/secret.go
+++ b/internal/services/servicefabricmesh/parse/secret.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SecretId struct {
@@ -39,7 +39,7 @@ func (id SecretId) ID() string {
 
 // SecretID parses a Secret ID into an SecretId struct
 func SecretID(input string) (*SecretId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicefabricmesh/parse/secret_value.go
+++ b/internal/services/servicefabricmesh/parse/secret_value.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SecretValueId struct {
@@ -42,7 +42,7 @@ func (id SecretValueId) ID() string {
 
 // SecretValueID parses a SecretValue ID into an SecretValueId struct
 func SecretValueID(input string) (*SecretValueId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_app.go
+++ b/internal/services/springcloud/parse/spring_cloud_app.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudAppId struct {
@@ -42,7 +42,7 @@ func (id SpringCloudAppId) ID() string {
 
 // SpringCloudAppID parses a SpringCloudApp ID into an SpringCloudAppId struct
 func SpringCloudAppID(input string) (*SpringCloudAppId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_app_association.go
+++ b/internal/services/springcloud/parse/spring_cloud_app_association.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudAppAssociationId struct {
@@ -45,7 +45,7 @@ func (id SpringCloudAppAssociationId) ID() string {
 
 // SpringCloudAppAssociationID parses a SpringCloudAppAssociation ID into an SpringCloudAppAssociationId struct
 func SpringCloudAppAssociationID(input string) (*SpringCloudAppAssociationId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_certificate.go
+++ b/internal/services/springcloud/parse/spring_cloud_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudCertificateId struct {
@@ -42,7 +42,7 @@ func (id SpringCloudCertificateId) ID() string {
 
 // SpringCloudCertificateID parses a SpringCloudCertificate ID into an SpringCloudCertificateId struct
 func SpringCloudCertificateID(input string) (*SpringCloudCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_custom_domain.go
+++ b/internal/services/springcloud/parse/spring_cloud_custom_domain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudCustomDomainId struct {
@@ -45,7 +45,7 @@ func (id SpringCloudCustomDomainId) ID() string {
 
 // SpringCloudCustomDomainID parses a SpringCloudCustomDomain ID into an SpringCloudCustomDomainId struct
 func SpringCloudCustomDomainID(input string) (*SpringCloudCustomDomainId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_deployment.go
+++ b/internal/services/springcloud/parse/spring_cloud_deployment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudDeploymentId struct {
@@ -45,7 +45,7 @@ func (id SpringCloudDeploymentId) ID() string {
 
 // SpringCloudDeploymentID parses a SpringCloudDeployment ID into an SpringCloudDeploymentId struct
 func SpringCloudDeploymentID(input string) (*SpringCloudDeploymentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/springcloud/parse/spring_cloud_service.go
+++ b/internal/services/springcloud/parse/spring_cloud_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SpringCloudServiceId struct {
@@ -39,7 +39,7 @@ func (id SpringCloudServiceId) ID() string {
 
 // SpringCloudServiceID parses a SpringCloudService ID into an SpringCloudServiceId struct
 func SpringCloudServiceID(input string) (*SpringCloudServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/azure_active_directory_administrator.go
+++ b/internal/services/sql/parse/azure_active_directory_administrator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AzureActiveDirectoryAdministratorId struct {
@@ -42,7 +42,7 @@ func (id AzureActiveDirectoryAdministratorId) ID() string {
 
 // AzureActiveDirectoryAdministratorID parses a AzureActiveDirectoryAdministrator ID into an AzureActiveDirectoryAdministratorId struct
 func AzureActiveDirectoryAdministratorID(input string) (*AzureActiveDirectoryAdministratorId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/database.go
+++ b/internal/services/sql/parse/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type DatabaseId struct {
@@ -42,7 +42,7 @@ func (id DatabaseId) ID() string {
 
 // DatabaseID parses a Database ID into an DatabaseId struct
 func DatabaseID(input string) (*DatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/elastic_pool.go
+++ b/internal/services/sql/parse/elastic_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ElasticPoolId struct {
@@ -42,7 +42,7 @@ func (id ElasticPoolId) ID() string {
 
 // ElasticPoolID parses a ElasticPool ID into an ElasticPoolId struct
 func ElasticPoolID(input string) (*ElasticPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/failover_group.go
+++ b/internal/services/sql/parse/failover_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FailoverGroupId struct {
@@ -42,7 +42,7 @@ func (id FailoverGroupId) ID() string {
 
 // FailoverGroupID parses a FailoverGroup ID into an FailoverGroupId struct
 func FailoverGroupID(input string) (*FailoverGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/firewall_rule.go
+++ b/internal/services/sql/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/managed_database.go
+++ b/internal/services/sql/parse/managed_database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedDatabaseId struct {
@@ -42,7 +42,7 @@ func (id ManagedDatabaseId) ID() string {
 
 // ManagedDatabaseID parses a ManagedDatabase ID into an ManagedDatabaseId struct
 func ManagedDatabaseID(input string) (*ManagedDatabaseId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/managed_instance.go
+++ b/internal/services/sql/parse/managed_instance.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedInstanceId struct {
@@ -39,7 +39,7 @@ func (id ManagedInstanceId) ID() string {
 
 // ManagedInstanceID parses a ManagedInstance ID into an ManagedInstanceId struct
 func ManagedInstanceID(input string) (*ManagedInstanceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/server.go
+++ b/internal/services/sql/parse/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ServerId struct {
@@ -39,7 +39,7 @@ func (id ServerId) ID() string {
 
 // ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/sql/parse/virtual_network_rule.go
+++ b/internal/services/sql/parse/virtual_network_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkRuleId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkRuleId) ID() string {
 
 // VirtualNetworkRuleID parses a VirtualNetworkRule ID into an VirtualNetworkRuleId struct
 func VirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/blob_inventory_policy.go
+++ b/internal/services/storage/parse/blob_inventory_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type BlobInventoryPolicyId struct {
@@ -42,7 +42,7 @@ func (id BlobInventoryPolicyId) ID() string {
 
 // BlobInventoryPolicyID parses a BlobInventoryPolicy ID into an BlobInventoryPolicyId struct
 func BlobInventoryPolicyID(input string) (*BlobInventoryPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/encryption_scope.go
+++ b/internal/services/storage/parse/encryption_scope.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EncryptionScopeId struct {
@@ -42,7 +42,7 @@ func (id EncryptionScopeId) ID() string {
 
 // EncryptionScopeID parses a EncryptionScope ID into an EncryptionScopeId struct
 func EncryptionScopeID(input string) (*EncryptionScopeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_account.go
+++ b/internal/services/storage/parse/storage_account.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageAccountId struct {
@@ -39,7 +39,7 @@ func (id StorageAccountId) ID() string {
 
 // StorageAccountID parses a StorageAccount ID into an StorageAccountId struct
 func StorageAccountID(input string) (*StorageAccountId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_account_management_policy.go
+++ b/internal/services/storage/parse/storage_account_management_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageAccountManagementPolicyId struct {
@@ -42,7 +42,7 @@ func (id StorageAccountManagementPolicyId) ID() string {
 
 // StorageAccountManagementPolicyID parses a StorageAccountManagementPolicy ID into an StorageAccountManagementPolicyId struct
 func StorageAccountManagementPolicyID(input string) (*StorageAccountManagementPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_container_resource_manager.go
+++ b/internal/services/storage/parse/storage_container_resource_manager.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageContainerResourceManagerId struct {
@@ -45,7 +45,7 @@ func (id StorageContainerResourceManagerId) ID() string {
 
 // StorageContainerResourceManagerID parses a StorageContainerResourceManager ID into an StorageContainerResourceManagerId struct
 func StorageContainerResourceManagerID(input string) (*StorageContainerResourceManagerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_disks_pool.go
+++ b/internal/services/storage/parse/storage_disks_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageDisksPoolId struct {
@@ -39,7 +39,7 @@ func (id StorageDisksPoolId) ID() string {
 
 // StorageDisksPoolID parses a StorageDisksPool ID into an StorageDisksPoolId struct
 func StorageDisksPoolID(input string) (*StorageDisksPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_share_resource_manager.go
+++ b/internal/services/storage/parse/storage_share_resource_manager.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageShareResourceManagerId struct {
@@ -45,7 +45,7 @@ func (id StorageShareResourceManagerId) ID() string {
 
 // StorageShareResourceManagerID parses a StorageShareResourceManager ID into an StorageShareResourceManagerId struct
 func StorageShareResourceManagerID(input string) (*StorageShareResourceManagerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_sync_cloud_endpoint.go
+++ b/internal/services/storage/parse/storage_sync_cloud_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageSyncCloudEndpointId struct {
@@ -45,7 +45,7 @@ func (id StorageSyncCloudEndpointId) ID() string {
 
 // StorageSyncCloudEndpointID parses a StorageSyncCloudEndpoint ID into an StorageSyncCloudEndpointId struct
 func StorageSyncCloudEndpointID(input string) (*StorageSyncCloudEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_sync_group.go
+++ b/internal/services/storage/parse/storage_sync_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageSyncGroupId struct {
@@ -42,7 +42,7 @@ func (id StorageSyncGroupId) ID() string {
 
 // StorageSyncGroupID parses a StorageSyncGroup ID into an StorageSyncGroupId struct
 func StorageSyncGroupID(input string) (*StorageSyncGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/storage/parse/storage_sync_service.go
+++ b/internal/services/storage/parse/storage_sync_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StorageSyncServiceId struct {
@@ -39,7 +39,7 @@ func (id StorageSyncServiceId) ID() string {
 
 // StorageSyncServiceID parses a StorageSyncService ID into an StorageSyncServiceId struct
 func StorageSyncServiceID(input string) (*StorageSyncServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/cluster.go
+++ b/internal/services/streamanalytics/parse/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ClusterId struct {
@@ -39,7 +39,7 @@ func (id ClusterId) ID() string {
 
 // ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/function.go
+++ b/internal/services/streamanalytics/parse/function.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FunctionId struct {
@@ -42,7 +42,7 @@ func (id FunctionId) ID() string {
 
 // FunctionID parses a Function ID into an FunctionId struct
 func FunctionID(input string) (*FunctionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/output.go
+++ b/internal/services/streamanalytics/parse/output.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type OutputId struct {
@@ -42,7 +42,7 @@ func (id OutputId) ID() string {
 
 // OutputID parses a Output ID into an OutputId struct
 func OutputID(input string) (*OutputId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/private_endpoint.go
+++ b/internal/services/streamanalytics/parse/private_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateEndpointId struct {
@@ -42,7 +42,7 @@ func (id PrivateEndpointId) ID() string {
 
 // PrivateEndpointID parses a PrivateEndpoint ID into an PrivateEndpointId struct
 func PrivateEndpointID(input string) (*PrivateEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/stream_input.go
+++ b/internal/services/streamanalytics/parse/stream_input.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StreamInputId struct {
@@ -42,7 +42,7 @@ func (id StreamInputId) ID() string {
 
 // StreamInputID parses a StreamInput ID into an StreamInputId struct
 func StreamInputID(input string) (*StreamInputId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/streamanalytics/parse/streaming_job.go
+++ b/internal/services/streamanalytics/parse/streaming_job.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StreamingJobId struct {
@@ -39,7 +39,7 @@ func (id StreamingJobId) ID() string {
 
 // StreamingJobID parses a StreamingJob ID into an StreamingJobId struct
 func StreamingJobID(input string) (*StreamingJobId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/firewall_rule.go
+++ b/internal/services/synapse/parse/firewall_rule.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FirewallRuleId struct {
@@ -42,7 +42,7 @@ func (id FirewallRuleId) ID() string {
 
 // FirewallRuleID parses a FirewallRule ID into an FirewallRuleId struct
 func FirewallRuleID(input string) (*FirewallRuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/integration_runtime.go
+++ b/internal/services/synapse/parse/integration_runtime.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type IntegrationRuntimeId struct {
@@ -42,7 +42,7 @@ func (id IntegrationRuntimeId) ID() string {
 
 // IntegrationRuntimeID parses a IntegrationRuntime ID into an IntegrationRuntimeId struct
 func IntegrationRuntimeID(input string) (*IntegrationRuntimeId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/linked_service.go
+++ b/internal/services/synapse/parse/linked_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type LinkedServiceId struct {
@@ -42,7 +42,7 @@ func (id LinkedServiceId) ID() string {
 
 // LinkedServiceID parses a LinkedService ID into an LinkedServiceId struct
 func LinkedServiceID(input string) (*LinkedServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/managed_private_endpoint.go
+++ b/internal/services/synapse/parse/managed_private_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedPrivateEndpointId struct {
@@ -45,7 +45,7 @@ func (id ManagedPrivateEndpointId) ID() string {
 
 // ManagedPrivateEndpointID parses a ManagedPrivateEndpoint ID into an ManagedPrivateEndpointId struct
 func ManagedPrivateEndpointID(input string) (*ManagedPrivateEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/private_link_hub.go
+++ b/internal/services/synapse/parse/private_link_hub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PrivateLinkHubId struct {
@@ -39,7 +39,7 @@ func (id PrivateLinkHubId) ID() string {
 
 // PrivateLinkHubID parses a PrivateLinkHub ID into an PrivateLinkHubId struct
 func PrivateLinkHubID(input string) (*PrivateLinkHubId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/spark_pool.go
+++ b/internal/services/synapse/parse/spark_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SparkPoolId struct {
@@ -42,7 +42,7 @@ func (id SparkPoolId) ID() string {
 
 // SparkPoolID parses a SparkPool ID into an SparkPoolId struct
 func SparkPoolID(input string) (*SparkPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool.go
+++ b/internal/services/synapse/parse/sql_pool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolId struct {
@@ -42,7 +42,7 @@ func (id SqlPoolId) ID() string {
 
 // SqlPoolID parses a SqlPool ID into an SqlPoolId struct
 func SqlPoolID(input string) (*SqlPoolId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool_extended_auditing_policy.go
+++ b/internal/services/synapse/parse/sql_pool_extended_auditing_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolExtendedAuditingPolicyId struct {
@@ -45,7 +45,7 @@ func (id SqlPoolExtendedAuditingPolicyId) ID() string {
 
 // SqlPoolExtendedAuditingPolicyID parses a SqlPoolExtendedAuditingPolicy ID into an SqlPoolExtendedAuditingPolicyId struct
 func SqlPoolExtendedAuditingPolicyID(input string) (*SqlPoolExtendedAuditingPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool_security_alert_policy.go
+++ b/internal/services/synapse/parse/sql_pool_security_alert_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolSecurityAlertPolicyId struct {
@@ -45,7 +45,7 @@ func (id SqlPoolSecurityAlertPolicyId) ID() string {
 
 // SqlPoolSecurityAlertPolicyID parses a SqlPoolSecurityAlertPolicy ID into an SqlPoolSecurityAlertPolicyId struct
 func SqlPoolSecurityAlertPolicyID(input string) (*SqlPoolSecurityAlertPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool_vulnerability_assessment.go
+++ b/internal/services/synapse/parse/sql_pool_vulnerability_assessment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolVulnerabilityAssessmentId struct {
@@ -45,7 +45,7 @@ func (id SqlPoolVulnerabilityAssessmentId) ID() string {
 
 // SqlPoolVulnerabilityAssessmentID parses a SqlPoolVulnerabilityAssessment ID into an SqlPoolVulnerabilityAssessmentId struct
 func SqlPoolVulnerabilityAssessmentID(input string) (*SqlPoolVulnerabilityAssessmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool_vulnerability_assessment_baseline.go
+++ b/internal/services/synapse/parse/sql_pool_vulnerability_assessment_baseline.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolVulnerabilityAssessmentBaselineId struct {
@@ -51,7 +51,7 @@ func (id SqlPoolVulnerabilityAssessmentBaselineId) ID() string {
 
 // SqlPoolVulnerabilityAssessmentBaselineID parses a SqlPoolVulnerabilityAssessmentBaseline ID into an SqlPoolVulnerabilityAssessmentBaselineId struct
 func SqlPoolVulnerabilityAssessmentBaselineID(input string) (*SqlPoolVulnerabilityAssessmentBaselineId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/sql_pool_workload_group.go
+++ b/internal/services/synapse/parse/sql_pool_workload_group.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SqlPoolWorkloadGroupId struct {
@@ -45,7 +45,7 @@ func (id SqlPoolWorkloadGroupId) ID() string {
 
 // SqlPoolWorkloadGroupID parses a SqlPoolWorkloadGroup ID into an SqlPoolWorkloadGroupId struct
 func SqlPoolWorkloadGroupID(input string) (*SqlPoolWorkloadGroupId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace.go
+++ b/internal/services/synapse/parse/workspace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceId struct {
@@ -39,7 +39,7 @@ func (id WorkspaceId) ID() string {
 
 // WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace_aad_admin.go
+++ b/internal/services/synapse/parse/workspace_aad_admin.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceAADAdminId struct {
@@ -42,7 +42,7 @@ func (id WorkspaceAADAdminId) ID() string {
 
 // WorkspaceAADAdminID parses a WorkspaceAADAdmin ID into an WorkspaceAADAdminId struct
 func WorkspaceAADAdminID(input string) (*WorkspaceAADAdminId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace_extended_auditing_policy.go
+++ b/internal/services/synapse/parse/workspace_extended_auditing_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceExtendedAuditingPolicyId struct {
@@ -42,7 +42,7 @@ func (id WorkspaceExtendedAuditingPolicyId) ID() string {
 
 // WorkspaceExtendedAuditingPolicyID parses a WorkspaceExtendedAuditingPolicy ID into an WorkspaceExtendedAuditingPolicyId struct
 func WorkspaceExtendedAuditingPolicyID(input string) (*WorkspaceExtendedAuditingPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace_keys.go
+++ b/internal/services/synapse/parse/workspace_keys.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceKeysId struct {
@@ -42,7 +42,7 @@ func (id WorkspaceKeysId) ID() string {
 
 // WorkspaceKeysID parses a WorkspaceKeys ID into an WorkspaceKeysId struct
 func WorkspaceKeysID(input string) (*WorkspaceKeysId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace_security_alert_policy.go
+++ b/internal/services/synapse/parse/workspace_security_alert_policy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceSecurityAlertPolicyId struct {
@@ -42,7 +42,7 @@ func (id WorkspaceSecurityAlertPolicyId) ID() string {
 
 // WorkspaceSecurityAlertPolicyID parses a WorkspaceSecurityAlertPolicy ID into an WorkspaceSecurityAlertPolicyId struct
 func WorkspaceSecurityAlertPolicyID(input string) (*WorkspaceSecurityAlertPolicyId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/synapse/parse/workspace_vulnerability_assessment.go
+++ b/internal/services/synapse/parse/workspace_vulnerability_assessment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type WorkspaceVulnerabilityAssessmentId struct {
@@ -42,7 +42,7 @@ func (id WorkspaceVulnerabilityAssessmentId) ID() string {
 
 // WorkspaceVulnerabilityAssessmentID parses a WorkspaceVulnerabilityAssessment ID into an WorkspaceVulnerabilityAssessmentId struct
 func WorkspaceVulnerabilityAssessmentID(input string) (*WorkspaceVulnerabilityAssessmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/trafficmanager/parse/azure_endpoint.go
+++ b/internal/services/trafficmanager/parse/azure_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AzureEndpointId struct {
@@ -42,7 +42,7 @@ func (id AzureEndpointId) ID() string {
 
 // AzureEndpointID parses a AzureEndpoint ID into an AzureEndpointId struct
 func AzureEndpointID(input string) (*AzureEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/trafficmanager/parse/external_endpoint.go
+++ b/internal/services/trafficmanager/parse/external_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ExternalEndpointId struct {
@@ -42,7 +42,7 @@ func (id ExternalEndpointId) ID() string {
 
 // ExternalEndpointID parses a ExternalEndpoint ID into an ExternalEndpointId struct
 func ExternalEndpointID(input string) (*ExternalEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/trafficmanager/parse/nested_endpoint.go
+++ b/internal/services/trafficmanager/parse/nested_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type NestedEndpointId struct {
@@ -42,7 +42,7 @@ func (id NestedEndpointId) ID() string {
 
 // NestedEndpointID parses a NestedEndpoint ID into an NestedEndpointId struct
 func NestedEndpointID(input string) (*NestedEndpointId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/trafficmanager/parse/traffic_manager_profile.go
+++ b/internal/services/trafficmanager/parse/traffic_manager_profile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type TrafficManagerProfileId struct {
@@ -39,7 +39,7 @@ func (id TrafficManagerProfileId) ID() string {
 
 // TrafficManagerProfileID parses a TrafficManagerProfile ID into an TrafficManagerProfileId struct
 func TrafficManagerProfileID(input string) (*TrafficManagerProfileId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/videoanalyzer/parse/edge_module.go
+++ b/internal/services/videoanalyzer/parse/edge_module.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type EdgeModuleId struct {
@@ -42,7 +42,7 @@ func (id EdgeModuleId) ID() string {
 
 // EdgeModuleID parses a EdgeModule ID into an EdgeModuleId struct
 func EdgeModuleID(input string) (*EdgeModuleId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/videoanalyzer/parse/video_analyzer.go
+++ b/internal/services/videoanalyzer/parse/video_analyzer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VideoAnalyzerId struct {
@@ -39,7 +39,7 @@ func (id VideoAnalyzerId) ID() string {
 
 // VideoAnalyzerID parses a VideoAnalyzer ID into an VideoAnalyzerId struct
 func VideoAnalyzerID(input string) (*VideoAnalyzerId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/app_service.go
+++ b/internal/services/web/parse/app_service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServiceId struct {
@@ -39,7 +39,7 @@ func (id AppServiceId) ID() string {
 
 // AppServiceID parses a AppService ID into an AppServiceId struct
 func AppServiceID(input string) (*AppServiceId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/app_service_environment.go
+++ b/internal/services/web/parse/app_service_environment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServiceEnvironmentId struct {
@@ -39,7 +39,7 @@ func (id AppServiceEnvironmentId) ID() string {
 
 // AppServiceEnvironmentID parses a AppServiceEnvironment ID into an AppServiceEnvironmentId struct
 func AppServiceEnvironmentID(input string) (*AppServiceEnvironmentId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/app_service_plan.go
+++ b/internal/services/web/parse/app_service_plan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServicePlanId struct {
@@ -39,7 +39,7 @@ func (id AppServicePlanId) ID() string {
 
 // AppServicePlanID parses a AppServicePlan ID into an AppServicePlanId struct
 func AppServicePlanID(input string) (*AppServicePlanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/app_service_slot.go
+++ b/internal/services/web/parse/app_service_slot.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServiceSlotId struct {
@@ -42,7 +42,7 @@ func (id AppServiceSlotId) ID() string {
 
 // AppServiceSlotID parses a AppServiceSlot ID into an AppServiceSlotId struct
 func AppServiceSlotID(input string) (*AppServiceSlotId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/certificate.go
+++ b/internal/services/web/parse/certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CertificateId struct {
@@ -39,7 +39,7 @@ func (id CertificateId) ID() string {
 
 // CertificateID parses a Certificate ID into an CertificateId struct
 func CertificateID(input string) (*CertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/certificate_order.go
+++ b/internal/services/web/parse/certificate_order.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type CertificateOrderId struct {
@@ -39,7 +39,7 @@ func (id CertificateOrderId) ID() string {
 
 // CertificateOrderID parses a CertificateOrder ID into an CertificateOrderId struct
 func CertificateOrderID(input string) (*CertificateOrderId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/function_app.go
+++ b/internal/services/web/parse/function_app.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FunctionAppId struct {
@@ -39,7 +39,7 @@ func (id FunctionAppId) ID() string {
 
 // FunctionAppID parses a FunctionApp ID into an FunctionAppId struct
 func FunctionAppID(input string) (*FunctionAppId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/function_app_slot.go
+++ b/internal/services/web/parse/function_app_slot.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type FunctionAppSlotId struct {
@@ -42,7 +42,7 @@ func (id FunctionAppSlotId) ID() string {
 
 // FunctionAppSlotID parses a FunctionAppSlot ID into an FunctionAppSlotId struct
 func FunctionAppSlotID(input string) (*FunctionAppSlotId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/hostname_binding.go
+++ b/internal/services/web/parse/hostname_binding.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HostnameBindingId struct {
@@ -42,7 +42,7 @@ func (id HostnameBindingId) ID() string {
 
 // HostnameBindingID parses a HostnameBinding ID into an HostnameBindingId struct
 func HostnameBindingID(input string) (*HostnameBindingId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/hybrid_connection.go
+++ b/internal/services/web/parse/hybrid_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type HybridConnectionId struct {
@@ -45,7 +45,7 @@ func (id HybridConnectionId) ID() string {
 
 // HybridConnectionID parses a HybridConnection ID into an HybridConnectionId struct
 func HybridConnectionID(input string) (*HybridConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/managed_certificate.go
+++ b/internal/services/web/parse/managed_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ManagedCertificateId struct {
@@ -39,7 +39,7 @@ func (id ManagedCertificateId) ID() string {
 
 // ManagedCertificateID parses a ManagedCertificate ID into an ManagedCertificateId struct
 func ManagedCertificateID(input string) (*ManagedCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/public_certificate.go
+++ b/internal/services/web/parse/public_certificate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type PublicCertificateId struct {
@@ -42,7 +42,7 @@ func (id PublicCertificateId) ID() string {
 
 // PublicCertificateID parses a PublicCertificate ID into an PublicCertificateId struct
 func PublicCertificateID(input string) (*PublicCertificateId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/slot_virtual_network_swift_connection.go
+++ b/internal/services/web/parse/slot_virtual_network_swift_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type SlotVirtualNetworkSwiftConnectionId struct {
@@ -45,7 +45,7 @@ func (id SlotVirtualNetworkSwiftConnectionId) ID() string {
 
 // SlotVirtualNetworkSwiftConnectionID parses a SlotVirtualNetworkSwiftConnection ID into an SlotVirtualNetworkSwiftConnectionId struct
 func SlotVirtualNetworkSwiftConnectionID(input string) (*SlotVirtualNetworkSwiftConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/static_site.go
+++ b/internal/services/web/parse/static_site.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StaticSiteId struct {
@@ -39,7 +39,7 @@ func (id StaticSiteId) ID() string {
 
 // StaticSiteID parses a StaticSite ID into an StaticSiteId struct
 func StaticSiteID(input string) (*StaticSiteId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/static_site_custom_domain.go
+++ b/internal/services/web/parse/static_site_custom_domain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type StaticSiteCustomDomainId struct {
@@ -42,7 +42,7 @@ func (id StaticSiteCustomDomainId) ID() string {
 
 // StaticSiteCustomDomainID parses a StaticSiteCustomDomain ID into an StaticSiteCustomDomainId struct
 func StaticSiteCustomDomainID(input string) (*StaticSiteCustomDomainId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/virtual_network_swift_connection.go
+++ b/internal/services/web/parse/virtual_network_swift_connection.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type VirtualNetworkSwiftConnectionId struct {
@@ -42,7 +42,7 @@ func (id VirtualNetworkSwiftConnectionId) ID() string {
 
 // VirtualNetworkSwiftConnectionID parses a VirtualNetworkSwiftConnection ID into an VirtualNetworkSwiftConnectionId struct
 func VirtualNetworkSwiftConnectionID(input string) (*VirtualNetworkSwiftConnectionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/generator-resource-id/main.go
+++ b/internal/tools/generator-resource-id/main.go
@@ -340,7 +340,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 %s
@@ -470,7 +470,7 @@ func (id ResourceIdGenerator) codeForParser() string {
 	return fmt.Sprintf(`
 // %[1]sID parses a %[1]s ID into an %[1]sId struct 
 func %[1]sID(input string) (*%[1]sId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +544,7 @@ func (id ResourceIdGenerator) codeForParserInsensitive() string {
 // Whilst this may seem strange, this enables Terraform have consistent casing
 // which works around issues in Core, whilst handling broken API responses.
 func %[1]sIDInsensitively(input string) (*%[1]sId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR switches the ID Parsers over to using the `ParseAzureResourceID` method from `hashicorp/go-azure-helpers` rather than within this package. This allows us to spot any remaining usages by hand which'll need to be generated so that we can switch over to the newer Resource ID parsers.

This regenerates every Resource ID Parser to use the moved method, so should be a noop but this can wait for next weeks release so that we have a full test run.

Given this regenerates everything, I've added a staged commit but will I'll re-run `make generate` prior to merge.