### PR TITLE
fix(lb_rule): change typo rsource to resource

### DIFF
--- a/internal/services/loadbalancer/rule_resource.go
+++ b/internal/services/loadbalancer/rule_resource.go
@@ -206,7 +206,7 @@ func resourceArmLoadBalancerRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	future, err := client.CreateOrUpdate(ctx, loadBalancerId.ResourceGroup, loadBalancerId.Name, loadBalancer)
 	if err != nil {
-		return fmt.Errorf("updating Loadbalancer %q (rsource group %q) for Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.Name, err)
+		return fmt.Errorf("updating Loadbalancer %q (resource group %q) for Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.Name, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {


### PR DESCRIPTION
Fix typo `rsource` to `resource` in `azurerm_lb_rule`