### PR TITLE
App Service Beta - property consistency renames carried from 14247 and 14305

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -47,12 +47,12 @@ type SiteConfigLinuxFunctionApp struct {
 	FtpsState                     string                             `tfschema:"ftps_state"`
 	HealthCheckPath               string                             `tfschema:"health_check_path"`
 	HealthCheckEvictionTime       int                                `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers               int                                `tfschema:"number_of_workers"`
+	WorkerCount                   int                                `tfschema:"worker_count"`
 	ApplicationStack              []ApplicationStackLinuxFunctionApp `tfschema:"application_stack"`
 	MinTlsVersion                 string                             `tfschema:"minimum_tls_version"`
 	ScmMinTlsVersion              string                             `tfschema:"scm_minimum_tls_version"`
 	Cors                          []CorsSetting                      `tfschema:"cors"`
-	DetailedErrorLogging          bool                               `tfschema:"detailed_error_logging"`
+	DetailedErrorLogging          bool                               `tfschema:"detailed_error_logging_enabled"`
 	LinuxFxVersion                string                             `tfschema:"linux_fx_version"`
 	VnetRouteAllEnabled           bool                               `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
 }
@@ -277,7 +277,7 @@ func SiteConfigSchemaLinuxFunctionApp() *pluginsdk.Schema {
 					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -318,7 +318,7 @@ func SiteConfigSchemaLinuxFunctionApp() *pluginsdk.Schema {
 					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:        pluginsdk.TypeBool,
 					Computed:    true,
 					Description: "Is detailed error logging enabled",
@@ -361,12 +361,12 @@ type SiteConfigWindowsFunctionApp struct {
 	FtpsState                     string                               `tfschema:"ftps_state"`
 	HealthCheckPath               string                               `tfschema:"health_check_path"`
 	HealthCheckEvictionTime       int                                  `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers               int                                  `tfschema:"number_of_workers"`
+	NumberOfWorkers               int                                  `tfschema:"worker_count"`
 	ApplicationStack              []ApplicationStackWindowsFunctionApp `tfschema:"application_stack"`
 	MinTlsVersion                 string                               `tfschema:"minimum_tls_version"`
 	ScmMinTlsVersion              string                               `tfschema:"scm_minimum_tls_version"`
 	Cors                          []CorsSetting                        `tfschema:"cors"`
-	DetailedErrorLogging          bool                                 `tfschema:"detailed_error_logging"`
+	DetailedErrorLogging          bool                                 `tfschema:"detailed_error_logging_enabled"`
 	WindowsFxVersion              string                               `tfschema:"windows_fx_version"`
 	VnetRouteAllEnabled           bool                                 `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
 }
@@ -577,7 +577,7 @@ func SiteConfigSchemaWindowsFunctionApp() *pluginsdk.Schema {
 					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -618,7 +618,7 @@ func SiteConfigSchemaWindowsFunctionApp() *pluginsdk.Schema {
 					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:        pluginsdk.TypeBool,
 					Computed:    true,
 					Description: "Is detailed error logging enabled",
@@ -1184,8 +1184,8 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 		expanded.HealthCheckPath = utils.String(linuxSiteConfig.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.number_of_workers") {
-		expanded.NumberOfWorkers = utils.Int32(int32(linuxSiteConfig.NumberOfWorkers))
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
+		expanded.NumberOfWorkers = utils.Int32(int32(linuxSiteConfig.WorkerCount))
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {
@@ -1411,7 +1411,7 @@ func ExpandSiteConfigWindowsFunctionApp(siteConfig []SiteConfigWindowsFunctionAp
 		expanded.HealthCheckPath = utils.String(windowsSiteConfig.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.number_of_workers") {
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
 		expanded.NumberOfWorkers = utils.Int32(int32(windowsSiteConfig.NumberOfWorkers))
 	}
 
@@ -1457,7 +1457,7 @@ func FlattenSiteConfigLinuxFunctionApp(functionAppSiteConfig *web.SiteConfig) (*
 		LinuxFxVersion:          utils.NormalizeNilableString(functionAppSiteConfig.LinuxFxVersion),
 		LoadBalancing:           string(functionAppSiteConfig.LoadBalancing),
 		ManagedPipelineMode:     string(functionAppSiteConfig.ManagedPipelineMode),
-		NumberOfWorkers:         int(utils.NormaliseNilableInt32(functionAppSiteConfig.NumberOfWorkers)),
+		WorkerCount:             int(utils.NormaliseNilableInt32(functionAppSiteConfig.NumberOfWorkers)),
 		ScmType:                 string(functionAppSiteConfig.ScmType),
 		FtpsState:               string(functionAppSiteConfig.FtpsState),
 		RuntimeScaleMonitoring:  utils.NormaliseNilableBool(functionAppSiteConfig.FunctionsRuntimeScaleMonitoringEnabled),

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -20,7 +20,7 @@ type SiteConfigWindows struct {
 	ApiManagementConfigId    string                    `tfschema:"api_management_api_id"`
 	ApiDefinition            string                    `tfschema:"api_definition_url"`
 	AppCommandLine           string                    `tfschema:"app_command_line"`
-	AutoHeal                 bool                      `tfschema:"auto_heal"`
+	AutoHeal                 bool                      `tfschema:"auto_heal_enabled"`
 	AutoHealSettings         []AutoHealSettingWindows  `tfschema:"auto_heal_setting"`
 	UseManagedIdentityACR    bool                      `tfschema:"container_registry_use_managed_identity"`
 	ContainerRegistryUserMSI string                    `tfschema:"container_registry_managed_identity_client_id"`
@@ -30,9 +30,9 @@ type SiteConfigWindows struct {
 	ScmUseMainIpRestriction  bool                      `tfschema:"scm_use_main_ip_restriction"`
 	ScmIpRestriction         []IpRestriction           `tfschema:"scm_ip_restriction"`
 	LoadBalancing            string                    `tfschema:"load_balancing_mode"`
-	LocalMysql               bool                      `tfschema:"local_mysql"`
+	LocalMysql               bool                      `tfschema:"local_mysql_enabled"`
 	ManagedPipelineMode      string                    `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging          bool                      `tfschema:"remote_debugging"`
+	RemoteDebugging          bool                      `tfschema:"remote_debugging_enabled"`
 	RemoteDebuggingVersion   string                    `tfschema:"remote_debugging_version"`
 	ScmType                  string                    `tfschema:"scm_type"`
 	Use32BitWorker           bool                      `tfschema:"use_32_bit_worker"`
@@ -40,14 +40,14 @@ type SiteConfigWindows struct {
 	FtpsState                string                    `tfschema:"ftps_state"`
 	HealthCheckPath          string                    `tfschema:"health_check_path"`
 	HealthCheckEvictionTime  int                       `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers          int                       `tfschema:"number_of_workers"`
+	WorkerCount              int                       `tfschema:"worker_count"`
 	ApplicationStack         []ApplicationStackWindows `tfschema:"application_stack"`
 	VirtualApplications      []VirtualApplication      `tfschema:"virtual_application"`
 	MinTlsVersion            string                    `tfschema:"minimum_tls_version"`
 	ScmMinTlsVersion         string                    `tfschema:"scm_minimum_tls_version"`
 	AutoSwapSlotName         string                    `tfschema:"auto_swap_slot_name"`
 	Cors                     []CorsSetting             `tfschema:"cors"`
-	DetailedErrorLogging     bool                      `tfschema:"detailed_error_logging"`
+	DetailedErrorLogging     bool                      `tfschema:"detailed_error_logging_enabled"`
 	WindowsFxVersion         string                    `tfschema:"windows_fx_version"`
 	VnetRouteAllEnabled      bool                      `tfschema:"vnet_route_all_enabled"`
 	// TODO new properties / blocks
@@ -60,7 +60,7 @@ type SiteConfigLinux struct {
 	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
 	ApiDefinition           string                  `tfschema:"api_definition_url"`
 	AppCommandLine          string                  `tfschema:"app_command_line"`
-	AutoHeal                bool                    `tfschema:"auto_heal"`
+	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
 	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
 	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
 	ContainerRegistryMSI    string                  `tfschema:"container_registry_managed_identity_client_id"`
@@ -70,9 +70,9 @@ type SiteConfigLinux struct {
 	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
 	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
 	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
-	LocalMysql              bool                    `tfschema:"local_mysql"`
+	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
 	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
-	RemoteDebugging         bool                    `tfschema:"remote_debugging"`
+	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
 	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
 	ScmType                 string                  `tfschema:"scm_type"`
 	Use32BitWorker          bool                    `tfschema:"use_32_bit_worker"`
@@ -80,12 +80,12 @@ type SiteConfigLinux struct {
 	FtpsState               string                  `tfschema:"ftps_state"`
 	HealthCheckPath         string                  `tfschema:"health_check_path"`
 	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers         int                     `tfschema:"number_of_workers"`
+	NumberOfWorkers         int                     `tfschema:"worker_count"`
 	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
 	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
 	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
 	Cors                    []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging"`
+	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
 	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
 	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
@@ -123,7 +123,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 					Optional: true,
 				},
 
-				"auto_heal": {
+				"auto_heal_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -171,7 +171,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchema(),
 
-				"local_mysql": {
+				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -201,7 +201,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 					}, false),
 				},
 
-				"remote_debugging": {
+				"remote_debugging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -257,7 +257,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -303,7 +303,7 @@ func SiteConfigSchemaWindows() *pluginsdk.Schema {
 					// TODO - Add slot name validation here?
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -350,7 +350,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"auto_heal": {
+				"auto_heal_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -389,7 +389,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchemaComputed(),
 
-				"local_mysql": {
+				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -404,7 +404,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"remote_debugging": {
+				"remote_debugging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -444,7 +444,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},
@@ -468,7 +468,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -519,7 +519,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 
 				"application_stack": linuxApplicationStackSchema(),
 
-				"auto_heal": {
+				"auto_heal_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					RequiredWith: []string{
@@ -566,7 +566,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchema(),
 
-				"local_mysql": {
+				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -596,7 +596,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					}, false),
 				},
 
-				"remote_debugging": {
+				"remote_debugging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -653,7 +653,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -697,7 +697,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -739,7 +739,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"application_stack": linuxApplicationStackSchemaComputed(),
 
-				"auto_heal": {
+				"auto_heal_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -778,7 +778,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchemaComputed(),
 
-				"local_mysql": {
+				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -793,7 +793,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"remote_debugging": {
+				"remote_debugging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -833,7 +833,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:     pluginsdk.TypeInt,
 					Computed: true,
 				},
@@ -855,7 +855,7 @@ func SiteConfigSchemaLinuxComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -1382,7 +1382,7 @@ func autoHealSettingSchemaWindows() *pluginsdk.Schema {
 			},
 		},
 		RequiredWith: []string{
-			"site_config.0.auto_heal",
+			"site_config.0.auto_heal_enabled",
 		},
 	}
 }
@@ -1414,7 +1414,7 @@ func autoHealSettingSchemaLinux() *pluginsdk.Schema {
 			},
 		},
 		RequiredWith: []string{
-			"site_config.0.auto_heal",
+			"site_config.0.auto_heal_enabled",
 		},
 	}
 }
@@ -2852,7 +2852,7 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.local_mysql") {
+	if metadata.ResourceData.HasChange("site_config.0.local_mysql_enabled") {
 		expanded.LocalMySQLEnabled = utils.Bool(winSiteConfig.LocalMysql)
 	}
 
@@ -2864,7 +2864,7 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.ManagedPipelineMode = web.ManagedPipelineMode(winSiteConfig.ManagedPipelineMode)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.remote_debugging") {
+	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_enabled") {
 		expanded.RemoteDebuggingEnabled = utils.Bool(winSiteConfig.RemoteDebugging)
 	}
 
@@ -2888,8 +2888,8 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.HealthCheckPath = utils.String(winSiteConfig.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.number_of_workers") {
-		expanded.NumberOfWorkers = utils.Int32(int32(winSiteConfig.NumberOfWorkers))
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
+		expanded.NumberOfWorkers = utils.Int32(int32(winSiteConfig.WorkerCount))
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {
@@ -2915,7 +2915,7 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.auto_heal") {
+	if metadata.ResourceData.HasChange("site_config.0.auto_heal_enabled") {
 		expanded.AutoHealEnabled = utils.Bool(winSiteConfig.AutoHeal)
 	}
 
@@ -3026,7 +3026,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.local_mysql") {
+	if metadata.ResourceData.HasChange("site_config.0.local_mysql_enabled") {
 		expanded.LocalMySQLEnabled = utils.Bool(linuxSiteConfig.LocalMysql)
 	}
 
@@ -3038,7 +3038,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.ManagedPipelineMode = web.ManagedPipelineMode(linuxSiteConfig.ManagedPipelineMode)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.remote_debugging") {
+	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_enabled") {
 		expanded.RemoteDebuggingEnabled = utils.Bool(linuxSiteConfig.RemoteDebugging)
 	}
 
@@ -3062,7 +3062,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.HealthCheckPath = utils.String(linuxSiteConfig.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.number_of_workers") {
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
 		expanded.NumberOfWorkers = utils.Int32(int32(linuxSiteConfig.NumberOfWorkers))
 	}
 
@@ -3084,7 +3084,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.Cors = cors
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.auto_heal") {
+	if metadata.ResourceData.HasChange("site_config.0.auto_heal_enabled") {
 		expanded.AutoHealEnabled = utils.Bool(linuxSiteConfig.AutoHeal)
 	}
 
@@ -3470,7 +3470,7 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 		LocalMysql:               utils.NormaliseNilableBool(appSiteConfig.LocalMySQLEnabled),
 		ManagedPipelineMode:      string(appSiteConfig.ManagedPipelineMode),
 		MinTlsVersion:            string(appSiteConfig.MinTLSVersion),
-		NumberOfWorkers:          int(utils.NormaliseNilableInt32(appSiteConfig.NumberOfWorkers)),
+		WorkerCount:              int(utils.NormaliseNilableInt32(appSiteConfig.NumberOfWorkers)),
 		RemoteDebugging:          utils.NormaliseNilableBool(appSiteConfig.RemoteDebuggingEnabled),
 		RemoteDebuggingVersion:   strings.ToUpper(utils.NormalizeNilableString(appSiteConfig.RemoteDebuggingVersion)),
 		ScmIpRestriction:         FlattenIpRestrictions(appSiteConfig.ScmIPSecurityRestrictions),
@@ -3497,7 +3497,7 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 	}
 
 	if appSiteConfig.NumberOfWorkers != nil {
-		siteConfig.NumberOfWorkers = int(*appSiteConfig.NumberOfWorkers)
+		siteConfig.WorkerCount = int(*appSiteConfig.NumberOfWorkers)
 	}
 
 	var winAppStack ApplicationStackWindows

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -18,7 +18,7 @@ type SiteConfigLinuxWebAppSlot struct {
 	ApiManagementConfigId   string                  `tfschema:"api_management_api_id"`
 	ApiDefinition           string                  `tfschema:"api_definition_url"`
 	AppCommandLine          string                  `tfschema:"app_command_line"`
-	AutoHeal                bool                    `tfschema:"auto_heal"`
+	AutoHeal                bool                    `tfschema:"auto_heal_enabled"`
 	AutoHealSettings        []AutoHealSettingLinux  `tfschema:"auto_heal_setting"`
 	AutoSwapSlotName        string                  `tfschema:"auto_swap_slot_name"`
 	UseManagedIdentityACR   bool                    `tfschema:"container_registry_use_managed_identity"`
@@ -29,7 +29,7 @@ type SiteConfigLinuxWebAppSlot struct {
 	ScmUseMainIpRestriction bool                    `tfschema:"scm_use_main_ip_restriction"`
 	ScmIpRestriction        []IpRestriction         `tfschema:"scm_ip_restriction"`
 	LoadBalancing           string                  `tfschema:"load_balancing_mode"`
-	LocalMysql              bool                    `tfschema:"local_mysql"`
+	LocalMysql              bool                    `tfschema:"local_mysql_enabled"`
 	ManagedPipelineMode     string                  `tfschema:"managed_pipeline_mode"`
 	RemoteDebugging         bool                    `tfschema:"remote_debugging_enabled"`
 	RemoteDebuggingVersion  string                  `tfschema:"remote_debugging_version"`
@@ -39,12 +39,12 @@ type SiteConfigLinuxWebAppSlot struct {
 	FtpsState               string                  `tfschema:"ftps_state"`
 	HealthCheckPath         string                  `tfschema:"health_check_path"`
 	HealthCheckEvictionTime int                     `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers         int                     `tfschema:"number_of_workers"`
+	WorkerCount             int                     `tfschema:"worker_count"`
 	ApplicationStack        []ApplicationStackLinux `tfschema:"application_stack"`
 	MinTlsVersion           string                  `tfschema:"minimum_tls_version"`
 	ScmMinTlsVersion        string                  `tfschema:"scm_minimum_tls_version"`
 	Cors                    []CorsSetting           `tfschema:"cors"`
-	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging"`
+	DetailedErrorLogging    bool                    `tfschema:"detailed_error_logging_enabled"`
 	LinuxFxVersion          string                  `tfschema:"linux_fx_version"`
 	VnetRouteAllEnabled     bool                    `tfschema:"vnet_route_all_enabled"`
 	// SiteLimits []SiteLimitsSettings `tfschema:"site_limits"` // TODO - New block to (possibly) support? No way to configure this in the portal?
@@ -82,7 +82,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 
 				"application_stack": linuxApplicationStackSchema(),
 
-				"auto_heal": {
+				"auto_heal_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					RequiredWith: []string{
@@ -130,7 +130,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 
 				"scm_ip_restriction": IpRestrictionSchema(),
 
-				"local_mysql": {
+				"local_mysql_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
 					Default:  false,
@@ -217,7 +217,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 					Description:  "The amount of time in minutes that a node is unhealthy before being removed from the load balancer. Possible values are between `2` and `10`. Defaults to `10`. Only valid in conjunction with `health_check_path`",
 				},
 
-				"number_of_workers": {
+				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
@@ -261,7 +261,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 					Description: "Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.",
 				},
 
-				"detailed_error_logging": {
+				"detailed_error_logging_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
@@ -371,7 +371,7 @@ func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, exi
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.local_mysql") {
+	if metadata.ResourceData.HasChange("site_config.0.local_mysql_enabled") {
 		expanded.LocalMySQLEnabled = utils.Bool(linuxSlotSiteConfig.LocalMysql)
 	}
 
@@ -407,8 +407,8 @@ func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, exi
 		expanded.HealthCheckPath = utils.String(linuxSlotSiteConfig.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.number_of_workers") {
-		expanded.NumberOfWorkers = utils.Int32(int32(linuxSlotSiteConfig.NumberOfWorkers))
+	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
+		expanded.NumberOfWorkers = utils.Int32(int32(linuxSlotSiteConfig.WorkerCount))
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {
@@ -433,7 +433,7 @@ func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, exi
 		expanded.Cors = cors
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.auto_heal") {
+	if metadata.ResourceData.HasChange("site_config.0.auto_heal_enabled") {
 		expanded.AutoHealEnabled = utils.Bool(linuxSlotSiteConfig.AutoHeal)
 	}
 
@@ -471,7 +471,7 @@ func FlattenSiteConfigLinuxWebAppSlot(appSiteSlotConfig *web.SiteConfig, healthC
 		LoadBalancing:           string(appSiteSlotConfig.LoadBalancing),
 		LocalMysql:              utils.NormaliseNilableBool(appSiteSlotConfig.LocalMySQLEnabled),
 		MinTlsVersion:           string(appSiteSlotConfig.MinTLSVersion),
-		NumberOfWorkers:         int(utils.NormaliseNilableInt32(appSiteSlotConfig.NumberOfWorkers)),
+		WorkerCount:             int(utils.NormaliseNilableInt32(appSiteSlotConfig.NumberOfWorkers)),
 		RemoteDebugging:         utils.NormaliseNilableBool(appSiteSlotConfig.RemoteDebuggingEnabled),
 		RemoteDebuggingVersion:  strings.ToUpper(utils.NormalizeNilableString(appSiteSlotConfig.RemoteDebuggingVersion)),
 		ScmIpRestriction:        FlattenIpRestrictions(appSiteSlotConfig.ScmIPSecurityRestrictions),

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -38,8 +38,8 @@ type LinuxFunctionAppModel struct {
 	AuthSettings              []helpers.AuthSettings               `tfschema:"auth_settings"`
 	Backup                    []helpers.Backup                     `tfschema:"backup"` // Not supported on Dynamic or Basic plans
 	BuiltinLogging            bool                                 `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled         bool                                 `tfschema:"client_cert_enabled"`
-	ClientCertMode            string                               `tfschema:"client_cert_mode"`
+	ClientCertEnabled         bool                                 `tfschema:"client_certificate_enabled"`
+	ClientCertMode            string                               `tfschema:"client_certificate_mode"`
 	ConnectionStrings         []helpers.ConnectionString           `tfschema:"connection_string"`
 	DailyMemoryTimeQuota      int                                  `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
 	Enabled                   bool                                 `tfschema:"enabled"`
@@ -151,14 +151,14 @@ func (r LinuxFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Description: "Should built in logging be enabled. Configures `AzureWebJobsDashboard` app setting based on the configured storage setting",
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:        pluginsdk.TypeBool,
 			Optional:    true,
 			Default:     false,
 			Description: "Should the function app use Client Certificates",
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  web.ClientCertModeOptional,
@@ -617,11 +617,11 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 				existing.SiteProperties.HTTPSOnly = utils.Bool(state.HttpsOnly)
 			}
 
-			if metadata.ResourceData.HasChange("client_cert_enabled") {
+			if metadata.ResourceData.HasChange("client_certificate_enabled") {
 				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
 			}
 
-			if metadata.ResourceData.HasChange("client_cert_mode") {
+			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -1479,9 +1479,9 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled = false
-  client_cert_enabled     = true
-  client_cert_mode        = "Required"
+  builtin_logging_enabled    = false
+  client_certificate_enabled = true
+  client_certificate_mode    = "Required"
 
   connection_string {
     name  = "Second"
@@ -1648,9 +1648,9 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled = false
-  client_cert_enabled     = true
-  client_cert_mode        = "OptionalInteractiveUser"
+  builtin_logging_enabled    = false
+  client_certificate_enabled = true
+  client_certificate_mode    = "OptionalInteractiveUser"
 
   connection_string {
     name  = "First"
@@ -1726,7 +1726,7 @@ resource "azurerm_linux_function_app" "test" {
     websockets_enabled = true
     ftps_state         = "FtpsOnly"
     health_check_path  = "/health-check"
-    number_of_workers  = 3
+    worker_count       = 3
 
     minimum_tls_version     = "1.1"
     scm_minimum_tls_version = "1.1"
@@ -1859,7 +1859,7 @@ resource "azurerm_linux_function_app" "test" {
     websockets_enabled = true
     ftps_state         = "FtpsOnly"
     health_check_path  = "/health-check"
-    number_of_workers  = 3
+    worker_count       = 3
 
     minimum_tls_version     = "1.1"
     scm_minimum_tls_version = "1.1"

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -28,8 +28,8 @@ type LinuxWebAppDataSourceModel struct {
 	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
 	Backup                        []helpers.Backup           `tfschema:"backup"`
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                       `tfschema:"client_cert_enabled"`
-	ClientCertMode                string                     `tfschema:"client_cert_mode"`
+	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
+	ClientCertMode                string                     `tfschema:"client_certificate_mode"`
 	Enabled                       bool                       `tfschema:"enabled"`
 	HttpsOnly                     bool                       `tfschema:"https_only"`
 	Identity                      []helpers.Identity         `tfschema:"identity"`
@@ -100,12 +100,12 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 			Computed: true,
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -3,7 +3,6 @@ package appservice
 import (
 	"context"
 	"fmt"
-	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -3,6 +3,7 @@ package appservice
 import (
 	"context"
 	"fmt"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ type LinuxWebAppDataSourceModel struct {
 	Enabled                       bool                       `tfschema:"enabled"`
 	HttpsOnly                     bool                       `tfschema:"https_only"`
 	Identity                      []helpers.Identity         `tfschema:"identity"`
+	KeyVaultReferenceIdentityID   string                     `tfschema:"key_vault_reference_identity_id"`
 	LogsConfig                    []helpers.LogsConfig       `tfschema:"logs"`
 	MetaData                      map[string]string          `tfschema:"app_metadata"`
 	SiteConfig                    []helpers.SiteConfigLinux  `tfschema:"site_config"`
@@ -134,6 +136,12 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"identity": helpers.IdentitySchemaComputed(),
+
+		"key_vault_reference_identity_id": {
+			Type:         pluginsdk.TypeString,
+			Computed:     true,
+			ValidateFunc: msivalidate.UserAssignedIdentityID,
+		},
 
 		"kind": {
 			Type:     pluginsdk.TypeString,

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -32,8 +32,8 @@ type LinuxWebAppModel struct {
 	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
 	Backup                        []helpers.Backup           `tfschema:"backup"`
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                       `tfschema:"client_cert_enabled"`
-	ClientCertMode                string                     `tfschema:"client_cert_mode"`
+	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
+	ClientCertMode                string                     `tfschema:"client_certificate_mode"`
 	Enabled                       bool                       `tfschema:"enabled"`
 	HttpsOnly                     bool                       `tfschema:"https_only"`
 	Identity                      []helpers.Identity         `tfschema:"identity"`
@@ -97,13 +97,13 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  "Required",
@@ -560,10 +560,10 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("client_affinity_enabled") {
 				existing.SiteProperties.ClientAffinityEnabled = utils.Bool(state.ClientAffinityEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_enabled") {
+			if metadata.ResourceData.HasChange("client_certificate_enabled") {
 				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_mode") {
+			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1203,7 +1203,7 @@ resource "azurerm_linux_web_app" "test" {
     }
 
     container_registry_use_managed_identity       = true
-    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.id
+    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
 
     // auto_swap_slot_name = // TODO
     auto_heal_enabled = true

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -201,7 +201,7 @@ func TestAccLinuxWebApp_withLogging(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -218,7 +218,7 @@ func TestAccLinuxWebApp_removeLogging(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -249,7 +249,7 @@ func TestAccLinuxWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withDetailedLogging(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -258,7 +258,7 @@ func TestAccLinuxWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withLogsHttpBlob(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("false"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("false"),
 			),
 		},
@@ -267,7 +267,7 @@ func TestAccLinuxWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -1146,9 +1146,9 @@ resource "azurerm_linux_web_app" "test" {
     }
   }
 
-  client_affinity_enabled = true
-  client_cert_enabled     = true
-  client_cert_mode        = "Optional"
+  client_affinity_enabled    = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Optional"
 
   connection_string {
     name  = "First"
@@ -1182,15 +1182,15 @@ resource "azurerm_linux_web_app" "test" {
     ]
     http2_enabled               = true
     scm_use_main_ip_restriction = true
-    local_mysql                 = true
+    local_mysql_enabled         = true
     managed_pipeline_mode       = "Integrated"
-    remote_debugging            = true
+    remote_debugging_enabled    = true
     remote_debugging_version    = "VS2019"
     use_32_bit_worker           = true
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health"
-    number_of_workers           = 1
+    worker_count                = 1
     minimum_tls_version         = "1.1"
     scm_minimum_tls_version     = "1.1"
     cors {
@@ -1206,7 +1206,7 @@ resource "azurerm_linux_web_app" "test" {
     container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.id
 
     // auto_swap_slot_name = // TODO
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -1315,9 +1315,9 @@ resource "azurerm_linux_web_app" "test" {
     }
   }
 
-  client_affinity_enabled = true
-  client_cert_enabled     = true
-  client_cert_mode        = "Optional"
+  client_affinity_enabled    = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Optional"
 
   connection_string {
     name  = "First"
@@ -1345,15 +1345,15 @@ resource "azurerm_linux_web_app" "test" {
     ]
     http2_enabled                     = false
     scm_use_main_ip_restriction       = false
-    local_mysql                       = false
+    local_mysql_enabled               = false
     managed_pipeline_mode             = "Integrated"
-    remote_debugging                  = true
+    remote_debugging_enabled          = true
     remote_debugging_version          = "VS2017"
     websockets_enabled                = true
     ftps_state                        = "FtpsOnly"
     health_check_path                 = "/health2"
     health_check_eviction_time_in_min = 7
-    number_of_workers                 = 2
+    worker_count                      = 2
     minimum_tls_version               = "1.2"
     scm_minimum_tls_version           = "1.2"
     cors {
@@ -1368,7 +1368,7 @@ resource "azurerm_linux_web_app" "test" {
 
     container_registry_use_managed_identity = true
 
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2124,7 +2124,7 @@ resource "azurerm_linux_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2160,7 +2160,7 @@ resource "azurerm_linux_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2201,7 +2201,7 @@ resource "azurerm_linux_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -33,8 +33,8 @@ type LinuxWebAppSlotModel struct {
 	AuthSettings                  []helpers.AuthSettings              `tfschema:"auth_settings"`
 	Backup                        []helpers.Backup                    `tfschema:"backup"`
 	ClientAffinityEnabled         bool                                `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                                `tfschema:"client_cert_enabled"`
-	ClientCertMode                string                              `tfschema:"client_cert_mode"`
+	ClientCertEnabled             bool                                `tfschema:"client_certificate_enabled"`
+	ClientCertMode                string                              `tfschema:"client_certificate_mode"`
 	Enabled                       bool                                `tfschema:"enabled"`
 	HttpsOnly                     bool                                `tfschema:"https_only"`
 	Identity                      []helpers.Identity                  `tfschema:"identity"`
@@ -114,13 +114,13 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  "Required",
@@ -516,10 +516,10 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("client_affinity_enabled") {
 				existing.SiteProperties.ClientAffinityEnabled = utils.Bool(state.ClientAffinityEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_enabled") {
+			if metadata.ResourceData.HasChange("client_certificate_enabled") {
 				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_mode") {
+			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -435,7 +435,7 @@ func TestAccLinuxWebAppSlot_withLoggingUpdate(t *testing.T) {
 			Config: r.withDetailedLogging(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -444,7 +444,7 @@ func TestAccLinuxWebAppSlot_withLoggingUpdate(t *testing.T) {
 			Config: r.withLogsHttpBlob(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("false"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("false"),
 			),
 		},
@@ -453,7 +453,7 @@ func TestAccLinuxWebAppSlot_withLoggingUpdate(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -958,7 +958,7 @@ resource "azurerm_linux_web_app_slot" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -995,7 +995,7 @@ resource "azurerm_linux_web_app_slot" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -1136,9 +1136,9 @@ resource "azurerm_linux_web_app_slot" "test" {
     }
   }
 
-  client_affinity_enabled = true
-  client_cert_enabled     = true
-  client_cert_mode        = "Optional"
+  client_affinity_enabled    = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Optional"
 
   connection_string {
     name  = "First"
@@ -1171,7 +1171,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     ]
     http2_enabled               = true
     scm_use_main_ip_restriction = true
-    local_mysql                 = true
+    local_mysql_enabled         = true
     managed_pipeline_mode       = "Integrated"
     remote_debugging_enabled    = true
     remote_debugging_version    = "VS2019"
@@ -1179,7 +1179,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health"
-    number_of_workers           = 1
+    worker_count                = 1
     minimum_tls_version         = "1.1"
     scm_minimum_tls_version     = "1.1"
     cors {
@@ -1195,7 +1195,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.id
 
     auto_swap_slot_name = "Production"
-    auto_heal           = true
+    auto_heal_enabled   = true
 
     auto_heal_setting {
       trigger {

--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -29,7 +29,7 @@ type ServicePlanDataSourceModel struct {
 	AppServiceEnvironmentId   string            `tfschema:"app_service_environment_id"`
 	PerSiteScaling            bool              `tfschema:"per_site_scaling_enabled"`
 	Reserved                  bool              `tfschema:"reserved"`
-	NumberOfWorkers           int               `tfschema:"number_of_workers"`
+	WorkerCount               int               `tfschema:"worker_count"`
 	MaximumElasticWorkerCount int               `tfschema:"maximum_elastic_worker_count"`
 	Tags                      map[string]string `tfschema:"tags"`
 }
@@ -78,7 +78,7 @@ func (r ServicePlanDataSource) Attributes() map[string]*pluginsdk.Schema {
 			Computed: true,
 		},
 
-		"number_of_workers": {
+		"worker_count": {
 			Type:     pluginsdk.TypeInt,
 			Computed: true,
 		},
@@ -130,7 +130,7 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 				if sku.Name != nil {
 					servicePlan.Sku = *sku.Name
 					if sku.Capacity != nil {
-						servicePlan.NumberOfWorkers = int(*sku.Capacity)
+						servicePlan.WorkerCount = int(*sku.Capacity)
 					}
 				}
 			}

--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -45,7 +45,7 @@ type ServicePlanModel struct {
 	AppServiceEnvironmentId   string            `tfschema:"app_service_environment_id"`
 	PerSiteScaling            bool              `tfschema:"per_site_scaling_enabled"`
 	Reserved                  bool              `tfschema:"reserved"`
-	NumberOfWorkers           int               `tfschema:"number_of_workers"`
+	WorkerCount               int               `tfschema:"worker_count"`
 	MaximumElasticWorkerCount int               `tfschema:"maximum_elastic_worker_count"`
 	Tags                      map[string]string `tfschema:"tags"`
 	// TODO properties
@@ -108,7 +108,7 @@ func (r ServicePlanResource) Arguments() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 
-		"number_of_workers": {
+		"worker_count": {
 			Type:         pluginsdk.TypeInt,
 			Optional:     true,
 			Computed:     true,
@@ -199,8 +199,8 @@ func (r ServicePlanResource) Create() sdk.ResourceFunc {
 				appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(servicePlan.MaximumElasticWorkerCount))
 			}
 
-			if servicePlan.NumberOfWorkers != 0 {
-				appServicePlan.Sku.Capacity = utils.Int32(int32(servicePlan.NumberOfWorkers))
+			if servicePlan.WorkerCount != 0 {
+				appServicePlan.Sku.Capacity = utils.Int32(int32(servicePlan.WorkerCount))
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServerfarmName, appServicePlan)
@@ -249,7 +249,7 @@ func (r ServicePlanResource) Read() sdk.ResourceFunc {
 				if sku.Name != nil {
 					state.Sku = *sku.Name
 					if sku.Capacity != nil {
-						state.NumberOfWorkers = int(*sku.Capacity)
+						state.WorkerCount = int(*sku.Capacity)
 					}
 				}
 			}
@@ -341,8 +341,8 @@ func (r ServicePlanResource) Update() sdk.ResourceFunc {
 				existing.Tags = tags.FromTypedObject(state.Tags)
 			}
 
-			if metadata.ResourceData.HasChange("number_of_workers") {
-				existing.Sku.Capacity = utils.Int32(int32(state.NumberOfWorkers))
+			if metadata.ResourceData.HasChange("worker_count") {
+				existing.Sku.Capacity = utils.Int32(int32(state.WorkerCount))
 			}
 
 			if metadata.ResourceData.HasChange("maximum_elastic_worker_count") {

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -243,7 +243,7 @@ resource "azurerm_service_plan" "test" {
   sku_name                 = "S1"
   os_type                  = "Linux"
   per_site_scaling_enabled = true
-  number_of_workers        = 2
+  worker_count             = 2
 
   tags = {
     environment = "AccTest"
@@ -271,7 +271,7 @@ resource "azurerm_service_plan" "test" {
   sku_name                 = "P1v2"
   os_type                  = "Linux"
   per_site_scaling_enabled = true
-  number_of_workers        = 3
+  worker_count             = 3
 
   tags = {
     Foo = "bar"

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -38,8 +38,8 @@ type WindowsFunctionAppModel struct {
 	AuthSettings              []helpers.AuthSettings                 `tfschema:"auth_settings"`
 	Backup                    []helpers.Backup                       `tfschema:"backup"` // Not supported on Dynamic or Basic plans
 	BuiltinLogging            bool                                   `tfschema:"builtin_logging_enabled"`
-	ClientCertEnabled         bool                                   `tfschema:"client_cert_enabled"`
-	ClientCertMode            string                                 `tfschema:"client_cert_mode"`
+	ClientCertEnabled         bool                                   `tfschema:"client_certificate_enabled"`
+	ClientCertMode            string                                 `tfschema:"client_certificate_mode"`
 	ConnectionStrings         []helpers.ConnectionString             `tfschema:"connection_string"`
 	DailyMemoryTimeQuota      int                                    `tfschema:"daily_memory_time_quota"`
 	Enabled                   bool                                   `tfschema:"enabled"`
@@ -151,14 +151,14 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Description: "Should built in logging be enabled. Configures `AzureWebJobsDashboard` app setting based on the configured storage setting",
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:        pluginsdk.TypeBool,
 			Optional:    true,
 			Default:     false,
 			Description: "Should the function app use Client Certificates",
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  web.ClientCertModeOptional,
@@ -616,11 +616,11 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 				existing.SiteProperties.HTTPSOnly = utils.Bool(state.HttpsOnly)
 			}
 
-			if metadata.ResourceData.HasChange("client_cert_enabled") {
+			if metadata.ResourceData.HasChange("client_certificate_enabled") {
 				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
 			}
 
-			if metadata.ResourceData.HasChange("client_cert_mode") {
+			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -917,9 +917,9 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled = false
-  client_cert_enabled     = true
-  client_cert_mode        = "Required"
+  builtin_logging_enabled    = false
+  client_certificate_enabled = true
+  client_certificate_mode    = "Required"
 
   connection_string {
     name  = "Second"
@@ -1083,9 +1083,9 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled = false
-  client_cert_enabled     = true
-  client_cert_mode        = "OptionalInteractiveUser"
+  builtin_logging_enabled    = false
+  client_certificate_enabled = true
+  client_certificate_mode    = "OptionalInteractiveUser"
 
   connection_string {
     name  = "First"
@@ -1158,7 +1158,7 @@ resource "azurerm_windows_function_app" "test" {
     websockets_enabled = true
     ftps_state         = "FtpsOnly"
     health_check_path  = "/health-check"
-    number_of_workers  = 3
+    worker_count       = 3
 
     minimum_tls_version     = "1.1"
     scm_minimum_tls_version = "1.1"
@@ -1282,7 +1282,7 @@ resource "azurerm_windows_function_app" "test" {
     websockets_enabled = true
     ftps_state         = "FtpsOnly"
     health_check_path  = "/health-check"
-    number_of_workers  = 3
+    worker_count       = 3
 
     minimum_tls_version     = "1.1"
     scm_minimum_tls_version = "1.1"

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -28,8 +28,8 @@ type WindowsWebAppDataSourceModel struct {
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                        `tfschema:"client_cert_enabled"`
-	ClientCertMode                string                      `tfschema:"client_cert_mode"`
+	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
+	ClientCertMode                string                      `tfschema:"client_certificate_mode"`
 	Enabled                       bool                        `tfschema:"enabled"`
 	HttpsOnly                     bool                        `tfschema:"https_only"`
 	Identity                      []helpers.Identity          `tfschema:"identity"`
@@ -96,12 +96,12 @@ func (d WindowsWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 			Computed: true,
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -30,8 +30,8 @@ type WindowsWebAppModel struct {
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
-	ClientCertEnabled             bool                        `tfschema:"client_cert_enabled"`
-	ClientCertMode                string                      `tfschema:"client_cert_mode"`
+	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
+	ClientCertMode                string                      `tfschema:"client_certificate_mode"`
 	Enabled                       bool                        `tfschema:"enabled"`
 	HttpsOnly                     bool                        `tfschema:"https_only"`
 	Identity                      []helpers.Identity          `tfschema:"identity"`
@@ -91,13 +91,13 @@ func (r WindowsWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 
-		"client_cert_enabled": {
+		"client_certificate_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
 
-		"client_cert_mode": {
+		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  string(web.ClientCertModeRequired),
@@ -575,10 +575,10 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("client_affinity_enabled") {
 				existing.SiteProperties.ClientAffinityEnabled = utils.Bool(state.ClientAffinityEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_enabled") {
+			if metadata.ResourceData.HasChange("client_certificate_enabled") {
 				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
 			}
-			if metadata.ResourceData.HasChange("client_cert_mode") {
+			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -178,7 +178,7 @@ func TestAccWindowsWebApp_withLogging(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -202,7 +202,7 @@ func TestAccWindowsWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withDetailedLogging(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -210,7 +210,7 @@ func TestAccWindowsWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withLogsHttpBlob(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("false"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("false"),
 			),
 		},
@@ -219,7 +219,7 @@ func TestAccWindowsWebApp_withLoggingUpdate(t *testing.T) {
 			Config: r.withLoggingComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging").HasValue("true"),
+				check.That(data.ResourceName).Key("site_config.0.detailed_error_logging_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("logs.0.detailed_error_messages").HasValue("true"),
 			),
 		},
@@ -1537,9 +1537,9 @@ resource "azurerm_windows_web_app" "test" {
     }
   }
 
-  client_affinity_enabled = true
-  client_cert_enabled     = true
-  client_cert_mode        = "Optional"
+  client_affinity_enabled    = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Optional"
 
   connection_string {
     name  = "First"
@@ -1573,15 +1573,15 @@ resource "azurerm_windows_web_app" "test" {
     ]
     http2_enabled               = true
     scm_use_main_ip_restriction = true
-    local_mysql                 = true
+    local_mysql_enabled         = true
     managed_pipeline_mode       = "Integrated"
-    remote_debugging            = true
+    remote_debugging_enabled    = true
     remote_debugging_version    = "VS2019"
     use_32_bit_worker           = true
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health"
-    number_of_workers           = 1
+    worker_count                = 1
     minimum_tls_version         = "1.1"
     scm_minimum_tls_version     = "1.1"
     cors {
@@ -1597,7 +1597,7 @@ resource "azurerm_windows_web_app" "test" {
     container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
 
     // auto_swap_slot_name = // TODO
-    auto_heal = true
+    auto_heal_enabled = true
 
     virtual_application {
       virtual_path  = "/"
@@ -1717,9 +1717,9 @@ resource "azurerm_windows_web_app" "test" {
     }
   }
 
-  client_affinity_enabled = true
-  client_cert_enabled     = true
-  client_cert_mode        = "Optional"
+  client_affinity_enabled    = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Optional"
 
   connection_string {
     name  = "First"
@@ -1747,14 +1747,14 @@ resource "azurerm_windows_web_app" "test" {
     ]
     http2_enabled               = false
     scm_use_main_ip_restriction = false
-    local_mysql                 = false
+    local_mysql_enabled         = false
     managed_pipeline_mode       = "Integrated"
-    remote_debugging            = true
+    remote_debugging_enabled    = true
     remote_debugging_version    = "VS2017"
     websockets_enabled          = true
     ftps_state                  = "FtpsOnly"
     health_check_path           = "/health2"
-    number_of_workers           = 2
+    worker_count                = 2
     minimum_tls_version         = "1.2"
     scm_minimum_tls_version     = "1.2"
     cors {
@@ -1769,7 +1769,7 @@ resource "azurerm_windows_web_app" "test" {
 
     container_registry_use_managed_identity = true
 
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2073,7 +2073,7 @@ resource "azurerm_windows_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2109,7 +2109,7 @@ resource "azurerm_windows_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {
@@ -2150,7 +2150,7 @@ resource "azurerm_windows_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {
-    auto_heal = true
+    auto_heal_enabled = true
 
     auto_heal_setting {
       trigger {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -868,7 +868,7 @@ func TestAccWindowsWebApp_containerRegistryCredentialsUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("site_config.0.container_registry_use_managed_identity").HasValue("true"),
-				check.That(data.ResourceName).Key("site_config.0.container_registry_managed_identity_client_id").HasValue(fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acct-%d", data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger)),
+				check.That(data.ResourceName).Key("site_config.0.container_registry_managed_identity_client_id").IsSet(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -49,9 +49,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_affinity_enabled` - Is Client Affinity enabled?
 
-* `client_cert_enabled` - Are Client Certificates enabled?
+* `client_certificate_enabled` - Are Client Certificates enabled?
 
-* `client_cert_mode` - The Client Certificate mode.
+* `client_certificate_mode` - The Client Certificate mode.
 
 * `connection_string` - A `connection_string` block as defined below.
 
@@ -347,7 +347,7 @@ A `site_config` block exports the following:
 
 * `application_stack` - A `application_stack` block as defined above.
 
-* `auto_heal` - Are Auto heal rules be enabled.
+* `auto_heal_enabled` - Are Auto heal rules be enabled.
 
 * `auto_heal_setting` - A `auto_heal_setting` block as defined above.
 
@@ -361,7 +361,7 @@ A `site_config` block exports the following:
 
 * `default_documents` - The list of Default Documents for the Linux Web App.
 
-* `detailed_error_logging` - Is Detailed Error Logging enabled.
+* `detailed_error_logging_enabled` - Is Detailed Error Logging enabled.
 
 * `ftps_state` - The State of FTP / FTPS service.
 
@@ -377,13 +377,11 @@ A `site_config` block exports the following:
 
 * `load_balancing_mode` - The site Load Balancing Mode.
 
-* `local_mysql` - Is the Local MySQL enabled.
+* `local_mysql_enabled` - Is the Local MySQL enabled.
 
 * `managed_pipeline_mode` - The Managed Pipeline Mode.
 
 * `minimum_tls_version` - The Minimum version of TLS for requests.
-
-* `number_of_workers` - The number of Workers for this Linux App Service.
 
 * `remote_debugging` - Is Remote Debugging enabled.
 
@@ -400,6 +398,8 @@ A `site_config` block exports the following:
 * `use_32_bit_worker` - Does the Linux Web App use a 32-bit worker.
 
 * `websockets_enabled` - Are Web Sockets enabled?
+
+* `worker_count` - The number of Workers for this Linux App Service.
 
 ---
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -47,9 +47,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_affinity_enabled` - Is Client Affinity enabled?
 
-* `client_cert_enabled` - Are Client Certificates enabled?
+* `client_certificate_enabled` - Are Client Certificates enabled?
 
-* `client_cert_mode` - The Client Certificate mode.
+* `client_certificate_mode` - The Client Certificate mode.
 
 * `connection_string` - A `connection_string` block as defined below.
 
@@ -357,7 +357,7 @@ A `site_config` block exports the following:
 
 * `application_stack` - A `application_stack` block as defined above.
 
-* `auto_heal` - Are Auto heal rules be enabled.
+* `auto_heal_enabled` - Are Auto heal rules to be enabled.
 
 * `auto_heal_setting` - A `auto_heal_setting` block as defined above.
 
@@ -371,7 +371,7 @@ A `site_config` block exports the following:
 
 * `default_documents` - The list of Default Documents for the Windows Web App.
 
-* `detailed_error_logging` - Is Detailed Error Logging enabled.
+* `detailed_error_logging_enabled` - Is Detailed Error Logging enabled.
 
 * `ftps_state` - The State of FTP / FTPS service.
 
@@ -385,13 +385,11 @@ A `site_config` block exports the following:
 
 * `load_balancing_mode` - The site Load Balancing Mode.
 
-* `local_mysql` - Is the Local MySQL enabled.
+* `local_mysql_enabled` - Is the Local MySQL enabled.
 
 * `managed_pipeline_mode` - The Managed Pipeline Mode.
 
 * `minimum_tls_version` - The Minimum version of TLS for requests.
-
-* `number_of_workers` - The number of Workers for this Windows App Service.
 
 * `remote_debugging` - Is Remote Debugging enabled.
 
@@ -412,6 +410,8 @@ A `site_config` block exports the following:
 * `websockets_enabled` - Are Web Sockets enabled?
 
 * `windows_fx_version` - The string representation of the Windows FX Version.
+
+* `worker_count` - The number of Workers for this Windows App Service.
 
 ---
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -78,9 +78,9 @@ The following arguments are supported:
 
 * `builtin_logging_enabled` - (Optional) Should built in logging be enabled. Configures `AzureWebJobsDashboard` app setting based on the configured storage setting.
 
-* `client_cert_enabled` - (Optional) Should the function app use Client Certificates.
+* `client_certificate_enabled` - (Optional) Should the function app use Client Certificates.
 
-* `client_cert_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
+* `client_certificate_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
@@ -409,8 +409,6 @@ A `site_config` block supports the following:
 
 * `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`.
 
-* `number_of_workers` - (Optional) The number of Workers for this Linux Function App.
-
 * `pre_warmed_instance_count` - (Optional) The number of pre-warmed instances for this function app. Only affects apps on an Elastic Premium plan.
 
 * `remote_debugging_enabled` - (Optional) Should Remote Debugging be enabled. Defaults to `false`.
@@ -430,6 +428,8 @@ A `site_config` block supports the following:
 * `vnet_route_all_enabled` - (Optional) Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.
 
 * `websockets_enabled` - (Optional) Should Web Sockets be enabled. Defaults to `false`.
+
+* `worker_count` - (Optional) The number of Workers for this Linux Function App.
 
 ---
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -69,9 +69,9 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should Client Affinity be enabled?
 
-* `client_cert_enabled` - (Optional) Should Client Certificates be enabled?
+* `client_certificate_enabled` - (Optional) Should Client Certificates be enabled?
 
-* `client_cert_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
+* `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
 
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
@@ -407,7 +407,7 @@ A `site_config` block supports the following:
 
 * `application_stack` - (Optional) A `application_stack` block as defined above.
 
-* `auto_heal` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
+* `auto_heal_enabled` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
 
 * `auto_heal_setting` - (Optional) A `auto_heal_setting` block as defined above. Required with `auto_heal`.
 
@@ -433,13 +433,11 @@ A `site_config` block supports the following:
 
 * `load_balancing_mode` - (Optional) The Site load balancing. Possible values include: `WeightedRoundRobin`, `LeastRequests`, `LeastResponseTime`, `WeightedTotalTraffic`, `RequestHash`, `PerSiteRoundRobin`. Defaults to `LeastRequests` if omitted.
 
-* `local_mysql` - (Optional) Use Local MySQL. Defaults to `false`.
+* `local_mysql_enabled` - (Optional) Use Local MySQL. Defaults to `false`.
 
 * `managed_pipeline_mode` - (Optional) Managed pipeline mode. Possible values include: `Integrated`, `Classic`.
 
 * `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`.
-
-* `number_of_workers` - (Optional) The number of Workers for this Linux App Service.
 
 * `remote_debugging` - (Optional) Should Remote Debugging be enabled. Defaults to `false`.
 
@@ -454,6 +452,8 @@ A `site_config` block supports the following:
 * `use_32_bit_worker` - (Optional) Should the Linux Web App use a 32-bit worker. Defaults to `true`.
 
 * `websockets` - (Optional) Should Web Sockets be enabled. Defaults to `false`.
+
+* `worker_count` - (Optional) The number of Workers for this Linux App Service.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -81,9 +81,9 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should Client Affinity be enabled?
 
-* `client_cert_enabled` - (Optional) Should Client Certificates be enabled?
+* `client_certificate_enabled` - (Optional) Should Client Certificates be enabled?
 
-* `client_cert_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
+* `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
 
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
@@ -423,7 +423,7 @@ A `site_config` block supports the following:
 
 * `application_stack` - (Optional) A `application_stack` block as defined above.
 
-* `auto_heal` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
+* `auto_heal_enabled` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
 
 * `auto_heal_setting` - (Optional) A `auto_heal_setting` block as defined above. Required with `auto_heal`.
 
@@ -453,13 +453,11 @@ A `site_config` block supports the following:
 
 * `load_balancing_mode` - (Optional) The Site load balancing. Possible values include: `WeightedRoundRobin`, `LeastRequests`, `LeastResponseTime`, `WeightedTotalTraffic`, `RequestHash`, `PerSiteRoundRobin`. Defaults to `LeastRequests` if omitted.
 
-* `local_mysql` - (Optional) Use Local MySQL. Defaults to `false`.
+* `local_mysql_enabled` - (Optional) Use Local MySQL. Defaults to `false`.
 
 * `managed_pipeline_mode` - (Optional) Managed pipeline mode. Possible values include: `Integrated`, `Classic`.
 
 * `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`.
-
-* `number_of_workers` - (Optional) The number of Workers for this Linux App Service.
 
 * `remote_debugging` - (Optional) Should Remote Debugging be enabled. Defaults to `false`.
 
@@ -474,6 +472,8 @@ A `site_config` block supports the following:
 * `use_32_bit_worker` - (Optional) Should the Linux Web App use a 32-bit worker. Defaults to `true`.
 
 * `websockets` - (Optional) Should Web Sockets be enabled. Defaults to `false`.
+
+* `worker_count` - (Optional) The number of Workers for this Linux App Service Slot.
 
 ---
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -78,9 +78,9 @@ The following arguments are supported:
 
 * `builtin_logging_enabled` - (Optional) Should built in logging be enabled. Configures `AzureWebJobsDashboard` app setting based on the configured storage setting.
 
-* `client_cert_enabled` - (Optional) Should the function app use Client Certificates.
+* `client_certificate_enabled` - (Optional) Should the function app use Client Certificates.
 
-* `client_cert_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
+* `client_certificate_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
@@ -383,8 +383,6 @@ A `site_config` block supports the following:
 
 * `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`.
 
-* `number_of_workers` - (Optional) The number of Workers for this Windows Function App.
-
 * `pre_warmed_instance_count` - (Optional) The number of pre-warmed instances for this function app. Only affects apps on an Elastic Premium plan.
 
 * `remote_debugging_enabled` - (Optional) Should Remote Debugging be enabled. Defaults to `false`.
@@ -404,6 +402,8 @@ A `site_config` block supports the following:
 * `vnet_route_all_enabled` - (Optional) Should all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied? Defaults to `false`.
 
 * `websockets_enabled` - (Optional) Should Web Sockets be enabled. Defaults to `false`.
+
+* `worker_count` - (Optional) The number of Workers for this Windows Function App.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -65,9 +65,9 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should Client Affinity be enabled?
 
-* `client_cert_enabled` - (Optional) Should Client Certificates be enabled?
+* `client_certificate_enabled` - (Optional) Should Client Certificates be enabled?
 
-* `client_cert_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
+* `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values include `Optional` and `Required`. This property has no effect when `client_cert_enabled` is `false`
 
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
@@ -411,7 +411,7 @@ A `site_config` block supports the following:
 
 * `application_stack` - (Optional) A `application_stack` block as defined above.
 
-* `auto_heal` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
+* `auto_heal_enabled` - (Optional) Should Auto heal rules be enabled. Required with `auto_heal_setting`.
 
 * `auto_heal_setting` - (Optional) A `auto_heal_setting` block as defined above. Required with `auto_heal`.
 
@@ -435,13 +435,11 @@ A `site_config` block supports the following:
 
 * `load_balancing_mode` - (Optional) The Site load balancing. Possible values include: `WeightedRoundRobin`, `LeastRequests`, `LeastResponseTime`, `WeightedTotalTraffic`, `RequestHash`, `PerSiteRoundRobin`. Defaults to `LeastRequests` if omitted.
 
-* `local_mysql` - (Optional) Use Local MySQL. Defaults to `false`.
+* `local_mysql_enabled` - (Optional) Use Local MySQL. Defaults to `false`.
 
 * `managed_pipeline_mode` - (Optional) Managed pipeline mode. Possible values include: `Integrated`, `Classic`.
 
 * `minimum_tls_version` - (Optional) The configures the minimum version of TLS required for SSL requests. Possible values include: `1.0`, `1.1`, and  `1.2`. Defaults to `1.2`. 
-
-* `number_of_workers` - (Optional) The number of Workers for this Windows App Service. 
 
 * `remote_debugging` - (Optional) Should Remote Debugging be enabled. Defaults to `false`.
 
@@ -458,6 +456,8 @@ A `site_config` block supports the following:
 * `virtual_application` - (Optional) One or more `virtual_application` blocks as defined below.
 
 * `websockets` - (Optional) Should Web Sockets be enabled. Defaults to `false`. 
+
+* `worker_count` - (Optional) The number of Workers for this Windows App Service.
 
 ---
 


### PR DESCRIPTION
This renames a number of properties in the App Service beta resources for consistency with the rest of the provider. As these are beta resources, this breaking change is not compensated for with deprecations or state migrations. Please update any configurations using these resources with the following details:

* `remote_debugging` renamed to `remote_debugging_enabled`
* `number_of_workers` renamed to `worker_count`
* `detailed_error_logging` renamed to `detailed_error_logging_enabled`
* `auto_heal` renamed to `auto_heal_enabled`
* `local_mysql` renamed to `local_mysql_enabled`
* `client_cert_enabled` renamed to `client_certificate_enabled`
* `client_cert_mode` renamed to `client_certificate_mode`