### PR TITLE
`r\azurerm_cosmosdb_account` Fix #14439 and #14630 by setting default value to `default_identity_type` when API return a nil.

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -995,7 +995,11 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		d.Set("enable_free_tier", props.EnableFreeTier)
 		d.Set("analytical_storage_enabled", props.EnableAnalyticalStorage)
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess == documentdb.PublicNetworkAccessEnabled)
-		d.Set("default_identity_type", props.DefaultIdentity)
+		defaultIdentity := props.DefaultIdentity
+		if defaultIdentity == nil {
+			defaultIdentity = utils.String("FirstPartyIdentity")
+		}
+		d.Set("default_identity_type", defaultIdentity)
 		d.Set("create_mode", props.CreateMode)
 
 		if v := resp.IsVirtualNetworkFilterEnabled; v != nil {


### PR DESCRIPTION
>Terraform should instead be defaulting this implied default value in the Read function where this isn't returned from the API 

As @tombuildsstuff suggested in #14439 , this patch set a default value to `default_identity_type` when API return nil.