### PR TITLE
Adds `startsWith` as an operator for `dynamic_criteria` in `azurerm_monitor_metric_alert`

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -217,6 +217,7 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											"Include",
 											"Exclude",
+											"StartsWith",
 										}, false),
 									},
 									"values": {


### PR DESCRIPTION
Closes #14678

This PR changes the validation for the `dynamic_criteria.dimension.operator` field, adding the `StartsWith` as a valid operator, just like #12181.