### PR TITLE
fix to fqdn behaviour on backend pool

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -176,7 +176,6 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						"fqdns": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
-							MinItems: 1,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
 								ValidateFunc: validation.NoZeroValues,


### PR DESCRIPTION
fqdns is an optional field. However, on creating a dynamic block and passing in an empty list it errors due to the minimum count being 1.

this should work but it doesn't:
```
locals {
      backend_address_pool = [
        {
          name            = "beap-01"
          fqdns            = [] # setting to null also fails
          ip_addresses = []
        }
      ]
}

dynamic "backend_address_pool" {
    for_each = local.backend_address_pool

    content {
      name            = backend_address_pool.value.name
      fqdns            = backend_address_pool.value.fqdns
      ip_addresses = backend_address_pool.value.ip_addresses
    }
  }
```
Error: Attribute requires 1 item minimum, but config has only 0 declared

However, this works:
```
backend_address_pool {
      name            = "beap-01"
}
```