### PR TITLE
`azurerm_iothub_dps`- set `apply_allocation_policy` to true and remove ForceNews from `linked_hub`

### DIFF
--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -3,6 +3,7 @@ package iothub
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"regexp"
 	"strconv"
@@ -88,7 +89,6 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
-							ForceNew:     true,
 							// Azure returns the key as ****. We'll suppress that here.
 							DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 								secretKeyRegex := regexp.MustCompile("(SharedAccessKey)=[^;]+")
@@ -102,12 +102,16 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 							StateFunc:    azure.NormalizeLocation,
-							ForceNew:     true,
 						},
 						"apply_allocation_policy": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default: func() bool {
+								if features.ThreePointOh() {
+									return true
+								}
+								return false
+							}(),
 						},
 						"allocation_weight": {
 							Type:         pluginsdk.TypeInt,

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -3,7 +3,6 @@ package iothub
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 	"regexp"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -107,10 +107,7 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default: func() bool {
-								if features.ThreePointOh() {
-									return true
-								}
-								return false
+								return features.ThreePointOh()
 							}(),
 						},
 						"allocation_weight": {

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -106,9 +106,7 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 						"apply_allocation_policy": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default: func() bool {
-								return features.ThreePointOh()
-							}(),
+							Default:  features.ThreePointOh(),
 						},
 						"allocation_weight": {
 							Type:         pluginsdk.TypeInt,

--- a/internal/services/iothub/iothub_dps_resource_test.go
+++ b/internal/services/iothub/iothub_dps_resource_test.go
@@ -84,6 +84,7 @@ func TestAccIotHubDPS_linkedHubs(t *testing.T) {
 			Config: r.linkedHubs(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("allocation_policy").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -240,9 +241,10 @@ resource "azurerm_iothub_dps" "test" {
   }
 
   linked_hub {
-    connection_string = "HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=booo"
-    location          = azurerm_resource_group.test.location
-    allocation_weight = 150
+    connection_string       = "HostName=test3.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=booo"
+    location                = azurerm_resource_group.test.location
+    allocation_weight       = 150
+    apply_allocation_policy = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/iothub_dps.html.markdown
+++ b/website/docs/r/iothub_dps.html.markdown
@@ -61,11 +61,11 @@ A `sku` block supports the following:
 
 A `linked_hub` block supports the following:
 
-* `connection_string` - (Required) The connection string to connect to the IoT Hub. Changing this forces a new resource.
+* `connection_string` - (Required) The connection string to connect to the IoT Hub.
 
-* `location` - (Required) The location of the IoT hub. Changing this forces a new resource.
+* `location` - (Required) The location of the IoT hub.
 
-* `apply_allocation_policy` - (Optional) Determines whether to apply allocation policies to the IoT Hub. Defaults to false.
+* `apply_allocation_policy` - (Optional) Determines whether to apply allocation policies to the IoT Hub. Defaults to true.
 
 * `allocation_weight` - (Optional) The weight applied to the IoT Hub. Defaults to 0.
 


### PR DESCRIPTION
fixes #10224, #6720, #11272

Changing default value of apply_allocation_policy from false to true as this matches the behaviour of azure policy.

Changing `linked_hub` should not force a new iothub_dps as this is just a reference and linked hubs can be added and deleted from iothub_dps.