### PR TITLE
Update `azurerm_function_app` `storage_account_access_key` docs

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -175,7 +175,7 @@ The following arguments are supported:
 
 * `storage_account_name` - (Required) The backend storage account name which will be used by this Function App (such as the dashboard, logs).
 
-* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Function App.
+* `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Function App.
 
 ~> **Note:** When integrating a `CI/CD pipeline` and expecting to run from a deployed package in `Azure` you must seed your `app settings` as part of terraform code for function app to be successfully deployed. `Important Default key pairs`: (`"WEBSITE_RUN_FROM_PACKAGE" = ""`, `"FUNCTIONS_WORKER_RUNTIME" = "node"` (or python, etc), `"WEBSITE_NODE_DEFAULT_VERSION" = "10.14.1"`, `"APPINSIGHTS_INSTRUMENTATIONKEY" = ""`).
 


### PR DESCRIPTION
This PR addresses #14506 and changes `storage_account_access_key` from `Optional` to `Required`.

The `storage_account_access_key` parameter isn't `required`, yet. 

https://github.com/hashicorp/terraform-provider-azurerm/blob/53af1da1bd00736831451b666b123ed8d8856f61/internal/services/web/function_app_resource.go#L187-L195

But it's made required via:

https://github.com/hashicorp/terraform-provider-azurerm/blob/53af1da1bd00736831451b666b123ed8d8856f61/internal/services/web/function_app.go#L307-L322

I think it's fair to update the docs and replace `Optional` with `Required`.

This will close PR #14506.