### PR TITLE
Fix #12001 by correct document `resource_type` from "Required" to "Optional".

### DIFF
--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 The following arguments are supported:
 
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
-* `resource_type` - (Required) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `OpenSourceRelationalDatabases`, `Containers` and `Dns`. 
+* `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `OpenSourceRelationalDatabases`, `Containers` and `Dns`. Defaults to `VirtualMachines`.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 


### PR DESCRIPTION
Fix #12001 by correct document `resource_type` from "Required" to "Optional". The [current code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/securitycenter/security_center_subscription_pricing_resource.go#L51) shows that `resource_type` is optional with default value `VirtualMachines`.