### PR TITLE
Updated lock duration 

### DIFF
--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `default_message_ttl` - (Optional) The Default message timespan to live as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
-* `lock_duration` - (Optional) The lock duration for the subscription as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The default value is `1` minute or `P0DT0H1M0S'. The maximum value is '5' minutes or 'P0DT0H5M0S' .
+* `lock_duration` - (Optional) The lock duration for the subscription as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The default value is `1` minute or  `P0DT0H1M0S` . The maximum value is `5` minutes or `P0DT0H5M0S` .
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Subscription has dead letter support when a message expires. Defaults to `false`.
 


### PR DESCRIPTION
I have updated lock_duration default and max value in servicebus_subscription.html.markdown file.  fixed  #10043 . Please have a look and suggest any changes required.