### PR TITLE
sdk: updating the deprecated resource definition

### DIFF
--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -96,11 +96,23 @@ type ResourceWithUpdate interface {
 	Update() ResourceFunc
 }
 
-// ResourceWithDeprecation is an optional interface
+// ResourceWithDeprecationReplacedBy is an optional interface
 //
 // Resources implementing this interface will be marked as Deprecated
 // and output the DeprecationMessage during Terraform operations.
-type ResourceWithDeprecation interface {
+type ResourceWithDeprecationReplacedBy interface {
+	Resource
+
+	// DeprecatedInFavourOfResource returns the name of the resource that this has been deprecated in favour of
+	// NOTE: this must return a non-empty string
+	DeprecatedInFavourOfResource() string
+}
+
+// ResourceWithDeprecationAndNoReplacement is an optional interface
+//
+// Resources implementing this interface will be marked as Deprecated
+// and output the DeprecationMessage during Terraform operations.
+type ResourceWithDeprecationAndNoReplacement interface {
 	Resource
 
 	// DeprecationMessage returns the Deprecation message for this resource

--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -103,6 +103,7 @@ type ResourceWithUpdate interface {
 type ResourceWithDeprecationReplacedBy interface {
 	Resource
 
+	// nolint gocritic
 	// DeprecatedInFavourOfResource returns the name of the resource that this has been deprecated in favour of
 	// NOTE: this must return a non-empty string
 	DeprecatedInFavourOfResource() string
@@ -110,6 +111,7 @@ type ResourceWithDeprecationReplacedBy interface {
 
 // ResourceWithDeprecationAndNoReplacement is an optional interface
 //
+// nolint gocritic
 // Resources implementing this interface will be marked as Deprecated
 // and output the DeprecationMessage during Terraform operations.
 type ResourceWithDeprecationAndNoReplacement interface {


### PR DESCRIPTION
In this case we've got two deprecation types:

1. Deprecated without a replacement (for when something is EOL - where there should always be a message):

```go
var _ sdk.ResourceWithDeprecationAndNoReplacement = DisksPoolResource{}

func (d DisksPoolResource) DeprecationMessage() string {
	return "Deprecated because this service is EOL on 01/01/2022"
}
```

2. Deprecated with a replacement (for when it's been renamed etc - where we can use a standardized message):

```go
var _ sdk.ResourceWithDeprecationReplacedBy = DisksPoolResource{}

func (d DisksPoolResource) DeprecatedInFavourOfResource() string {
	return "azurerm_disks_pool"
}
```