### PR TITLE
`r\iothub_endpoint_storage_container`: Fix `file_name_format` Schema

### DIFF
--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -63,9 +63,9 @@ func resourceIotHubEndpointStorageContainer() *pluginsdk.Resource {
 			},
 
 			"file_name_format": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  false,
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: iothubValidate.FileNameFormat,
 			},
 
 			"batch_frequency_in_seconds": {


### PR DESCRIPTION
`file_name_format` should not have default value set to `false`, instead it should have a `ValidateFunc` same as the nested `endpoint` property in `iothub`.
https://github.com/hashicorp/terraform-provider-azurerm/blob/d966a79a5f8a08305b198bfe6f0edb67d86fdea9/internal/services/iothub/iothub_resource.go#L279-L283
Test result:
$ TF_ACC=1 go test -v ./internal/services/iothub -run=TestAccIotHubEndpointStorageContainer_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccIotHubEndpointStorageContainer_basic
=== PAUSE TestAccIotHubEndpointStorageContainer_basic
=== RUN   TestAccIotHubEndpointStorageContainer_requiresImport
=== PAUSE TestAccIotHubEndpointStorageContainer_requiresImport
=== CONT  TestAccIotHubEndpointStorageContainer_basic
=== CONT  TestAccIotHubEndpointStorageContainer_requiresImport
--- PASS: TestAccIotHubEndpointStorageContainer_basic (556.70s)
--- PASS: TestAccIotHubEndpointStorageContainer_requiresImport (597.94s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub        598.822s