### PR TITLE
`r\shared_image` Add support for `trusted_launch_enabled`

### DIFF
--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
 
 * `release_note_uri` - (Optional) The URI containing the Release Notes associated with this Shared Image.
 
+* `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image. Defaults to `false`. Changing this forces a new resource to be created.
+
 * `tags` - (Optional) A mapping of tags to assign to the Shared Image.
 
 ---


### PR DESCRIPTION
To create a `vtpm_enabled`/`secure_boot_enabled` virtual machine from a shared gallery image, the image needs the feature `SecurityType` set to `TrustedLaunch`. 

Test result:
$ TF_ACC=1 go test -v ./internal/services/compute -run=TestAccSharedImage_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSharedImage_basic
=== PAUSE TestAccSharedImage_basic
=== RUN   TestAccSharedImage_basic_hyperVGeneration_V2
=== PAUSE TestAccSharedImage_basic_hyperVGeneration_V2
=== RUN   TestAccSharedImage_requiresImport
=== PAUSE TestAccSharedImage_requiresImport
=== RUN   TestAccSharedImage_complete
=== PAUSE TestAccSharedImage_complete
=== RUN   TestAccSharedImage_specialized
=== PAUSE TestAccSharedImage_specialized
=== RUN   TestAccSharedImage_withTrustedLaunchEnabled
=== PAUSE TestAccSharedImage_withTrustedLaunchEnabled
=== CONT  TestAccSharedImage_basic
=== CONT  TestAccSharedImage_complete
=== CONT  TestAccSharedImage_withTrustedLaunchEnabled
=== CONT  TestAccSharedImage_specialized
=== CONT  TestAccSharedImage_requiresImport
=== CONT  TestAccSharedImage_basic_hyperVGeneration_V2
--- PASS: TestAccSharedImage_withTrustedLaunchEnabled (494.67s)
--- PASS: TestAccSharedImage_basic_hyperVGeneration_V2 (495.57s)
--- PASS: TestAccSharedImage_complete (499.50s)
--- PASS: TestAccSharedImage_specialized (500.49s)
--- PASS: TestAccSharedImage_basic (500.77s)
--- PASS: TestAccSharedImage_requiresImport (517.39s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       518.142s