### PR TITLE
`r\azurerm_azurerm_web_application_firewall_policy` fix #12817 by loose `file_upload_limit_in_mb` to 4000.

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -269,7 +269,7 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 						"file_upload_limit_in_mb": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 750),
+							ValidateFunc: validation.IntBetween(1, 4000),
 							Default:      100,
 						},
 						"max_request_body_size_in_kb": {

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -168,11 +168,11 @@ The `policy_settings` block supports the following:
 
 * `mode` - (Optional) Describes if it is in detection mode or prevention mode at the policy level. Defaults to `Prevention`.
 
-* `file_upload_limit_in_mb` - (Optional) The File Upload Limit in MB. Accepted values are in the range `1` to `750`. Defaults to `100`.
+* `file_upload_limit_in_mb` - (Optional) The File Upload Limit in MB. Accepted values are in the range `1` to `4000`. Defaults to `100`.
 
 * `request_body_check` - (Optional) Is Request Body Inspection enabled? Defaults to `true`.
 
-* `max_request_body_size_in_kb` - (Optional) The Maximum Request Body Size in KB.  Accepted values are in the range `8` to `128`. Defaults to `128`.
+* `max_request_body_size_in_kb` - (Optional) The Maximum Request Body Size in KB.  Accepted values are in the range `8` to `2000`. Defaults to `128`.
 
 ---
 


### PR DESCRIPTION
Fix #12817 by loose `file_upload_limit_in_mb` to 4000.

Acc test:

=== RUN   TestAccWebApplicationFirewallPolicy_basic
=== PAUSE TestAccWebApplicationFirewallPolicy_basic
=== CONT  TestAccWebApplicationFirewallPolicy_basic
--- PASS: TestAccWebApplicationFirewallPolicy_basic (285.01s)
=== RUN   TestAccWebApplicationFirewallPolicy_complete
=== PAUSE TestAccWebApplicationFirewallPolicy_complete
=== CONT  TestAccWebApplicationFirewallPolicy_complete
--- PASS: TestAccWebApplicationFirewallPolicy_complete (298.41s)
=== RUN   TestAccWebApplicationFirewallPolicy_update
=== PAUSE TestAccWebApplicationFirewallPolicy_update
=== CONT  TestAccWebApplicationFirewallPolicy_update
--- PASS: TestAccWebApplicationFirewallPolicy_update (352.67s)
PASS
