### PR TITLE
[Document]`r\azurerm_private_link_service` The `network_interfaces` attribute seems never existed.

### DIFF
--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -130,8 +130,6 @@ The following attributes are exported:
 
 * `alias` - A globally unique DNS Name for your Private Link Service. You can use this alias to request a connection to your Private Link Service.
 
-* `network_interfaces` - A list of network interface resource ids that are being used by the service.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
[Document]`r\azurerm_private_link_service` The `network_interfaces` attribute seems never existed. The nearest `network_interface_ids` was removed at 9f53e4e61844d347658bc335213ab720aa98b130 .