### PR TITLE
Remove invalid validation from azurerm_firewall_policy_rule_collection_group

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -93,12 +93,12 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 									"name": {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
-										ValidateFunc: validate.FirewallPolicyRuleName(),
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"description": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
-										ValidateFunc: validate.FirewallPolicyRuleName(),
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
 										Type:     pluginsdk.TypeSet,
@@ -229,7 +229,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 									"name": {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
-										ValidateFunc: validate.FirewallPolicyRuleName(),
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
 										Type:     pluginsdk.TypeSet,
@@ -343,7 +343,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 									"name": {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
-										ValidateFunc: validate.FirewallPolicyRuleName(),
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
 										Type:     pluginsdk.TypeSet,


### PR DESCRIPTION
Currently the rule `name` attributes are validated with `FirewallPolicyRuleName()`, which denies characters that are actually allowed by Azure.

This PR changes the validation to only check for empty strings (this is also done in the non-policy resources like `azurerm_application_rule_collection`)

I've also double checked if the API allows special characters and I could set the name successfully:
```json
{
  "Name": "DefaultNetworkRuleCollectionGroup",
  "Properties": {
    "Priority": 200,
    "RuleCollection": [
      {
        "Action": {
          "Type": "Allow"
        },
        "Rules": [
          {
            "protocols": [
              "TCP"
            ],
            "SourceAddresses": [
              "*"
            ],
            "DestinationAddresses": [
              "*"
            ],
            "SourceIpGroups": [],
            "DestinationIpGroups": [],
            "DestinationPorts": [
              "*"
            ],
            "DestinationFqdns": [],
            "Name": "!\"§$%&/()=?`*'_:;MB 1234 djjjddj -.,<>",
            "RuleType": "NetworkRule"
          },
          {
            "protocols": [
              "TCP"
            ],
            "SourceAddresses": [
              "*"
            ],
            "DestinationAddresses": [
              "*"
            ],
            "SourceIpGroups": [],
            "DestinationIpGroups": [],
            "DestinationPorts": [
              "*"
            ],
            "DestinationFqdns": [],
            "Name": "juioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fefjuioejdiouw3870 230984f -fef",
            "RuleType": "NetworkRule"
          }
        ],
        "Name": "demo",
        "Priority": 1000,
        "RuleCollectionType": "FirewallPolicyFilterRuleCollection"
      }
    ],
    "Name": null,
    "Etag": null,
    "Id": ""
  }
}
```