### PR TITLE
`azurerm_iothub_endpoint_eventhub` - deprecate `iothub_name` in favour of `iothub_id`

### DIFF
--- a/internal/services/iothub/iothub_endpoint_eventhub_resource.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource.go
@@ -58,7 +58,6 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 				ConflictsWith: []string{"iothub_id"},
 			},
 
-			// TODO state migration?
 			"iothub_id": {
 				Type: pluginsdk.TypeString,
 				// TODO add Required: true in 3.0

--- a/internal/services/iothub/iothub_endpoint_eventhub_resource.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource.go
@@ -47,11 +47,26 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			// TODO remove in 3.0
 			"iothub_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.IoTHubName,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  validate.IoTHubName,
+				Deprecated:    "Deprecated in favour of `iothub_id`",
+				ConflictsWith: []string{"iothub_id"},
+			},
+
+			// TODO state migration?
+			"iothub_id": {
+				Type: pluginsdk.TypeString,
+				// TODO add Required: true in 3.0
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  validate.IotHubID,
+				ConflictsWith: []string{"iothub_name"},
 			},
 
 			"connection_string": {
@@ -77,25 +92,38 @@ func resourceIotHubEndpointEventHubCreateUpdate(d *pluginsdk.ResourceData, meta 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewEndpointEventhubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iothub_name").(string), d.Get("name").(string))
+	endpointRG := d.Get("resource_group_name").(string)
+	iotHubName := d.Get("iothub_name").(string)
+	iotHubRG := endpointRG
 
-	locks.ByName(id.IotHubName, IothubResourceName)
-	defer locks.UnlockByName(id.IotHubName, IothubResourceName)
+	if iotHubName == "" {
+		id, err := parse.IotHubID(d.Get("iothub_id").(string))
+		if err != nil {
+			return err
+		}
+		iotHubName = id.Name
+		iotHubRG = id.ResourceGroup
+	}
 
-	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
+	id := parse.NewEndpointEventhubID(subscriptionId, iotHubRG, iotHubName, d.Get("name").(string))
+
+	locks.ByName(iotHubName, IothubResourceName)
+	defer locks.UnlockByName(iotHubName, IothubResourceName)
+
+	iothub, err := client.Get(ctx, iotHubRG, iotHubName)
 	if err != nil {
 		if utils.ResponseWasNotFound(iothub.Response) {
-			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", id.IotHubName, id.ResourceGroup)
+			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", iotHubName, iotHubRG)
 		}
 
-		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
+		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", iotHubName, iotHubRG, err)
 	}
 
 	eventhubEndpoint := devices.RoutingEventHubProperties{
 		ConnectionString: utils.String(d.Get("connection_string").(string)),
 		Name:             utils.String(id.EndpointName),
 		SubscriptionID:   utils.String(meta.(*clients.Client).Account.SubscriptionId),
-		ResourceGroup:    utils.String(id.ResourceGroup),
+		ResourceGroup:    utils.String(endpointRG),
 	}
 
 	routing := iothub.Properties.Routing
@@ -136,7 +164,7 @@ func resourceIotHubEndpointEventHubCreateUpdate(d *pluginsdk.ResourceData, meta 
 	}
 	routing.Endpoints.EventHubs = &endpoints
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IotHubName, iothub, "")
+	future, err := client.CreateOrUpdate(ctx, iotHubRG, iotHubName, iothub, "")
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
@@ -166,7 +194,9 @@ func resourceIotHubEndpointEventHubRead(d *pluginsdk.ResourceData, meta interfac
 
 	d.Set("name", id.EndpointName)
 	d.Set("iothub_name", id.IotHubName)
-	d.Set("resource_group_name", id.ResourceGroup)
+
+	iotHubId := parse.NewIotHubID(id.SubscriptionId, id.ResourceGroup, id.IotHubName)
+	d.Set("iothub_id", iotHubId.ID())
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
 		return nil
@@ -177,6 +207,7 @@ func resourceIotHubEndpointEventHubRead(d *pluginsdk.ResourceData, meta interfac
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					d.Set("connection_string", endpoint.ConnectionString)
+					d.Set("resource_group_name", endpoint.ResourceGroup)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
@@ -32,6 +32,21 @@ func TestAccIotHubEndpointEventHub_basic(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointEventHub_IotHubIdAndTwoResourceGroups(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIotHubIdAndTwoResourceGroups(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccIotHubEndpointEventHub_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
 	r := IotHubEndpointEventHubResource{}
@@ -126,24 +141,88 @@ resource "azurerm_iothub_endpoint_eventhub" "import" {
 `, r.basic(data))
 }
 
+func (IotHubEndpointEventHubResource) withIotHubIdAndTwoResourceGroups(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eventhub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctesteventhub-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  location            = azurerm_resource_group.test2.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "acctest"
+  iothub_id           = azurerm_iothub.test.id
+
+  connection_string = azurerm_eventhub_authorization_rule.test.primary_connection_string
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (t IotHubEndpointEventHubResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.EndpointEventhubID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	iothubName := id.IotHubName
-	endpointName := id.EndpointName
 
-	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, resourceGroup, iothubName)
+	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil || iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
-		return nil, fmt.Errorf("reading IotHuB Endpoint Eventhub (%s): %+v", id, err)
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
 	if endpoints := iothub.Properties.Routing.Endpoints.EventHubs; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
-				if strings.EqualFold(*existingEndpointName, endpointName) {
+				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					return utils.Bool(true), nil
 				}
 			}

--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -78,6 +78,12 @@ The following arguments are supported:
 
 * `connection_string` - (Required) The connection string for the endpoint.
 
+* `iothub_name` - (Optional) The IoTHub name for the endpoint.
+
+~> **NOTE:** The `iothub_name` property is deprecated, use `iothub_id` instead.
+
+* `iothub_id` - (Optional) The IoTHub ID for the endpoint.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
fixes #14304

Endpoints can be in a different resource group from the IotHub - using `iothub_id` allows for extracting the correct IotHub resource group in cases where it is different from the Endpoint resource group.
