### PR TITLE
`iothub`: Support Identity-Based Endpoint

### DIFF
--- a/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
@@ -50,45 +50,78 @@ func TestAccIotHubEndpointEventHub_requiresImport(t *testing.T) {
 	})
 }
 
-func (IotHubEndpointEventHubResource) basic(data acceptance.TestData) string {
+func TestAccIotHubEndpointEventHub_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointEventHub_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointEventHub_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubEndpointEventHubResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-iothub-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_eventhub_namespace" "test" {
-  name                = "acctesteventhubnamespace-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
-}
-
-resource "azurerm_eventhub" "test" {
-  name                = "acctesteventhub-%[1]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  partition_count     = 2
-  message_retention   = 1
-}
-
-resource "azurerm_eventhub_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  eventhub_name       = azurerm_eventhub.test.name
-  resource_group_name = azurerm_resource_group.test.name
-
-  listen = false
-  send   = true
-  manage = false
-}
+%s
 
 resource "azurerm_iothub" "test" {
-  name                = "acctestIoTHub-%[1]d"
+  name                = "acctestIoTHub-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -109,7 +142,7 @@ resource "azurerm_iothub_endpoint_eventhub" "test" {
 
   connection_string = azurerm_eventhub_authorization_rule.test.primary_connection_string
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r IotHubEndpointEventHubResource) requiresImport(data acceptance.TestData) string {
@@ -151,4 +184,144 @@ func (t IotHubEndpointEventHubResource) Exists(ctx context.Context, clients *cli
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  connection_string = azurerm_eventhub_authorization_rule.test.primary_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_eventhub.test.name
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_eventhub.test.name
+}
+`, r.authenticationTemplate(data))
+}
+
+func (IotHubEndpointEventHubResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctesteventhub-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_user" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_system" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -12,8 +12,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -42,7 +45,7 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubEndpointName,
+				ValidateFunc: iothubValidate.IoTHubEndpointName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -51,12 +54,44 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubName,
+				ValidateFunc: iothubValidate.IoTHubName,
+			},
+
+			"authentication_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(devices.AuthenticationTypeKeyBased),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(devices.AuthenticationTypeKeyBased),
+					string(devices.AuthenticationTypeIdentityBased),
+				}, false),
+			},
+
+			"identity_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  msivalidate.UserAssignedIdentityID,
+				ConflictsWith: []string{"connection_string"},
+			},
+
+			"endpoint_uri": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"entity_path"},
+				ExactlyOneOf: []string{"endpoint_uri", "connection_string"},
+			},
+
+			"entity_path": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.QueueName(),
+				RequiredWith: []string{"endpoint_uri"},
 			},
 
 			"connection_string": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					sharedAccessKeyRegex := regexp.MustCompile("SharedAccessKey=[^;]+")
 					sbProtocolRegex := regexp.MustCompile("sb://([^:]+)(:5671)?/;")
@@ -65,7 +100,9 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 					maskedNew = sharedAccessKeyRegex.ReplaceAllString(maskedNew, "SharedAccessKey=****")
 					return (new == d.Get(k).(string)) && (maskedNew == old)
 				},
-				Sensitive: true,
+				Sensitive:     true,
+				ConflictsWith: []string{"identity_id"},
+				ExactlyOneOf:  []string{"endpoint_uri", "connection_string"},
 			},
 		},
 	}
@@ -92,11 +129,34 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
+	authenticationType := devices.AuthenticationType(d.Get("authentication_type").(string))
+
 	queueEndpoint := devices.RoutingServiceBusQueueEndpointProperties{
-		ConnectionString: utils.String(d.Get("connection_string").(string)),
-		Name:             utils.String(id.EndpointName),
-		SubscriptionID:   utils.String(subscriptionID),
-		ResourceGroup:    utils.String(id.ResourceGroup),
+		AuthenticationType: authenticationType,
+		Name:               utils.String(id.EndpointName),
+		SubscriptionID:     utils.String(subscriptionID),
+		ResourceGroup:      utils.String(id.ResourceGroup),
+	}
+
+	if authenticationType == devices.AuthenticationTypeKeyBased {
+		if v, ok := d.GetOk("connection_string"); ok {
+			queueEndpoint.ConnectionString = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+		}
+	} else {
+		if v, ok := d.GetOk("endpoint_uri"); ok {
+			queueEndpoint.EndpointURI = utils.String(v.(string))
+			queueEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+		} else {
+			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
+		}
+
+		if v, ok := d.GetOk("identity_id"); ok {
+			queueEndpoint.Identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v.(string)),
+			}
+		}
 	}
 
 	routing := iothub.Properties.Routing
@@ -177,7 +237,35 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					d.Set("connection_string", endpoint.ConnectionString)
+					authenticationType := string(devices.AuthenticationTypeKeyBased)
+					if string(endpoint.AuthenticationType) != "" {
+						authenticationType = string(endpoint.AuthenticationType)
+					}
+					d.Set("authentication_type", authenticationType)
+
+					connectionStr := ""
+					if endpoint.ConnectionString != nil {
+						connectionStr = *endpoint.ConnectionString
+					}
+					d.Set("connection_string", connectionStr)
+
+					endpointUri := ""
+					if endpoint.EndpointURI != nil {
+						endpointUri = *endpoint.EndpointURI
+					}
+					d.Set("endpoint_uri", endpointUri)
+
+					entityPath := ""
+					if endpoint.EntityPath != nil {
+						entityPath = *endpoint.EntityPath
+					}
+					d.Set("entity_path", entityPath)
+
+					identityId := ""
+					if endpoint.Identity != nil && endpoint.Identity.UserAssignedIdentity != nil {
+						identityId = *endpoint.Identity.UserAssignedIdentity
+					}
+					d.Set("identity_id", identityId)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
@@ -50,45 +50,78 @@ func TestAccIotHubEndpointServiceBusQueue_requiresImport(t *testing.T) {
 	})
 }
 
-func (IotHubEndpointServiceBusQueueResource) basic(data acceptance.TestData) string {
+func TestAccIotHubEndpointServiceBusQueue_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_queue", "test")
+	r := IotHubEndpointServiceBusQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusQueue_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_queue", "test")
+	r := IotHubEndpointServiceBusQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusQueue_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_queue", "test")
+	r := IotHubEndpointServiceBusQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubEndpointServiceBusQueueResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-iothub-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_servicebus_namespace" "test" {
-  name                = "acctest-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_servicebus_queue" "test" {
-  name                = "acctest-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-
-  enable_partitioning = true
-}
-
-resource "azurerm_servicebus_queue_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  queue_name          = azurerm_servicebus_queue.test.name
-  resource_group_name = azurerm_resource_group.test.name
-
-  listen = false
-  send   = true
-  manage = false
-}
+%s
 
 resource "azurerm_iothub" "test" {
-  name                = "acctestIoTHub-%[1]d"
+  name                = "acctestIoTHub-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -109,7 +142,7 @@ resource "azurerm_iothub_endpoint_servicebus_queue" "test" {
 
   connection_string = azurerm_servicebus_queue_authorization_rule.test.primary_connection_string
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r IotHubEndpointServiceBusQueueResource) requiresImport(data acceptance.TestData) string {
@@ -151,4 +184,145 @@ func (t IotHubEndpointServiceBusQueueResource) Exists(ctx context.Context, clien
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointServiceBusQueueResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_queue" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  connection_string = azurerm_servicebus_queue_authorization_rule.test.primary_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusQueueResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_queue" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_queue.test.name
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusQueueResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_queue" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_queue.test.name
+}
+`, r.authenticationTemplate(data))
+}
+
+func (IotHubEndpointServiceBusQueueResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_queue" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_servicebus_namespace.test.name
+
+  enable_partitioning = true
+}
+
+resource "azurerm_servicebus_queue_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  queue_name          = azurerm_servicebus_queue.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IotHubEndpointServiceBusQueueResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_user" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_queue.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_system" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_queue.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource.go
@@ -12,8 +12,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -42,7 +45,7 @@ func resourceIotHubEndpointServiceBusTopic() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubEndpointName,
+				ValidateFunc: iothubValidate.IoTHubEndpointName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -51,12 +54,44 @@ func resourceIotHubEndpointServiceBusTopic() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubName,
+				ValidateFunc: iothubValidate.IoTHubName,
+			},
+
+			"authentication_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(devices.AuthenticationTypeKeyBased),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(devices.AuthenticationTypeKeyBased),
+					string(devices.AuthenticationTypeIdentityBased),
+				}, false),
+			},
+
+			"identity_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  msivalidate.UserAssignedIdentityID,
+				ConflictsWith: []string{"connection_string"},
+			},
+
+			"endpoint_uri": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"entity_path"},
+				ExactlyOneOf: []string{"endpoint_uri", "connection_string"},
+			},
+
+			"entity_path": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.TopicName(),
+				RequiredWith: []string{"endpoint_uri"},
 			},
 
 			"connection_string": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					sharedAccessKeyRegex := regexp.MustCompile("SharedAccessKey=[^;]+")
 					sbProtocolRegex := regexp.MustCompile("sb://([^:]+)(:5671)?/;")
@@ -65,7 +100,9 @@ func resourceIotHubEndpointServiceBusTopic() *pluginsdk.Resource {
 					maskedNew = sharedAccessKeyRegex.ReplaceAllString(maskedNew, "SharedAccessKey=****")
 					return (new == d.Get(k).(string)) && (maskedNew == old)
 				},
-				Sensitive: true,
+				Sensitive:     true,
+				ConflictsWith: []string{"identity_id"},
+				ExactlyOneOf:  []string{"endpoint_uri", "connection_string"},
 			},
 		},
 	}
@@ -92,11 +129,34 @@ func resourceIotHubEndpointServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
+	authenticationType := devices.AuthenticationType(d.Get("authentication_type").(string))
+
 	topicEndpoint := devices.RoutingServiceBusTopicEndpointProperties{
-		ConnectionString: utils.String(d.Get("connection_string").(string)),
-		Name:             utils.String(id.EndpointName),
-		SubscriptionID:   utils.String(subscriptionID),
-		ResourceGroup:    utils.String(id.ResourceGroup),
+		AuthenticationType: authenticationType,
+		Name:               utils.String(id.EndpointName),
+		SubscriptionID:     utils.String(subscriptionID),
+		ResourceGroup:      utils.String(id.ResourceGroup),
+	}
+
+	if authenticationType == devices.AuthenticationTypeKeyBased {
+		if v, ok := d.GetOk("connection_string"); ok {
+			topicEndpoint.ConnectionString = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+		}
+	} else {
+		if v, ok := d.GetOk("endpoint_uri"); ok {
+			topicEndpoint.EndpointURI = utils.String(v.(string))
+			topicEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+		} else {
+			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
+		}
+
+		if v, ok := d.GetOk("identity_id"); ok {
+			topicEndpoint.Identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v.(string)),
+			}
+		}
 	}
 
 	routing := iothub.Properties.Routing
@@ -177,7 +237,35 @@ func resourceIotHubEndpointServiceBusTopicRead(d *pluginsdk.ResourceData, meta i
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					d.Set("connection_string", endpoint.ConnectionString)
+					authenticationType := string(devices.AuthenticationTypeKeyBased)
+					if string(endpoint.AuthenticationType) != "" {
+						authenticationType = string(endpoint.AuthenticationType)
+					}
+					d.Set("authentication_type", authenticationType)
+
+					connectionStr := ""
+					if endpoint.ConnectionString != nil {
+						connectionStr = *endpoint.ConnectionString
+					}
+					d.Set("connection_string", connectionStr)
+
+					endpointUri := ""
+					if endpoint.EndpointURI != nil {
+						endpointUri = *endpoint.EndpointURI
+					}
+					d.Set("endpoint_uri", endpointUri)
+
+					entityPath := ""
+					if endpoint.EntityPath != nil {
+						entityPath = *endpoint.EntityPath
+					}
+					d.Set("entity_path", entityPath)
+
+					identityId := ""
+					if endpoint.Identity != nil && endpoint.Identity.UserAssignedIdentity != nil {
+						identityId = *endpoint.Identity.UserAssignedIdentity
+					}
+					d.Set("identity_id", identityId)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
@@ -50,43 +50,78 @@ func TestAccIotHubEndpointServiceBusTopic_requiresImport(t *testing.T) {
 	})
 }
 
-func (IotHubEndpointServiceBusTopicResource) basic(data acceptance.TestData) string {
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubEndpointServiceBusTopicResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-iothub-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_servicebus_namespace" "test" {
-  name                = "acctest-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_servicebus_topic_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  resource_group_name = azurerm_resource_group.test.name
-
-  listen = false
-  send   = true
-  manage = false
-}
+%s
 
 resource "azurerm_iothub" "test" {
-  name                = "acctestIoTHub-%[1]d"
+  name                = "acctestIoTHub-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -107,7 +142,7 @@ resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
 
   connection_string = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r IotHubEndpointServiceBusTopicResource) requiresImport(data acceptance.TestData) string {
@@ -149,4 +184,143 @@ func (t IotHubEndpointServiceBusTopicResource) Exists(ctx context.Context, clien
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  connection_string = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_topic.test.name
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_topic.test.name
+}
+`, r.authenticationTemplate(data))
+}
+
+func (IotHubEndpointServiceBusTopicResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name                = "acctestservicebustopic-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_user" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_system" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -82,16 +83,42 @@ func resourceIotHubEndpointStorageContainer() *pluginsdk.Resource {
 				ValidateFunc: validation.IntBetween(10485760, 524288000),
 			},
 
+			"authentication_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(devices.AuthenticationTypeKeyBased),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(devices.AuthenticationTypeKeyBased),
+					string(devices.AuthenticationTypeIdentityBased),
+				}, false),
+			},
+
+			"identity_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  msivalidate.UserAssignedIdentityID,
+				ConflictsWith: []string{"connection_string"},
+			},
+
+			"endpoint_uri": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"endpoint_uri", "connection_string"},
+			},
+
 			"connection_string": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					accountKeyRegex := regexp.MustCompile("AccountKey=[^;]+")
 
 					maskedNew := accountKeyRegex.ReplaceAllString(new, "AccountKey=****")
 					return (new == d.Get(k).(string)) && (maskedNew == old)
 				},
-				Sensitive: true,
+				Sensitive:     true,
+				ConflictsWith: []string{"identity_id"},
+				ExactlyOneOf:  []string{"endpoint_uri", "connection_string"},
 			},
 
 			"encoding": {
@@ -128,7 +155,7 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
-	connectionStr := d.Get("connection_string").(string)
+	authenticationType := devices.AuthenticationType(d.Get("authentication_type").(string))
 	containerName := d.Get("container_name").(string)
 	fileNameFormat := d.Get("file_name_format").(string)
 	batchFrequencyInSeconds := int32(d.Get("batch_frequency_in_seconds").(int))
@@ -136,7 +163,7 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 	encoding := d.Get("encoding").(string)
 
 	storageContainerEndpoint := devices.RoutingStorageContainerProperties{
-		ConnectionString:        &connectionStr,
+		AuthenticationType:      authenticationType,
 		Name:                    &id.EndpointName,
 		SubscriptionID:          &subscriptionID,
 		ResourceGroup:           &id.ResourceGroup,
@@ -145,6 +172,26 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 		BatchFrequencyInSeconds: &batchFrequencyInSeconds,
 		MaxChunkSizeInBytes:     &maxChunkSizeInBytes,
 		Encoding:                devices.Encoding(encoding),
+	}
+
+	if authenticationType == devices.AuthenticationTypeKeyBased {
+		if v, ok := d.GetOk("connection_string"); ok {
+			storageContainerEndpoint.ConnectionString = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+		}
+	} else {
+		if v, ok := d.GetOk("endpoint_uri"); ok {
+			storageContainerEndpoint.EndpointURI = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`endpoint_uri` must be specified when `authentication_type` is `identityBased`")
+		}
+
+		if v, ok := d.GetOk("identity_id"); ok {
+			storageContainerEndpoint.Identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v.(string)),
+			}
+		}
 	}
 
 	routing := iothub.Properties.Routing
@@ -227,12 +274,35 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					d.Set("connection_string", endpoint.ConnectionString)
 					d.Set("container_name", endpoint.ContainerName)
 					d.Set("file_name_format", endpoint.FileNameFormat)
 					d.Set("batch_frequency_in_seconds", endpoint.BatchFrequencyInSeconds)
 					d.Set("max_chunk_size_in_bytes", endpoint.MaxChunkSizeInBytes)
 					d.Set("encoding", endpoint.Encoding)
+
+					authenticationType := string(devices.AuthenticationTypeKeyBased)
+					if string(endpoint.AuthenticationType) != "" {
+						authenticationType = string(endpoint.AuthenticationType)
+					}
+					d.Set("authentication_type", authenticationType)
+
+					connectionStr := ""
+					if endpoint.ConnectionString != nil {
+						connectionStr = *endpoint.ConnectionString
+					}
+					d.Set("connection_string", connectionStr)
+
+					endpointUri := ""
+					if endpoint.EndpointURI != nil {
+						endpointUri = *endpoint.EndpointURI
+					}
+					d.Set("endpoint_uri", endpointUri)
+
+					identityId := ""
+					if endpoint.Identity != nil && endpoint.Identity.UserAssignedIdentity != nil {
+						identityId = *endpoint.Identity.UserAssignedIdentity
+					}
+					d.Set("identity_id", identityId)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
@@ -54,33 +54,78 @@ func TestAccIotHubEndpointStorageContainer_requiresImport(t *testing.T) {
 	})
 }
 
-func (IotHubEndpointStorageContainerResource) basic(data acceptance.TestData) string {
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubEndpointStorageContainerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-iothub-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acc%[1]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_storage_container" "test" {
-  name                  = "acctestcont"
-  storage_account_name  = azurerm_storage_account.test.name
-  container_access_type = "private"
-}
+%s
 
 resource "azurerm_iothub" "test" {
-  name                = "acctestIoTHub-%[1]d"
+  name                = "acctestIoTHub-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -107,7 +152,7 @@ resource "azurerm_iothub_endpoint_storage_container" "test" {
   max_chunk_size_in_bytes    = 10485760
   encoding                   = "JSON"
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r IotHubEndpointStorageContainerResource) requiresImport(data acceptance.TestData) string {
@@ -155,4 +200,148 @@ func (t IotHubEndpointStorageContainerResource) Exists(ctx context.Context, clie
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  container_name    = azurerm_storage_container.test.name
+  connection_string = azurerm_storage_account.test.primary_blob_connection_string
+
+  file_name_format           = "{iothub}/{partition}_{YYYY}_{MM}_{DD}_{HH}_{mm}"
+  batch_frequency_in_seconds = 60
+  max_chunk_size_in_bytes    = 10485760
+  encoding                   = "JSON"
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  container_name      = azurerm_storage_container.test.name
+  endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+
+  file_name_format           = "{iothub}/{partition}_{YYYY}_{MM}_{DD}_{HH}_{mm}"
+  batch_frequency_in_seconds = 60
+  max_chunk_size_in_bytes    = 10485760
+  encoding                   = "JSON"
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  container_name      = azurerm_storage_container.test.name
+  endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+
+  file_name_format           = "{iothub}/{partition}_{YYYY}_{MM}_{DD}_{HH}_{mm}"
+  batch_frequency_in_seconds = 60
+  max_chunk_size_in_bytes    = 10485760
+  encoding                   = "JSON"
+}
+`, r.authenticationTemplate(data))
+}
+
+func (IotHubEndpointStorageContainerResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acc%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "acctestcont"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_user" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_system" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
Cont. of https://github.com/hashicorp/terraform-provider-azurerm/pull/14354. Adding support for identity-based authentication to custom routing endpoint of iot hub. There are four endpoint resources.
- `eventhub`, `servicebus_queue` and `servicebus_topic`
  - `authentication_type`: whether to use `keyBased`(default) or `identityBased`
  - `identity_id`: user-assigned managed identity id when using `identityBased`
  - `endpoint_uri` and `entity_path`: set together, to specify the target endpoint in `identityBased` case
  - `connection_string`: update from `Required` to `Optional`, this is used in `keyBased` case
- `storage_container`
  - `authentication_type`, `identity_id`, `endpoint_uri`, `connection_string`: same as above.
  - `entity_path` is not applicable because `container_name` is already used