### PR TITLE
More relevant / standard route_table name

### DIFF
--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_route_table" "example" {
-  name                          = "acceptanceTestSecurityGroup1"
+  name                          = "example-route-table"
   location                      = azurerm_resource_group.example.location
   resource_group_name           = azurerm_resource_group.example.name
   disable_bgp_route_propagation = false


### PR DESCRIPTION
This is to bring route_table name in this code sample inline with code samples for other resources.