### PR TITLE
Fix #12884 by change eventhub name length upper limitation from 50 to 256.

### DIFF
--- a/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/internal/services/eventhub/eventhub_cluster_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/sdk/2018-01-01-preview/eventhubsclusters"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -43,10 +42,13 @@ func resourceEventHubCluster() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ValidateEventHubName(),
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,48}[a-zA-Z0-9])?$"),
+					"The event hub name can contain only letters, numbers, periods (.), hyphens (-),and underscores (_), up to 50 characters, and it must begin and end with a letter or number.",
+				),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/internal/services/eventhub/helpers_test.go
+++ b/internal/services/eventhub/helpers_test.go
@@ -35,7 +35,7 @@ func TestValidateEventHubName(t *testing.T) {
 		},
 		{
 			name:  "Invalid long name",
-			input: strings.Repeat("a", 51),
+			input: strings.Repeat("a", 257),
 			valid: false,
 		},
 		{

--- a/internal/services/eventhub/validate/eventhub_names.go
+++ b/internal/services/eventhub/validate/eventhub_names.go
@@ -17,8 +17,8 @@ func ValidateEventHubNamespaceName() pluginsdk.SchemaValidateFunc {
 
 func ValidateEventHubName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,48}[a-zA-Z0-9])?$"),
-		"The event hub name can contain only letters, numbers, periods (.), hyphens (-),and underscores (_), up to 50 characters, and it must begin and end with a letter or number.",
+		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,254}[a-zA-Z0-9])?$"),
+		"The event hub name can contain only letters, numbers, periods (.), hyphens (-),and underscores (_), up to 256 characters, and it must begin and end with a letter or number.",
 	)
 }
 

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/aad/mgmt/2017-04-01/aad"
@@ -11,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	authRuleParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/sdk/2017-04-01/authorizationrulesnamespaces"
-	eventhubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	logAnalyticsParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/parse"
 	logAnalyticsValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/parse"
@@ -53,10 +53,13 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 
 			// When absent, will use the default eventhub, whilst the Diagnostic Setting API will return this property as an empty string. Therefore, it is useless to make this property as Computed.
 			"eventhub_name": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: eventhubValidate.ValidateEventHubName(),
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,48}[a-zA-Z0-9])?$"),
+					"The event hub name can contain only letters, numbers, periods (.), hyphens (-),and underscores (_), up to 50 characters, and it must begin and end with a letter or number.",
+				),
 			},
 
 			"eventhub_authorization_rule_id": {


### PR DESCRIPTION
Fix #12884 by change eventhub name length upper limitation from 50 to 256 according to [doc](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers).

`azurerm_eventhub_cluster.name`'s length limitation is still 50. As for `azurerm_monitor_add_diagnostic_setting` I have no idea how to run test for it for now(acc tests in teamcity failed too), keep it unchanged for this time.

The following resources were affected:

* `azurerm_eventhub`
* `azurerm_eventhub_consumer_group`
* `azurerm_eventhub_authorization_rule`
* `azurerm_api_management_logger`
* `azurerm_iot_time_series_insights_event_source_eventhub`
* `azurerm_monitor_diagnostic_setting`

The following data sources were affected:

* `azurerm_eventhub_consumer_group`
* `azurerm_eventhub_authorization_rule`

The following code would success:

```hcl
provider "azurerm" {
  features {}
}

resource "random_pet" "ns" {}

resource "azurerm_resource_group" "example" {
  location = "Central US"
  name     = "zjhe-f12884-${random_pet.ns.id}"
}

resource "azurerm_eventhub_namespace" "example" {
  name                = "zjhe-f12884-${random_pet.ns.id}"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  sku                 = "Standard"
  capacity            = 2
}

resource "random_string" "length256" {
  length = 256
  special = false
  lower = true
  upper = false
  number = false
}

resource "azurerm_eventhub" "example" {
  name                = random_string.length256.id
  namespace_name      = azurerm_eventhub_namespace.example.name
  resource_group_name = azurerm_resource_group.example.name
  partition_count     = 2
  message_retention   = 1
}

resource "random_string" "length50" {
  length = 50
  special = false
  lower = true
  upper = false
  number = false
}

resource "azurerm_eventhub_cluster" "test" {
  name                = random_string.length50.id
  resource_group_name = azurerm_resource_group.example.name
  location            = azurerm_resource_group.example.location
  sku_name            = "Dedicated_1"
}

//This resource would met error: Cluster name is not valid.
#resource "azurerm_eventhub_cluster" "invalid" {
#  name                = "${random_string.length50.id}d"
#  resource_group_name = azurerm_resource_group.example.name
#  location            = azurerm_resource_group.example.location
#  sku_name            = "Dedicated_1"
#}

resource "azurerm_eventhub_consumer_group" "example" {
  name                = "zjhe-12884-${random_pet.ns.id}"
  namespace_name      = azurerm_eventhub_namespace.example.name
  eventhub_name       = azurerm_eventhub.example.name
  resource_group_name = azurerm_resource_group.example.name
  user_metadata       = "some-meta-data"
}

data "azurerm_eventhub_consumer_group" "test" {
  name                = azurerm_eventhub_consumer_group.example.name
  namespace_name      = azurerm_eventhub_namespace.example.name
  eventhub_name       = azurerm_eventhub.example.name
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_eventhub_authorization_rule" "example" {
  name                = "zjhef12884-${random_pet.ns.id}"
  namespace_name      = azurerm_eventhub_namespace.example.name
  eventhub_name       = azurerm_eventhub.example.name
  resource_group_name = azurerm_resource_group.example.name
  listen              = true
  send                = false
  manage              = false
}

data "azurerm_eventhub_authorization_rule" "test" {
  name                = azurerm_eventhub_authorization_rule.example.name
  namespace_name      = azurerm_eventhub_namespace.example.name
  eventhub_name       = azurerm_eventhub.example.name
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_application_insights" "example" {
  name                = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  application_type    = "other"
}

resource "azurerm_api_management" "example" {
  name                = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  publisher_name      = "My Company"
  publisher_email     = "company@terraform.io"

  sku_name = "Developer_1"
  timeouts {
    create = "90m"
    delete = "90m"
  }
}

resource "azurerm_api_management_logger" "example" {
  name                = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  api_management_name = azurerm_api_management.example.name
  resource_group_name = azurerm_resource_group.example.name
  resource_id         = azurerm_application_insights.example.id

  eventhub {
    connection_string = azurerm_eventhub_namespace.example.default_primary_connection_string
    name              = azurerm_eventhub.example.name
  }
}

resource "azurerm_storage_account" "example" {
  name                     = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location                 = azurerm_resource_group.example.location
  resource_group_name      = azurerm_resource_group.example.name
  account_tier             = "Standard"
  account_replication_type = "LRS"
}

resource "azurerm_iot_time_series_insights_gen2_environment" "example" {
  name                = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  sku_name            = "L1"
  id_properties       = ["id"]

  storage {
    name = azurerm_storage_account.example.name
    key  = azurerm_storage_account.example.primary_access_key
  }
}

resource "azurerm_iot_time_series_insights_event_source_eventhub" "example" {
  name                     = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location                 = azurerm_resource_group.example.location
  environment_id           = azurerm_iot_time_series_insights_gen2_environment.example.id
  eventhub_name            = azurerm_eventhub.example.name
  namespace_name           = azurerm_eventhub_namespace.example.name
  shared_access_key        = azurerm_eventhub_authorization_rule.example.primary_key
  shared_access_key_name   = azurerm_eventhub_authorization_rule.example.name
  consumer_group_name      = azurerm_eventhub_consumer_group.example.name
  event_source_resource_id = azurerm_eventhub.example.id
}
#######################
#resource "azurerm_monitor_aad_diagnostic_setting" "example" {
#  name               = "zjhe12884"
#  storage_account_id = azurerm_storage_account.example.id
#  eventhub_name      = azurerm_eventhub.example.name
#  log {
#    category = "ManagedIdentitySignInLogs"
#    enabled  = false
#    retention_policy {}
#  }
#}
#######################
resource "azurerm_key_vault" "example" {
  name                        = "zjhe12884${replace(random_pet.ns.id, "-", "")}"
  location                    = azurerm_resource_group.example.location
  resource_group_name         = azurerm_resource_group.example.name
  enabled_for_disk_encryption = true
  tenant_id                   = "################"
  soft_delete_retention_days  = 7
  purge_protection_enabled    = false

  sku_name = "standard"
}

resource "azurerm_monitor_diagnostic_setting" "example" {
  name               = "example"
  target_resource_id = azurerm_key_vault.example.id
  storage_account_id = azurerm_storage_account.example.id
  eventhub_name      = azurerm_eventhub.example.name
  log {
    category = "AuditEvent"
    enabled  = false

    retention_policy {
      enabled = false
    }
  }

  metric {
    category = "AllMetrics"

    retention_policy {
      enabled = false
    }
  }
  lifecycle {
    ignore_changes = [eventhub_name]
  }
}
```

As this patch eased the restrictions, I think it would not fail the acc tests so I skipped it. If acc tests results are required, I would be happy to provider all tests results.

As for `azurerm_monitor_aad_diagnostic_setting`, as an Azure newbie, I must confess that I didn't quite caught the meaning of "This resource can only be used with Azure CLI authentication." in the [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_aad_diagnostic_setting), I tried login with `az login` then `az account set -s #########`, but still failed with 403. If anyone who could kindly told me how to run test, please teach me, thanks!