### PR TITLE
azurerm_iothub  - Fix iothub `encoding` and `file_name_format` schema

### DIFF
--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -15,6 +15,7 @@ import (
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -65,6 +66,7 @@ func resourceIotHubEndpointStorageContainer() *pluginsdk.Resource {
 			"file_name_format": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				Default:      "{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}",
 				ValidateFunc: iothubValidate.FileNameFormat,
 			},
 
@@ -95,8 +97,11 @@ func resourceIotHubEndpointStorageContainer() *pluginsdk.Resource {
 			},
 
 			"encoding": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          string(devices.EncodingAvro),
+				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(devices.EncodingAvro),
 					string(devices.EncodingAvroDeflate),

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -263,6 +263,8 @@ func resourceIotHub() *pluginsdk.Resource {
 							DiffSuppressFunc: suppressIfTypeIsNot("AzureIotHub.StorageContainer"),
 						},
 
+						// encoding should be case-sensitive but kept case-insensitive for backward compatibility.
+						// todo remove suppress.CaseDifference, make encoding case-sensitive and normalize it with pandora in 3.0 or 4.0
 						"encoding": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -502,11 +502,11 @@ resource "azurerm_iothub" "test" {
   event_hub_partition_count   = 77
 
   endpoint {
-    type                       = "AzureIotHub.StorageContainer"
-    connection_string          = azurerm_storage_account.test.primary_blob_connection_string
-    name                       = "export"
-    container_name             = azurerm_storage_container.test.name
-    resource_group_name        = azurerm_resource_group.test.name
+    type                = "AzureIotHub.StorageContainer"
+    connection_string   = azurerm_storage_account.test.primary_blob_connection_string
+    name                = "export"
+    container_name      = azurerm_storage_container.test.name
+    resource_group_name = azurerm_resource_group.test.name
   }
 
   endpoint {

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -504,8 +504,6 @@ resource "azurerm_iothub" "test" {
     batch_frequency_in_seconds = 60
     max_chunk_size_in_bytes    = 10485760
     container_name             = azurerm_storage_container.test.name
-    encoding                   = "Avro"
-    file_name_format           = "{iothub}/{partition}_{YYYY}_{MM}_{DD}_{HH}_{mm}"
     resource_group_name        = azurerm_resource_group.test.name
   }
 

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -97,6 +97,10 @@ func TestAccIotHub_customRoutes(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("endpoint.#").HasValue("2"),
 				check.That(data.ResourceName).Key("endpoint.0.type").HasValue("AzureIotHub.StorageContainer"),
+				check.That(data.ResourceName).Key("endpoint.0.batch_frequency_in_seconds").HasValue("300"),
+				check.That(data.ResourceName).Key("endpoint.0.max_chunk_size_in_bytes").HasValue("314572800"),
+				check.That(data.ResourceName).Key("endpoint.0.encoding").HasValue("Avro"),
+				check.That(data.ResourceName).Key("endpoint.0.file_name_format").HasValue("{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}"),
 				check.That(data.ResourceName).Key("endpoint.1.type").HasValue("AzureIotHub.EventHub"),
 				check.That(data.ResourceName).Key("route.#").HasValue("2"),
 			),
@@ -501,8 +505,6 @@ resource "azurerm_iothub" "test" {
     type                       = "AzureIotHub.StorageContainer"
     connection_string          = azurerm_storage_account.test.primary_blob_connection_string
     name                       = "export"
-    batch_frequency_in_seconds = 60
-    max_chunk_size_in_bytes    = 10485760
     container_name             = azurerm_storage_container.test.name
     resource_group_name        = azurerm_resource_group.test.name
   }

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -174,15 +174,15 @@ An `endpoint` block supports the following:
 
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
 
-* `batch_frequency_in_seconds` - (Optional) Time interval at which blobs are written to storage. Value should be between 60 and 720 seconds. Default value is 300 seconds. This attribute is mandatory for endpoint type `AzureIotHub.StorageContainer`.
+* `batch_frequency_in_seconds` - (Optional) Time interval at which blobs are written to storage. Value should be between 60 and 720 seconds. Default value is 300 seconds. This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`.
 
-* `max_chunk_size_in_bytes` - (Optional) Maximum number of bytes for each blob written to storage. Value should be between 10485760(10MB) and 524288000(500MB). Default value is 314572800(300MB). This attribute is mandatory for endpoint type `AzureIotHub.StorageContainer`.
+* `max_chunk_size_in_bytes` - (Optional) Maximum number of bytes for each blob written to storage. Value should be between 10485760(10MB) and 524288000(500MB). Default value is 314572800(300MB). This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`.
 
 * `container_name` - (Optional) The name of storage container in the storage account. This attribute is mandatory for endpoint type `AzureIotHub.StorageContainer`.
 
-* `encoding` - (Optional) Encoding that is used to serialize messages to blobs. Supported values are 'avro' and 'avrodeflate'. Default value is 'avro'. This attribute is mandatory for endpoint type `AzureIotHub.StorageContainer`.
+* `encoding` - (Optional) Encoding that is used to serialize messages to blobs. Supported values are `Avro`, `AvroDeflate` and `JSON`. Default value is `Avro`. This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`. Changing this forces a new resource to be created.
 
-* `file_name_format` - (Optional) File name format for the blob. Default format is ``{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}``. All parameters are mandatory but can be reordered. This attribute is mandatory for endpoint type `AzureIotHub.StorageContainer`.
+* `file_name_format` - (Optional) File name format for the blob. Default format is ``{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}``. All parameters are mandatory but can be reordered. This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`.
 
 * `resource_group_name` - (Optional) The resource group in which the endpoint will be created.
 

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `container_name` - (Required) The name of storage container in the storage account.
 *
-* `encoding` - (Optional) Encoding that is used to serialize messages to blobs. Supported values are 'avro' and 'avrodeflate'. Default value is 'avro'.
+* `encoding` - (Optional) Encoding that is used to serialize messages to blobs. Supported values are `Avro`, `AvroDeflate` and `JSON`. Default value is `Avro`. Changing this forces a new resource to be created.
 
 * `file_name_format` - (Optional) File name format for the blob. Default format is ``{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}``. All parameters are mandatory but can be reordered.
 


### PR DESCRIPTION
- Background
    When creating custom endpoint in `iothub` or `iothub_endpoint_storage_container` without `encoding` and `file_name_format`, server assigns them default values, so the second `terraform apply` gives below output:
    ```
  ~ resource "azurerm_iothub" "test" {
      ~ endpoint                    = [
          ~ {
              ~ encoding                   = "avro" -> null
              ~ file_name_format           = "{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}" -> null
    ```
- Fix
  1. Add default value to these two properties in the two resources. Doc of [iothub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/iothub#encoding) and [iothub_endpoint_storage_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/iothub_endpoint_storage_container#encoding) already have the default value specified. There are some small fixes in the doc as well.
  2. Add `suppress.CaseDifference` to `encoding` in `iothub_endpoint_storage_container`, because old resources are created with `avro` instead of `Avro` *(service assigns `avro` when encoding is not provided instead of `Avro`)*
  3. Update the suppress method used in `encoding` from `supressWhenAll` to `suppressWhenAny` in `iothub`. When either of  `suppressIfTypeIsNot("AzureIotHub.StorageContainer")` or `suppress.CaseDifference` is satisfied, the change of `encoding` should be suppressed, as it is only used for StorageContainer and it needs to be case-insensitive due to the 2nd point. The original method suppresses when both of them are satisfied.
  4. `encoding` cannot be updated by API, set it to `ForceNew`
  5. Update corresponding acc tests. The issue was not caught earlier because the tests set these two properties explicitly.
- Test result
![image](https://user-images.githubusercontent.com/10579712/145031563-8a0227c1-8632-424b-9f8f-4731614a6a5a.png)