### PR TITLE
azurerm_public_ip_prefix : support customIPPrefix property of Public Ip Prefix resource

### DIFF
--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -265,7 +265,7 @@ func resourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if props := resp.PublicIPPrefixPropertiesFormat; props != nil {
 		d.Set("prefix_length", props.PrefixLength)
 		d.Set("ip_prefix", props.IPPrefix)
-		if props.CustomIPPrefix != nil {
+		if props.CustomIPPrefix != nil && props.CustomIPPrefix.ID != nil {
 			d.Set("custom_ip_prefix_id", props.CustomIPPrefix.ID)
 		}
 		if version := props.PublicIPAddressVersion; version != "" {

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 
 -> **Note**: Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. 
 
+* `custom_ip_prefix_id` - (Optional) The ID of the Custom IP Prefix resource used for limit the IP allocation range of the Public IP Prefix. Changing this forces a new resource to be created.
+
 * `ip_version` - (Optional) The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.
 
 * `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 31 (2 addresses). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.


### PR DESCRIPTION
The purpose of this PR:

1. Support customIPPrefix property of the Public Ip Prefix resource requested from service team. Since the Custom Ip Prefix resource has not been supported in TF(because it takes a few days to create a customIpPrefix to be provisioned, whether to support it to be determined), there is no test case that support this property in this PR. It has been tested locally by using the test data of existing Custom Ip Prefix resource.

2. Update the value of Zone-Redundant from "1,2" to the correct value "1,2,3".

Test result (The failed test case is the same error before modification ):

> PASS: TestAccPublicIpPrefix_disappears (131.66s)
> FAIL: TestAccPublicIpPrefix_prefixLength24 (147.43s)
> PASS: TestAccPublicIpPrefix_availabilityZoneRedundant (187.16s)
> PASS: TestAccPublicIpPrefix_availabilityZoneSingle (190.12s)
> PASS: TestAccPublicIpPrefix_availabilityZoneSNoZone (193.71s)
> PASS: TestAccPublicIpPrefix_prefixLength31 (200.56s)
> PASS: TestAccPublicIpPrefix_basic (203.01s)
> PASS: TestAccPublicIpPrefix_ipv6 (204.66s)
> PASS: TestAccPublicIpPrefix_requiresImport (220.47s)
> PASS: TestAccPublicIpPrefix_update (256.83s)