### PR TITLE
New data sources `azurerm_management_group_template_deployment`, `azurerm_resource_group_template_deployment`, `azurerm_subscription_template_deployment`, `azurerm_tenant_template_deployment`

### DIFF
--- a/internal/services/resource/management_group_template_deployment_data_source.go
+++ b/internal/services/resource/management_group_template_deployment_data_source.go
@@ -65,6 +65,8 @@ func dataSourceManagementGroupTemplateDeploymentRead(d *schema.ResourceData, met
 		return fmt.Errorf("retrieving Management Group Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
+	d.SetId(id.ID())
+
 	if props := resp.Properties; props != nil {
 		flattenedOutputs, err := flattenTemplateDeploymentBody(props.Outputs)
 		if err != nil {

--- a/internal/services/resource/management_group_template_deployment_data_source.go
+++ b/internal/services/resource/management_group_template_deployment_data_source.go
@@ -57,9 +57,7 @@ func dataSourceManagementGroupTemplateDeploymentRead(d *schema.ResourceData, met
 	resp, err := client.GetAtManagementGroupScope(ctx, id.ManagementGroupName, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Management Group Template Deployment %q was not found", id.DeploymentName)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Management Group %s was not found", *id)
 		}
 
 		return fmt.Errorf("retrieving Management Group Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/management_group_template_deployment_data_source.go
+++ b/internal/services/resource/management_group_template_deployment_data_source.go
@@ -2,6 +2,9 @@ package resource
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	mgValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
@@ -10,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"log"
-	"time"
 )
 
 func dataSourceManagementGroupTemplateDeployment() *pluginsdk.Resource {

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -1,0 +1,1 @@
+package resource_test

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -66,8 +66,8 @@ func (r ManagementGroupTemplateDeploymentDataSource) withDataSource(data accepta
 %s
 
 data "azurerm_management_group_template_deployment" "test" {
-  name                  = azurerm_management_group_template_deployment.test.name
-  management_group_id   = azurerm_management_group.test.id
+  name                = azurerm_management_group_template_deployment.test.name
+  management_group_id = azurerm_management_group.test.id
 }
 `, r.withOutputsConfig(data))
 }

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -2,13 +2,13 @@ package resource_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"testing"
 )
 
-type ManagementGroupTemplateDeploymentDataSource struct {
-}
+type ManagementGroupTemplateDeploymentDataSource struct{}
 
 func TestAccDataSourceManagementGroupTemplateDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_management_group_template_deployment", "test")

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -67,7 +67,7 @@ func (r ManagementGroupTemplateDeploymentDataSource) withDataSource(data accepta
 
 data "azurerm_management_group_template_deployment" "test" {
   name                  = azurerm_management_group_template_deployment.test.name
-  management_group_name = azurerm_management_group.test.name
+  management_group_id   = azurerm_management_group.test.id
 }
 `, r.withOutputsConfig(data))
 }

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -1,1 +1,54 @@
 package resource_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type ManagementGroupTemplateDeploymentDataSource struct {
+}
+
+func (ManagementGroupTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {
+  name = "TestAcc-Deployment-%[1]d"
+}
+
+resource "azurerm_management_group_template_deployment" "test" {
+  name                = "acctestMGdeploy-%[1]d"
+  management_group_id = azurerm_management_group.test.id
+  location            = %[2]q
+
+  template_content = <<TEMPLATE
+{
+ "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+ "contentVersion": "1.0.0.0",
+ "parameters": {},
+ "variables": {},
+ "resources": [],
+ "outputs": {
+    "testOutput": {
+      "type": "String",
+      "value": "some-value"
+    }
+  }
+}
+TEMPLATE
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ManagementGroupTemplateDeploymentDataSource) withDataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_management_group_template_deployment" "test" {
+  name                  = azurerm_management_group_template_deployment.test.name
+  management_group_name = azurerm_management_group.test.name
+}
+`, r.withOutputsConfig(data))
+}

--- a/internal/services/resource/management_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/management_group_template_deployment_data_source_test.go
@@ -3,9 +3,28 @@ package resource_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"testing"
 )
 
 type ManagementGroupTemplateDeploymentDataSource struct {
+}
+
+func TestAccDataSourceManagementGroupTemplateDeployment(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_management_group_template_deployment", "test")
+	r := ManagementGroupTemplateDeploymentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withOutputsConfig(data),
+		},
+		{
+			Config: r.withDataSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output_content").HasValue("{\"testOutput\":{\"type\":\"String\",\"value\":\"some-value\"}}"),
+			),
+		},
+	})
 }
 
 func (ManagementGroupTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {

--- a/internal/services/resource/registration.go
+++ b/internal/services/resource/registration.go
@@ -29,9 +29,13 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_resources":             dataSourceResources(),
-		"azurerm_resource_group":        dataSourceResourceGroup(),
-		"azurerm_template_spec_version": dataSourceTemplateSpecVersion(),
+		"azurerm_resources":                            dataSourceResources(),
+		"azurerm_resource_group":                       dataSourceResourceGroup(),
+		"azurerm_template_spec_version":                dataSourceTemplateSpecVersion(),
+		"azurerm_management_group_template_deployment": dataSourceManagementGroupTemplateDeployment(),
+		"azurerm_resource_group_template_deployment":   dataSourceResourceGroupTemplateDeployment(),
+		"azurerm_subscription_template_deployment":     dataSourceSubscriptionTemplateDeployment(),
+		"azurerm_tenant_template_deployment":           dataSourceTenantTemplateDeployment(),
 	}
 }
 

--- a/internal/services/resource/resource_group_template_deployment_data_source.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source.go
@@ -2,6 +2,9 @@ package resource
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -10,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"log"
-	"time"
 )
 
 func dataSourceResourceGroupTemplateDeployment() *pluginsdk.Resource {

--- a/internal/services/resource/resource_group_template_deployment_data_source.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/services/resource/resource_group_template_deployment_data_source.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source.go
@@ -53,9 +53,7 @@ func dataSourceResourceGroupTemplateDeploymentRead(d *schema.ResourceData, meta 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Template Deployment %q (Resource Group %q) was not found", id.DeploymentName, id.ResourceGroup)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Resource Group %s was not found", *id)
 		}
 
 		return fmt.Errorf("retrieving Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)

--- a/internal/services/resource/resource_group_template_deployment_data_source.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source.go
@@ -48,11 +48,14 @@ func dataSourceResourceGroupTemplateDeploymentRead(d *schema.ResourceData, meta 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewResourceGroupTemplateDeploymentID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	resourceGroupName := d.Get("resource_group_name").(string)
+	deploymentName := d.Get("name").(string)
+	id := parse.NewResourceGroupTemplateDeploymentID(subscriptionId, resourceGroupName, deploymentName)
+
 	resp, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Resource Group %s was not found", *id)
+			return fmt.Errorf("template %s in resource Group %s was not found", deploymentName, resourceGroupName)
 		}
 
 		return fmt.Errorf("retrieving Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)

--- a/internal/services/resource/resource_group_template_deployment_data_source.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source.go
@@ -1,0 +1,74 @@
+package resource
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"log"
+	"time"
+)
+
+func dataSourceResourceGroupTemplateDeployment() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceResourceGroupTemplateDeploymentRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.TemplateDeploymentName,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			// Computed
+			"output_content": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
+				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
+			},
+		},
+	}
+}
+
+func dataSourceResourceGroupTemplateDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.DeploymentsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewResourceGroupTemplateDeploymentID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Template Deployment %q (Resource Group %q) was not found", id.DeploymentName, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)
+	}
+
+	d.SetId(id.ID())
+
+	if props := resp.Properties; props != nil {
+		flattenedOutputs, err := flattenTemplateDeploymentBody(props.Outputs)
+		if err != nil {
+			return fmt.Errorf("flattening `output_content`: %+v", err)
+		}
+		return d.Set("output_content", flattenedOutputs)
+	}
+
+	return nil
+}

--- a/internal/services/resource/resource_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source_test.go
@@ -1,0 +1,1 @@
+package resource_test

--- a/internal/services/resource/resource_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source_test.go
@@ -2,13 +2,13 @@ package resource_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"testing"
 )
 
-type ResourceGroupTemplateDeploymentDataSource struct {
-}
+type ResourceGroupTemplateDeploymentDataSource struct{}
 
 func TestAccDataSourceResourceGroupTemplateDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_resource_group_template_deployment", "test")

--- a/internal/services/resource/resource_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source_test.go
@@ -1,1 +1,55 @@
 package resource_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type ResourceGroupTemplateDeploymentDataSource struct {
+}
+
+func (ResourceGroupTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = %q
+}
+
+resource "azurerm_resource_group_template_deployment" "test" {
+  name                = "acctest"
+  resource_group_name = azurerm_resource_group.test.name
+  deployment_mode     = "Complete"
+
+  template_content = <<TEMPLATE
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [],
+  "outputs": {
+    "testOutput": {
+      "type": "String",
+      "value": "some-value"
+    }
+  }
+}
+TEMPLATE
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ResourceGroupTemplateDeploymentDataSource) withDataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_resource_group_template_deployment" "test" {
+  name                = azurerm_resource_group_template_deployment.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.withOutputsConfig(data))
+}

--- a/internal/services/resource/resource_group_template_deployment_data_source_test.go
+++ b/internal/services/resource/resource_group_template_deployment_data_source_test.go
@@ -3,9 +3,28 @@ package resource_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"testing"
 )
 
 type ResourceGroupTemplateDeploymentDataSource struct {
+}
+
+func TestAccDataSourceResourceGroupTemplateDeployment(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_resource_group_template_deployment", "test")
+	r := ResourceGroupTemplateDeploymentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withOutputsConfig(data),
+		},
+		{
+			Config: r.withDataSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output_content").HasValue("{\"testOutput\":{\"type\":\"String\",\"value\":\"some-value\"}}"),
+			),
+		},
+	})
 }
 
 func (ResourceGroupTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {

--- a/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -369,7 +369,7 @@ resource "azurerm_resource_group_template_deployment" "test" {
   resource_group_name = azurerm_resource_group.test.name
   deployment_mode     = %q
   tags = {
-    Hello = "World"
+    hello = "world"
   }
 
   template_content = <<TEMPLATE

--- a/internal/services/resource/subscription_template_deployment_data_source.go
+++ b/internal/services/resource/subscription_template_deployment_data_source.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/services/resource/subscription_template_deployment_data_source.go
+++ b/internal/services/resource/subscription_template_deployment_data_source.go
@@ -2,6 +2,9 @@ package resource
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
@@ -9,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"log"
-	"time"
 )
 
 func dataSourceSubscriptionTemplateDeployment() *pluginsdk.Resource {

--- a/internal/services/resource/subscription_template_deployment_data_source.go
+++ b/internal/services/resource/subscription_template_deployment_data_source.go
@@ -1,0 +1,70 @@
+package resource
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"log"
+	"time"
+)
+
+func dataSourceSubscriptionTemplateDeployment() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceSubscriptionTemplateDeploymentRead,
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.TemplateDeploymentName,
+			},
+
+			// Computed
+			"output_content": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
+				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
+			},
+		},
+	}
+}
+
+func dataSourceSubscriptionTemplateDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.DeploymentsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewSubscriptionTemplateDeploymentID(subscriptionId, d.Get("name").(string))
+
+	resp, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Subscription Template Deployment %q was not found", id.DeploymentName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Subscription Template Deployment %q: %+v", id.DeploymentName, err)
+	}
+
+	d.SetId(id.ID())
+
+	if props := resp.Properties; props != nil {
+		flattenedOutputs, err := flattenTemplateDeploymentBody(props.Outputs)
+		if err != nil {
+			return fmt.Errorf("flattening `output_content`: %+v", err)
+		}
+		return d.Set("output_content", flattenedOutputs)
+	}
+
+	return nil
+}

--- a/internal/services/resource/subscription_template_deployment_data_source.go
+++ b/internal/services/resource/subscription_template_deployment_data_source.go
@@ -49,9 +49,7 @@ func dataSourceSubscriptionTemplateDeploymentRead(d *schema.ResourceData, meta i
 	resp, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Subscription Template Deployment %q was not found", id.DeploymentName)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Subscription %s was not found", *id)
 		}
 
 		return fmt.Errorf("retrieving Subscription Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/subscription_template_deployment_data_source.go
+++ b/internal/services/resource/subscription_template_deployment_data_source.go
@@ -48,7 +48,7 @@ func dataSourceSubscriptionTemplateDeploymentRead(d *schema.ResourceData, meta i
 	resp, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Subscription %s was not found", *id)
+			return fmt.Errorf("template %s in subscription %s was not found", id.DeploymentName, subscriptionId)
 		}
 
 		return fmt.Errorf("retrieving Subscription Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/subscription_template_deployment_data_source_test.go
+++ b/internal/services/resource/subscription_template_deployment_data_source_test.go
@@ -1,0 +1,1 @@
+package resource

--- a/internal/services/resource/subscription_template_deployment_data_source_test.go
+++ b/internal/services/resource/subscription_template_deployment_data_source_test.go
@@ -3,9 +3,28 @@ package resource_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"testing"
 )
 
 type SubscriptionTemplateDeploymentDataSource struct {
+}
+
+func TestAccDataSourceSubscriptionTemplateDeployment(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_subscription_template_deployment", "test")
+	r := SubscriptionTemplateDeploymentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withOutputsConfig(data),
+		},
+		{
+			Config: r.withDataSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output_content").HasValue("{\"testOutput\":{\"type\":\"String\",\"value\":\"some-value\"}}"),
+			),
+		},
+	})
 }
 
 func (SubscriptionTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {

--- a/internal/services/resource/subscription_template_deployment_data_source_test.go
+++ b/internal/services/resource/subscription_template_deployment_data_source_test.go
@@ -2,13 +2,13 @@ package resource_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"testing"
 )
 
-type SubscriptionTemplateDeploymentDataSource struct {
-}
+type SubscriptionTemplateDeploymentDataSource struct{}
 
 func TestAccDataSourceSubscriptionTemplateDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_subscription_template_deployment", "test")

--- a/internal/services/resource/subscription_template_deployment_data_source_test.go
+++ b/internal/services/resource/subscription_template_deployment_data_source_test.go
@@ -1,1 +1,48 @@
-package resource
+package resource_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type SubscriptionTemplateDeploymentDataSource struct {
+}
+
+func (SubscriptionTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_subscription_template_deployment" "test" {
+  name     = "acctestsubdeploy-%d"
+  location = %q
+
+  template_content = <<TEMPLATE
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [],
+  "outputs": {
+    "testOutput": {
+      "type": "String",
+      "value": "some-value"
+    }
+  }
+}
+TEMPLATE
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r SubscriptionTemplateDeploymentDataSource) withDataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_subscription_template_deployment" "test" {
+  name = azurerm_subscription_template_deployment.test.name
+}
+`, r.withOutputsConfig(data))
+}

--- a/internal/services/resource/tenant_template_deployment_data_source.go
+++ b/internal/services/resource/tenant_template_deployment_data_source.go
@@ -47,7 +47,7 @@ func dataSourceTenantTemplateDeploymentRead(d *schema.ResourceData, meta interfa
 	resp, err := client.GetAtTenantScope(ctx, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Tenant %s was not found", *id)
+			return fmt.Errorf("template %s in tenant was not found", id.DeploymentName)
 		}
 
 		return fmt.Errorf("retrieving Tenant Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/tenant_template_deployment_data_source.go
+++ b/internal/services/resource/tenant_template_deployment_data_source.go
@@ -2,6 +2,9 @@ package resource
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
@@ -9,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"log"
-	"time"
 )
 
 func dataSourceTenantTemplateDeployment() *pluginsdk.Resource {

--- a/internal/services/resource/tenant_template_deployment_data_source.go
+++ b/internal/services/resource/tenant_template_deployment_data_source.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/services/resource/tenant_template_deployment_data_source.go
+++ b/internal/services/resource/tenant_template_deployment_data_source.go
@@ -48,9 +48,7 @@ func dataSourceTenantTemplateDeploymentRead(d *schema.ResourceData, meta interfa
 	resp, err := client.GetAtTenantScope(ctx, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Tenant Template Deployment %q was not found", id.DeploymentName)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Tenant %s was not found", *id)
 		}
 
 		return fmt.Errorf("retrieving Tenant Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/tenant_template_deployment_data_source.go
+++ b/internal/services/resource/tenant_template_deployment_data_source.go
@@ -1,0 +1,69 @@
+package resource
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"log"
+	"time"
+)
+
+func dataSourceTenantTemplateDeployment() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceTenantTemplateDeploymentRead,
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.TemplateDeploymentName,
+			},
+
+			// Computed
+			"output_content": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
+				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
+			},
+		},
+	}
+}
+
+func dataSourceTenantTemplateDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.DeploymentsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewTenantTemplateDeploymentID(d.Get("name").(string))
+
+	resp, err := client.GetAtTenantScope(ctx, id.DeploymentName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Tenant Template Deployment %q was not found", id.DeploymentName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Tenant Template Deployment %q: %+v", id.DeploymentName, err)
+	}
+
+	d.SetId(id.ID())
+
+	if props := resp.Properties; props != nil {
+		flattenedOutputs, err := flattenTemplateDeploymentBody(props.Outputs)
+		if err != nil {
+			return fmt.Errorf("flattening `output_content`: %+v", err)
+		}
+		return d.Set("output_content", flattenedOutputs)
+	}
+
+	return nil
+}

--- a/internal/services/resource/tenant_template_deployment_data_source_test.go
+++ b/internal/services/resource/tenant_template_deployment_data_source_test.go
@@ -1,0 +1,1 @@
+package resource_test

--- a/internal/services/resource/tenant_template_deployment_data_source_test.go
+++ b/internal/services/resource/tenant_template_deployment_data_source_test.go
@@ -3,9 +3,28 @@ package resource_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"testing"
 )
 
 type TenantTemplateDeploymentDataSource struct {
+}
+
+func TestAccDataSourceTenantTemplateDeployment(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_tenant_template_deployment", "test")
+	r := TenantTemplateDeploymentDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withOutputsConfig(data),
+		},
+		{
+			Config: r.withDataSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output_content").HasValue("{\"testOutput\":{\"type\":\"String\",\"value\":\"some-value\"}}"),
+			),
+		},
+	})
 }
 
 func (TenantTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {

--- a/internal/services/resource/tenant_template_deployment_data_source_test.go
+++ b/internal/services/resource/tenant_template_deployment_data_source_test.go
@@ -1,1 +1,48 @@
 package resource_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type TenantTemplateDeploymentDataSource struct {
+}
+
+func (TenantTemplateDeploymentDataSource) withOutputsConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_tenant_template_deployment" "test" {
+  name     = "acctestTenantDeploy-%d"
+  location = %q
+
+  template_content = <<TEMPLATE
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [],
+  "outputs": {
+    "testOutput": {
+      "type": "String",
+      "value": "some-value"
+    }
+  }
+}
+TEMPLATE
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r TenantTemplateDeploymentDataSource) withDataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_tenant_template_deployment" "test" {
+  name = azurerm_tenant_template_deployment.test.name
+}
+`, r.withOutputsConfig(data))
+}

--- a/internal/services/resource/tenant_template_deployment_data_source_test.go
+++ b/internal/services/resource/tenant_template_deployment_data_source_test.go
@@ -2,13 +2,13 @@ package resource_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"testing"
 )
 
-type TenantTemplateDeploymentDataSource struct {
-}
+type TenantTemplateDeploymentDataSource struct{}
 
 func TestAccDataSourceTenantTemplateDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_tenant_template_deployment", "test")

--- a/internal/services/resource/tenant_template_deployment_data_source_test.go
+++ b/internal/services/resource/tenant_template_deployment_data_source_test.go
@@ -12,6 +12,10 @@ type TenantTemplateDeploymentDataSource struct{}
 
 func TestAccDataSourceTenantTemplateDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_tenant_template_deployment", "test")
+	if data.Client().IsServicePrincipal {
+		t.Skip("Skipping due to permissions unavailable on tenant scope")
+	}
+
 	r := TenantTemplateDeploymentDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/website/docs/d/management_group_template_deployment.html.markdown
+++ b/website/docs/d/management_group_template_deployment.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Management Group Te
 
 ```hcl
 data "azurerm_management_group_template_deployment" "example" {
-  name                  = "existing"
+  name                = "existing"
   management_group_id = "00000000-0000-0000-000000000000"
 }
 

--- a/website/docs/d/management_group_template_deployment.html.markdown
+++ b/website/docs/d/management_group_template_deployment.html.markdown
@@ -31,7 +31,7 @@ output "example_output" {
 
 The following arguments are supported:
 
-* `management_group_name` - (Required) The name of the Management Group to which this template was applied.
+* `management_group_id` - (Required) The ID of the Management Group to which this template was applied.
 
 * `name` - (Required) The name of this Management Group Template Deployment.
 

--- a/website/docs/d/management_group_template_deployment.html.markdown
+++ b/website/docs/d/management_group_template_deployment.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Template"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_management_group_template_deployment"
+description: |-
+  Gets information about an existing Management Group Template Deployment.
+---
+
+# Data Source: azurerm_management_group_template_deployment
+
+Use this data source to access information about an existing Management Group Template Deployment.
+
+## Example Usage
+
+```hcl
+data "azurerm_management_group_template_deployment" "example" {
+  name = "existing"
+  management_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_management_group_template_deployment.example.id
+}
+
+output "example_output" {
+  value = jsondecode(data.azurerm_management_group_template_deployment.example.output_content).exampleOutput.value
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `management_group_name` - (Required) The name of the Management Group to which this template was applied.
+
+* `name` - (Required) The name of this Management Group Template Deployment.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Management Group Template Deployment.
+
+* `output_content` - The JSON Content of the Outputs of the ARM Template Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Management Group Template Deployment.

--- a/website/docs/d/management_group_template_deployment.html.markdown
+++ b/website/docs/d/management_group_template_deployment.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Management Group Te
 
 ```hcl
 data "azurerm_management_group_template_deployment" "example" {
-  name = "existing"
+  name                  = "existing"
   management_group_name = "existing"
 }
 

--- a/website/docs/d/management_group_template_deployment.html.markdown
+++ b/website/docs/d/management_group_template_deployment.html.markdown
@@ -15,7 +15,7 @@ Use this data source to access information about an existing Management Group Te
 ```hcl
 data "azurerm_management_group_template_deployment" "example" {
   name                  = "existing"
-  management_group_name = "existing"
+  management_group_id = "00000000-0000-0000-000000000000"
 }
 
 output "id" {

--- a/website/docs/d/resource_group_template_deployment.html.markdown
+++ b/website/docs/d/resource_group_template_deployment.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Template"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_resource_group_template_deployment"
+description: |-
+  Gets information about an existing Resource Group Template Deployment.
+---
+
+# Data Source: azurerm_resource_group_template_deployment
+
+Use this data source to access information about an existing Resource Group Template Deployment.
+
+## Example Usage
+
+```hcl
+data "azurerm_resource_group_template_deployment" "example" {
+  name = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_resource_group_template_deployment.example.id
+}
+
+output "example_output" {
+  value = jsondecode(data.azurerm_resource_group_template_deployment.example.output_content).exampleOutput.value
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Resource Group Template Deployment.
+
+* `resource_group_name` - (Required) The name of the Resource Group to which the Resource Group Template Deployment was applied.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Resource Group Template Deployment.
+
+* `output_content` - The JSON Content of the Outputs of the ARM Template Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Resource Group Template Deployment.

--- a/website/docs/d/resource_group_template_deployment.html.markdown
+++ b/website/docs/d/resource_group_template_deployment.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Resource Group Temp
 
 ```hcl
 data "azurerm_resource_group_template_deployment" "example" {
-  name = "existing"
+  name                = "existing"
   resource_group_name = "existing"
 }
 

--- a/website/docs/d/subscription_template_deployment.html.markdown
+++ b/website/docs/d/subscription_template_deployment.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "Template"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_subscription_template_deployment"
+description: |-
+  Gets information about an existing Subscription Template Deployment.
+---
+
+# Data Source: azurerm_subscription_template_deployment
+
+Use this data source to access information about an existing Subscription Template Deployment.
+
+## Example Usage
+
+```hcl
+data "azurerm_subscription_template_deployment" "example" {
+  name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_subscription_template_deployment.example.id
+}
+
+output "example_output" {
+  value = jsondecode(data.azurerm_subscription_template_deployment.example.output_content).exampleOutput.value
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Subscription Template Deployment.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Subscription Template Deployment.
+
+* `output_content` - The JSON Content of the Outputs of the ARM Template Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Subscription Template Deployment.

--- a/website/docs/d/tenant_template_deployment.html.markdown
+++ b/website/docs/d/tenant_template_deployment.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "Template"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_tenant_template_deployment"
+description: |-
+  Gets information about an existing Tenant Template Deployment.
+---
+
+# Data Source: azurerm_tenant_template_deployment
+
+Use this data source to access information about an existing Tenant Template Deployment.
+
+## Example Usage
+
+```hcl
+data "azurerm_tenant_template_deployment" "example" {
+  name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_tenant_template_deployment.example.id
+}
+
+output "example_output" {
+  value = jsondecode(data.azurerm_tenant_template_deployment.example.output_content).exampleOutput.value
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Tenant Template Deployment.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Tenant Template Deployment.
+
+* `output_content` - The JSON Content of the Outputs of the ARM Template Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Tenant Template Deployment.


### PR DESCRIPTION
Fixes #14523

Adds data sources as mentioned in the title so that you can retrieve the values of outputs of deployed templates.