### PR TITLE
Throwing an error for property `default_action` of the resource `servicebus_namespace_network_rule_set`

### DIFF
--- a/internal/services/desktopvirtualization/parse/scaling_plan.go
+++ b/internal/services/desktopvirtualization/parse/scaling_plan.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 type ScalingPlanId struct {
@@ -39,7 +39,7 @@ func (id ScalingPlanId) ID() string {
 
 // ScalingPlanID parses a ScalingPlan ID into an ScalingPlanId struct
 func ScalingPlanID(input string) (*ScalingPlanId, error) {
-	id, err := azure.ParseAzureResourceID(input)
+	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
@@ -128,7 +128,7 @@ func resourceServiceBusNamespaceNetworkRuleSetCreateUpdate(d *pluginsdk.Resource
 	ipRule := expandServiceBusNamespaceIPRules(d.Get("ip_rules").(*pluginsdk.Set).List())
 
 	// API doesn't accept "Deny" to be set for "default_action" if no "ip_rules" or "network_rules" is defined and returns no error message to the user
-	// The check won't be needed when 2021-11-01 API is released since service team will fail the update with bad request in that version
+	// TODO: The check won't be needed when 2021-11-01 API is released since service team will fail the update with bad request in that version
 	if defaultAction == servicebus.DefaultActionDeny && vnetRule == nil && ipRule == nil {
 		return fmt.Errorf(" The default action of %s can only be set to `Allow` if no `ip_rules` or `network_rules` is set", resourceId)
 	}

--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
@@ -128,6 +128,7 @@ func resourceServiceBusNamespaceNetworkRuleSetCreateUpdate(d *pluginsdk.Resource
 	ipRule := expandServiceBusNamespaceIPRules(d.Get("ip_rules").(*pluginsdk.Set).List())
 
 	// API doesn't accept "Deny" to be set for "default_action" if no "ip_rules" or "network_rules" is defined and returns no error message to the user
+	// The check won't be needed when 2021-11-01 API is released since service team will fail the update with bad request in that version
 	if defaultAction == servicebus.DefaultActionDeny && vnetRule == nil && ipRule == nil {
 		return fmt.Errorf(" The default action of %s can only be set to `Allow` if no `ip_rules` or `network_rules` is set", resourceId)
 	}


### PR DESCRIPTION
Resolving GH issue [#14001](https://github.com/hashicorp/terraform-provider-azurerm/issues/14001) The default action of the service bus namespace network rulesets can only be set to "Allow" if no `ip_rules` or `network_rules` is set, however, API doesn't throws an error if user pass the value "Deny" . API changed the value to "Allow" without notifying the user.

ACC test:

```log
--- PASS: TestAccServiceBusNamespaceNetworkRule_basic (546.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    547.616s

--- PASS: TestAccServiceBusNamespaceNetworkRule_complete (571.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    572.691s

--- PASS: TestAccServiceBusNamespaceNetworkRule_requiresImport (539.31s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    540.301s

--- PASS: TestAccServiceBusNamespaceNetworkRule_update (1219.89s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    1220.741s

```