### PR TITLE
azurerm_recovery_services_vault: support storage_mode_type property

### DIFF
--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	BackupOperationStatusesClient             *backup.OperationStatusesClient
 	VaultsClient                              *recoveryservices.VaultsClient
 	VaultsConfigsClient                       *backup.ResourceVaultConfigsClient // Not sure why this is in backup, but https://github.com/Azure/azure-sdk-for-go/issues/7279
+	StorageConfigsClient                      *backup.ResourceStorageConfigsClient
 	FabricClient                              func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient
 	ProtectionContainerClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainersClient
 	ReplicationPoliciesClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationPoliciesClient
@@ -28,6 +29,9 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	vaultConfigsClient := backup.NewResourceVaultConfigsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultConfigsClient.Client, o.ResourceManagerAuthorizer)
+
+	storageConfigsClient := backup.NewResourceStorageConfigsClient(o.SubscriptionId)
+	o.ConfigureClient(&storageConfigsClient.Client, o.ResourceManagerAuthorizer)
 
 	vaultsClient := recoveryservices.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
@@ -99,6 +103,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		BackupOperationStatusesClient:             &backupOperationStatusesClient,
 		VaultsClient:                              &vaultsClient,
 		VaultsConfigsClient:                       &vaultConfigsClient,
+		StorageConfigsClient:                      &storageConfigsClient,
 		FabricClient:                              fabricClient,
 		ProtectionContainerClient:                 protectionContainerClient,
 		ReplicationPoliciesClient:                 replicationPoliciesClient,

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -198,8 +198,7 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		},
 	}
 
-	_, err = storageCfgsClient.Update(ctx, id.Name, id.ResourceGroup, storageCfg)
-	if err != nil {
+	if _, err = storageCfgsClient.Update(ctx, id.Name, id.ResourceGroup, storageCfg); err != nil {
 		return fmt.Errorf("updating Recovery Service Storage Cfg %s: %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -91,6 +91,16 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 				}, true),
 			},
 
+			"storage_mode_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  backup.StorageTypeGeoRedundant,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(backup.StorageTypeGeoRedundant),
+					string(backup.StorageTypeLocallyRedundant),
+				}, false),
+			},
+
 			"soft_delete_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -103,6 +113,7 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).RecoveryServices.VaultsClient
 	cfgsClient := meta.(*clients.Client).RecoveryServices.VaultsConfigsClient
+	storageCfgsClient := meta.(*clients.Client).RecoveryServices.StorageConfigsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -181,6 +192,17 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
 	}
 
+	storageCfg := backup.ResourceConfigResource{
+		Properties: &backup.ResourceConfig{
+			StorageModelType: backup.StorageType(d.Get("storage_mode_type").(string)),
+		},
+	}
+
+	_, err = storageCfgsClient.Update(ctx, id.Name, id.ResourceGroup, storageCfg)
+	if err != nil {
+		return fmt.Errorf("updating Recovery Service Storage Cfg %s: %+v", id.String(), err)
+	}
+
 	d.SetId(id.ID())
 	return resourceRecoveryServicesVaultRead(d, meta)
 }
@@ -188,6 +210,7 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).RecoveryServices.VaultsClient
 	cfgsClient := meta.(*clients.Client).RecoveryServices.VaultsConfigsClient
+	storageCfgsClient := meta.(*clients.Client).RecoveryServices.StorageConfigsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -226,6 +249,15 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 
 	if props := cfg.Properties; props != nil {
 		d.Set("soft_delete_enabled", props.SoftDeleteFeatureState == backup.SoftDeleteFeatureStateEnabled)
+	}
+
+	storageCfg, err := storageCfgsClient.Get(ctx, id.Name, id.ResourceGroup)
+	if err != nil {
+		return fmt.Errorf("reading Recovery Service storage Cfg %s: %+v", id.String(), err)
+	}
+
+	if props := storageCfg.Properties; props != nil {
+		d.Set("storage_mode_type", string(props.StorageModelType))
 	}
 
 	if err := d.Set("identity", flattenVaultIdentity(resp.Identity)); err != nil {

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -190,6 +190,7 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                 = "Standard"
 
   soft_delete_enabled = false
+  storage_mode_type   = "LocallyRedundant"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `sku` - (Required) Sets the vault's SKU. Possible values include: `Standard`, `RS0`.
 
+* `storage_mode_type` - (Optional) The storage type of the Recovery Services Vault. Possible values are `GeoRedundant` and `LocallyRedundant`. Defaults to `GeoRedundant`.
+
 * `soft_delete_enabled` - (Optional) Is soft delete enable for this Vault? Defaults to `true`.
 
 ---


### PR DESCRIPTION
The purpose of this PR:

Support `storage_mode_type` property for azurerm_recovery_services_vault resource.

Test Results:
PASS: TestAccRecoveryServicesVault_basic (137.86s)
PASS: TestAccRecoveryServicesVault_basicWithIdentity (168.08s)
PASS: TestAccRecoveryServicesVault_complete (201.89s)
PASS: TestAccRecoveryServicesVault_requiresImport (218.07s)
PASS: TestAccRecoveryServicesVault_update (296.40s)