### PR TITLE
Fix Logz test cases probabilistic failure issue

### DIFF
--- a/internal/services/logz/logz_monitor_resource_test.go
+++ b/internal/services/logz/logz_monitor_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -21,9 +22,10 @@ func TestAccLogzMonitor_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_monitor", "test")
 	r := LogzMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, effectiveDate),
+			Config: r.basic(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -36,14 +38,18 @@ func TestAccLogzMonitor_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_monitor", "test")
 	r := LogzMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, effectiveDate),
+			Config: r.basic(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.RequiresImportErrorStep(r.requiresImport),
+		{
+			Config:      r.requiresImport(data, effectiveDate, email),
+			ExpectError: acceptance.RequiresImportError(data.ResourceType),
+		},
 	})
 }
 
@@ -51,9 +57,10 @@ func TestAccLogzMonitor_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_monitor", "test")
 	r := LogzMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, effectiveDate),
+			Config: r.complete(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -66,23 +73,24 @@ func TestAccLogzMonitor_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_monitor", "test")
 	r := LogzMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, effectiveDate),
+			Config: r.basic(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("user"),
 		{
-			Config: r.update(data, effectiveDate),
+			Config: r.update(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("user"),
 		{
-			Config: r.basic(data, effectiveDate),
+			Config: r.basic(data, effectiveDate, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -119,7 +127,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r LogzMonitorResource) basic(data acceptance.TestData, effectiveDate string) string {
+func (r LogzMonitorResource) basic(data acceptance.TestData, effectiveDate string, email string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -136,16 +144,16 @@ resource "azurerm_logz_monitor" "test" {
   }
 
   user {
-    email        = "e081a27c-bc01-4159-bc06-7f9f711e3b3a@example.com"
+    email        = "%s@example.com"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
   }
 }
-`, template, getLogzInstanceName(data.RandomInteger), effectiveDate)
+`, template, getLogzInstanceName(data.RandomInteger), effectiveDate, email)
 }
 
-func (r LogzMonitorResource) update(data acceptance.TestData, effectiveDate string) string {
+func (r LogzMonitorResource) update(data acceptance.TestData, effectiveDate string, email string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -162,19 +170,18 @@ resource "azurerm_logz_monitor" "test" {
   }
 
   user {
-    email        = "e081a27c-bc01-4159-bc06-7f9f711e3b3a@example.com"
+    email        = "%s@example.com"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
   }
   enabled = false
 }
-`, template, getLogzInstanceName(data.RandomInteger), effectiveDate)
+`, template, getLogzInstanceName(data.RandomInteger), effectiveDate, email)
 }
 
-func (r LogzMonitorResource) requiresImport(data acceptance.TestData) string {
-	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
-	config := r.basic(data, effectiveDate)
+func (r LogzMonitorResource) requiresImport(data acceptance.TestData, effectiveDate string, email string) string {
+	config := r.basic(data, effectiveDate, email)
 	return fmt.Sprintf(`
 %s
 
@@ -190,16 +197,16 @@ resource "azurerm_logz_monitor" "import" {
   }
 
   user {
-    email        = "e081a27c-bc01-4159-bc06-7f9f711e3b3a@example.com"
+    email        = "%s@example.com"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
   }
 }
-`, config, effectiveDate)
+`, config, effectiveDate, email)
 }
 
-func (r LogzMonitorResource) complete(data acceptance.TestData, effectiveDate string) string {
+func (r LogzMonitorResource) complete(data acceptance.TestData, effectiveDate string, email string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -219,7 +226,7 @@ resource "azurerm_logz_monitor" "test" {
   }
 
   user {
-    email        = "e081a27c-bc01-4159-bc06-7f9f711e3b3a@example.com"
+    email        = "%s@example.com"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
@@ -229,7 +236,7 @@ resource "azurerm_logz_monitor" "test" {
     ENV = "Test"
   }
 }
-`, template, getLogzInstanceName(data.RandomInteger), effectiveDate)
+`, template, getLogzInstanceName(data.RandomInteger), effectiveDate, email)
 }
 
 func getLogzInstanceName(randomInteger int) string {

--- a/internal/services/logz/logz_tag_rule_resource_test.go
+++ b/internal/services/logz/logz_tag_rule_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -19,9 +20,10 @@ type LogzTagRuleResource struct{}
 func TestAccLogzTagRule_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_tag_rule", "test")
 	r := LogzTagRuleResource{}
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -33,23 +35,28 @@ func TestAccLogzTagRule_basic(t *testing.T) {
 func TestAccLogzTagRule_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_tag_rule", "test")
 	r := LogzTagRuleResource{}
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.RequiresImportErrorStep(r.requiresImport),
+		{
+			Config:      r.requiresImport(data, email),
+			ExpectError: acceptance.RequiresImportError(data.ResourceType),
+		},
 	})
 }
 
 func TestAccLogzTagRule_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_tag_rule", "test")
 	r := LogzTagRuleResource{}
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -61,23 +68,24 @@ func TestAccLogzTagRule_complete(t *testing.T) {
 func TestAccLogzTagRule_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logz_tag_rule", "test")
 	r := LogzTagRuleResource{}
+	email := uuid.New().String()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, email),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -101,7 +109,7 @@ func (r LogzTagRuleResource) Exists(ctx context.Context, clients *clients.Client
 	return utils.Bool(true), nil
 }
 
-func (r LogzTagRuleResource) template(data acceptance.TestData) string {
+func (r LogzTagRuleResource) template(data acceptance.TestData, email string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -124,17 +132,17 @@ resource "azurerm_logz_monitor" "test" {
   }
 
   user {
-    email        = "e081a27c-bc01-4159-bc06-7f9f711e3b3a@example.com"
+    email        = "%s@example.com"
     first_name   = "first"
     last_name    = "last"
     phone_number = "123456"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, getLogzInstanceName(data.RandomInteger), getEffectiveDate())
+`, data.RandomInteger, data.Locations.Primary, getLogzInstanceName(data.RandomInteger), getEffectiveDate(), email)
 }
 
-func (r LogzTagRuleResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
+func (r LogzTagRuleResource) basic(data acceptance.TestData, email string) string {
+	template := r.template(data, email)
 	return fmt.Sprintf(`
 %s
 
@@ -144,8 +152,8 @@ resource "azurerm_logz_tag_rule" "test" {
 `, template)
 }
 
-func (r LogzTagRuleResource) requiresImport(data acceptance.TestData) string {
-	config := r.basic(data)
+func (r LogzTagRuleResource) requiresImport(data acceptance.TestData, email string) string {
+	config := r.basic(data, email)
 	return fmt.Sprintf(`
 %s
 
@@ -155,8 +163,8 @@ resource "azurerm_logz_tag_rule" "import" {
 `, config)
 }
 
-func (r LogzTagRuleResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
+func (r LogzTagRuleResource) complete(data acceptance.TestData, email string) string {
+	template := r.template(data, email)
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
It is reported from Logz.io that parallel creating Logz.io instances with the same Email address may cause low probabilistic error. This PR will make each test case uses a separate email address.