### PR TITLE
Tooling: update golangci-lint output to line-number for visibility in GHA build logs

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -24,4 +24,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: 'v1.41.1'
-          args: -v
+          args: -v --out-format=line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,3 +42,6 @@ linters-settings:
       - exportfs
   nakedret:
     max-func-lines: 40
+
+output:
+  format: line-number

--- a/internal/services/advisor/advisor_recommendations_data_source.go
+++ b/internal/services/advisor/advisor_recommendations_data_source.go
@@ -189,6 +189,7 @@ func flattenAzureRmAdvisorRecommendations(recommends []advisor.ResourceRecommend
 	}
 
 	return result
+	return nil
 }
 
 func expandAzureRmAdvisorRecommendationsMapString(t string, input []interface{}) string {


### PR DESCRIPTION
Note: This change will remove the annotations in the Diffs but provide better detail in the build logs on failure. Not all linting failures result in useful annotation.