### PR TITLE
azurerm_blueprint_assignment  - Added lock_exclude_actions 

### DIFF
--- a/internal/services/blueprints/blueprint_assignment_resource.go
+++ b/internal/services/blueprints/blueprint_assignment_resource.go
@@ -100,6 +100,15 @@ func resourceBlueprintAssignment() *pluginsdk.Resource {
 				},
 			},
 
+			"lock_exclude_actions": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 200,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
 			"description": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -160,6 +169,11 @@ func resourceBlueprintAssignmentCreateUpdate(d *pluginsdk.ResourceData, meta int
 			excludedPrincipalsRaw := d.Get("lock_exclude_principals").([]interface{})
 			if len(excludedPrincipalsRaw) != 0 {
 				assignmentLockSettings.ExcludedPrincipals = utils.ExpandStringSlice(excludedPrincipalsRaw)
+			}
+
+			excludedActionsRaw := d.Get("lock_exclude_actions").([]interface{})
+			if len(excludedActionsRaw) != 0 {
+				assignmentLockSettings.ExcludedActions = utils.ExpandStringSlice(excludedActionsRaw)
 			}
 		}
 		assignment.AssignmentProperties.Locks = assignmentLockSettings
@@ -281,6 +295,9 @@ func resourceBlueprintAssignmentRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("lock_mode", locks.Mode)
 			if locks.ExcludedPrincipals != nil {
 				d.Set("lock_exclude_principals", locks.ExcludedPrincipals)
+			}
+			if locks.ExcludedActions != nil {
+				d.Set("lock_exclude_actions", locks.ExcludedActions)
 			}
 		}
 	}

--- a/internal/services/blueprints/blueprint_assignment_resource_test.go
+++ b/internal/services/blueprints/blueprint_assignment_resource_test.go
@@ -242,6 +242,10 @@ resource "azurerm_blueprint_assignment" "test" {
     data.azurerm_client_config.current.object_id,
   ]
 
+  lock_exclude_actions = [
+    "Microsoft.Resources/subscriptions/resourceGroups/write"
+  ]
+
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]

--- a/website/docs/r/blueprint_assignment.html.markdown
+++ b/website/docs/r/blueprint_assignment.html.markdown
@@ -128,6 +128,8 @@ resource "azurerm_blueprint_assignment" "example" {
 
 * `lock_exclude_principals` - (Optional) a list of up to 5 Principal IDs that are permitted to bypass the locks applied by the Blueprint.
 
+* `lock_exclude_actions` - (Optional) a list of up to 200 actions that are permitted to bypass the locks applied by the Blueprint.
+
 ---
 
 An `identity` block supports the following Arguments


### PR DESCRIPTION
Added support for lock_exclude_actions to the Blueprint assignment resource. This was added to the SDK not too long ago so just adding it into Terraform.