### PR TITLE
[WIP] `azurerm_kubernetes_cluster` Fix #14472 by parse user assigned identity id insensititvely.

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1877,7 +1877,7 @@ func flattenKubernetesClusterIdentityProfile(profile map[string]*containerservic
 
 		userAssignedIdentityId := ""
 		if resourceid := kubeletidentity.ResourceID; resourceid != nil {
-			parsedId, err := msiparse.UserAssignedIdentityID(*resourceid)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(*resourceid)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fix #14472.
It seems like the identity returned by api contains incorrect `resourcegroups` instead of `resourceGroups` and caused the error.

[Current code](https://github.com/hashicorp/terraform-provider-azurerm/blob/d966a79a5f8a08305b198bfe6f0edb67d86fdea9/internal/services/containers/kubernetes_cluster_resource.go#L1879):

```go
if resourceid := kubeletidentity.ResourceID; resourceid != nil {
			parsedId, err := msiparse.UserAssignedIdentityID(*resourceid)
			if err != nil {
				return nil, err
			}

			userAssignedIdentityId = parsedId.ID()
		}
```

`resourceid` returned by api contained incorrect `resourcegroups` and caused error.