### PR TITLE
Automation datasource initialization issue

### DIFF
--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -51,7 +51,7 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("name").(string), d.Get("resource_group_name").(string))
+	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -86,7 +86,7 @@ func resourceAutomationAccountCreateUpdate(d *pluginsdk.ResourceData, meta inter
 
 	log.Printf("[INFO] preparing arguments for Automation Account create/update.")
 
-	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("name").(string), d.Get("resource_group_name").(string))
+	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)


### PR DESCRIPTION
Linked to issue #14463 

---

## Expected Behaviour
Using a datasource for an already created Automation account should find it in Azure.

## Steps to Reproduce
Using a datasource for an already existing automation account will throw a not found error:
```
Automation Account: (Name "<resource group name>" / Resource Group "<automation account name>") was not found
```

## Possible issue found in code

Resource group and name seems to be inverted

https://github.com/hashicorp/terraform-provider-azurerm/blob/d65781db71babf989c7e0ae17964c839af6acc90/internal/services/automation/automation_account_data_source.go#L54

Function definition:
https://github.com/hashicorp/terraform-provider-azurerm/blob/d65781db71babf989c7e0ae17964c839af6acc90/internal/services/automation/parse/automation_account.go#L18