### PR TITLE
IotHub Endpoints: deprecate `iothub_name` in favour of `iothub_id` cont.

### DIFF
--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -47,11 +47,25 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			// TODO remove in 3.0
 			"iothub_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.IoTHubName,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  validate.IoTHubName,
+				Deprecated:    "Deprecated in favour of `iothub_id`",
+				ConflictsWith: []string{"iothub_id"},
+			},
+
+			"iothub_id": {
+				Type: pluginsdk.TypeString,
+				// TODO add Required: true in 3.0
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  validate.IotHubID,
+				ConflictsWith: []string{"iothub_name"},
 			},
 
 			"connection_string": {
@@ -78,25 +92,38 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 	defer cancel()
 	subscriptionID := meta.(*clients.Client).Account.SubscriptionId
 
-	id := parse.NewEndpointServiceBusQueueID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iothub_name").(string), d.Get("name").(string))
+	endpointRG := d.Get("resource_group_name").(string)
+	iotHubName := d.Get("iothub_name").(string)
+	iotHubRG := endpointRG
 
-	locks.ByName(id.IotHubName, IothubResourceName)
-	defer locks.UnlockByName(id.IotHubName, IothubResourceName)
+	if iotHubName == "" {
+		id, err := parse.IotHubID(d.Get("iothub_id").(string))
+		if err != nil {
+			return err
+		}
+		iotHubName = id.Name
+		iotHubRG = id.ResourceGroup
+	}
 
-	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
+	id := parse.NewEndpointServiceBusQueueID(subscriptionId, iotHubRG, iotHubName, d.Get("name").(string))
+
+	locks.ByName(iotHubName, IothubResourceName)
+	defer locks.UnlockByName(iotHubName, IothubResourceName)
+
+	iothub, err := client.Get(ctx, iotHubRG, iotHubName)
 	if err != nil {
 		if utils.ResponseWasNotFound(iothub.Response) {
-			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", id.IotHubName, id.ResourceGroup)
+			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", iotHubName, iotHubRG)
 		}
 
-		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
+		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", iotHubName, iotHubRG, err)
 	}
 
 	queueEndpoint := devices.RoutingServiceBusQueueEndpointProperties{
 		ConnectionString: utils.String(d.Get("connection_string").(string)),
 		Name:             utils.String(id.EndpointName),
 		SubscriptionID:   utils.String(subscriptionID),
-		ResourceGroup:    utils.String(id.ResourceGroup),
+		ResourceGroup:    utils.String(endpointRG),
 	}
 
 	routing := iothub.Properties.Routing
@@ -136,7 +163,7 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 	}
 	routing.Endpoints.ServiceBusQueues = &endpoints
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IotHubName, iothub, "")
+	future, err := client.CreateOrUpdate(ctx, iotHubRG, iotHubName, iothub, "")
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
@@ -167,7 +194,9 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 
 	d.Set("name", id.EndpointName)
 	d.Set("iothub_name", id.IotHubName)
-	d.Set("resource_group_name", id.ResourceGroup)
+
+	iotHubId := parse.NewIotHubID(id.SubscriptionId, id.ResourceGroup, id.IotHubName)
+	d.Set("iothub_id", iotHubId.ID())
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
 		return nil
@@ -178,6 +207,7 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					d.Set("connection_string", endpoint.ConnectionString)
+					d.Set("resource_group_name", endpoint.ResourceGroup)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
@@ -32,6 +32,21 @@ func TestAccIotHubEndpointServiceBusQueue_basic(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointServiceBusQueue_IotHubIdAndTwoResourceGroups(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_queue", "test")
+	r := IotHubEndpointServiceBusQueueResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIotHubIdAndTwoResourceGroups(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccIotHubEndpointServiceBusQueue_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_queue", "test")
 	r := IotHubEndpointServiceBusQueueResource{}
@@ -126,24 +141,88 @@ resource "azurerm_iothub_endpoint_servicebus_queue" "import" {
 `, r.basic(data))
 }
 
+func (IotHubEndpointServiceBusQueueResource) withIotHubIdAndTwoResourceGroups(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eventhub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_queue" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_servicebus_namespace.test.name
+
+  enable_partitioning = true
+}
+
+resource "azurerm_servicebus_queue_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  queue_name          = azurerm_servicebus_queue.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  location            = azurerm_resource_group.test2.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_endpoint_servicebus_queue" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "acctest"
+  iothub_id           = azurerm_iothub.test.id
+
+  connection_string = azurerm_servicebus_queue_authorization_rule.test.primary_connection_string
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (t IotHubEndpointServiceBusQueueResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.EndpointServiceBusQueueID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	iothubName := id.IotHubName
-	endpointName := id.EndpointName
 
-	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, resourceGroup, iothubName)
+	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil || iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
-		return nil, fmt.Errorf("reading IotHuB Endpoint Service Bus (%s): %+v", id, err)
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
 	if endpoints := iothub.Properties.Routing.Endpoints.ServiceBusQueues; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
-				if strings.EqualFold(*existingEndpointName, endpointName) {
+				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					return utils.Bool(true), nil
 				}
 			}

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
@@ -32,6 +32,21 @@ func TestAccIotHubEndpointServiceBusTopic_basic(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointServiceBusTopic_IotHubIdAndTwoResourceGroups(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIotHubIdAndTwoResourceGroups(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccIotHubEndpointServiceBusTopic_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
 	r := IotHubEndpointServiceBusTopicResource{}
@@ -124,24 +139,86 @@ resource "azurerm_iothub_endpoint_servicebus_topic" "import" {
 `, r.basic(data))
 }
 
+func (IotHubEndpointServiceBusTopicResource) withIotHubIdAndTwoResourceGroups(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eventhub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name                = "acctestservicebustopic-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  location            = azurerm_resource_group.test2.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "acctest"
+  iothub_id           = azurerm_iothub.test.id
+
+  connection_string = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (t IotHubEndpointServiceBusTopicResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.EndpointServiceBusTopicID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	iothubName := id.IotHubName
-	endpointName := id.EndpointName
 
-	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, resourceGroup, iothubName)
+	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil || iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
-		return nil, fmt.Errorf("reading IotHuB Endpoint Service Bus Topics (%s): %+v", id, err)
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
 	if endpoints := iothub.Properties.Routing.Endpoints.ServiceBusTopics; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
-				if strings.EqualFold(*existingEndpointName, endpointName) {
+				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					return utils.Bool(true), nil
 				}
 			}

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -50,11 +50,25 @@ func resourceIotHubEndpointStorageContainer() *pluginsdk.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			// TODO remove in 3.0
 			"iothub_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: iothubValidate.IoTHubName,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  iothubValidate.IoTHubName,
+				Deprecated:    "Deprecated in favour of `iothub_id`",
+				ConflictsWith: []string{"iothub_id"},
+			},
+
+			"iothub_id": {
+				Type: pluginsdk.TypeString,
+				// TODO add Required: true in 3.0
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  iothubValidate.IotHubID,
+				ConflictsWith: []string{"iothub_name"},
 			},
 
 			"container_name": {
@@ -119,18 +133,31 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 	defer cancel()
 	subscriptionID := meta.(*clients.Client).Account.SubscriptionId
 
-	id := parse.NewEndpointStorageContainerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iothub_name").(string), d.Get("name").(string))
+	endpointRG := d.Get("resource_group_name").(string)
+	iotHubName := d.Get("iothub_name").(string)
+	iotHubRG := endpointRG
 
-	locks.ByName(id.IotHubName, IothubResourceName)
-	defer locks.UnlockByName(id.IotHubName, IothubResourceName)
+	if iotHubName == "" {
+		id, err := parse.IotHubID(d.Get("iothub_id").(string))
+		if err != nil {
+			return err
+		}
+		iotHubName = id.Name
+		iotHubRG = id.ResourceGroup
+	}
 
-	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
+	id := parse.NewEndpointStorageContainerID(subscriptionId, iotHubRG, iotHubName, d.Get("name").(string))
+
+	locks.ByName(iotHubName, IothubResourceName)
+	defer locks.UnlockByName(iotHubName, IothubResourceName)
+
+	iothub, err := client.Get(ctx, iotHubRG, iotHubName)
 	if err != nil {
 		if utils.ResponseWasNotFound(iothub.Response) {
-			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", id.IotHubName, id.ResourceGroup)
+			return fmt.Errorf("IotHub %q (Resource Group %q) was not found", iotHubName, iotHubRG)
 		}
 
-		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
+		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", iotHubName, iotHubRG, err)
 	}
 
 	connectionStr := d.Get("connection_string").(string)
@@ -144,7 +171,7 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 		ConnectionString:        &connectionStr,
 		Name:                    &id.EndpointName,
 		SubscriptionID:          &subscriptionID,
-		ResourceGroup:           &id.ResourceGroup,
+		ResourceGroup:           &endpointRG,
 		ContainerName:           &containerName,
 		FileNameFormat:          &fileNameFormat,
 		BatchFrequencyInSeconds: &batchFrequencyInSeconds,
@@ -191,7 +218,7 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 	}
 	routing.Endpoints.StorageContainers = &endpoints
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IotHubName, iothub, "")
+	future, err := client.CreateOrUpdate(ctx, iotHubRG, iotHubName, iothub, "")
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
@@ -222,7 +249,9 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 
 	d.Set("name", id.EndpointName)
 	d.Set("iothub_name", id.IotHubName)
-	d.Set("resource_group_name", id.ResourceGroup)
+
+	iotHubId := parse.NewIotHubID(id.SubscriptionId, id.ResourceGroup, id.IotHubName)
+	d.Set("iothub_id", iotHubId.ID())
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
 		return nil
@@ -238,6 +267,7 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 					d.Set("batch_frequency_in_seconds", endpoint.BatchFrequencyInSeconds)
 					d.Set("max_chunk_size_in_bytes", endpoint.MaxChunkSizeInBytes)
 					d.Set("encoding", endpoint.Encoding)
+					d.Set("resource_group_name", endpoint.ResourceGroup)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
@@ -51,6 +51,21 @@ func TestAccIotHubEndpointStorageContainer_complete(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointStorageContainer_IotHubIdAndTwoResourceGroups(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIotHubIdAndTwoResourceGroups(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccIotHubEndpointStorageContainer_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
 	r := IotHubEndpointStorageContainerResource{}
@@ -196,24 +211,77 @@ resource "azurerm_iothub_endpoint_storage_container" "import" {
 `, r.basic(data))
 }
 
+func (IotHubEndpointStorageContainerResource) withIotHubIdAndTwoResourceGroups(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eventhub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acc%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "acctestcont"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  location            = azurerm_resource_group.test2.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "acctest"
+  iothub_id           = azurerm_iothub.test.id
+
+  container_name    = "acctestcont"
+  connection_string = azurerm_storage_account.test.primary_blob_connection_string
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (t IotHubEndpointStorageContainerResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.EndpointStorageContainerID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	iothubName := id.IotHubName
-	endpointName := id.EndpointName
 
-	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, resourceGroup, iothubName)
+	iothub, err := clients.IoTHub.ResourceClient.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil || iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
-		return nil, fmt.Errorf("reading IotHuB Endpoint Storage Container (%s): %+v", id, err)
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
 	if endpoints := iothub.Properties.Routing.Endpoints.StorageContainers; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
-				if strings.EqualFold(*existingEndpointName, endpointName) {
+				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
 					return utils.Bool(true), nil
 				}
 			}

--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
 
+* `resource_group_name` - (Required) The name of the resource group under which the Event Hub has been created. Changing this forces a new resource to be created.
+
 * `connection_string` - (Required) The connection string for the endpoint.
 
 * `iothub_name` - (Optional) The IoTHub name for the endpoint.

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -76,7 +76,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
 
+* `resource_group_name` - (Required) The name of the resource group under which the Service Bus Queue has been created. Changing this forces a new resource to be created.
+
 * `connection_string` - (Required) The connection string for the endpoint.
+
+* `iothub_name` - (Optional) The IoTHub name for the endpoint.
+
+~> **NOTE:** The `iothub_name` property is deprecated, use `iothub_id` instead.
+
+* `iothub_id` - (Optional) The IoTHub ID for the endpoint.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -74,7 +74,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
 
+* `resource_group_name` - (Required) The name of the resource group under which the Service Bus Topic has been created. Changing this forces a new resource to be created.
+
 * `connection_string` - (Required) The connection string for the endpoint.
+
+* `iothub_name` - (Optional) The IoTHub name for the endpoint.
+
+~> **NOTE:** The `iothub_name` property is deprecated, use `iothub_id` instead.
+
+* `iothub_id` - (Optional) The IoTHub ID for the endpoint.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -66,9 +66,13 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
 
-* `resource_group_name` - (Required) The name of the resource group under which the IotHub Storage Container Endpoint resource has to be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group under which the Storage Container has been created. Changing this forces a new resource to be created.
 
-* `iothub_name` - (Required) The name of the IoTHub to which this Storage Container Endpoint belongs. Changing this forces a new resource to be created.
+* `iothub_name` - (Optional) The IoTHub name for the endpoint.
+
+~> **NOTE:** The `iothub_name` property is deprecated, use `iothub_id` instead.
+
+* `iothub_id` - (Optional) The IoTHub ID for the endpoint.
 
 * `connection_string` - (Required) The connection string for the endpoint.
 


### PR DESCRIPTION
Cont. of #14632, apply the same fix for `iothub_endpoint_servicebus_queue_resource` `iothub_endpoint_servicebus_topic_resource` `iothub_endpoint_storage_container_resource`.
Add missing `resource_group_name` description in document as well.
Test result:
![image](https://user-images.githubusercontent.com/10579712/146879660-6085af1b-8e84-4187-9451-14cb8e136f96.png)
