### PR TITLE
Remove interpolation syntax. Deprecated as of Terraform 0.12+.

### DIFF
--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_cognitive_account" "test" {
 }
 
 output "primary_access_key" {
-  value = "${data.azurerm_cognitive_account.test.primary_access_key}"
+  value = data.azurerm_cognitive_account.test.primary_access_key
 }
 ```
 ## Argument Reference

--- a/website/docs/d/database_migration_project.html.markdown
+++ b/website/docs/d/database_migration_project.html.markdown
@@ -24,7 +24,7 @@ data "azurerm_database_migration_project" "example" {
 }
 
 output "name" {
-  value = "${data.azurerm_database_migration_project.example.name}"
+  value = data.azurerm_database_migration_project.example.name
 }
 ```
 

--- a/website/docs/d/database_migration_service.html.markdown
+++ b/website/docs/d/database_migration_service.html.markdown
@@ -24,7 +24,7 @@ data "azurerm_database_migration_service" "example" {
 }
 
 output "azurerm_dms_id" {
-  value = "${data.azurerm_database_migration_service.example.id}"
+  value = data.azurerm_database_migration_service.example.id
 }
 ```
 

--- a/website/docs/d/eventhub_authorization_rule.html.markdown
+++ b/website/docs/d/eventhub_authorization_rule.html.markdown
@@ -15,9 +15,9 @@ Use this data source to access information about an existing Event Hubs Authoriz
 ```hcl
 data "azurerm_eventhub_authorization_rule" "test" {
   name                = "test"
-  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-  eventhub_name       = "${azurerm_eventhub.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 ```
 

--- a/website/docs/d/eventhub_consumer_group.html.markdown
+++ b/website/docs/d/eventhub_consumer_group.html.markdown
@@ -14,10 +14,10 @@ Use this data source to access information about an existing Event Hubs Consumer
 
 ```hcl
 data "azurerm_eventhub_consumer_group" "test" {
-  name                = "${azurerm_eventhub_consumer_group.test.name}"
-  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-  eventhub_name       = "${azurerm_eventhub.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = azurerm_eventhub_consumer_group.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 ```
 

--- a/website/docs/d/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/d/monitor_scheduled_query_rules_alert.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_monitor_scheduled_query_rules_alert" "example" {
 }
 
 output "query_rule_id" {
-  value = "${data.azurerm_monitor_scheduled_query_rules_alert.example.id}"
+  value = data.azurerm_monitor_scheduled_query_rules_alert.example.id
 }
 ```
 

--- a/website/docs/d/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/d/monitor_scheduled_query_rules_log.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_monitor_scheduled_query_rules_log" "example" {
 }
 
 output "query_rule_id" {
-  value = "${data.azurerm_monitor_scheduled_query_rules_log.example.id}"
+  value = data.azurerm_monitor_scheduled_query_rules_log.example.id
 }
 ```
 

--- a/website/docs/d/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_topic_authorization_rule.html.markdown
@@ -21,7 +21,7 @@ data "azurerm_servicebus_topic_authorization_rule" "example" {
 }
 
 output "servicebus_authorization_rule_id" {
-  value = "${data.azurem_servicebus_topic_authorization_rule.example.id}"
+  value = data.azurem_servicebus_topic_authorization_rule.example.id
 
 }
 ```

--- a/website/docs/d/spring_cloud_service.html.markdown
+++ b/website/docs/d/spring_cloud_service.html.markdown
@@ -23,7 +23,7 @@ data "azurerm_spring_cloud_service" "example" {
 }
 
 output "spring_cloud_service_id" {
-  value = "${data.azurerm_spring_cloud_service.example.id}"
+  value = data.azurerm_spring_cloud_service.example.id
 }
 ```
 

--- a/website/docs/r/automation_connection_certificate.html.markdown
+++ b/website/docs/r/automation_connection_certificate.html.markdown
@@ -36,8 +36,8 @@ resource "azurerm_automation_account" "example" {
 
 resource "azurerm_automation_certificate" "example" {
   name                    = "certificate-example"
-  resource_group_name     = "${azurerm_resource_group.example.name}"
-  automation_account_name = "${azurerm_automation_account.example.name}"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
   base64                  = filebase64("certificate.pfx")
 }
 

--- a/website/docs/r/bot_channel_email.html.markdown
+++ b/website/docs/r/bot_channel_email.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 
 resource "azurerm_bot_channel_email" "example" {

--- a/website/docs/r/bot_channel_ms_teams.html.markdown
+++ b/website/docs/r/bot_channel_ms_teams.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 
 resource "azurerm_bot_channel_ms_teams" "example" {

--- a/website/docs/r/bot_channel_slack.html.markdown
+++ b/website/docs/r/bot_channel_slack.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 
 resource "azurerm_bot_channel_slack" "example" {

--- a/website/docs/r/bot_channels_registration.html.markdown
+++ b/website/docs/r/bot_channels_registration.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 ```
 

--- a/website/docs/r/bot_connection.html.markdown
+++ b/website/docs/r/bot_connection.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 
 resource "azurerm_bot_connection" "example" {

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_web_app" "example" {
   location            = "global"
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
 }
 ```
 


### PR DESCRIPTION
There's a typo in the commit message. It's from https://www.terraform.io/upgrade-guides/0-12.html#first-class-expressions

While doing this, I noticed that not all examples work. The `azurerm_kubernetes_cluster` in https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/r/devspace_controller.html.markdown is not running, but it's probably not really an issue due to the retirement.

