### PR TITLE
`r/azurerm_app_service_ip_restriction`: Adding `azurerm_app_service_ip_restriction` resource

### DIFF
--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -866,6 +866,110 @@ func schemaAppServiceDataSourceSiteConfig() *pluginsdk.Schema {
 	}
 }
 
+func schemaAppServiceIpRestrictionElement() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"ip_address": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"service_tag": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"virtual_network_subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"priority": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Default:      65000,
+			ValidateFunc: validation.IntBetween(1, 2147483647),
+		},
+
+		"action": {
+			Type:     pluginsdk.TypeString,
+			Default:  "Allow",
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Allow",
+				"Deny",
+			}, false),
+		},
+
+		//lintignore:XS003
+		"headers": {
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			Computed:   true,
+			MaxItems:   1,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+
+					// lintignore:S018
+					"x_forwarded_host": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						MaxItems: 8,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					// lintignore:S018
+					"x_forwarded_for": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						MaxItems: 8,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.IsCIDR,
+						},
+					},
+
+					// lintignore:S018
+					"x_azure_fdid": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						MaxItems: 8,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.IsUUID,
+						},
+					},
+
+					// lintignore:S018
+					"x_fd_health_probe": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice([]string{
+								"1",
+							}, false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func schemaAppServiceIpRestriction() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:       pluginsdk.TypeList,
@@ -873,106 +977,7 @@ func schemaAppServiceIpRestriction() *pluginsdk.Schema {
 		Computed:   true,
 		ConfigMode: pluginsdk.SchemaConfigModeAttr,
 		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"ip_address": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"service_tag": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"virtual_network_subnet_id": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"name": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"priority": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Default:      65000,
-					ValidateFunc: validation.IntBetween(1, 2147483647),
-				},
-
-				"action": {
-					Type:     pluginsdk.TypeString,
-					Default:  "Allow",
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
-				},
-
-				//lintignore:XS003
-				"headers": {
-					Type:       pluginsdk.TypeList,
-					Optional:   true,
-					Computed:   true,
-					MaxItems:   1,
-					ConfigMode: pluginsdk.SchemaConfigModeAttr,
-					Elem: &pluginsdk.Resource{
-						Schema: map[string]*pluginsdk.Schema{
-							//lintignore:S018
-							"x_forwarded_host": {
-								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
-								Elem: &pluginsdk.Schema{
-									Type: pluginsdk.TypeString,
-								},
-							},
-
-							//lintignore:S018
-							"x_forwarded_for": {
-								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
-								Elem: &pluginsdk.Schema{
-									Type:         pluginsdk.TypeString,
-									ValidateFunc: validation.IsCIDR,
-								},
-							},
-
-							//lintignore:S018
-							"x_azure_fdid": {
-								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
-								Elem: &pluginsdk.Schema{
-									Type:         pluginsdk.TypeString,
-									ValidateFunc: validation.IsUUID,
-								},
-							},
-
-							//lintignore:S018
-							"x_fd_health_probe": {
-								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 1,
-								Elem: &pluginsdk.Schema{
-									Type: pluginsdk.TypeString,
-									ValidateFunc: validation.StringInSlice([]string{
-										"1",
-									}, false),
-								},
-							},
-						},
-					},
-				},
-			},
+			Schema: schemaAppServiceIpRestrictionElement(),
 		},
 	}
 }

--- a/internal/services/web/app_service_ip_restriction.go
+++ b/internal/services/web/app_service_ip_restriction.go
@@ -1,0 +1,300 @@
+package web
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+var appServiceResourceName = "azurerm_app_service"
+
+func resourceAppServiceIpRestriction() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceAppServiceIpRestrictionCreate,
+		Read:   resourceAppServiceIpRestrictionRead,
+		Update: resourceAppServiceIpRestrictionUpdate,
+		Delete: resourceAppServiceIpRestrictionDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"app_service_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"ip_restriction": {
+				Type:       pluginsdk.TypeList,
+				Required:   true,
+				MinItems:   1,
+				MaxItems:   1,
+				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Elem: &pluginsdk.Resource{
+					Schema: schemaAppServiceIpRestrictionElement(),
+				},
+			},
+		},
+	}
+}
+
+func resourceAppServiceIpRestrictionCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	appServiceId := d.Get("app_service_id").(string)
+	id, err := parse.AppServiceID(appServiceId)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("error checking for presence of existing App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+		}
+	}
+
+	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
+		return fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", id.SiteName, id.ResourceGroup)
+	}
+
+	// Locking to prevent parallel changes causing issues
+	locks.ByName(id.SiteName, appServiceResourceName)
+	defer locks.UnlockByName(id.SiteName, appServiceResourceName)
+
+	ipRestrictionArr, err := expandAppServiceIpRestriction(d.Get("ip_restriction"))
+	if err != nil {
+		return err
+	}
+
+	name := ipRestrictionArr[0].Name
+	if name == nil || *name == "" {
+		return fmt.Errorf("no name specified for IP restriction for App Service %q (Resource Group %q)", id.SiteName, id.ResourceGroup)
+	}
+
+	// This is because azure doesn't have an 'id' for single app service ip restriction
+	// In order to compensate for this and allow importing of this resource we are artificially
+	// creating an identity for an app service ip restriction object
+	// /subscriptions/<guid>/resourceGroups/<rg-name>/providers/Microsoft.Web/sites/<site-name>/ipRestriction/<restriction-name>
+	resourceId := fmt.Sprintf("%s/ipRestriction/%s", *resp.ID, *name)
+	_, ipRestriction := FindIPRestriction(resp.SiteConfig.IPSecurityRestrictions, *name)
+	if ipRestriction != nil {
+		return tf.ImportAsExistsError("azurerm_app_service_ip_restriction", resourceId)
+	}
+
+	restrictions := append(*resp.SiteConfig.IPSecurityRestrictions, ipRestrictionArr...)
+	resp.SiteConfig.IPSecurityRestrictions = &restrictions
+
+	siteConfigResource := web.SiteConfigResource{
+		SiteConfig: resp.SiteConfig,
+	}
+
+	if _, err := client.CreateOrUpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, siteConfigResource); err != nil {
+		return fmt.Errorf("updating Configuration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+	}
+
+	d.SetId(resourceId)
+	return resourceAppServiceIpRestrictionRead(d, meta)
+}
+
+func resourceAppServiceIpRestrictionRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	siteName := id.Path["sites"]
+	restrictionName := id.Path["ipRestriction"]
+
+	resp, err := client.Get(ctx, id.ResourceGroup, siteName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("error checking for presence of existing App Service %q (Resource Group %q): %s", siteName, id.ResourceGroup, err)
+		}
+	}
+
+	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
+		return fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", siteName, id.ResourceGroup)
+	}
+
+	_, restriction := FindIPRestriction(resp.SiteConfig.IPSecurityRestrictions, restrictionName)
+
+	if restriction == nil {
+		log.Printf("[INFO] IP Restriction %q was not found in App Service %q (Resource Group %q) - removing from state", restrictionName, siteName, id.ResourceGroup)
+		d.SetId("")
+		return nil
+	}
+
+	restrictionArr := []web.IPSecurityRestriction{*restriction}
+	appServiceIpRestriction := flattenAppServiceIpRestriction(&restrictionArr)
+	if len(appServiceIpRestriction) != 1 {
+		return fmt.Errorf("failed to flatten IP Restriction %q for App Service %q (resource group %q)", restrictionName, siteName, id.ResourceGroup)
+	}
+	d.Set("ip_restriction", appServiceIpRestriction)
+
+	return nil
+}
+
+func resourceAppServiceIpRestrictionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	appServiceId := d.Get("app_service_id").(string)
+	id, err := parse.AppServiceID(appServiceId)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("error checking for presence of existing App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+		}
+	}
+
+	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
+		return fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", id.SiteName, id.ResourceGroup)
+	}
+
+	// Locking to prevent parallel changes causing issues
+	locks.ByName(id.SiteName, appServiceResourceName)
+	defer locks.UnlockByName(id.SiteName, appServiceResourceName)
+
+	if d.HasChange("ip_restriction") {
+
+		ipRestrictionArr, err := expandAppServiceIpRestriction(d.Get("ip_restriction"))
+		if err != nil {
+			return err
+		}
+
+		name := ipRestrictionArr[0].Name
+		if name == nil || *name == "" {
+			return fmt.Errorf("no name specified for IP restriction for App Service %q (Resource Group %q)", id.SiteName, id.ResourceGroup)
+		}
+
+		idx, _ := FindIPRestriction(resp.SiteConfig.IPSecurityRestrictions, *name)
+
+		if idx < 0 {
+			d.SetId("")
+			return fmt.Errorf(" IP Restriction %q was not found in App Service %q (Resource Group %q) - removing from state", *name, id.SiteName, id.ResourceGroup)
+		}
+
+		(*resp.SiteConfig.IPSecurityRestrictions)[idx] = ipRestrictionArr[0]
+
+		siteConfigResource := web.SiteConfigResource{
+			SiteConfig: resp.SiteConfig,
+		}
+
+		if _, err := client.CreateOrUpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, siteConfigResource); err != nil {
+			return fmt.Errorf("updating Configuration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAppServiceIpRestrictionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	appServiceId := d.Get("app_service_id").(string)
+	id, err := parse.AppServiceID(appServiceId)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("error checking for presence of existing App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+		}
+	}
+
+	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
+		return fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", id.SiteName, id.ResourceGroup)
+	}
+
+	// Locking to prevent parallel changes causing issues
+	locks.ByName(id.SiteName, appServiceResourceName)
+	defer locks.UnlockByName(id.SiteName, appServiceResourceName)
+
+	ipRestrictionArr, err := expandAppServiceIpRestriction(d.Get("ip_restriction"))
+	if err != nil {
+		return err
+	}
+
+	name := ipRestrictionArr[0].Name
+	if name == nil || *name == "" {
+		return fmt.Errorf("no name specified for IP restriction for App Service %q (Resource Group %q)", id.SiteName, id.ResourceGroup)
+	}
+
+	restrictions, itemToRemove := removeIPRestriction(resp.SiteConfig.IPSecurityRestrictions, *name)
+
+	if itemToRemove == nil {
+		log.Printf("[INFO] IP Restriction %q was not found in App Service %q (Resource Group %q) - removing from state", *name, id.SiteName, id.ResourceGroup)
+		d.SetId("")
+		return nil
+	}
+
+	resp.SiteConfig.IPSecurityRestrictions = restrictions
+	siteConfigResource := web.SiteConfigResource{
+		SiteConfig: resp.SiteConfig,
+	}
+
+	if _, err := client.CreateOrUpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, siteConfigResource); err != nil {
+		return fmt.Errorf("updating Configuration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func removeIPRestriction(restrictions *[]web.IPSecurityRestriction, name string) (*[]web.IPSecurityRestriction, *web.IPSecurityRestriction) {
+	if restrictions == nil || len(*restrictions) == 0 {
+		return nil, nil
+	}
+	for i, item := range *restrictions {
+		if item.Name != nil && strings.EqualFold(*item.Name, name) {
+			arr := append((*restrictions)[:i], (*restrictions)[i+1:]...)
+			return &arr, &item
+		}
+	}
+	return restrictions, nil
+}
+
+func FindIPRestriction(restrictions *[]web.IPSecurityRestriction, name string) (int, *web.IPSecurityRestriction) {
+	if restrictions == nil || len(*restrictions) == 0 {
+		return -1, nil
+	}
+	for idx, item := range *restrictions {
+		if item.Name != nil && strings.EqualFold(*item.Name, name) {
+			return idx, &item
+		}
+	}
+	return -1, nil
+}

--- a/internal/services/web/app_service_ip_restriction.go
+++ b/internal/services/web/app_service_ip_restriction.go
@@ -267,7 +267,7 @@ func resourceAppServiceIpRestrictionDelete(d *pluginsdk.ResourceData, meta inter
 		return nil
 	}
 
-	restrictions, itemToRemove := removeIPRestriction(resp.SiteConfig.IPSecurityRestrictions, *name)
+	restrictions, itemToRemove := RemoveIPRestriction(resp.SiteConfig.IPSecurityRestrictions, *name)
 
 	if itemToRemove == nil {
 		log.Printf("[INFO] IP Restriction %q was not found in App Service %q (Resource Group %q) - removing from state", *name, id.SiteName, id.ResourceGroup)
@@ -288,13 +288,14 @@ func resourceAppServiceIpRestrictionDelete(d *pluginsdk.ResourceData, meta inter
 	return nil
 }
 
-func removeIPRestriction(restrictions *[]web.IPSecurityRestriction, name string) (*[]web.IPSecurityRestriction, *web.IPSecurityRestriction) {
+func RemoveIPRestriction(restrictions *[]web.IPSecurityRestriction, name string) (*[]web.IPSecurityRestriction, *web.IPSecurityRestriction) {
 	if restrictions == nil || len(*restrictions) == 0 {
 		return nil, nil
 	}
 	for i, item := range *restrictions {
 		if item.Name != nil && strings.EqualFold(*item.Name, name) {
-			arr := append((*restrictions)[:i], (*restrictions)[i+1:]...)
+			arr := (*restrictions)[:i]
+			arr = append(arr, (*restrictions)[i+1:]...)
 			return &arr, &item
 		}
 	}

--- a/internal/services/web/app_service_ip_restriction.go
+++ b/internal/services/web/app_service_ip_restriction.go
@@ -20,6 +20,9 @@ import (
 var appServiceResourceName = "azurerm_app_service"
 
 func resourceAppServiceIpRestriction() *pluginsdk.Resource {
+	restrictionSchemaElement := schemaAppServiceIpRestrictionElement()
+	restrictionSchemaElement["name"].Optional = false
+	restrictionSchemaElement["name"].Required = true
 	return &pluginsdk.Resource{
 		Create: resourceAppServiceIpRestrictionCreate,
 		Read:   resourceAppServiceIpRestrictionRead,
@@ -48,7 +51,7 @@ func resourceAppServiceIpRestriction() *pluginsdk.Resource {
 				MaxItems:   1,
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				Elem: &pluginsdk.Resource{
-					Schema: schemaAppServiceIpRestrictionElement(),
+					Schema: restrictionSchemaElement,
 				},
 			},
 		},

--- a/internal/services/web/app_service_ip_restriction_test.go
+++ b/internal/services/web/app_service_ip_restriction_test.go
@@ -1,0 +1,111 @@
+package web_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type AppServiceIpRestrictionResource struct {
+}
+
+func TestAccAppServiceIpRestriction_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_ip_restriction", "test")
+	r := AppServiceIpRestrictionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+				check.That(data.ResourceName).Key("ip_restriction.0.action").HasValue("Allow"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t AppServiceIpRestrictionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := azure.ParseAzureResourceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	siteName := id.Path["sites"]
+	restrictionName := id.Path["ipRestriction"]
+
+	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, siteName)
+	if err != nil {
+		return nil, fmt.Errorf("reading App Service %q (Resource Group %q): %s", siteName, id.ResourceGroup, err)
+	}
+	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
+		return nil, fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", siteName, id.ResourceGroup)
+	}
+
+	idx, _ := web.FindIPRestriction(resp.SiteConfig.IPSecurityRestrictions, restrictionName)
+	return utils.Bool(idx >= 0), nil
+}
+
+func (r AppServiceIpRestrictionResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_ip_restriction" "test" {
+  app_service_id = azurerm_app_service.test.id
+
+  ip_restriction {
+	ip_address = "10.10.10.10/32"
+	action     = "Allow"
+  }
+}
+`, template)
+}
+
+func (r AppServiceIpRestrictionResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  app_service_name    = azurerm_app_service.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/web/app_service_ip_restriction_test.go
+++ b/internal/services/web/app_service_ip_restriction_test.go
@@ -26,8 +26,97 @@ func TestAccAppServiceIpRestriction_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_restriction.0.name").HasValue("basic-restriction"),
 				check.That(data.ResourceName).Key("ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
 				check.That(data.ResourceName).Key("ip_restriction.0.action").HasValue("Allow"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAppServiceIpRestriction_basicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_ip_restriction", "test")
+	r := AppServiceIpRestrictionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_restriction.0.name").HasValue("basic-restriction"),
+				check.That(data.ResourceName).Key("ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+				check.That(data.ResourceName).Key("ip_restriction.0.action").HasValue("Allow"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_restriction.0.name").HasValue("basic-restriction"),
+				check.That(data.ResourceName).Key("ip_restriction.0.ip_address").HasValue("20.20.20.20/32"),
+				check.That(data.ResourceName).Key("ip_restriction.0.action").HasValue("Allow"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_azure_fdid.#").HasValue("1"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_azure_fdid.0").HasValue("55ce4ed1-4b06-4bf1-b40e-4638452104da"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAppServiceIpRestriction_headers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_ip_restriction", "test")
+	r := AppServiceIpRestrictionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.headers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+				check.That(data.ResourceName).Key("ip_restriction.0.name").HasValue("headers-restriction"),
+				check.That(data.ResourceName).Key("ip_restriction.0.priority").HasValue("123"),
+				check.That(data.ResourceName).Key("ip_restriction.0.action").HasValue("Allow"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_forwarded_for.#").HasValue("2"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_forwarded_for.0").HasValue("2002::1234:abcd:ffff:c0a8:101/64"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_forwarded_for.1").HasValue("9.9.9.9/32"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_azure_fdid.#").HasValue("1"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_azure_fdid.0").HasValue("55ce4ed1-4b06-4bf1-b40e-4638452104da"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_fd_health_probe.#").HasValue("1"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_fd_health_probe.0").HasValue("1"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_forwarded_host.#").HasValue("1"),
+				check.That(data.ResourceName).Key("ip_restriction.0.headers.0.x_forwarded_host.0").HasValue("example.com"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAppServiceIpRestriction_multipleResources(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_ip_restriction", "test")
+	r := AppServiceIpRestrictionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleResources(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_app_service_ip_restriction.test").Key("ip_restriction.0.name").HasValue("basic-restriction"),
+				check.That("azurerm_app_service_ip_restriction.test").Key("ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+				check.That("azurerm_app_service_ip_restriction.test").Key("ip_restriction.0.action").HasValue("Allow"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.ip_address").HasValue("20.20.20.20/32"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.name").HasValue("headers-restriction"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.priority").HasValue("123"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.action").HasValue("Allow"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_forwarded_for.#").HasValue("2"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_forwarded_for.0").HasValue("2002::1234:abcd:ffff:c0a8:101/64"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_forwarded_for.1").HasValue("9.9.9.9/32"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_azure_fdid.#").HasValue("1"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_azure_fdid.0").HasValue("55ce4ed1-4b06-4bf1-b40e-4638452104da"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_fd_health_probe.#").HasValue("1"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_fd_health_probe.0").HasValue("1"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_forwarded_host.#").HasValue("1"),
+				check.That("azurerm_app_service_ip_restriction.test-1").Key("ip_restriction.0.headers.0.x_forwarded_host.0").HasValue("example.com"),
 			),
 		},
 		data.ImportStep(),
@@ -43,12 +132,16 @@ func (t AppServiceIpRestrictionResource) Exists(ctx context.Context, clients *cl
 	siteName := id.Path["sites"]
 	restrictionName := id.Path["ipRestriction"]
 
-	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, siteName)
+	if restrictionName == "" {
+		return nil, fmt.Errorf("ID was missing the 'ipRestriction' element")
+	}
+
+	resp, err := clients.Web.AppServicesClient.GetConfiguration(ctx, id.ResourceGroup, siteName)
 	if err != nil {
 		return nil, fmt.Errorf("reading App Service %q (Resource Group %q): %s", siteName, id.ResourceGroup, err)
 	}
 	if resp.SiteConfig == nil || resp.SiteConfig.IPSecurityRestrictions == nil {
-		return nil, fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", siteName, id.ResourceGroup)
+		return utils.Bool(false), fmt.Errorf("failed reading IP Restrictions for %q (resource group %q)", siteName, id.ResourceGroup)
 	}
 
 	idx, _ := web.FindIPRestriction(resp.SiteConfig.IPSecurityRestrictions, restrictionName)
@@ -64,11 +157,90 @@ resource "azurerm_app_service_ip_restriction" "test" {
   app_service_id = azurerm_app_service.test.id
 
   ip_restriction {
-	name       = "basic"
-	ip_address = "10.10.10.10/32"
-	action     = "Allow"
+		name       = "basic-restriction"
+		ip_address = "10.10.10.10/32"
+		action     = "Allow"
   }
 }
+`, template)
+}
+
+func (r AppServiceIpRestrictionResource) basicUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_ip_restriction" "test" {
+  app_service_id = azurerm_app_service.test.id
+
+  ip_restriction {
+		name       = "basic-restriction"
+		ip_address = "20.20.20.20/32"
+		action     = "Allow"
+		headers {
+			x_azure_fdid      = ["55ce4ed1-4b06-4bf1-b40e-4638452104da"]
+		}
+  }
+}
+`, template)
+}
+
+func (r AppServiceIpRestrictionResource) headers(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_ip_restriction" "test" {
+	app_service_id = azurerm_app_service.test.id
+
+	ip_restriction {
+		ip_address = "10.10.10.10/32"
+		name       = "headers-restriction"
+		priority   = 123
+		action     = "Allow"
+		headers {
+			x_azure_fdid      = ["55ce4ed1-4b06-4bf1-b40e-4638452104da"]
+			x_fd_health_probe = ["1"]
+			x_forwarded_for   = ["9.9.9.9/32", "2002::1234:abcd:ffff:c0a8:101/64"]
+			x_forwarded_host  = ["example.com"]
+		}
+	}
+}
+`, template)
+}
+
+func (r AppServiceIpRestrictionResource) multipleResources(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_ip_restriction" "test" {
+  app_service_id = azurerm_app_service.test.id
+
+  ip_restriction {
+		name       = "basic-restriction"
+		ip_address = "10.10.10.10/32"
+		action     = "Allow"
+  }
+}
+
+resource "azurerm_app_service_ip_restriction" "test-1" {
+	app_service_id = azurerm_app_service.test.id
+
+	ip_restriction {
+		ip_address = "20.20.20.20/32"
+		name       = "headers-restriction"
+		priority   = 123
+		action     = "Allow"
+		headers {
+			x_azure_fdid      = ["55ce4ed1-4b06-4bf1-b40e-4638452104da"]
+			x_fd_health_probe = ["1"]
+			x_forwarded_for   = ["9.9.9.9/32", "2002::1234:abcd:ffff:c0a8:101/64"]
+			x_forwarded_host  = ["example.com"]
+		}
+	}
+}
+
 `, template)
 }
 

--- a/internal/services/web/app_service_ip_restriction_test.go
+++ b/internal/services/web/app_service_ip_restriction_test.go
@@ -64,6 +64,7 @@ resource "azurerm_app_service_ip_restriction" "test" {
   app_service_id = azurerm_app_service.test.id
 
   ip_restriction {
+	name       = "basic"
 	ip_address = "10.10.10.10/32"
 	action     = "Allow"
   }
@@ -99,13 +100,5 @@ resource "azurerm_app_service" "test" {
   resource_group_name = azurerm_resource_group.test.name
   app_service_plan_id = azurerm_app_service_plan.test.id
 }
-
-resource "azurerm_app_service_slot" "test" {
-  name                = "acctestASSlot-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-  app_service_name    = azurerm_app_service.test.name
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/web/parse/app_service_ip_restriction.go
+++ b/internal/services/web/parse/app_service_ip_restriction.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+type AppServiceIPRestrictionId struct {
+	SubscriptionId    string
+	ResourceGroup     string
+	SiteName          string
+	IpRestrictionName string
+}
+
+func NewAppServiceIPRestrictionID(subscriptionId, resourceGroup, siteName, ipRestrictionName string) AppServiceIPRestrictionId {
+	return AppServiceIPRestrictionId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroup:     resourceGroup,
+		SiteName:          siteName,
+		IpRestrictionName: ipRestrictionName,
+	}
+}
+
+func (id AppServiceIPRestrictionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Ip Restriction Name %q", id.IpRestrictionName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "App Service I P Restriction", segmentsStr)
+}
+
+func (id AppServiceIPRestrictionId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/sites/%s/ipRestriction/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.SiteName, id.IpRestrictionName)
+}
+
+// AppServiceIPRestrictionID parses a AppServiceIPRestriction ID into an AppServiceIPRestrictionId struct
+func AppServiceIPRestrictionID(input string) (*AppServiceIPRestrictionId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AppServiceIPRestrictionId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.SiteName, err = id.PopSegment("sites"); err != nil {
+		return nil, err
+	}
+	if resourceId.IpRestrictionName, err = id.PopSegment("ipRestriction"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/web/parse/app_service_ip_restriction.go
+++ b/internal/services/web/parse/app_service_ip_restriction.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type AppServiceIPRestrictionId struct {
@@ -42,7 +42,7 @@ func (id AppServiceIPRestrictionId) ID() string {
 
 // AppServiceIPRestrictionID parses a AppServiceIPRestriction ID into an AppServiceIPRestrictionId struct
 func AppServiceIPRestrictionID(input string) (*AppServiceIPRestrictionId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/web/parse/app_service_ip_restriction_test.go
+++ b/internal/services/web/parse/app_service_ip_restriction_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = AppServiceIPRestrictionId{}
+
+func TestAppServiceIPRestrictionIDFormatter(t *testing.T) {
+	actual := NewAppServiceIPRestrictionID("12345678-1234-9876-4563-123456789012", "resGroup1", "site1", "name").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/name"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAppServiceIPRestrictionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AppServiceIPRestrictionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing SiteName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/",
+			Error: true,
+		},
+
+		{
+			// missing value for SiteName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/",
+			Error: true,
+		},
+
+		{
+			// missing IpRestrictionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/",
+			Error: true,
+		},
+
+		{
+			// missing value for IpRestrictionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/name",
+			Expected: &AppServiceIPRestrictionId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:     "resGroup1",
+				SiteName:          "site1",
+				IpRestrictionName: "name",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/IPRESTRICTION/NAME",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AppServiceIPRestrictionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.SiteName != v.Expected.SiteName {
+			t.Fatalf("Expected %q but got %q for SiteName", v.Expected.SiteName, actual.SiteName)
+		}
+		if actual.IpRestrictionName != v.Expected.IpRestrictionName {
+			t.Fatalf("Expected %q but got %q for IpRestrictionName", v.Expected.IpRestrictionName, actual.IpRestrictionName)
+		}
+	}
+}

--- a/internal/services/web/registration.go
+++ b/internal/services/web/registration.go
@@ -50,6 +50,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_app_service_slot_virtual_network_swift_connection": resourceAppServiceSlotVirtualNetworkSwiftConnection(),
 		"azurerm_app_service_source_control_token":                  resourceAppServiceSourceControlToken(),
 		"azurerm_app_service_virtual_network_swift_connection":      resourceAppServiceVirtualNetworkSwiftConnection(),
+		"azurerm_app_service_ip_restriction":                        resourceAppServiceIpRestriction(),
 		"azurerm_app_service":                                       resourceAppService(),
 		"azurerm_function_app":                                      resourceFunctionApp(),
 		"azurerm_function_app_slot":                                 resourceFunctionAppSlot(),

--- a/internal/services/web/resourceids.go
+++ b/internal/services/web/resourceids.go
@@ -17,3 +17,4 @@ package web
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=StaticSite -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Web/staticSites/my-static-site1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=StaticSiteCustomDomain -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Web/staticSites/my-static-site1/customDomains/name.contoso.com
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkSwiftConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/config/virtualNetwork
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppServiceIPRestriction -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/name

--- a/internal/services/web/validate/app_service_ip_restriction_id.go
+++ b/internal/services/web/validate/app_service_ip_restriction_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
+)
+
+func AppServiceIPRestrictionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.AppServiceIPRestrictionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/web/validate/app_service_ip_restriction_id_test.go
+++ b/internal/services/web/validate/app_service_ip_restriction_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestAppServiceIPRestrictionID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing SiteName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SiteName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/",
+			Valid: false,
+		},
+
+		{
+			// missing IpRestrictionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IpRestrictionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/ipRestriction/name",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/IPRESTRICTION/NAME",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := AppServiceIPRestrictionID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/app_service_ip_restriction.html.markdown
+++ b/website/docs/r/app_service_ip_restriction.html.markdown
@@ -1,0 +1,115 @@
+---
+subcategory: "App Service (Web Apps)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_ip_restriction"
+description: |-
+  Manages a App Service IP Restriction.
+---
+
+# azurerm_app_service_ip_restriction
+
+Manages a App Service IP Restriction.
+
+## Disclaimers
+
+~> **NOTE:** It's possible to define App Service IP Restrictions both within [the `azurerm_app_service` resource](azurerm_app_service.html) via `ip_restriction` blocks inside the `site_config` block and by using [the `azurerm_app_service_ip_restriction` resource](azurerm_app_service_ip_restriction.html). However it's not possible to use both methods to manage IP Restrictions for an App Service, since there'll be conflicts.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "example-appserviceplan"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "example-app-service"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+}
+
+resource "azurerm_app_service_ip_restriction" "example" {
+  app_service_id = azurerm_app_service.example.id
+
+  ip_restriction = {
+    name       = "example"
+    ip_address = "10.10.10.10/32"
+    action     = "Allow"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `app_service_id` - (Required) The ID of the TODO. Changing this forces a new App Service IP Restriction to be created.
+
+* `ip_restriction` - (Required) A `ip_restriction` block as defined below.
+
+---
+
+A `ip_restriction` block supports the following:
+
+* `name` - (Required) The name for this IP Restriction.
+
+* `action` - (Optional) Allow or Deny access for this IP range. Defaults to Allow.
+
+* `headers` - (Optional) A `headers` block as defined blow.
+
+* `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
+
+* `priority` - (Optional) The priority for this IP Restriction. Restrictions are enforced in priority order. By default, priority is set to 65000 if not specified.
+
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
+* `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
+
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
+
+---
+
+A `headers` block supports the following:
+
+* `x_azure_fdid` - (Optional) A list of allowed Azure FrontDoor IDs in UUID notation with a maximum of 8.
+
+* `x_fd_health_probe` - (Optional) A list to allow the Azure FrontDoor health probe header. Only allowed value is "1".
+
+* `x_forwarded_for` - (Optional) A list of allowed 'X-Forwarded-For' IPs in CIDR notation with a maximum of 8
+
+* `x_forwarded_host` - (Optional) A list of allowed 'X-Forwarded-Host' domains with a maximum of 8.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the App Service IP Restriction.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the App Service IP Restriction.
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Service IP Restriction.
+* `update` - (Defaults to 30 minutes) Used when updating the App Service IP Restriction.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Service IP Restriction.
+
+## Import
+
+App Service IP Restrictions can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_service_ip_restriction.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Web/sites/siteName/ipRestriction/name
+```


### PR DESCRIPTION
This PR contains the new resource `azurerm_app_service_ip_restriction` which can be used to manage IP restriction of a AppService WebApp. This comes especially in handy when IP restrictions for an app service app shall be managed aside from the `azurerm_app_service` instance. 

The idea behind this new resource is the same as the `azurerm_key_vault_access_policy`, which allows the management of Key Vault Access Policies aside the `azurerm_key_vault` resource. Thus the same warning about potential issues when IP restrictions are created via `azurerm_app_service_ip_restriction` and simultaneously by a `azurerm_app_service` resources are located in the documaentation for this new resource.