### PR TITLE
`iothub`: Support Identity-Based Endpoint

### DIFF
--- a/internal/services/iothub/iothub_endpoint_eventhub_resource.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource.go
@@ -11,9 +11,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -42,7 +45,7 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubEndpointName,
+				ValidateFunc: iothubValidate.IoTHubEndpointName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -53,7 +56,7 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validate.IoTHubName,
+				ValidateFunc:  iothubValidate.IoTHubName,
 				Deprecated:    "Deprecated in favour of `iothub_id`",
 				ConflictsWith: []string{"iothub_id"},
 			},
@@ -64,13 +67,45 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validate.IotHubID,
+				ValidateFunc:  iothubValidate.IotHubID,
 				ConflictsWith: []string{"iothub_name"},
+			},
+
+			"authentication_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(devices.AuthenticationTypeKeyBased),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(devices.AuthenticationTypeKeyBased),
+					string(devices.AuthenticationTypeIdentityBased),
+				}, false),
+			},
+
+			"identity_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  msivalidate.UserAssignedIdentityID,
+				ConflictsWith: []string{"connection_string"},
+			},
+
+			"endpoint_uri": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"entity_path"},
+				ExactlyOneOf: []string{"endpoint_uri", "connection_string"},
+			},
+
+			"entity_path": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.ValidateEventHubName(),
+				RequiredWith: []string{"endpoint_uri"},
 			},
 
 			"connection_string": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					sharedAccessKeyRegex := regexp.MustCompile("SharedAccessKey=[^;]+")
 					sbProtocolRegex := regexp.MustCompile("sb://([^:]+)(:5671)?/;")
@@ -79,7 +114,9 @@ func resourceIotHubEndpointEventHub() *pluginsdk.Resource {
 					maskedNew = sharedAccessKeyRegex.ReplaceAllString(maskedNew, "SharedAccessKey=****")
 					return (new == d.Get(k).(string)) && (maskedNew == old)
 				},
-				Sensitive: true,
+				Sensitive:     true,
+				ConflictsWith: []string{"identity_id"},
+				ExactlyOneOf:  []string{"endpoint_uri", "connection_string"},
 			},
 		},
 	}
@@ -118,11 +155,34 @@ func resourceIotHubEndpointEventHubCreateUpdate(d *pluginsdk.ResourceData, meta 
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", iotHubName, iotHubRG, err)
 	}
 
+	authenticationType := devices.AuthenticationType(d.Get("authentication_type").(string))
+
 	eventhubEndpoint := devices.RoutingEventHubProperties{
-		ConnectionString: utils.String(d.Get("connection_string").(string)),
-		Name:             utils.String(id.EndpointName),
-		SubscriptionID:   utils.String(meta.(*clients.Client).Account.SubscriptionId),
-		ResourceGroup:    utils.String(endpointRG),
+		AuthenticationType: authenticationType,
+		Name:               utils.String(id.EndpointName),
+		SubscriptionID:     utils.String(meta.(*clients.Client).Account.SubscriptionId),
+		ResourceGroup:      utils.String(endpointRG),
+	}
+
+	if authenticationType == devices.AuthenticationTypeKeyBased {
+		if v, ok := d.GetOk("connection_string"); ok {
+			eventhubEndpoint.ConnectionString = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+		}
+	} else {
+		if v, ok := d.GetOk("endpoint_uri"); ok {
+			eventhubEndpoint.EndpointURI = utils.String(v.(string))
+			eventhubEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+		} else {
+			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
+		}
+
+		if v, ok := d.GetOk("identity_id"); ok {
+			eventhubEndpoint.Identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v.(string)),
+			}
+		}
 	}
 
 	routing := iothub.Properties.Routing
@@ -205,8 +265,37 @@ func resourceIotHubEndpointEventHubRead(d *pluginsdk.ResourceData, meta interfac
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					d.Set("connection_string", endpoint.ConnectionString)
 					d.Set("resource_group_name", endpoint.ResourceGroup)
+
+					authenticationType := string(devices.AuthenticationTypeKeyBased)
+					if string(endpoint.AuthenticationType) != "" {
+						authenticationType = string(endpoint.AuthenticationType)
+					}
+					d.Set("authentication_type", authenticationType)
+
+					connectionStr := ""
+					if endpoint.ConnectionString != nil {
+						connectionStr = *endpoint.ConnectionString
+					}
+					d.Set("connection_string", connectionStr)
+
+					endpointUri := ""
+					if endpoint.EndpointURI != nil {
+						endpointUri = *endpoint.EndpointURI
+					}
+					d.Set("endpoint_uri", endpointUri)
+
+					entityPath := ""
+					if endpoint.EntityPath != nil {
+						entityPath = *endpoint.EntityPath
+					}
+					d.Set("entity_path", entityPath)
+
+					identityId := ""
+					if endpoint.Identity != nil && endpoint.Identity.UserAssignedIdentity != nil {
+						identityId = *endpoint.Identity.UserAssignedIdentity
+					}
+					d.Set("identity_id", identityId)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
@@ -65,6 +65,72 @@ func TestAccIotHubEndpointEventHub_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointEventHub_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointEventHub_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointEventHub_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_eventhub", "test")
+	r := IotHubEndpointEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (IotHubEndpointEventHubResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -230,4 +296,138 @@ func (t IotHubEndpointEventHubResource) Exists(ctx context.Context, clients *cli
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  connection_string = azurerm_eventhub_authorization_rule.test.primary_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_eventhub.test.name
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointEventHubResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_eventhub" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_eventhub.test.name
+}
+`, r.authenticationTemplate(data))
+}
+
+func (IotHubEndpointEventHubResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctesteventhub-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_user" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_system" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -12,8 +12,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -42,7 +45,7 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubEndpointName,
+				ValidateFunc: iothubValidate.IoTHubEndpointName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -53,7 +56,7 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validate.IoTHubName,
+				ValidateFunc:  iothubValidate.IoTHubName,
 				Deprecated:    "Deprecated in favour of `iothub_id`",
 				ConflictsWith: []string{"iothub_id"},
 			},
@@ -64,13 +67,45 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validate.IotHubID,
+				ValidateFunc:  iothubValidate.IotHubID,
 				ConflictsWith: []string{"iothub_name"},
+			},
+
+			"authentication_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(devices.AuthenticationTypeKeyBased),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(devices.AuthenticationTypeKeyBased),
+					string(devices.AuthenticationTypeIdentityBased),
+				}, false),
+			},
+
+			"identity_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  msivalidate.UserAssignedIdentityID,
+				ConflictsWith: []string{"connection_string"},
+			},
+
+			"endpoint_uri": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"entity_path"},
+				ExactlyOneOf: []string{"endpoint_uri", "connection_string"},
+			},
+
+			"entity_path": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.QueueName(),
+				RequiredWith: []string{"endpoint_uri"},
 			},
 
 			"connection_string": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					sharedAccessKeyRegex := regexp.MustCompile("SharedAccessKey=[^;]+")
 					sbProtocolRegex := regexp.MustCompile("sb://([^:]+)(:5671)?/;")
@@ -79,7 +114,9 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 					maskedNew = sharedAccessKeyRegex.ReplaceAllString(maskedNew, "SharedAccessKey=****")
 					return (new == d.Get(k).(string)) && (maskedNew == old)
 				},
-				Sensitive: true,
+				Sensitive:     true,
+				ConflictsWith: []string{"identity_id"},
+				ExactlyOneOf:  []string{"endpoint_uri", "connection_string"},
 			},
 		},
 	}
@@ -119,11 +156,34 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", iotHubName, iotHubRG, err)
 	}
 
+	authenticationType := devices.AuthenticationType(d.Get("authentication_type").(string))
+
 	queueEndpoint := devices.RoutingServiceBusQueueEndpointProperties{
-		ConnectionString: utils.String(d.Get("connection_string").(string)),
-		Name:             utils.String(id.EndpointName),
-		SubscriptionID:   utils.String(subscriptionID),
-		ResourceGroup:    utils.String(endpointRG),
+		AuthenticationType: authenticationType,
+		Name:               utils.String(id.EndpointName),
+		SubscriptionID:     utils.String(subscriptionID),
+		ResourceGroup:      utils.String(endpointRG),
+	}
+
+	if authenticationType == devices.AuthenticationTypeKeyBased {
+		if v, ok := d.GetOk("connection_string"); ok {
+			queueEndpoint.ConnectionString = utils.String(v.(string))
+		} else {
+			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+		}
+	} else {
+		if v, ok := d.GetOk("endpoint_uri"); ok {
+			queueEndpoint.EndpointURI = utils.String(v.(string))
+			queueEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+		} else {
+			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
+		}
+
+		if v, ok := d.GetOk("identity_id"); ok {
+			queueEndpoint.Identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v.(string)),
+			}
+		}
 	}
 
 	routing := iothub.Properties.Routing
@@ -206,8 +266,37 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					d.Set("connection_string", endpoint.ConnectionString)
 					d.Set("resource_group_name", endpoint.ResourceGroup)
+
+					authenticationType := string(devices.AuthenticationTypeKeyBased)
+					if string(endpoint.AuthenticationType) != "" {
+						authenticationType = string(endpoint.AuthenticationType)
+					}
+					d.Set("authentication_type", authenticationType)
+
+					connectionStr := ""
+					if endpoint.ConnectionString != nil {
+						connectionStr = *endpoint.ConnectionString
+					}
+					d.Set("connection_string", connectionStr)
+
+					endpointUri := ""
+					if endpoint.EndpointURI != nil {
+						endpointUri = *endpoint.EndpointURI
+					}
+					d.Set("endpoint_uri", endpointUri)
+
+					entityPath := ""
+					if endpoint.EntityPath != nil {
+						entityPath = *endpoint.EntityPath
+					}
+					d.Set("entity_path", entityPath)
+
+					identityId := ""
+					if endpoint.Identity != nil && endpoint.Identity.UserAssignedIdentity != nil {
+						identityId = *endpoint.Identity.UserAssignedIdentity
+					}
+					d.Set("identity_id", identityId)
 				}
 			}
 		}

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
@@ -65,6 +65,72 @@ func TestAccIotHubEndpointServiceBusTopic_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointServiceBusTopic_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_servicebus_topic", "test")
+	r := IotHubEndpointServiceBusTopicResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (IotHubEndpointServiceBusTopicResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -226,4 +292,137 @@ func (t IotHubEndpointServiceBusTopicResource) Exists(ctx context.Context, clien
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  connection_string = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_topic.test.name
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_servicebus_topic" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+  entity_path         = azurerm_servicebus_topic.test.name
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointServiceBusTopicResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name                = "acctestservicebustopic-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_user" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_azure_service_bus_data_sender_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_system" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
@@ -84,6 +84,72 @@ func TestAccIotHubEndpointStorageContainer_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeSystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubEndpointStorageContainer_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_endpoint_storage_container", "test")
+	r := IotHubEndpointStorageContainerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (IotHubEndpointStorageContainerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -289,4 +355,127 @@ func (t IotHubEndpointStorageContainerResource) Exists(ctx context.Context, clie
 	}
 
 	return utils.Bool(false), nil
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  container_name    = azurerm_storage_container.test.name
+  connection_string = azurerm_storage_account.test.primary_blob_connection_string
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  container_name      = azurerm_storage_container.test.name
+  endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_system,
+  ]
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_endpoint_storage_container" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  authentication_type = "identityBased"
+  identity_id         = azurerm_user_assigned_identity.test.id
+  container_name      = azurerm_storage_container.test.name
+  endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+}
+`, r.authenticationTemplate(data))
+}
+
+func (r IotHubEndpointStorageContainerResource) authenticationTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acc%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "acctestcont"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_user" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+  ]
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_system" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -18,9 +18,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	eventhubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
 	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	servicebusValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -39,6 +42,15 @@ func suppressIfTypeIsNot(t string) pluginsdk.SchemaDiffSuppressFunc {
 		path := strings.Split(k, ".")
 		path[len(path)-1] = "type"
 		return d.Get(strings.Join(path, ".")).(string) != t
+	}
+}
+
+// nolint unparam
+func suppressIfTypeIs(t string) pluginsdk.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *pluginsdk.ResourceData) bool {
+		path := strings.Split(k, ".")
+		path[len(path)-1] = "type"
+		return d.Get(strings.Join(path, ".")).(string) == t
 	}
 }
 
@@ -222,9 +234,42 @@ func resourceIotHub() *pluginsdk.Resource {
 							}, false),
 						},
 
+						"authentication_type": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							Default:  string(devices.AuthenticationTypeKeyBased),
+							ValidateFunc: validation.StringInSlice([]string{
+								string(devices.AuthenticationTypeKeyBased),
+								string(devices.AuthenticationTypeIdentityBased),
+							}, false),
+						},
+
+						"identity_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: msivalidate.UserAssignedIdentityID,
+						},
+
+						"endpoint_uri": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"entity_path": {
+							Type:             pluginsdk.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfTypeIs("AzureIotHub.StorageContainer"),
+							ValidateFunc: validation.Any(
+								servicebusValidate.QueueName(),
+								servicebusValidate.TopicName(),
+								eventhubValidate.ValidateEventHubName(),
+							),
+						},
+
 						"connection_string": {
 							Type:     pluginsdk.TypeString,
-							Required: true,
+							Optional: true,
 							DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 								secretKeyRegex := regexp.MustCompile("(SharedAccessKey|AccountKey)=[^;]+")
 								sbProtocolRegex := regexp.MustCompile("sb://([^:]+)(:5671)?/;")
@@ -600,7 +645,10 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if _, ok := d.GetOk("endpoint"); ok {
-		routingProperties.Endpoints = expandIoTHubEndpoints(d, subscriptionId)
+		routingProperties.Endpoints, err = expandIoTHubEndpoints(d, subscriptionId)
+		if err != nil {
+			return fmt.Errorf("expanding `endpoint`: %+v", err)
+		}
 	}
 
 	storageEndpoints, messagingEndpoints, enableFileUploadNotifications := expandIoTHubFileUpload(d)
@@ -974,7 +1022,7 @@ func expandIoTHubFileUpload(d *pluginsdk.ResourceData) (map[string]*devices.Stor
 	return storageEndpointProperties, messagingEndpointProperties, notifications
 }
 
-func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) *devices.RoutingEndpoints {
+func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) (*devices.RoutingEndpoints, error) {
 	routeEndpointList := d.Get("endpoint").([]interface{})
 
 	serviceBusQueueEndpointProperties := make([]devices.RoutingServiceBusQueueEndpointProperties, 0)
@@ -986,21 +1034,68 @@ func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) *de
 		endpoint := endpointRaw.(map[string]interface{})
 
 		t := endpoint["type"]
-		connectionStr := endpoint["connection_string"].(string)
 		name := endpoint["name"].(string)
 		resourceGroup := endpoint["resource_group_name"].(string)
+		authenticationType := devices.AuthenticationType(endpoint["authentication_type"].(string))
 		subscriptionID := subscriptionId
+
+		var identity *devices.ManagedIdentity
+		var endpointUri *string
+		var entityPath *string
+		var connectionStr *string
+		if v := endpoint["identity_id"].(string); v != "" {
+			identity = &devices.ManagedIdentity{
+				UserAssignedIdentity: utils.String(v),
+			}
+		}
+		if v := endpoint["endpoint_uri"].(string); v != "" {
+			endpointUri = utils.String(v)
+		}
+		if v := endpoint["entity_path"].(string); v != "" {
+			entityPath = utils.String(v)
+		}
+		if v := endpoint["connection_string"].(string); v != "" {
+			connectionStr = utils.String(v)
+		}
+
+		if authenticationType == devices.AuthenticationTypeKeyBased {
+			if connectionStr == nil {
+				return nil, fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
+			}
+			if identity != nil || endpointUri != nil || entityPath != nil {
+				return nil, fmt.Errorf("`identity_id`, `endpoint_uri` or `entity_path` cannot be specified when `authentication_type` is `keyBased`")
+			}
+		} else {
+			if endpointUri == nil {
+				return nil, fmt.Errorf("`endpoint_uri` must be specified when `authentication_type` is `identityBased`")
+			}
+
+			if entityPath == nil && t != "AzureIotHub.StorageContainer" {
+				return nil, fmt.Errorf("`entity_path` must be specified when `authentication_type` is `identityBased` and `type` is `%s`", t)
+			}
+
+			if connectionStr != nil {
+				return nil, fmt.Errorf("`connection_string` cannot be specified when `authentication_type` is `identityBased`")
+			}
+		}
 
 		switch t {
 		case "AzureIotHub.StorageContainer":
 			containerName := endpoint["container_name"].(string)
+			if containerName == "" {
+				return nil, fmt.Errorf("`container_name` must be specified when `type` is `AzureIotHub.StorageContainer`")
+			}
+
 			fileNameFormat := endpoint["file_name_format"].(string)
 			batchFrequencyInSeconds := int32(endpoint["batch_frequency_in_seconds"].(int))
 			maxChunkSizeInBytes := int32(endpoint["max_chunk_size_in_bytes"].(int))
 			encoding := endpoint["encoding"].(string)
 
 			storageContainer := devices.RoutingStorageContainerProperties{
-				ConnectionString:        &connectionStr,
+				AuthenticationType:      authenticationType,
+				Identity:                identity,
+				EndpointURI:             endpointUri,
+				ConnectionString:        connectionStr,
 				Name:                    &name,
 				SubscriptionID:          &subscriptionID,
 				ResourceGroup:           &resourceGroup,
@@ -1014,28 +1109,40 @@ func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) *de
 
 		case "AzureIotHub.ServiceBusQueue":
 			sbQueue := devices.RoutingServiceBusQueueEndpointProperties{
-				ConnectionString: &connectionStr,
-				Name:             &name,
-				SubscriptionID:   &subscriptionID,
-				ResourceGroup:    &resourceGroup,
+				AuthenticationType: authenticationType,
+				Identity:           identity,
+				EndpointURI:        endpointUri,
+				EntityPath:         entityPath,
+				ConnectionString:   connectionStr,
+				Name:               &name,
+				SubscriptionID:     &subscriptionID,
+				ResourceGroup:      &resourceGroup,
 			}
 			serviceBusQueueEndpointProperties = append(serviceBusQueueEndpointProperties, sbQueue)
 
 		case "AzureIotHub.ServiceBusTopic":
 			sbTopic := devices.RoutingServiceBusTopicEndpointProperties{
-				ConnectionString: &connectionStr,
-				Name:             &name,
-				SubscriptionID:   &subscriptionID,
-				ResourceGroup:    &resourceGroup,
+				AuthenticationType: authenticationType,
+				Identity:           identity,
+				EndpointURI:        endpointUri,
+				EntityPath:         entityPath,
+				ConnectionString:   connectionStr,
+				Name:               &name,
+				SubscriptionID:     &subscriptionID,
+				ResourceGroup:      &resourceGroup,
 			}
 			serviceBusTopicEndpointProperties = append(serviceBusTopicEndpointProperties, sbTopic)
 
 		case "AzureIotHub.EventHub":
 			eventHub := devices.RoutingEventHubProperties{
-				ConnectionString: &connectionStr,
-				Name:             &name,
-				SubscriptionID:   &subscriptionID,
-				ResourceGroup:    &resourceGroup,
+				AuthenticationType: authenticationType,
+				Identity:           identity,
+				EndpointURI:        endpointUri,
+				EntityPath:         entityPath,
+				ConnectionString:   connectionStr,
+				Name:               &name,
+				SubscriptionID:     &subscriptionID,
+				ResourceGroup:      &resourceGroup,
 			}
 			eventHubProperties = append(eventHubProperties, eventHub)
 		}
@@ -1046,7 +1153,7 @@ func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) *de
 		ServiceBusTopics:  &serviceBusTopicEndpointProperties,
 		EventHubs:         &eventHubProperties,
 		StorageContainers: &storageContainerProperties,
-	}
+	}, nil
 }
 
 func expandIoTHubFallbackRoute(d *pluginsdk.ResourceData) *devices.FallbackRouteProperties {
@@ -1192,9 +1299,30 @@ func flattenIoTHubEndpoint(input *devices.RoutingProperties) []interface{} {
 			for _, container := range *containers {
 				output := make(map[string]interface{})
 
-				if connString := container.ConnectionString; connString != nil {
-					output["connection_string"] = *connString
+				authenticationType := string(devices.AuthenticationTypeKeyBased)
+				if string(container.AuthenticationType) != "" {
+					authenticationType = string(container.AuthenticationType)
 				}
+				output["authentication_type"] = authenticationType
+
+				connectionStr := ""
+				if container.ConnectionString != nil {
+					connectionStr = *container.ConnectionString
+				}
+				output["connection_string"] = connectionStr
+
+				endpointUri := ""
+				if container.EndpointURI != nil {
+					endpointUri = *container.EndpointURI
+				}
+				output["endpoint_uri"] = endpointUri
+
+				identityId := ""
+				if container.Identity != nil && container.Identity.UserAssignedIdentity != nil {
+					identityId = *container.Identity.UserAssignedIdentity
+				}
+				output["identity_id"] = identityId
+
 				if name := container.Name; name != nil {
 					output["name"] = *name
 				}
@@ -1225,9 +1353,36 @@ func flattenIoTHubEndpoint(input *devices.RoutingProperties) []interface{} {
 			for _, queue := range *queues {
 				output := make(map[string]interface{})
 
-				if connString := queue.ConnectionString; connString != nil {
-					output["connection_string"] = *connString
+				authenticationType := string(devices.AuthenticationTypeKeyBased)
+				if string(queue.AuthenticationType) != "" {
+					authenticationType = string(queue.AuthenticationType)
 				}
+				output["authentication_type"] = authenticationType
+
+				connectionStr := ""
+				if queue.ConnectionString != nil {
+					connectionStr = *queue.ConnectionString
+				}
+				output["connection_string"] = connectionStr
+
+				endpointUri := ""
+				if queue.EndpointURI != nil {
+					endpointUri = *queue.EndpointURI
+				}
+				output["endpoint_uri"] = endpointUri
+
+				entityPath := ""
+				if queue.EntityPath != nil {
+					entityPath = *queue.EntityPath
+				}
+				output["entity_path"] = entityPath
+
+				identityId := ""
+				if queue.Identity != nil && queue.Identity.UserAssignedIdentity != nil {
+					identityId = *queue.Identity.UserAssignedIdentity
+				}
+				output["identity_id"] = identityId
+
 				if name := queue.Name; name != nil {
 					output["name"] = *name
 				}
@@ -1245,9 +1400,36 @@ func flattenIoTHubEndpoint(input *devices.RoutingProperties) []interface{} {
 			for _, topic := range *topics {
 				output := make(map[string]interface{})
 
-				if connString := topic.ConnectionString; connString != nil {
-					output["connection_string"] = *connString
+				authenticationType := string(devices.AuthenticationTypeKeyBased)
+				if string(topic.AuthenticationType) != "" {
+					authenticationType = string(topic.AuthenticationType)
 				}
+				output["authentication_type"] = authenticationType
+
+				connectionStr := ""
+				if topic.ConnectionString != nil {
+					connectionStr = *topic.ConnectionString
+				}
+				output["connection_string"] = connectionStr
+
+				endpointUri := ""
+				if topic.EndpointURI != nil {
+					endpointUri = *topic.EndpointURI
+				}
+				output["endpoint_uri"] = endpointUri
+
+				entityPath := ""
+				if topic.EntityPath != nil {
+					entityPath = *topic.EntityPath
+				}
+				output["entity_path"] = entityPath
+
+				identityId := ""
+				if topic.Identity != nil && topic.Identity.UserAssignedIdentity != nil {
+					identityId = *topic.Identity.UserAssignedIdentity
+				}
+				output["identity_id"] = identityId
+
 				if name := topic.Name; name != nil {
 					output["name"] = *name
 				}
@@ -1265,9 +1447,36 @@ func flattenIoTHubEndpoint(input *devices.RoutingProperties) []interface{} {
 			for _, eventHub := range *eventHubs {
 				output := make(map[string]interface{})
 
-				if connString := eventHub.ConnectionString; connString != nil {
-					output["connection_string"] = *connString
+				authenticationType := string(devices.AuthenticationTypeKeyBased)
+				if string(eventHub.AuthenticationType) != "" {
+					authenticationType = string(eventHub.AuthenticationType)
 				}
+				output["authentication_type"] = authenticationType
+
+				connectionStr := ""
+				if eventHub.ConnectionString != nil {
+					connectionStr = *eventHub.ConnectionString
+				}
+				output["connection_string"] = connectionStr
+
+				endpointUri := ""
+				if eventHub.EndpointURI != nil {
+					endpointUri = *eventHub.EndpointURI
+				}
+				output["endpoint_uri"] = endpointUri
+
+				entityPath := ""
+				if eventHub.EntityPath != nil {
+					entityPath = *eventHub.EntityPath
+				}
+				output["entity_path"] = entityPath
+
+				identityId := ""
+				if eventHub.Identity != nil && eventHub.Identity.UserAssignedIdentity != nil {
+					identityId = *eventHub.Identity.UserAssignedIdentity
+				}
+				output["identity_id"] = identityId
+
 				if name := eventHub.Name; name != nil {
 					output["name"] = *name
 				}

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -377,6 +377,57 @@ func TestAccIotHub_identityUpdate(t *testing.T) {
 	})
 }
 
+func TestAccIotHub_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	r := IotHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.endpointAuthenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHub_AuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	r := IotHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.endpointAuthenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.endpointAuthenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.endpointAuthenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.endpointAuthenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t IotHubResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.IotHubID(state.ID)
 	if err != nil {
@@ -1316,4 +1367,379 @@ resource "azurerm_iothub" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r IotHubResource) endpointAuthenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  endpoint {
+    type                = "AzureIotHub.StorageContainer"
+    name                = "endpoint1"
+    resource_group_name = azurerm_resource_group.test.name
+
+    container_name    = azurerm_storage_container.test.name
+    connection_string = azurerm_storage_account.test.primary_blob_connection_string
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusQueue"
+    name                = "endpoint2"
+    resource_group_name = azurerm_resource_group.test.name
+
+    connection_string = azurerm_servicebus_queue_authorization_rule.test.primary_connection_string
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusTopic"
+    name                = "endpoint3"
+    resource_group_name = azurerm_resource_group.test.name
+
+    connection_string = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+  }
+
+  endpoint {
+    type                = "AzureIotHub.EventHub"
+    name                = "endpoint4"
+    resource_group_name = azurerm_resource_group.test.name
+
+    connection_string = azurerm_eventhub_authorization_rule.test.primary_connection_string
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_queue_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_topic_user,
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_user,
+  ]
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, r.endpointTemplate(data), data.RandomInteger)
+}
+
+func (r IotHubResource) endpointAuthenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  endpoint {
+    type                = "AzureIotHub.StorageContainer"
+    name                = "endpoint1"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    container_name      = azurerm_storage_container.test.name
+    endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusQueue"
+    name                = "endpoint2"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_servicebus_queue.test.name
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusTopic"
+    name                = "endpoint3"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_servicebus_topic.test.name
+  }
+
+  endpoint {
+    type                = "AzureIotHub.EventHub"
+    name                = "endpoint4"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_eventhub.test.name
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_queue_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_topic_user,
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_user,
+  ]
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, r.endpointTemplate(data), data.RandomInteger)
+}
+
+func (r IotHubResource) endpointAuthenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  endpoint {
+    type                = "AzureIotHub.StorageContainer"
+    name                = "endpoint1"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    identity_id         = azurerm_user_assigned_identity.test.id
+    container_name      = azurerm_storage_container.test.name
+    endpoint_uri        = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusQueue"
+    name                = "endpoint2"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    identity_id         = azurerm_user_assigned_identity.test.id
+    endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_servicebus_queue.test.name
+  }
+
+  endpoint {
+    type                = "AzureIotHub.ServiceBusTopic"
+    name                = "endpoint3"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    identity_id         = azurerm_user_assigned_identity.test.id
+    endpoint_uri        = "sb://${azurerm_servicebus_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_servicebus_topic.test.name
+  }
+
+  endpoint {
+    type                = "AzureIotHub.EventHub"
+    name                = "endpoint4"
+    resource_group_name = azurerm_resource_group.test.name
+
+    authentication_type = "identityBased"
+    identity_id         = azurerm_user_assigned_identity.test.id
+    endpoint_uri        = "sb://${azurerm_eventhub_namespace.test.name}.servicebus.windows.net"
+    entity_path         = azurerm_eventhub.test.name
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_queue_user,
+    azurerm_role_assignment.test_azure_service_bus_data_sender_topic_user,
+    azurerm_role_assignment.test_azure_event_hubs_data_sender_user,
+  ]
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, r.endpointTemplate(data), data.RandomInteger)
+}
+
+func (IotHubResource) endpointTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acc%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "acctestcont"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_queue" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_servicebus_namespace.test.name
+
+  enable_partitioning = true
+}
+
+resource "azurerm_servicebus_queue_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  queue_name          = azurerm_servicebus_queue.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name                = "acctestservicebustopic-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctesteventhub-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_authorization_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_user" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_queue_user" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_queue.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_topic_user" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_user" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_system" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_queue_system" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_queue.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_service_bus_data_sender_topic_system" {
+  role_definition_name = "Azure Service Bus Data Sender"
+  scope                = azurerm_servicebus_topic.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "test_azure_event_hubs_data_sender_system" {
+  role_definition_name = "Azure Event Hubs Data Sender"
+  scope                = azurerm_eventhub.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -194,7 +194,7 @@ An `endpoint` block supports the following:
 
 ~> **NOTE:** System Assigned Managed Identity can only be used in an update because access to the endpoint cannot be granted before the creation is done. The extracted resources `azurerm_iothub_endpoint_*` can be used to create endpoints with System Assigned Managed Identity without the need of an update. 
 
-* `endpoint_uri` - (Optional) URI of the Service Bus or Event Hub Namespace endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased` for endpoint type `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
+* `endpoint_uri` - (Optional) URI of the Service Bus or Event Hubs Namespace endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased` for endpoint type `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
 
 * `entity_path` - (Optional) Name of the Service Bus Queue/Topic or Event Hub. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased` for endpoint type `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
 

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -184,9 +184,21 @@ An `endpoint` block supports the following:
 
 * `type` - (Required) The type of the endpoint. Possible values are `AzureIotHub.StorageContainer`, `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
 
-* `connection_string` - (Required) The connection string for the endpoint.
-
 * `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
+
+* `authentication_type` - (Optional) Type used to authenticate against the endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) ID of the User Managed Identity used to authenticate against the endpoint.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
+
+~> **NOTE:** System Assigned Managed Identity can only be used in an update because access to the endpoint cannot be granted before the creation is done. The extracted resources `azurerm_iothub_endpoint_*` can be used to create endpoints with System Assigned Managed Identity without the need of an update. 
+
+* `endpoint_uri` - (Optional) URI of the Service Bus or Event Hub Namespace endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased` for endpoint type `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
+
+* `entity_path` - (Optional) Name of the Service Bus Queue/Topic or Event Hub. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased` for endpoint type `AzureIotHub.ServiceBusQueue`, `AzureIotHub.ServiceBusTopic` or `AzureIotHub.EventHub`.
+
+* `connection_string` - (Optional) The connection string for the endpoint. This attribute is mandatory and can only be specified when `authentication_type` is `keyBased`.
 
 * `batch_frequency_in_seconds` - (Optional) Time interval at which blobs are written to storage. Value should be between 60 and 720 seconds. Default value is 300 seconds. This attribute is applicable for endpoint type `AzureIotHub.StorageContainer`.
 

--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -78,7 +78,17 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group under which the Event Hub has been created. Changing this forces a new resource to be created.
 
-* `connection_string` - (Required) The connection string for the endpoint.
+* `authentication_type` - (Optional) Type used to authenticate against the Event Hub endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) ID of the User Managed Identity used to authenticate against the Event Hub endpoint.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
+
+* `endpoint_uri` - (Optional) URI of the Event Hubs Namespace endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `entity_path` - (Optional) Name of the Event Hub. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
 * `iothub_name` - (Optional) The IoTHub name for the endpoint.
 

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -78,7 +78,17 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group under which the Service Bus Queue has been created. Changing this forces a new resource to be created.
 
-* `connection_string` - (Required) The connection string for the endpoint.
+* `authentication_type` - (Optional) Type used to authenticate against the Service Bus Queue endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) ID of the User Managed Identity used to authenticate against the Service Bus Queue endpoint.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
+
+* `endpoint_uri` - (Optional) URI of the Service Bus endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `entity_path` - (Optional) Name of the Service Bus Queue. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
 * `iothub_name` - (Optional) The IoTHub name for the endpoint.
 

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -76,7 +76,17 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group under which the Service Bus Topic has been created. Changing this forces a new resource to be created.
 
-* `connection_string` - (Required) The connection string for the endpoint.
+* `authentication_type` - (Optional) Type used to authenticate against the Service Bus Topic endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) ID of the User Managed Identity used to authenticate against the Service Bus Topic endpoint.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
+
+* `endpoint_uri` - (Optional) URI of the Service Bus endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `entity_path` - (Optional) Name of the Service Bus Topic. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
 * `iothub_name` - (Optional) The IoTHub name for the endpoint.
 

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -68,20 +68,28 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group under which the Storage Container has been created. Changing this forces a new resource to be created.
 
+* `container_name` - (Required) The name of storage container in the storage account.
+
 * `iothub_name` - (Optional) The IoTHub name for the endpoint.
 
 ~> **NOTE:** The `iothub_name` property is deprecated, use `iothub_id` instead.
 
 * `iothub_id` - (Optional) The IoTHub ID for the endpoint.
 
-* `connection_string` - (Required) The connection string for the endpoint.
+* `authentication_type` - (Optional) Type used to authenticate against the storage endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) ID of the User Managed Identity used to authenticate against the storage endpoint.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
+
+* `endpoint_uri` - (Optional) URI of the Storage Container endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+
+* `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
 * `batch_frequency_in_seconds` - (Optional) Time interval at which blobs are written to storage. Value should be between 60 and 720 seconds. Default value is 300 seconds.
 
 * `max_chunk_size_in_bytes` - (Optional) Maximum number of bytes for each blob written to storage. Value should be between 10485760(10MB) and 524288000(500MB). Default value is 314572800(300MB).
 
-* `container_name` - (Required) The name of storage container in the storage account.
-*
 * `encoding` - (Optional) Encoding that is used to serialize messages to blobs. Supported values are `Avro`, `AvroDeflate` and `JSON`. Default value is `Avro`. Changing this forces a new resource to be created.
 
 * `file_name_format` - (Optional) File name format for the blob. Default format is ``{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}``. All parameters are mandatory but can be reordered.


### PR DESCRIPTION
Cont. of #14354. Adding support for identity-based authentication to custom routing endpoint of iot hub. There are four endpoint resources and the main iot_hub resource. Fix #9139

- `eventhub`, `servicebus_queue` and `servicebus_topic`
  - `authentication_type`: whether to use `keyBased`(default) or `identityBased`
  - `identity_id`: user-assigned managed identity id when using `identityBased`
  - `endpoint_uri` and `entity_path`: set together, to specify the target endpoint in `identityBased` case
  - `connection_string`: update from `Required` to `Optional`, this is used in `keyBased` case
- `storage_container`
  - `authentication_type`, `identity_id`, `endpoint_uri`, `connection_string`: same as above.
  - `entity_path` is not applicable because `container_name` is already used
- `iothub`
  Endpoints can be specified directly on iothub, above properties are added here as well. Due to the limitation of schema in a TypeList, restrictions of these properties are put into code instead.
Test result:
![image](https://user-images.githubusercontent.com/10579712/147190832-6fa8de0f-b28f-4414-babe-1b31e0d0b0cd.png)
