### PR TITLE
Unify managed disk test name

### DIFF
--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -346,13 +346,13 @@ func TestAccManagedDisk_attachedTierUpdate(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_networkPolicy(t *testing.T) {
+func TestAccManagedDisk_networkPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_create(data),
+			Config: r.networkPolicy_create(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -361,13 +361,13 @@ func TestAccAzureRMManagedDisk_networkPolicy(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_networkPolicy_update(t *testing.T) {
+func TestAccManagedDisk_networkPolicy_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_create(data),
+			Config: r.networkPolicy_create(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data.ResourceName, "network_access_policy", "DenyAll"),
@@ -375,7 +375,7 @@ func TestAccAzureRMManagedDisk_networkPolicy_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_update(data),
+			Config: r.networkPolicy_update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data.ResourceName, "network_access_policy", "DenyAll"),
@@ -385,13 +385,13 @@ func TestAccAzureRMManagedDisk_networkPolicy_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate(t *testing.T) {
+func TestAccManagedDisk_networkPolicy_create_withAllowPrivate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate(data),
+			Config: r.networkPolicy_create_withAllowPrivate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -400,13 +400,13 @@ func TestAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate(t *testing.
 	})
 }
 
-func TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate(t *testing.T) {
+func TestAccManagedDisk_networkPolicy_update_withAllowPrivate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate(data),
+			Config: r.networkPolicy_create_withAllowPrivate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data.ResourceName, "network_access_policy", "AllowPrivate"),
@@ -414,7 +414,7 @@ func TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate(t *testing.
 		},
 		data.ImportStep(),
 		{
-			Config: testAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate(data),
+			Config: r.networkPolicy_update_withAllowPrivate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				acceptance.TestCheckResourceAttr(data.ResourceName, "network_access_policy", "AllowPrivate"),
@@ -424,7 +424,7 @@ func TestAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate(t *testing.
 	})
 }
 
-func TestAccAzureRMManagedDisk_publicNetworkAccessDefault(t *testing.T) {
+func TestAccManagedDisk_publicNetworkAccessDefault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -440,7 +440,7 @@ func TestAccAzureRMManagedDisk_publicNetworkAccessDefault(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_publicNetworkAccessDisabled(t *testing.T) {
+func TestAccManagedDisk_publicNetworkAccessDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -456,7 +456,7 @@ func TestAccAzureRMManagedDisk_publicNetworkAccessDisabled(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_publicNetworkAccessUpdated(t *testing.T) {
+func TestAccManagedDisk_publicNetworkAccessUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -480,7 +480,7 @@ func TestAccAzureRMManagedDisk_publicNetworkAccessUpdated(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_update_withMaxShares(t *testing.T) {
+func TestAccManagedDisk_update_withMaxShares(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -501,7 +501,7 @@ func TestAccAzureRMManagedDisk_update_withMaxShares(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_create_withLogicalSectorSize(t *testing.T) {
+func TestAccManagedDisk_create_withLogicalSectorSize(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -516,7 +516,7 @@ func TestAccAzureRMManagedDisk_create_withLogicalSectorSize(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled(t *testing.T) {
+func TestAccManagedDisk_create_withTrustedLaunchEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -531,7 +531,7 @@ func TestAccAzureRMManagedDisk_create_withTrustedLaunchEnabled(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing.T) {
+func TestAccManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -552,7 +552,7 @@ func TestAccAzureRMManagedDisk_update_withIOpsReadOnlyAndMBpsReadOnly(t *testing
 	})
 }
 
-func TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled(t *testing.T) {
+func TestAccManagedDisk_create_withOnDemandBurstingEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -567,7 +567,7 @@ func TestAccAzureRMManagedDisk_create_withOnDemandBurstingEnabled(t *testing.T) 
 	})
 }
 
-func TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled(t *testing.T) {
+func TestAccManagedDisk_update_withOnDemandBurstingEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -589,7 +589,7 @@ func TestAccAzureRMManagedDisk_update_withOnDemandBurstingEnabled(t *testing.T) 
 	})
 }
 
-func TestAccAzureRMManagedDisk_create_withHyperVGeneration(t *testing.T) {
+func TestAccManagedDisk_create_withHyperVGeneration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
@@ -1352,7 +1352,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMManagedDisk_networkPolicy_create(data acceptance.TestData) string {
+func (ManagedDiskResource) networkPolicy_create(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1381,7 +1381,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMManagedDisk_networkPolicy_update(data acceptance.TestData) string {
+func (ManagedDiskResource) networkPolicy_update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1410,7 +1410,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMManagedDisk_networkPolicy_create_withAllowPrivate(data acceptance.TestData) string {
+func (ManagedDiskResource) networkPolicy_create_withAllowPrivate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1450,7 +1450,7 @@ resource "azurerm_managed_disk" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMManagedDisk_networkPolicy_update_withAllowPrivate(data acceptance.TestData) string {
+func (ManagedDiskResource) networkPolicy_update_withAllowPrivate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
There are two prefixes `TestAccManagedDisk_` and `TestAccAzureRMManagedDisk_` in managed disk resource acc tests, which could lead new contributors missing some acc tests when searching by prefix. Unifying them with the first prefix

There are some configuration template misnamed, updating them as well: e.g. `func testAccAzureRMManagedDisk_networkPolicy_update` -> `func (ManagedDiskResource) networkPolicy_update`