### PR TITLE
disks: scaffolding the service package & adding the embedded sdk

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -40,6 +40,7 @@ import (
 	devspace "github.com/hashicorp/terraform-provider-azurerm/internal/services/devspace/client"
 	devtestlabs "github.com/hashicorp/terraform-provider-azurerm/internal/services/devtestlabs/client"
 	digitaltwins "github.com/hashicorp/terraform-provider-azurerm/internal/services/digitaltwins/client"
+	disks "github.com/hashicorp/terraform-provider-azurerm/internal/services/disks/client"
 	dns "github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/client"
 	domainservices "github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/client"
 	eventgrid "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid/client"
@@ -147,6 +148,7 @@ type Client struct {
 	DevSpace              *devspace.Client
 	DevTestLabs           *devtestlabs.Client
 	DigitalTwins          *digitaltwins.Client
+	Disks                 *disks.Client
 	Dns                   *dns.Client
 	DomainServices        *domainservices.Client
 	EventGrid             *eventgrid.Client
@@ -256,6 +258,7 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	client.DevSpace = devspace.NewClient(o)
 	client.DevTestLabs = devtestlabs.NewClient(o)
 	client.DigitalTwins = digitaltwins.NewClient(o)
+	client.Disks = disks.NewClient(o)
 	client.Dns = dns.NewClient(o)
 	client.DomainServices = domainservices.NewClient(o)
 	client.EventGrid = eventgrid.NewClient(o)

--- a/internal/services/disks/client/client.go
+++ b/internal/services/disks/client/client.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+type Client struct {
+}
+
+func NewClient(o *common.ClientOptions) *Client {
+	return &Client{}
+}

--- a/internal/services/disks/client/client.go
+++ b/internal/services/disks/client/client.go
@@ -2,11 +2,18 @@ package client
 
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/disks/sdk/2021-08-01/diskpools"
 )
 
 type Client struct {
+	DiskPoolsClient *diskpools.DiskPoolsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
-	return &Client{}
+	diskPoolsClient := diskpools.NewDiskPoolsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&diskPoolsClient.Client, o.ResourceManagerAuthorizer)
+
+	return &Client{
+		DiskPoolsClient: &diskPoolsClient,
+	}
 }

--- a/internal/services/disks/registration.go
+++ b/internal/services/disks/registration.go
@@ -1,0 +1,26 @@
+package disks
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+var _ sdk.TypedServiceRegistration = Registration{}
+
+type Registration struct{}
+
+func (r Registration) Name() string {
+	return "Disks"
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{}
+}
+
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		// TODO: introduce "Disks"
+		"Storage",
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/client.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/client.go
@@ -1,0 +1,15 @@
+package diskpools
+
+import "github.com/Azure/go-autorest/autorest"
+
+type DiskPoolsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewDiskPoolsClientWithBaseURI(endpoint string) DiskPoolsClient {
+	return DiskPoolsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/constants.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/constants.go
@@ -1,0 +1,129 @@
+package diskpools
+
+import "strings"
+
+type CreatedByType string
+
+const (
+	CreatedByTypeApplication     CreatedByType = "Application"
+	CreatedByTypeKey             CreatedByType = "Key"
+	CreatedByTypeManagedIdentity CreatedByType = "ManagedIdentity"
+	CreatedByTypeUser            CreatedByType = "User"
+)
+
+func PossibleValuesForCreatedByType() []string {
+	return []string{
+		string(CreatedByTypeApplication),
+		string(CreatedByTypeKey),
+		string(CreatedByTypeManagedIdentity),
+		string(CreatedByTypeUser),
+	}
+}
+
+func parseCreatedByType(input string) (*CreatedByType, error) {
+	vals := map[string]CreatedByType{
+		"application":     CreatedByTypeApplication,
+		"key":             CreatedByTypeKey,
+		"managedidentity": CreatedByTypeManagedIdentity,
+		"user":            CreatedByTypeUser,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CreatedByType(input)
+	return &out, nil
+}
+
+type OperationalStatus string
+
+const (
+	OperationalStatusHealthy            OperationalStatus = "Healthy"
+	OperationalStatusInvalid            OperationalStatus = "Invalid"
+	OperationalStatusRunning            OperationalStatus = "Running"
+	OperationalStatusStopped            OperationalStatus = "Stopped"
+	OperationalStatusStoppedDeallocated OperationalStatus = "Stopped (deallocated)"
+	OperationalStatusUnhealthy          OperationalStatus = "Unhealthy"
+	OperationalStatusUnknown            OperationalStatus = "Unknown"
+	OperationalStatusUpdating           OperationalStatus = "Updating"
+)
+
+func PossibleValuesForOperationalStatus() []string {
+	return []string{
+		string(OperationalStatusHealthy),
+		string(OperationalStatusInvalid),
+		string(OperationalStatusRunning),
+		string(OperationalStatusStopped),
+		string(OperationalStatusStoppedDeallocated),
+		string(OperationalStatusUnhealthy),
+		string(OperationalStatusUnknown),
+		string(OperationalStatusUpdating),
+	}
+}
+
+func parseOperationalStatus(input string) (*OperationalStatus, error) {
+	vals := map[string]OperationalStatus{
+		"healthy":               OperationalStatusHealthy,
+		"invalid":               OperationalStatusInvalid,
+		"running":               OperationalStatusRunning,
+		"stopped":               OperationalStatusStopped,
+		"stopped (deallocated)": OperationalStatusStoppedDeallocated,
+		"unhealthy":             OperationalStatusUnhealthy,
+		"unknown":               OperationalStatusUnknown,
+		"updating":              OperationalStatusUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationalStatus(input)
+	return &out, nil
+}
+
+type ProvisioningStates string
+
+const (
+	ProvisioningStatesCanceled  ProvisioningStates = "Canceled"
+	ProvisioningStatesCreating  ProvisioningStates = "Creating"
+	ProvisioningStatesDeleting  ProvisioningStates = "Deleting"
+	ProvisioningStatesFailed    ProvisioningStates = "Failed"
+	ProvisioningStatesInvalid   ProvisioningStates = "Invalid"
+	ProvisioningStatesPending   ProvisioningStates = "Pending"
+	ProvisioningStatesSucceeded ProvisioningStates = "Succeeded"
+	ProvisioningStatesUpdating  ProvisioningStates = "Updating"
+)
+
+func PossibleValuesForProvisioningStates() []string {
+	return []string{
+		string(ProvisioningStatesCanceled),
+		string(ProvisioningStatesCreating),
+		string(ProvisioningStatesDeleting),
+		string(ProvisioningStatesFailed),
+		string(ProvisioningStatesInvalid),
+		string(ProvisioningStatesPending),
+		string(ProvisioningStatesSucceeded),
+		string(ProvisioningStatesUpdating),
+	}
+}
+
+func parseProvisioningStates(input string) (*ProvisioningStates, error) {
+	vals := map[string]ProvisioningStates{
+		"canceled":  ProvisioningStatesCanceled,
+		"creating":  ProvisioningStatesCreating,
+		"deleting":  ProvisioningStatesDeleting,
+		"failed":    ProvisioningStatesFailed,
+		"invalid":   ProvisioningStatesInvalid,
+		"pending":   ProvisioningStatesPending,
+		"succeeded": ProvisioningStatesSucceeded,
+		"updating":  ProvisioningStatesUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningStates(input)
+	return &out, nil
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_diskpool.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_diskpool.go
@@ -1,0 +1,124 @@
+package diskpools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DiskPoolId{}
+
+// DiskPoolId is a struct representing the Resource ID for a Disk Pool
+type DiskPoolId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	DiskPoolName      string
+}
+
+// NewDiskPoolID returns a new DiskPoolId struct
+func NewDiskPoolID(subscriptionId string, resourceGroupName string, diskPoolName string) DiskPoolId {
+	return DiskPoolId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		DiskPoolName:      diskPoolName,
+	}
+}
+
+// ParseDiskPoolID parses 'input' into a DiskPoolId
+func ParseDiskPoolID(input string) (*DiskPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DiskPoolId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DiskPoolId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseDiskPoolIDInsensitively parses 'input' case-insensitively into a DiskPoolId
+// note: this method should only be used for API response data and not user input
+func ParseDiskPoolIDInsensitively(input string) (*DiskPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DiskPoolId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DiskPoolId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateDiskPoolID checks that 'input' can be parsed as a Disk Pool ID
+func ValidateDiskPoolID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDiskPoolID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Disk Pool ID
+func (id DiskPoolId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.StoragePool/diskPools/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.DiskPoolName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Disk Pool ID
+func (id DiskPoolId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStoragePool", "Microsoft.StoragePool", "Microsoft.StoragePool"),
+		resourceids.StaticSegment("staticDiskPools", "diskPools", "diskPools"),
+		resourceids.UserSpecifiedSegment("diskPoolName", "diskPoolValue"),
+	}
+}
+
+// String returns a human-readable description of this Disk Pool ID
+func (id DiskPoolId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Disk Pool Name: %q", id.DiskPoolName),
+	}
+	return fmt.Sprintf("Disk Pool (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_diskpool_test.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_diskpool_test.go
@@ -1,0 +1,279 @@
+package diskpools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DiskPoolId{}
+
+func TestNewDiskPoolID(t *testing.T) {
+	id := NewDiskPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.DiskPoolName != "diskPoolValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'DiskPoolName'", id.DiskPoolName, "diskPoolValue")
+	}
+}
+
+func TestFormatDiskPoolID(t *testing.T) {
+	actual := NewDiskPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseDiskPoolID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DiskPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseDiskPoolID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+	}
+}
+
+func TestParseDiskPoolIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DiskPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				DiskPoolName:      "dIsKpOoLvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseDiskPoolIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+	}
+}
+
+func TestSegmentsForDiskPoolId(t *testing.T) {
+	segments := DiskPoolId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("DiskPoolId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_resourcegroup.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_resourcegroup.go
@@ -1,0 +1,109 @@
+package diskpools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ResourceGroupId{}
+
+// ResourceGroupId is a struct representing the Resource ID for a Resource Group
+type ResourceGroupId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+}
+
+// NewResourceGroupID returns a new ResourceGroupId struct
+func NewResourceGroupID(subscriptionId string, resourceGroupName string) ResourceGroupId {
+	return ResourceGroupId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+	}
+}
+
+// ParseResourceGroupID parses 'input' into a ResourceGroupId
+func ParseResourceGroupID(input string) (*ResourceGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ResourceGroupId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ResourceGroupId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseResourceGroupIDInsensitively parses 'input' case-insensitively into a ResourceGroupId
+// note: this method should only be used for API response data and not user input
+func ParseResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ResourceGroupId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ResourceGroupId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateResourceGroupID checks that 'input' can be parsed as a Resource Group ID
+func ValidateResourceGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseResourceGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Resource Group ID
+func (id ResourceGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Resource Group ID
+func (id ResourceGroupId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+	}
+}
+
+// String returns a human-readable description of this Resource Group ID
+func (id ResourceGroupId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+	}
+	return fmt.Sprintf("Resource Group (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_resourcegroup_test.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_resourcegroup_test.go
@@ -1,0 +1,204 @@
+package diskpools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ResourceGroupId{}
+
+func TestNewResourceGroupID(t *testing.T) {
+	id := NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+}
+
+func TestFormatResourceGroupID(t *testing.T) {
+	actual := NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseResourceGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Expected: &ResourceGroupId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseResourceGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+	}
+}
+
+func TestParseResourceGroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Expected: &ResourceGroupId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Expected: &ResourceGroupId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseResourceGroupIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+	}
+}
+
+func TestSegmentsForResourceGroupId(t *testing.T) {
+	segments := ResourceGroupId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ResourceGroupId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_subscription.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_subscription.go
@@ -1,0 +1,96 @@
+package diskpools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = SubscriptionId{}
+
+// SubscriptionId is a struct representing the Resource ID for a Subscription
+type SubscriptionId struct {
+	SubscriptionId string
+}
+
+// NewSubscriptionID returns a new SubscriptionId struct
+func NewSubscriptionID(subscriptionId string) SubscriptionId {
+	return SubscriptionId{
+		SubscriptionId: subscriptionId,
+	}
+}
+
+// ParseSubscriptionID parses 'input' into a SubscriptionId
+func ParseSubscriptionID(input string) (*SubscriptionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(SubscriptionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := SubscriptionId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseSubscriptionIDInsensitively parses 'input' case-insensitively into a SubscriptionId
+// note: this method should only be used for API response data and not user input
+func ParseSubscriptionIDInsensitively(input string) (*SubscriptionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(SubscriptionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := SubscriptionId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateSubscriptionID checks that 'input' can be parsed as a Subscription ID
+func ValidateSubscriptionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSubscriptionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Subscription ID
+func (id SubscriptionId) ID() string {
+	fmtString := "/subscriptions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Subscription ID
+func (id SubscriptionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+	}
+}
+
+// String returns a human-readable description of this Subscription ID
+func (id SubscriptionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+	}
+	return fmt.Sprintf("Subscription (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/id_subscription_test.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/id_subscription_test.go
@@ -1,0 +1,159 @@
+package diskpools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = SubscriptionId{}
+
+func TestNewSubscriptionID(t *testing.T) {
+	id := NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+}
+
+func TestFormatSubscriptionID(t *testing.T) {
+	actual := NewSubscriptionID("12345678-1234-9876-4563-123456789012").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseSubscriptionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Expected: &SubscriptionId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+	}
+}
+
+func TestParseSubscriptionIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Expected: &SubscriptionId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Expected: &SubscriptionId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseSubscriptionIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+	}
+}
+
+func TestSegmentsForSubscriptionId(t *testing.T) {
+	segments := SubscriptionId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("SubscriptionId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_createorupdate_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_createorupdate_autorest.go
@@ -1,0 +1,75 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type CreateOrUpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c DiskPoolsClient) CreateOrUpdate(ctx context.Context, id DiskPoolId, input DiskPoolCreate) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c DiskPoolsClient) CreateOrUpdateThenPoll(ctx context.Context, id DiskPoolId, input DiskPoolCreate) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c DiskPoolsClient) preparerForCreateOrUpdate(ctx context.Context, id DiskPoolId, input DiskPoolCreate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_deallocate_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_deallocate_autorest.go
@@ -1,0 +1,74 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type DeallocateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Deallocate ...
+func (c DiskPoolsClient) Deallocate(ctx context.Context, id DiskPoolId) (result DeallocateResponse, err error) {
+	req, err := c.preparerForDeallocate(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Deallocate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDeallocate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Deallocate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeallocateThenPoll performs Deallocate then polls until it's completed
+func (c DiskPoolsClient) DeallocateThenPoll(ctx context.Context, id DiskPoolId) error {
+	result, err := c.Deallocate(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Deallocate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Deallocate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDeallocate prepares the Deallocate request.
+func (c DiskPoolsClient) preparerForDeallocate(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/deallocate", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDeallocate sends the Deallocate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForDeallocate(ctx context.Context, req *http.Request) (future DeallocateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_delete_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_delete_autorest.go
@@ -1,0 +1,73 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type DeleteResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c DiskPoolsClient) Delete(ctx context.Context, id DiskPoolId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c DiskPoolsClient) DeleteThenPoll(ctx context.Context, id DiskPoolId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c DiskPoolsClient) preparerForDelete(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_get_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_get_autorest.go
@@ -1,0 +1,64 @@
+package diskpools
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *DiskPool
+}
+
+// Get ...
+func (c DiskPoolsClient) Get(ctx context.Context, id DiskPoolId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c DiskPoolsClient) preparerForGet(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c DiskPoolsClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_listbyresourcegroup_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,183 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListByResourceGroupResponse struct {
+	HttpResponse *http.Response
+	Model        *[]DiskPool
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByResourceGroupResponse, error)
+}
+
+type ListByResourceGroupCompleteResult struct {
+	Items []DiskPool
+}
+
+func (r ListByResourceGroupResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByResourceGroupResponse) LoadMore(ctx context.Context) (resp ListByResourceGroupResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByResourceGroup ...
+func (c DiskPoolsClient) ListByResourceGroup(ctx context.Context, id ResourceGroupId) (resp ListByResourceGroupResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListByResourceGroupComplete retrieves all of the results into a single object
+func (c DiskPoolsClient) ListByResourceGroupComplete(ctx context.Context, id ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, DiskPoolPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DiskPoolsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id ResourceGroupId, predicate DiskPoolPredicate) (resp ListByResourceGroupCompleteResult, err error) {
+	items := make([]DiskPool, 0)
+
+	page, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c DiskPoolsClient) preparerForListByResourceGroup(ctx context.Context, id ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.StoragePool/diskPools", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByResourceGroupWithNextLink prepares the ListByResourceGroup request with the given nextLink token.
+func (c DiskPoolsClient) preparerForListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c DiskPoolsClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupResponse, err error) {
+	type page struct {
+		Values   []DiskPool `json:"value"`
+		NextLink *string    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByResourceGroupResponse, err error) {
+			req, err := c.preparerForListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_listbysubscription_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_listbysubscription_autorest.go
@@ -1,0 +1,183 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListBySubscriptionResponse struct {
+	HttpResponse *http.Response
+	Model        *[]DiskPool
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListBySubscriptionResponse, error)
+}
+
+type ListBySubscriptionCompleteResult struct {
+	Items []DiskPool
+}
+
+func (r ListBySubscriptionResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListBySubscriptionResponse) LoadMore(ctx context.Context) (resp ListBySubscriptionResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListBySubscription ...
+func (c DiskPoolsClient) ListBySubscription(ctx context.Context, id SubscriptionId) (resp ListBySubscriptionResponse, err error) {
+	req, err := c.preparerForListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListBySubscriptionComplete retrieves all of the results into a single object
+func (c DiskPoolsClient) ListBySubscriptionComplete(ctx context.Context, id SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, DiskPoolPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DiskPoolsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id SubscriptionId, predicate DiskPoolPredicate) (resp ListBySubscriptionCompleteResult, err error) {
+	items := make([]DiskPool, 0)
+
+	page, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListBySubscription prepares the ListBySubscription request.
+func (c DiskPoolsClient) preparerForListBySubscription(ctx context.Context, id SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.StoragePool/diskPools", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListBySubscriptionWithNextLink prepares the ListBySubscription request with the given nextLink token.
+func (c DiskPoolsClient) preparerForListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListBySubscription handles the response to the ListBySubscription request. The method always
+// closes the http.Response Body.
+func (c DiskPoolsClient) responderForListBySubscription(resp *http.Response) (result ListBySubscriptionResponse, err error) {
+	type page struct {
+		Values   []DiskPool `json:"value"`
+		NextLink *string    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListBySubscriptionResponse, err error) {
+			req, err := c.preparerForListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_listoutboundnetworkdependenciesendpoints_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_listoutboundnetworkdependenciesendpoints_autorest.go
@@ -1,0 +1,183 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListOutboundNetworkDependenciesEndpointsResponse struct {
+	HttpResponse *http.Response
+	Model        *[]OutboundEnvironmentEndpoint
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOutboundNetworkDependenciesEndpointsResponse, error)
+}
+
+type ListOutboundNetworkDependenciesEndpointsCompleteResult struct {
+	Items []OutboundEnvironmentEndpoint
+}
+
+func (r ListOutboundNetworkDependenciesEndpointsResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOutboundNetworkDependenciesEndpointsResponse) LoadMore(ctx context.Context) (resp ListOutboundNetworkDependenciesEndpointsResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListOutboundNetworkDependenciesEndpoints ...
+func (c DiskPoolsClient) ListOutboundNetworkDependenciesEndpoints(ctx context.Context, id DiskPoolId) (resp ListOutboundNetworkDependenciesEndpointsResponse, err error) {
+	req, err := c.preparerForListOutboundNetworkDependenciesEndpoints(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListOutboundNetworkDependenciesEndpoints(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListOutboundNetworkDependenciesEndpointsComplete retrieves all of the results into a single object
+func (c DiskPoolsClient) ListOutboundNetworkDependenciesEndpointsComplete(ctx context.Context, id DiskPoolId) (ListOutboundNetworkDependenciesEndpointsCompleteResult, error) {
+	return c.ListOutboundNetworkDependenciesEndpointsCompleteMatchingPredicate(ctx, id, OutboundEnvironmentEndpointPredicate{})
+}
+
+// ListOutboundNetworkDependenciesEndpointsCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DiskPoolsClient) ListOutboundNetworkDependenciesEndpointsCompleteMatchingPredicate(ctx context.Context, id DiskPoolId, predicate OutboundEnvironmentEndpointPredicate) (resp ListOutboundNetworkDependenciesEndpointsCompleteResult, err error) {
+	items := make([]OutboundEnvironmentEndpoint, 0)
+
+	page, err := c.ListOutboundNetworkDependenciesEndpoints(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListOutboundNetworkDependenciesEndpointsCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListOutboundNetworkDependenciesEndpoints prepares the ListOutboundNetworkDependenciesEndpoints request.
+func (c DiskPoolsClient) preparerForListOutboundNetworkDependenciesEndpoints(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/outboundNetworkDependenciesEndpoints", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListOutboundNetworkDependenciesEndpointsWithNextLink prepares the ListOutboundNetworkDependenciesEndpoints request with the given nextLink token.
+func (c DiskPoolsClient) preparerForListOutboundNetworkDependenciesEndpointsWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListOutboundNetworkDependenciesEndpoints handles the response to the ListOutboundNetworkDependenciesEndpoints request. The method always
+// closes the http.Response Body.
+func (c DiskPoolsClient) responderForListOutboundNetworkDependenciesEndpoints(resp *http.Response) (result ListOutboundNetworkDependenciesEndpointsResponse, err error) {
+	type page struct {
+		Values   []OutboundEnvironmentEndpoint `json:"value"`
+		NextLink *string                       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOutboundNetworkDependenciesEndpointsResponse, err error) {
+			req, err := c.preparerForListOutboundNetworkDependenciesEndpointsWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListOutboundNetworkDependenciesEndpoints(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "ListOutboundNetworkDependenciesEndpoints", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_start_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_start_autorest.go
@@ -1,0 +1,74 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type StartResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Start ...
+func (c DiskPoolsClient) Start(ctx context.Context, id DiskPoolId) (result StartResponse, err error) {
+	req, err := c.preparerForStart(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Start", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForStart(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Start", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// StartThenPoll performs Start then polls until it's completed
+func (c DiskPoolsClient) StartThenPoll(ctx context.Context, id DiskPoolId) error {
+	result, err := c.Start(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Start: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Start: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForStart prepares the Start request.
+func (c DiskPoolsClient) preparerForStart(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/start", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForStart sends the Start request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForStart(ctx context.Context, req *http.Request) (future StartResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_update_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_update_autorest.go
@@ -1,0 +1,75 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type UpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c DiskPoolsClient) Update(ctx context.Context, id DiskPoolId, input DiskPoolUpdate) (result UpdateResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c DiskPoolsClient) UpdateThenPoll(ctx context.Context, id DiskPoolId, input DiskPoolUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c DiskPoolsClient) preparerForUpdate(ctx context.Context, id DiskPoolId, input DiskPoolUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/method_upgrade_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/method_upgrade_autorest.go
@@ -1,0 +1,74 @@
+package diskpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type UpgradeResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Upgrade ...
+func (c DiskPoolsClient) Upgrade(ctx context.Context, id DiskPoolId) (result UpgradeResponse, err error) {
+	req, err := c.preparerForUpgrade(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Upgrade", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpgrade(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpools.DiskPoolsClient", "Upgrade", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpgradeThenPoll performs Upgrade then polls until it's completed
+func (c DiskPoolsClient) UpgradeThenPoll(ctx context.Context, id DiskPoolId) error {
+	result, err := c.Upgrade(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Upgrade: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Upgrade: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpgrade prepares the Upgrade request.
+func (c DiskPoolsClient) preparerForUpgrade(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/upgrade", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpgrade sends the Upgrade request. The method will close the
+// http.Response Body if it receives an error.
+func (c DiskPoolsClient) senderForUpgrade(ctx context.Context, req *http.Request) (future UpgradeResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_disk.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_disk.go
@@ -1,0 +1,5 @@
+package diskpools
+
+type Disk struct {
+	Id string `json:"id"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpool.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpool.go
@@ -1,0 +1,14 @@
+package diskpools
+
+type DiskPool struct {
+	Id                *string            `json:"id,omitempty"`
+	Location          string             `json:"location"`
+	ManagedBy         *string            `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string          `json:"managedByExtended,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Properties        DiskPoolProperties `json:"properties"`
+	Sku               *Sku               `json:"sku,omitempty"`
+	SystemData        *SystemMetadata    `json:"systemData,omitempty"`
+	Tags              *map[string]string `json:"tags,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolcreate.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolcreate.go
@@ -1,0 +1,13 @@
+package diskpools
+
+type DiskPoolCreate struct {
+	Id                *string                  `json:"id,omitempty"`
+	Location          string                   `json:"location"`
+	ManagedBy         *string                  `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string                `json:"managedByExtended,omitempty"`
+	Name              *string                  `json:"name,omitempty"`
+	Properties        DiskPoolCreateProperties `json:"properties"`
+	Sku               Sku                      `json:"sku"`
+	Tags              *map[string]string       `json:"tags,omitempty"`
+	Type              *string                  `json:"type,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolcreateproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolcreateproperties.go
@@ -1,0 +1,8 @@
+package diskpools
+
+type DiskPoolCreateProperties struct {
+	AdditionalCapabilities *[]string `json:"additionalCapabilities,omitempty"`
+	AvailabilityZones      *[]string `json:"availabilityZones,omitempty"`
+	Disks                  *[]Disk   `json:"disks,omitempty"`
+	SubnetId               string    `json:"subnetId"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolproperties.go
@@ -1,0 +1,10 @@
+package diskpools
+
+type DiskPoolProperties struct {
+	AdditionalCapabilities *[]string          `json:"additionalCapabilities,omitempty"`
+	AvailabilityZones      []string           `json:"availabilityZones"`
+	Disks                  *[]Disk            `json:"disks,omitempty"`
+	ProvisioningState      ProvisioningStates `json:"provisioningState"`
+	Status                 OperationalStatus  `json:"status"`
+	SubnetId               string             `json:"subnetId"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolupdate.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolupdate.go
@@ -1,0 +1,9 @@
+package diskpools
+
+type DiskPoolUpdate struct {
+	ManagedBy         *string                  `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string                `json:"managedByExtended,omitempty"`
+	Properties        DiskPoolUpdateProperties `json:"properties"`
+	Sku               *Sku                     `json:"sku,omitempty"`
+	Tags              *map[string]string       `json:"tags,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolupdateproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_diskpoolupdateproperties.go
@@ -1,0 +1,5 @@
+package diskpools
+
+type DiskPoolUpdateProperties struct {
+	Disks *[]Disk `json:"disks,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_endpointdependency.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_endpointdependency.go
@@ -1,0 +1,6 @@
+package diskpools
+
+type EndpointDependency struct {
+	DomainName      *string           `json:"domainName,omitempty"`
+	EndpointDetails *[]EndpointDetail `json:"endpointDetails,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_endpointdetail.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_endpointdetail.go
@@ -1,0 +1,8 @@
+package diskpools
+
+type EndpointDetail struct {
+	IpAddress    *string  `json:"ipAddress,omitempty"`
+	IsAccessible *bool    `json:"isAccessible,omitempty"`
+	Latency      *float64 `json:"latency,omitempty"`
+	Port         *int64   `json:"port,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_outboundenvironmentendpoint.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_outboundenvironmentendpoint.go
@@ -1,0 +1,6 @@
+package diskpools
+
+type OutboundEnvironmentEndpoint struct {
+	Category  *string               `json:"category,omitempty"`
+	Endpoints *[]EndpointDependency `json:"endpoints,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_sku.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_sku.go
@@ -1,0 +1,6 @@
+package diskpools
+
+type Sku struct {
+	Name string  `json:"name"`
+	Tier *string `json:"tier,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/model_systemmetadata.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/model_systemmetadata.go
@@ -1,0 +1,40 @@
+package diskpools
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+type SystemMetadata struct {
+	CreatedAt          *string        `json:"createdAt,omitempty"`
+	CreatedBy          *string        `json:"createdBy,omitempty"`
+	CreatedByType      *CreatedByType `json:"createdByType,omitempty"`
+	LastModifiedAt     *string        `json:"lastModifiedAt,omitempty"`
+	LastModifiedBy     *string        `json:"lastModifiedBy,omitempty"`
+	LastModifiedByType *CreatedByType `json:"lastModifiedByType,omitempty"`
+}
+
+func (o SystemMetadata) GetCreatedAtAsTime() (*time.Time, error) {
+	if o.CreatedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemMetadata) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o SystemMetadata) GetLastModifiedAtAsTime() (*time.Time, error) {
+	if o.LastModifiedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastModifiedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemMetadata) SetLastModifiedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastModifiedAt = &formatted
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/predicates.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/predicates.go
@@ -1,0 +1,47 @@
+package diskpools
+
+type DiskPoolPredicate struct {
+	Id        *string
+	Location  *string
+	ManagedBy *string
+	Name      *string
+	Type      *string
+}
+
+func (p DiskPoolPredicate) Matches(input DiskPool) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.ManagedBy != nil && (input.ManagedBy == nil && *p.ManagedBy != *input.ManagedBy) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type OutboundEnvironmentEndpointPredicate struct {
+	Category *string
+}
+
+func (p OutboundEnvironmentEndpointPredicate) Matches(input OutboundEnvironmentEndpoint) bool {
+
+	if p.Category != nil && (input.Category == nil && *p.Category != *input.Category) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpools/version.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpools/version.go
@@ -1,0 +1,9 @@
+package diskpools
+
+import "fmt"
+
+const defaultApiVersion = "2021-08-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/diskpools/%s", defaultApiVersion)
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/client.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/client.go
@@ -1,0 +1,15 @@
+package diskpoolzones
+
+import "github.com/Azure/go-autorest/autorest"
+
+type DiskPoolZonesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewDiskPoolZonesClientWithBaseURI(endpoint string) DiskPoolZonesClient {
+	return DiskPoolZonesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/id_location.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/id_location.go
@@ -1,0 +1,111 @@
+package diskpoolzones
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	Location       string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, location string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.StoragePool/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStoragePool", "Microsoft.StoragePool", "Microsoft.StoragePool"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/id_location_test.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/id_location_test.go
@@ -1,0 +1,234 @@
+package diskpoolzones
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+func TestNewLocationID(t *testing.T) {
+	id := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+}
+
+func TestFormatLocationID(t *testing.T) {
+	actual := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseLocationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestParseLocationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs/lOcAtIoNvAlUe",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs/lOcAtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestSegmentsForLocationId(t *testing.T) {
+	segments := LocationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("LocationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/method_list_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/method_list_autorest.go
@@ -1,0 +1,183 @@
+package diskpoolzones
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListResponse struct {
+	HttpResponse *http.Response
+	Model        *[]DiskPoolZoneInfo
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []DiskPoolZoneInfo
+}
+
+func (r ListResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c DiskPoolZonesClient) List(ctx context.Context, id LocationId) (resp ListResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c DiskPoolZonesClient) ListComplete(ctx context.Context, id LocationId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, DiskPoolZoneInfoPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DiskPoolZonesClient) ListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate DiskPoolZoneInfoPredicate) (resp ListCompleteResult, err error) {
+	items := make([]DiskPoolZoneInfo, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForList prepares the List request.
+func (c DiskPoolZonesClient) preparerForList(ctx context.Context, id LocationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/diskPoolZones", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c DiskPoolZonesClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c DiskPoolZonesClient) responderForList(resp *http.Response) (result ListResponse, err error) {
+	type page struct {
+		Values   []DiskPoolZoneInfo `json:"value"`
+		NextLink *string            `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "diskpoolzones.DiskPoolZonesClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/model_diskpoolzoneinfo.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/model_diskpoolzoneinfo.go
@@ -1,0 +1,7 @@
+package diskpoolzones
+
+type DiskPoolZoneInfo struct {
+	AdditionalCapabilities *[]string `json:"additionalCapabilities,omitempty"`
+	AvailabilityZones      *[]string `json:"availabilityZones,omitempty"`
+	Sku                    *Sku      `json:"sku,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/model_sku.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/model_sku.go
@@ -1,0 +1,6 @@
+package diskpoolzones
+
+type Sku struct {
+	Name string  `json:"name"`
+	Tier *string `json:"tier,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/predicates.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/predicates.go
@@ -1,0 +1,9 @@
+package diskpoolzones
+
+type DiskPoolZoneInfoPredicate struct {
+}
+
+func (p DiskPoolZoneInfoPredicate) Matches(input DiskPoolZoneInfo) bool {
+
+	return true
+}

--- a/internal/services/disks/sdk/2021-08-01/diskpoolzones/version.go
+++ b/internal/services/disks/sdk/2021-08-01/diskpoolzones/version.go
@@ -1,0 +1,9 @@
+package diskpoolzones
+
+import "fmt"
+
+const defaultApiVersion = "2021-08-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/diskpoolzones/%s", defaultApiVersion)
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/client.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/client.go
@@ -1,0 +1,15 @@
+package iscsitargets
+
+import "github.com/Azure/go-autorest/autorest"
+
+type IscsiTargetsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewIscsiTargetsClientWithBaseURI(endpoint string) IscsiTargetsClient {
+	return IscsiTargetsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/constants.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/constants.go
@@ -1,0 +1,157 @@
+package iscsitargets
+
+import "strings"
+
+type CreatedByType string
+
+const (
+	CreatedByTypeApplication     CreatedByType = "Application"
+	CreatedByTypeKey             CreatedByType = "Key"
+	CreatedByTypeManagedIdentity CreatedByType = "ManagedIdentity"
+	CreatedByTypeUser            CreatedByType = "User"
+)
+
+func PossibleValuesForCreatedByType() []string {
+	return []string{
+		string(CreatedByTypeApplication),
+		string(CreatedByTypeKey),
+		string(CreatedByTypeManagedIdentity),
+		string(CreatedByTypeUser),
+	}
+}
+
+func parseCreatedByType(input string) (*CreatedByType, error) {
+	vals := map[string]CreatedByType{
+		"application":     CreatedByTypeApplication,
+		"key":             CreatedByTypeKey,
+		"managedidentity": CreatedByTypeManagedIdentity,
+		"user":            CreatedByTypeUser,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CreatedByType(input)
+	return &out, nil
+}
+
+type IscsiTargetAclMode string
+
+const (
+	IscsiTargetAclModeDynamic IscsiTargetAclMode = "Dynamic"
+	IscsiTargetAclModeStatic  IscsiTargetAclMode = "Static"
+)
+
+func PossibleValuesForIscsiTargetAclMode() []string {
+	return []string{
+		string(IscsiTargetAclModeDynamic),
+		string(IscsiTargetAclModeStatic),
+	}
+}
+
+func parseIscsiTargetAclMode(input string) (*IscsiTargetAclMode, error) {
+	vals := map[string]IscsiTargetAclMode{
+		"dynamic": IscsiTargetAclModeDynamic,
+		"static":  IscsiTargetAclModeStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IscsiTargetAclMode(input)
+	return &out, nil
+}
+
+type OperationalStatus string
+
+const (
+	OperationalStatusHealthy            OperationalStatus = "Healthy"
+	OperationalStatusInvalid            OperationalStatus = "Invalid"
+	OperationalStatusRunning            OperationalStatus = "Running"
+	OperationalStatusStopped            OperationalStatus = "Stopped"
+	OperationalStatusStoppedDeallocated OperationalStatus = "Stopped (deallocated)"
+	OperationalStatusUnhealthy          OperationalStatus = "Unhealthy"
+	OperationalStatusUnknown            OperationalStatus = "Unknown"
+	OperationalStatusUpdating           OperationalStatus = "Updating"
+)
+
+func PossibleValuesForOperationalStatus() []string {
+	return []string{
+		string(OperationalStatusHealthy),
+		string(OperationalStatusInvalid),
+		string(OperationalStatusRunning),
+		string(OperationalStatusStopped),
+		string(OperationalStatusStoppedDeallocated),
+		string(OperationalStatusUnhealthy),
+		string(OperationalStatusUnknown),
+		string(OperationalStatusUpdating),
+	}
+}
+
+func parseOperationalStatus(input string) (*OperationalStatus, error) {
+	vals := map[string]OperationalStatus{
+		"healthy":               OperationalStatusHealthy,
+		"invalid":               OperationalStatusInvalid,
+		"running":               OperationalStatusRunning,
+		"stopped":               OperationalStatusStopped,
+		"stopped (deallocated)": OperationalStatusStoppedDeallocated,
+		"unhealthy":             OperationalStatusUnhealthy,
+		"unknown":               OperationalStatusUnknown,
+		"updating":              OperationalStatusUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationalStatus(input)
+	return &out, nil
+}
+
+type ProvisioningStates string
+
+const (
+	ProvisioningStatesCanceled  ProvisioningStates = "Canceled"
+	ProvisioningStatesCreating  ProvisioningStates = "Creating"
+	ProvisioningStatesDeleting  ProvisioningStates = "Deleting"
+	ProvisioningStatesFailed    ProvisioningStates = "Failed"
+	ProvisioningStatesInvalid   ProvisioningStates = "Invalid"
+	ProvisioningStatesPending   ProvisioningStates = "Pending"
+	ProvisioningStatesSucceeded ProvisioningStates = "Succeeded"
+	ProvisioningStatesUpdating  ProvisioningStates = "Updating"
+)
+
+func PossibleValuesForProvisioningStates() []string {
+	return []string{
+		string(ProvisioningStatesCanceled),
+		string(ProvisioningStatesCreating),
+		string(ProvisioningStatesDeleting),
+		string(ProvisioningStatesFailed),
+		string(ProvisioningStatesInvalid),
+		string(ProvisioningStatesPending),
+		string(ProvisioningStatesSucceeded),
+		string(ProvisioningStatesUpdating),
+	}
+}
+
+func parseProvisioningStates(input string) (*ProvisioningStates, error) {
+	vals := map[string]ProvisioningStates{
+		"canceled":  ProvisioningStatesCanceled,
+		"creating":  ProvisioningStatesCreating,
+		"deleting":  ProvisioningStatesDeleting,
+		"failed":    ProvisioningStatesFailed,
+		"invalid":   ProvisioningStatesInvalid,
+		"pending":   ProvisioningStatesPending,
+		"succeeded": ProvisioningStatesSucceeded,
+		"updating":  ProvisioningStatesUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningStates(input)
+	return &out, nil
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/id_diskpool.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/id_diskpool.go
@@ -1,0 +1,124 @@
+package iscsitargets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DiskPoolId{}
+
+// DiskPoolId is a struct representing the Resource ID for a Disk Pool
+type DiskPoolId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	DiskPoolName      string
+}
+
+// NewDiskPoolID returns a new DiskPoolId struct
+func NewDiskPoolID(subscriptionId string, resourceGroupName string, diskPoolName string) DiskPoolId {
+	return DiskPoolId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		DiskPoolName:      diskPoolName,
+	}
+}
+
+// ParseDiskPoolID parses 'input' into a DiskPoolId
+func ParseDiskPoolID(input string) (*DiskPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DiskPoolId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DiskPoolId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseDiskPoolIDInsensitively parses 'input' case-insensitively into a DiskPoolId
+// note: this method should only be used for API response data and not user input
+func ParseDiskPoolIDInsensitively(input string) (*DiskPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DiskPoolId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DiskPoolId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateDiskPoolID checks that 'input' can be parsed as a Disk Pool ID
+func ValidateDiskPoolID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDiskPoolID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Disk Pool ID
+func (id DiskPoolId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.StoragePool/diskPools/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.DiskPoolName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Disk Pool ID
+func (id DiskPoolId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStoragePool", "Microsoft.StoragePool", "Microsoft.StoragePool"),
+		resourceids.StaticSegment("staticDiskPools", "diskPools", "diskPools"),
+		resourceids.UserSpecifiedSegment("diskPoolName", "diskPoolValue"),
+	}
+}
+
+// String returns a human-readable description of this Disk Pool ID
+func (id DiskPoolId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Disk Pool Name: %q", id.DiskPoolName),
+	}
+	return fmt.Sprintf("Disk Pool (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/id_diskpool_test.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/id_diskpool_test.go
@@ -1,0 +1,279 @@
+package iscsitargets
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DiskPoolId{}
+
+func TestNewDiskPoolID(t *testing.T) {
+	id := NewDiskPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.DiskPoolName != "diskPoolValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'DiskPoolName'", id.DiskPoolName, "diskPoolValue")
+	}
+}
+
+func TestFormatDiskPoolID(t *testing.T) {
+	actual := NewDiskPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseDiskPoolID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DiskPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseDiskPoolID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+	}
+}
+
+func TestParseDiskPoolIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DiskPoolId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe",
+			Expected: &DiskPoolId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				DiskPoolName:      "dIsKpOoLvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseDiskPoolIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+	}
+}
+
+func TestSegmentsForDiskPoolId(t *testing.T) {
+	segments := DiskPoolId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("DiskPoolId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/id_iscsitarget.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/id_iscsitarget.go
@@ -1,0 +1,137 @@
+package iscsitargets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = IscsiTargetId{}
+
+// IscsiTargetId is a struct representing the Resource ID for a Iscsi Target
+type IscsiTargetId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	DiskPoolName      string
+	IscsiTargetName   string
+}
+
+// NewIscsiTargetID returns a new IscsiTargetId struct
+func NewIscsiTargetID(subscriptionId string, resourceGroupName string, diskPoolName string, iscsiTargetName string) IscsiTargetId {
+	return IscsiTargetId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		DiskPoolName:      diskPoolName,
+		IscsiTargetName:   iscsiTargetName,
+	}
+}
+
+// ParseIscsiTargetID parses 'input' into a IscsiTargetId
+func ParseIscsiTargetID(input string) (*IscsiTargetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(IscsiTargetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := IscsiTargetId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	if id.IscsiTargetName, ok = parsed.Parsed["iscsiTargetName"]; !ok {
+		return nil, fmt.Errorf("the segment 'iscsiTargetName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseIscsiTargetIDInsensitively parses 'input' case-insensitively into a IscsiTargetId
+// note: this method should only be used for API response data and not user input
+func ParseIscsiTargetIDInsensitively(input string) (*IscsiTargetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(IscsiTargetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := IscsiTargetId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
+		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+	}
+
+	if id.IscsiTargetName, ok = parsed.Parsed["iscsiTargetName"]; !ok {
+		return nil, fmt.Errorf("the segment 'iscsiTargetName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateIscsiTargetID checks that 'input' can be parsed as a Iscsi Target ID
+func ValidateIscsiTargetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseIscsiTargetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Iscsi Target ID
+func (id IscsiTargetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.StoragePool/diskPools/%s/iscsiTargets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.DiskPoolName, id.IscsiTargetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Iscsi Target ID
+func (id IscsiTargetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStoragePool", "Microsoft.StoragePool", "Microsoft.StoragePool"),
+		resourceids.StaticSegment("staticDiskPools", "diskPools", "diskPools"),
+		resourceids.UserSpecifiedSegment("diskPoolName", "diskPoolValue"),
+		resourceids.StaticSegment("staticIscsiTargets", "iscsiTargets", "iscsiTargets"),
+		resourceids.UserSpecifiedSegment("iscsiTargetName", "iscsiTargetValue"),
+	}
+}
+
+// String returns a human-readable description of this Iscsi Target ID
+func (id IscsiTargetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Disk Pool Name: %q", id.DiskPoolName),
+		fmt.Sprintf("Iscsi Target Name: %q", id.IscsiTargetName),
+	}
+	return fmt.Sprintf("Iscsi Target (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/id_iscsitarget_test.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/id_iscsitarget_test.go
@@ -1,0 +1,324 @@
+package iscsitargets
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = IscsiTargetId{}
+
+func TestNewIscsiTargetID(t *testing.T) {
+	id := NewIscsiTargetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue", "iscsiTargetValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.DiskPoolName != "diskPoolValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'DiskPoolName'", id.DiskPoolName, "diskPoolValue")
+	}
+
+	if id.IscsiTargetName != "iscsiTargetValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'IscsiTargetName'", id.IscsiTargetName, "iscsiTargetValue")
+	}
+}
+
+func TestFormatIscsiTargetID(t *testing.T) {
+	actual := NewIscsiTargetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "diskPoolValue", "iscsiTargetValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets/iscsiTargetValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseIscsiTargetID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *IscsiTargetId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets/iscsiTargetValue",
+			Expected: &IscsiTargetId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+				IscsiTargetName:   "iscsiTargetValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets/iscsiTargetValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseIscsiTargetID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+		if actual.IscsiTargetName != v.Expected.IscsiTargetName {
+			t.Fatalf("Expected %q but got %q for IscsiTargetName", v.Expected.IscsiTargetName, actual.IscsiTargetName)
+		}
+
+	}
+}
+
+func TestParseIscsiTargetIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *IscsiTargetId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe/iScSiTaRgEtS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets/iscsiTargetValue",
+			Expected: &IscsiTargetId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				DiskPoolName:      "diskPoolValue",
+				IscsiTargetName:   "iscsiTargetValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.StoragePool/diskPools/diskPoolValue/iscsiTargets/iscsiTargetValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe/iScSiTaRgEtS/iScSiTaRgEtVaLuE",
+			Expected: &IscsiTargetId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				DiskPoolName:      "dIsKpOoLvAlUe",
+				IscsiTargetName:   "iScSiTaRgEtVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/dIsKpOoLs/dIsKpOoLvAlUe/iScSiTaRgEtS/iScSiTaRgEtVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseIscsiTargetIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.DiskPoolName != v.Expected.DiskPoolName {
+			t.Fatalf("Expected %q but got %q for DiskPoolName", v.Expected.DiskPoolName, actual.DiskPoolName)
+		}
+
+		if actual.IscsiTargetName != v.Expected.IscsiTargetName {
+			t.Fatalf("Expected %q but got %q for IscsiTargetName", v.Expected.IscsiTargetName, actual.IscsiTargetName)
+		}
+
+	}
+}
+
+func TestSegmentsForIscsiTargetId(t *testing.T) {
+	segments := IscsiTargetId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("IscsiTargetId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/method_createorupdate_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/method_createorupdate_autorest.go
@@ -1,0 +1,75 @@
+package iscsitargets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type CreateOrUpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c IscsiTargetsClient) CreateOrUpdate(ctx context.Context, id IscsiTargetId, input IscsiTargetCreate) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c IscsiTargetsClient) CreateOrUpdateThenPoll(ctx context.Context, id IscsiTargetId, input IscsiTargetCreate) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c IscsiTargetsClient) preparerForCreateOrUpdate(ctx context.Context, id IscsiTargetId, input IscsiTargetCreate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c IscsiTargetsClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/method_delete_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/method_delete_autorest.go
@@ -1,0 +1,73 @@
+package iscsitargets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type DeleteResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c IscsiTargetsClient) Delete(ctx context.Context, id IscsiTargetId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c IscsiTargetsClient) DeleteThenPoll(ctx context.Context, id IscsiTargetId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c IscsiTargetsClient) preparerForDelete(ctx context.Context, id IscsiTargetId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c IscsiTargetsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/method_get_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/method_get_autorest.go
@@ -1,0 +1,64 @@
+package iscsitargets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *IscsiTarget
+}
+
+// Get ...
+func (c IscsiTargetsClient) Get(ctx context.Context, id IscsiTargetId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c IscsiTargetsClient) preparerForGet(ctx context.Context, id IscsiTargetId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c IscsiTargetsClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/method_listbydiskpool_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/method_listbydiskpool_autorest.go
@@ -1,0 +1,183 @@
+package iscsitargets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListByDiskPoolResponse struct {
+	HttpResponse *http.Response
+	Model        *[]IscsiTarget
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByDiskPoolResponse, error)
+}
+
+type ListByDiskPoolCompleteResult struct {
+	Items []IscsiTarget
+}
+
+func (r ListByDiskPoolResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByDiskPoolResponse) LoadMore(ctx context.Context) (resp ListByDiskPoolResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByDiskPool ...
+func (c IscsiTargetsClient) ListByDiskPool(ctx context.Context, id DiskPoolId) (resp ListByDiskPoolResponse, err error) {
+	req, err := c.preparerForListByDiskPool(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByDiskPool(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListByDiskPoolComplete retrieves all of the results into a single object
+func (c IscsiTargetsClient) ListByDiskPoolComplete(ctx context.Context, id DiskPoolId) (ListByDiskPoolCompleteResult, error) {
+	return c.ListByDiskPoolCompleteMatchingPredicate(ctx, id, IscsiTargetPredicate{})
+}
+
+// ListByDiskPoolCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c IscsiTargetsClient) ListByDiskPoolCompleteMatchingPredicate(ctx context.Context, id DiskPoolId, predicate IscsiTargetPredicate) (resp ListByDiskPoolCompleteResult, err error) {
+	items := make([]IscsiTarget, 0)
+
+	page, err := c.ListByDiskPool(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByDiskPoolCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListByDiskPool prepares the ListByDiskPool request.
+func (c IscsiTargetsClient) preparerForListByDiskPool(ctx context.Context, id DiskPoolId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/iscsiTargets", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByDiskPoolWithNextLink prepares the ListByDiskPool request with the given nextLink token.
+func (c IscsiTargetsClient) preparerForListByDiskPoolWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByDiskPool handles the response to the ListByDiskPool request. The method always
+// closes the http.Response Body.
+func (c IscsiTargetsClient) responderForListByDiskPool(resp *http.Response) (result ListByDiskPoolResponse, err error) {
+	type page struct {
+		Values   []IscsiTarget `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByDiskPoolResponse, err error) {
+			req, err := c.preparerForListByDiskPoolWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByDiskPool(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "ListByDiskPool", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/method_update_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/method_update_autorest.go
@@ -1,0 +1,75 @@
+package iscsitargets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type UpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c IscsiTargetsClient) Update(ctx context.Context, id IscsiTargetId, input IscsiTargetUpdate) (result UpdateResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "iscsitargets.IscsiTargetsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c IscsiTargetsClient) UpdateThenPoll(ctx context.Context, id IscsiTargetId, input IscsiTargetUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c IscsiTargetsClient) preparerForUpdate(ctx context.Context, id IscsiTargetId, input IscsiTargetUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c IscsiTargetsClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_acl.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_acl.go
@@ -1,0 +1,6 @@
+package iscsitargets
+
+type Acl struct {
+	InitiatorIqn string   `json:"initiatorIqn"`
+	MappedLuns   []string `json:"mappedLuns"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsilun.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsilun.go
@@ -1,0 +1,7 @@
+package iscsitargets
+
+type IscsiLun struct {
+	Lun                        *int64 `json:"lun,omitempty"`
+	ManagedDiskAzureResourceId string `json:"managedDiskAzureResourceId"`
+	Name                       string `json:"name"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitarget.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitarget.go
@@ -1,0 +1,11 @@
+package iscsitargets
+
+type IscsiTarget struct {
+	Id                *string               `json:"id,omitempty"`
+	ManagedBy         *string               `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string             `json:"managedByExtended,omitempty"`
+	Name              *string               `json:"name,omitempty"`
+	Properties        IscsiTargetProperties `json:"properties"`
+	SystemData        *SystemMetadata       `json:"systemData,omitempty"`
+	Type              *string               `json:"type,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetcreate.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetcreate.go
@@ -1,0 +1,10 @@
+package iscsitargets
+
+type IscsiTargetCreate struct {
+	Id                *string                     `json:"id,omitempty"`
+	ManagedBy         *string                     `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string                   `json:"managedByExtended,omitempty"`
+	Name              *string                     `json:"name,omitempty"`
+	Properties        IscsiTargetCreateProperties `json:"properties"`
+	Type              *string                     `json:"type,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetcreateproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetcreateproperties.go
@@ -1,0 +1,8 @@
+package iscsitargets
+
+type IscsiTargetCreateProperties struct {
+	AclMode    IscsiTargetAclMode `json:"aclMode"`
+	Luns       *[]IscsiLun        `json:"luns,omitempty"`
+	StaticAcls *[]Acl             `json:"staticAcls,omitempty"`
+	TargetIqn  *string            `json:"targetIqn,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetproperties.go
@@ -1,0 +1,13 @@
+package iscsitargets
+
+type IscsiTargetProperties struct {
+	AclMode           IscsiTargetAclMode `json:"aclMode"`
+	Endpoints         *[]string          `json:"endpoints,omitempty"`
+	Luns              *[]IscsiLun        `json:"luns,omitempty"`
+	Port              *int64             `json:"port,omitempty"`
+	ProvisioningState ProvisioningStates `json:"provisioningState"`
+	Sessions          *[]string          `json:"sessions,omitempty"`
+	StaticAcls        *[]Acl             `json:"staticAcls,omitempty"`
+	Status            OperationalStatus  `json:"status"`
+	TargetIqn         string             `json:"targetIqn"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetupdate.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetupdate.go
@@ -1,0 +1,10 @@
+package iscsitargets
+
+type IscsiTargetUpdate struct {
+	Id                *string                     `json:"id,omitempty"`
+	ManagedBy         *string                     `json:"managedBy,omitempty"`
+	ManagedByExtended *[]string                   `json:"managedByExtended,omitempty"`
+	Name              *string                     `json:"name,omitempty"`
+	Properties        IscsiTargetUpdateProperties `json:"properties"`
+	Type              *string                     `json:"type,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetupdateproperties.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_iscsitargetupdateproperties.go
@@ -1,0 +1,6 @@
+package iscsitargets
+
+type IscsiTargetUpdateProperties struct {
+	Luns       *[]IscsiLun `json:"luns,omitempty"`
+	StaticAcls *[]Acl      `json:"staticAcls,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/model_systemmetadata.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/model_systemmetadata.go
@@ -1,0 +1,40 @@
+package iscsitargets
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+type SystemMetadata struct {
+	CreatedAt          *string        `json:"createdAt,omitempty"`
+	CreatedBy          *string        `json:"createdBy,omitempty"`
+	CreatedByType      *CreatedByType `json:"createdByType,omitempty"`
+	LastModifiedAt     *string        `json:"lastModifiedAt,omitempty"`
+	LastModifiedBy     *string        `json:"lastModifiedBy,omitempty"`
+	LastModifiedByType *CreatedByType `json:"lastModifiedByType,omitempty"`
+}
+
+func (o SystemMetadata) GetCreatedAtAsTime() (*time.Time, error) {
+	if o.CreatedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemMetadata) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o SystemMetadata) GetLastModifiedAtAsTime() (*time.Time, error) {
+	if o.LastModifiedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastModifiedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemMetadata) SetLastModifiedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastModifiedAt = &formatted
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/predicates.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/predicates.go
@@ -1,0 +1,29 @@
+package iscsitargets
+
+type IscsiTargetPredicate struct {
+	Id        *string
+	ManagedBy *string
+	Name      *string
+	Type      *string
+}
+
+func (p IscsiTargetPredicate) Matches(input IscsiTarget) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.ManagedBy != nil && (input.ManagedBy == nil && *p.ManagedBy != *input.ManagedBy) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/disks/sdk/2021-08-01/iscsitargets/version.go
+++ b/internal/services/disks/sdk/2021-08-01/iscsitargets/version.go
@@ -1,0 +1,9 @@
+package iscsitargets
+
+import "fmt"
+
+const defaultApiVersion = "2021-08-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/iscsitargets/%s", defaultApiVersion)
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/client.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/client.go
@@ -1,0 +1,15 @@
+package resourceskus
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ResourceSkusClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewResourceSkusClientWithBaseURI(endpoint string) ResourceSkusClient {
+	return ResourceSkusClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/constants.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/constants.go
@@ -1,0 +1,59 @@
+package resourceskus
+
+import "strings"
+
+type ResourceSkuRestrictionsReasonCode string
+
+const (
+	ResourceSkuRestrictionsReasonCodeNotAvailableForSubscription ResourceSkuRestrictionsReasonCode = "NotAvailableForSubscription"
+	ResourceSkuRestrictionsReasonCodeQuotaId                     ResourceSkuRestrictionsReasonCode = "QuotaId"
+)
+
+func PossibleValuesForResourceSkuRestrictionsReasonCode() []string {
+	return []string{
+		string(ResourceSkuRestrictionsReasonCodeNotAvailableForSubscription),
+		string(ResourceSkuRestrictionsReasonCodeQuotaId),
+	}
+}
+
+func parseResourceSkuRestrictionsReasonCode(input string) (*ResourceSkuRestrictionsReasonCode, error) {
+	vals := map[string]ResourceSkuRestrictionsReasonCode{
+		"notavailableforsubscription": ResourceSkuRestrictionsReasonCodeNotAvailableForSubscription,
+		"quotaid":                     ResourceSkuRestrictionsReasonCodeQuotaId,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceSkuRestrictionsReasonCode(input)
+	return &out, nil
+}
+
+type ResourceSkuRestrictionsType string
+
+const (
+	ResourceSkuRestrictionsTypeLocation ResourceSkuRestrictionsType = "Location"
+	ResourceSkuRestrictionsTypeZone     ResourceSkuRestrictionsType = "Zone"
+)
+
+func PossibleValuesForResourceSkuRestrictionsType() []string {
+	return []string{
+		string(ResourceSkuRestrictionsTypeLocation),
+		string(ResourceSkuRestrictionsTypeZone),
+	}
+}
+
+func parseResourceSkuRestrictionsType(input string) (*ResourceSkuRestrictionsType, error) {
+	vals := map[string]ResourceSkuRestrictionsType{
+		"location": ResourceSkuRestrictionsTypeLocation,
+		"zone":     ResourceSkuRestrictionsTypeZone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceSkuRestrictionsType(input)
+	return &out, nil
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/id_location.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/id_location.go
@@ -1,0 +1,111 @@
+package resourceskus
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	Location       string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, location string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.StoragePool/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStoragePool", "Microsoft.StoragePool", "Microsoft.StoragePool"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/id_location_test.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/id_location_test.go
@@ -1,0 +1,234 @@
+package resourceskus
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+func TestNewLocationID(t *testing.T) {
+	id := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+}
+
+func TestFormatLocationID(t *testing.T) {
+	actual := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseLocationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestParseLocationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.StoragePool/locations/locationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs/lOcAtIoNvAlUe",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.sToRaGePoOl/lOcAtIoNs/lOcAtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestSegmentsForLocationId(t *testing.T) {
+	segments := LocationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("LocationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/method_list_autorest.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/method_list_autorest.go
@@ -1,0 +1,183 @@
+package resourceskus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ResourceSkuInfo
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ResourceSkuInfo
+}
+
+func (r ListResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ResourceSkusClient) List(ctx context.Context, id LocationId) (resp ListResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ResourceSkusClient) ListComplete(ctx context.Context, id LocationId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ResourceSkuInfoPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ResourceSkusClient) ListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate ResourceSkuInfoPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ResourceSkuInfo, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForList prepares the List request.
+func (c ResourceSkusClient) preparerForList(ctx context.Context, id LocationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/skus", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ResourceSkusClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ResourceSkusClient) responderForList(resp *http.Response) (result ListResponse, err error) {
+	type page struct {
+		Values   []ResourceSkuInfo `json:"value"`
+		NextLink *string           `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "resourceskus.ResourceSkusClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskucapability.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskucapability.go
@@ -1,0 +1,6 @@
+package resourceskus
+
+type ResourceSkuCapability struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskuinfo.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskuinfo.go
@@ -1,0 +1,11 @@
+package resourceskus
+
+type ResourceSkuInfo struct {
+	ApiVersion   *string                    `json:"apiVersion,omitempty"`
+	Capabilities *[]ResourceSkuCapability   `json:"capabilities,omitempty"`
+	LocationInfo *ResourceSkuLocationInfo   `json:"locationInfo,omitempty"`
+	Name         *string                    `json:"name,omitempty"`
+	ResourceType *string                    `json:"resourceType,omitempty"`
+	Restrictions *[]ResourceSkuRestrictions `json:"restrictions,omitempty"`
+	Tier         *string                    `json:"tier,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskulocationinfo.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskulocationinfo.go
@@ -1,0 +1,7 @@
+package resourceskus
+
+type ResourceSkuLocationInfo struct {
+	Location    *string                   `json:"location,omitempty"`
+	ZoneDetails *[]ResourceSkuZoneDetails `json:"zoneDetails,omitempty"`
+	Zones       *[]string                 `json:"zones,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskurestrictioninfo.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskurestrictioninfo.go
@@ -1,0 +1,6 @@
+package resourceskus
+
+type ResourceSkuRestrictionInfo struct {
+	Locations *[]string `json:"locations,omitempty"`
+	Zones     *[]string `json:"zones,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskurestrictions.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskurestrictions.go
@@ -1,0 +1,8 @@
+package resourceskus
+
+type ResourceSkuRestrictions struct {
+	ReasonCode      *ResourceSkuRestrictionsReasonCode `json:"reasonCode,omitempty"`
+	RestrictionInfo *ResourceSkuRestrictionInfo        `json:"restrictionInfo,omitempty"`
+	Type            *ResourceSkuRestrictionsType       `json:"type,omitempty"`
+	Values          *[]string                          `json:"values,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskuzonedetails.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/model_resourceskuzonedetails.go
@@ -1,0 +1,6 @@
+package resourceskus
+
+type ResourceSkuZoneDetails struct {
+	Capabilities *[]ResourceSkuCapability `json:"capabilities,omitempty"`
+	Name         *[]string                `json:"name,omitempty"`
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/predicates.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/predicates.go
@@ -1,0 +1,29 @@
+package resourceskus
+
+type ResourceSkuInfoPredicate struct {
+	ApiVersion   *string
+	Name         *string
+	ResourceType *string
+	Tier         *string
+}
+
+func (p ResourceSkuInfoPredicate) Matches(input ResourceSkuInfo) bool {
+
+	if p.ApiVersion != nil && (input.ApiVersion == nil && *p.ApiVersion != *input.ApiVersion) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.ResourceType != nil && (input.ResourceType == nil && *p.ResourceType != *input.ResourceType) {
+		return false
+	}
+
+	if p.Tier != nil && (input.Tier == nil && *p.Tier != *input.Tier) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/disks/sdk/2021-08-01/resourceskus/version.go
+++ b/internal/services/disks/sdk/2021-08-01/resourceskus/version.go
@@ -1,0 +1,9 @@
+package resourceskus
+
+import "fmt"
+
+const defaultApiVersion = "2021-08-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/resourceskus/%s", defaultApiVersion)
+}

--- a/internal/services/disks/validate/disk_pool_name.go
+++ b/internal/services/disks/validate/disk_pool_name.go
@@ -1,0 +1,19 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func DiskPoolName() pluginsdk.SchemaValidateFunc {
+	return validation.All(
+		validation.StringIsNotEmpty,
+		validation.StringLenBetween(7, 30),
+		validation.StringMatch(
+			regexp.MustCompile(`^[A-Za-z\d][A-Za-z\d.\-_]*[A-Za-z\d_]$`),
+			"The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens.",
+		),
+	)
+}

--- a/internal/services/disks/validate/disk_pool_sku.go
+++ b/internal/services/disks/validate/disk_pool_sku.go
@@ -1,0 +1,16 @@
+package validate
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func DiskPoolSku() pluginsdk.SchemaValidateFunc {
+	return validation.StringInSlice(
+		[]string{
+			"Basic_B1",
+			"Standard_S1",
+			"Premium_P1",
+		}, false,
+	)
+}


### PR DESCRIPTION
Foundational work for splitting out Disk Pools into their own service package - since this has been incorrectly added to the `storage` package when it's unrelated (and so also needs renaming etc).