### PR TITLE
Bugfix: parse User Assigned Identity ID insensitively

### DIFF
--- a/internal/services/apimanagement/api_management_data_source.go
+++ b/internal/services/apimanagement/api_management_data_source.go
@@ -382,7 +382,7 @@ func flattenApiManagementDataSourceIdentity(identity *apimanagement.ServiceIdent
 	identityIds := make([]interface{}, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -1361,7 +1361,7 @@ func flattenAzureRmApiManagementMachineIdentity(identity *apimanagement.ServiceI
 	identityIds := make([]interface{}, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -51,7 +51,7 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("name").(string), d.Get("resource_group_name").(string))
+	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -86,7 +86,7 @@ func resourceAutomationAccountCreateUpdate(d *pluginsdk.ResourceData, meta inter
 
 	log.Printf("[INFO] preparing arguments for Automation Account create/update.")
 
-	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("name").(string), d.Get("resource_group_name").(string))
+	id := parse.NewAutomationAccountID(client.SubscriptionID, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -1284,7 +1284,7 @@ func flattenContainerGroupIdentity(identity *containerinstance.ContainerGroupIde
 			}
 		*/
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -973,7 +973,7 @@ func flattenKubernetesClusterDataSourceAddOnIdentityProfile(profile *containerse
 
 	userAssignedIdentityID := ""
 	if resourceid := profile.ResourceID; resourceid != nil {
-		parsedId, err := msiparse.UserAssignedIdentityID(*resourceid)
+		parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(*resourceid)
 		if err != nil {
 			return nil, err
 		}
@@ -1118,7 +1118,7 @@ func flattenKubernetesClusterDataSourceIdentityProfile(profile map[string]*conta
 
 		userAssignedIdentityId := ""
 		if resourceid := kubeletidentity.ResourceID; resourceid != nil {
-			parsedId, err := msiparse.UserAssignedIdentityID(*resourceid)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(*resourceid)
 			if err != nil {
 				return nil, err
 			}
@@ -1281,7 +1281,7 @@ func flattenKubernetesClusterDataSourceManagedClusterIdentity(input *containerse
 			keys = append(keys, key)
 		}
 		if len(keys) > 0 {
-			parsedId, err := msiparse.UserAssignedIdentityID(keys[0])
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(keys[0])
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1877,7 +1877,7 @@ func flattenKubernetesClusterIdentityProfile(profile map[string]*containerservic
 
 		userAssignedIdentityId := ""
 		if resourceid := kubeletidentity.ResourceID; resourceid != nil {
-			parsedId, err := msiparse.UserAssignedIdentityID(*resourceid)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(*resourceid)
 			if err != nil {
 				return nil, err
 			}
@@ -2493,7 +2493,7 @@ func flattenKubernetesClusterManagedClusterIdentity(input *containerservice.Mana
 			keys = append(keys, key)
 		}
 		if len(keys) > 0 {
-			parsedId, err := msiparse.UserAssignedIdentityID(keys[0])
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(keys[0])
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/datafactory/data_factory_resource.go
+++ b/internal/services/datafactory/data_factory_resource.go
@@ -587,7 +587,7 @@ func flattenDataFactoryIdentity(identity *datafactory.FactoryIdentity) (interfac
 	var identityIds []string
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			id, err := msiParse.UserAssignedIdentityID(key)
+			id, err := msiParse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -92,7 +92,7 @@ func flattenIdentity(input *kusto.Identity) ([]interface{}, error) {
 	identityIds := make([]string, 0)
 	if input.UserAssignedIdentities != nil {
 		for key := range input.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
+++ b/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
@@ -53,7 +53,7 @@ func (UserAssignedIdentityV0ToV1) Schema() map[string]*pluginsdk.Schema {
 func (UserAssignedIdentityV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
-		id, err := parse.UserAssignedIdentityID(oldId)
+		id, err := parse.UserAssignedIdentityIDInsensitively(oldId)
 		if err != nil {
 			return rawState, err
 		}

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -511,7 +511,7 @@ func resourceMsSqlServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess == sql.ServerNetworkAccessFlagEnabled)
 		primaryUserAssignedIdentityID := ""
 		if props.PrimaryUserAssignedIdentityID != nil && *props.PrimaryUserAssignedIdentityID != "" {
-			parsedPrimaryUserAssignedIdentityID, err := msiparse.UserAssignedIdentityID(*props.PrimaryUserAssignedIdentityID)
+			parsedPrimaryUserAssignedIdentityID, err := msiparse.UserAssignedIdentityIDInsensitively(*props.PrimaryUserAssignedIdentityID)
 			if err != nil {
 				return err
 			}
@@ -611,7 +611,7 @@ func flattenSqlServerIdentity(identity *sql.ResourceIdentity) ([]interface{}, er
 	identityIds := make([]string, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1833,7 +1833,7 @@ func flattenRmApplicationGatewayIdentity(identity *network.ManagedServiceIdentit
 	identityIds := make([]string, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiParse.UserAssignedIdentityID(key)
+			parsedId, err := msiParse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -1646,7 +1646,7 @@ func flattenAppServiceIdentity(identity *web.ManagedServiceIdentity) ([]interfac
 	identityIds := make([]string, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := parse.UserAssignedIdentityID(key)
+			parsedId, err := parse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
* `data.azurerm_api_management` - fix a bug when parsing IDs for managed identities
* `azurerm_api_management` - fix a bug when parsing IDs for managed identities
* `azurerm_app_service` - fix a bug when parsing IDs for managed identities
* `azurerm_app_service_slot` - fix a bug when parsing IDs for managed identities
* `azurerm_application_gateway` - fix a bug when parsing IDs for managed identities
* `data.azurerm_automation_account` - fix a bug when parsing the ID for this resource [GH-14464]
* `azurerm_automation_account` - fix a bug when parsing the ID for this resource [GH-14464]
* `azurerm_container_group` - fix a bug when parsing IDs for managed identities
* `azurerm_data_factory` - fix a bug when parsing IDs for managed identities
* `azurerm_function_app` - fix a bug when parsing IDs for managed identities
* `azurerm_function_app_slot` - fix a bug when parsing IDs for managed identities
* `data.azurerm_kubernetes_cluster` - fix a bug when parsing IDs for managed identities
* `azurerm_kubernetes_cluster` - fix a bug when parsing IDs for managed identities
* `azurerm_kusto_cluster` - fix a bug when parsing IDs for managed identities
* `azurerm_mssql_server` - fix a bug when parsing IDs for managed identities

Closes: #14456