### PR TITLE
New resource: `storage_account_network_rule`

### DIFF
--- a/internal/services/storage/parse/storage_account_network_rule.go
+++ b/internal/services/storage/parse/storage_account_network_rule.go
@@ -124,5 +124,9 @@ func StorageAccountNetworkRuleID(input string) (*StorageAccountNetworkRuleId, er
 		}
 	}
 
+	if id.IPRule == nil && id.VirtualNetworkRule == nil && id.ResourceAccessRule == nil {
+		return nil, fmt.Errorf("ID was missing the 'networkRuleId' element")
+	}
+
 	return &id, nil
 }

--- a/internal/services/storage/parse/storage_account_network_rule.go
+++ b/internal/services/storage/parse/storage_account_network_rule.go
@@ -1,0 +1,128 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type StorageAccountNetworkRuleId struct {
+	StorageAccountId   *StorageAccountId
+	IPRule             *storage.IPRule
+	VirtualNetworkRule *storage.VirtualNetworkRule
+	ResourceAccessRule *storage.ResourceAccessRule
+}
+
+func (id StorageAccountNetworkRuleId) ID() string {
+	networkRuleId := ""
+	if id.IPRule != nil && id.IPRule.IPAddressOrRange != nil {
+		networkRuleId = fmt.Sprintf("ipAddressOrRange/%s", *id.IPRule.IPAddressOrRange)
+	}
+
+	if id.VirtualNetworkRule != nil && id.VirtualNetworkRule.VirtualNetworkResourceID != nil {
+		subnetId := *id.VirtualNetworkRule.VirtualNetworkResourceID
+		networkRuleId = fmt.Sprintf("subnetId/%s", strings.TrimPrefix(subnetId, "/"))
+	}
+
+	if id.ResourceAccessRule != nil && id.ResourceAccessRule.TenantID != nil && id.ResourceAccessRule.ResourceID != nil {
+		resourceId := *id.ResourceAccessRule.ResourceID
+		networkRuleId = fmt.Sprintf("tenantId/%s/resourceId/%s", *id.ResourceAccessRule.TenantID, strings.TrimPrefix(resourceId, "/"))
+	}
+
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s;%s"
+	return fmt.Sprintf(fmtString, id.StorageAccountId.SubscriptionId, id.StorageAccountId.ResourceGroup, id.StorageAccountId.Name, networkRuleId)
+}
+
+func (id StorageAccountNetworkRuleId) String() string {
+	segments := make([]string, 0)
+	if id.IPRule != nil {
+		segments = append(segments, fmt.Sprintf("IPAddressOrRange %q", *id.IPRule.IPAddressOrRange))
+	}
+	if id.VirtualNetworkRule != nil {
+		segments = append(segments, fmt.Sprintf("SubnetID %q", *id.VirtualNetworkRule.VirtualNetworkResourceID))
+	}
+	if id.ResourceAccessRule != nil {
+		segments = append(segments, fmt.Sprintf("TenantID %q", *id.ResourceAccessRule.TenantID))
+		segments = append(segments, fmt.Sprintf("ResourceID %q", *id.ResourceAccessRule.ResourceID))
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s) for %s", "Network Rule", segmentsStr, id.StorageAccountId.String())
+}
+
+func StorageAccountNetworkRuleID(input string) (*StorageAccountNetworkRuleId, error) {
+	segments := strings.Split(input, ";")
+	if len(segments) != 2 {
+		return nil, fmt.Errorf("storage network rule ID is composed as format `storageAccountId;networkRuleId`")
+	}
+
+	storageAccountId, err := StorageAccountID(segments[0])
+	if err != nil {
+		return nil, err
+	}
+
+	id := StorageAccountNetworkRuleId{
+		StorageAccountId: storageAccountId,
+	}
+
+	if len(segments[1]) == 0 {
+		return nil, fmt.Errorf("ID was missing the 'networkRuleId' element")
+	}
+
+	if strings.HasPrefix(segments[1], "ipAddressOrRange") {
+		id.IPRule = &storage.IPRule{
+			IPAddressOrRange: utils.String(strings.TrimPrefix(segments[1], "ipAddressOrRange/")),
+		}
+	}
+
+	if strings.HasPrefix(segments[1], "subnetId") {
+		id.VirtualNetworkRule = &storage.VirtualNetworkRule{
+			VirtualNetworkResourceID: utils.String(strings.TrimPrefix(segments[1], "subnetId")),
+		}
+	}
+
+	if strings.HasPrefix(segments[1], "tenantId") {
+		var tenantId string
+		var resourceId string
+
+		components := strings.SplitN(segments[1], "/", 4)
+		if len(components)%2 != 0 {
+			return nil, fmt.Errorf("the number of path segments is not divisible by 2 in %q", segments[1])
+		}
+
+		for current := 0; current < len(components); current += 2 {
+			key := components[current]
+			value := components[current+1]
+			if key == "" || value == "" {
+				return nil, fmt.Errorf("Key/Value cannot be empty strings. Key: '%s', Value: '%s'", key, value)
+			}
+
+			switch {
+			case key == "tenantId":
+				tenantId = value
+			case key == "resourceId":
+				resourceId = "/" + value
+			}
+		}
+
+		_, errors := validation.IsUUID(tenantId, "tenantId")
+		if len(errors) != 0 {
+			return nil, fmt.Errorf("%q should be a valid UUID: %q", tenantId, errors)
+		}
+
+		_, errors = azure.ValidateResourceID(resourceId, "resourceId")
+		if len(errors) != 0 {
+			return nil, fmt.Errorf("%q should be a valid Resource ID: %q", resourceId, errors)
+		}
+
+		id.ResourceAccessRule = &storage.ResourceAccessRule{
+			TenantID:   utils.String(tenantId),
+			ResourceID: utils.String(resourceId),
+		}
+	}
+
+	return &id, nil
+}

--- a/internal/services/storage/parse/storage_account_network_rule_test.go
+++ b/internal/services/storage/parse/storage_account_network_rule_test.go
@@ -25,7 +25,7 @@ func TestStorageAccountNetworkRuleID(t *testing.T) {
 
 		{
 			// missing value for StorageAccountID
-			Input: "ipRule/127.0.0.1",
+			Input: "ipAddressOrRange/127.0.0.1",
 			Error: true,
 		},
 
@@ -36,8 +36,8 @@ func TestStorageAccountNetworkRuleID(t *testing.T) {
 		},
 
 		{
-			// valid ipRule
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;ipRule/127.0.0.1",
+			// valid IPRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;ipAddressOrRange/127.0.0.1",
 			Expected: &StorageAccountNetworkRuleId{
 				StorageAccountId: &StorageAccountId{
 					SubscriptionId: "12345678-1234-9876-4563-123456789012",
@@ -51,8 +51,8 @@ func TestStorageAccountNetworkRuleID(t *testing.T) {
 		},
 
 		{
-			// valid virtualNetworkRule
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;virtualNetworkRule/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
+			// valid VirtualNetworkRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;subnetId/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
 			Expected: &StorageAccountNetworkRuleId{
 				StorageAccountId: &StorageAccountId{
 					SubscriptionId: "12345678-1234-9876-4563-123456789012",
@@ -66,8 +66,8 @@ func TestStorageAccountNetworkRuleID(t *testing.T) {
 		},
 
 		{
-			// valid resourceAccessRule
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;resourceAccessRule/12345678-1234-9876-4563-123456789012/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2",
+			// valid ResourceAccessRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;tenantId/12345678-1234-9876-4563-123456789012/resourceId/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2",
 			Expected: &StorageAccountNetworkRuleId{
 				StorageAccountId: &StorageAccountId{
 					SubscriptionId: "12345678-1234-9876-4563-123456789012",
@@ -108,19 +108,15 @@ func TestStorageAccountNetworkRuleID(t *testing.T) {
 			}
 		}
 
-		if actual.IPRule != v.Expected.IPRule {
-			if !strings.EqualFold(*actual.IPRule.IPAddressOrRange, *v.Expected.IPRule.IPAddressOrRange) {
-				t.Fatalf("Expected %+v but got %+v for IPRule.IPAddressOrRange", *v.Expected.IPRule.IPAddressOrRange, *actual.IPRule.IPAddressOrRange)
-			}
+		if actual.IPRule != nil && v.Expected.IPRule != nil && !strings.EqualFold(*actual.IPRule.IPAddressOrRange, *v.Expected.IPRule.IPAddressOrRange) {
+			t.Fatalf("Expected %+v but got %+v for IPRule.IPAddressOrRange", *v.Expected.IPRule.IPAddressOrRange, *actual.IPRule.IPAddressOrRange)
 		}
 
-		if actual.VirtualNetworkRule != v.Expected.VirtualNetworkRule {
-			if !strings.EqualFold(*actual.VirtualNetworkRule.VirtualNetworkResourceID, *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID) {
-				t.Fatalf("Expected %+v but got %+v for VirtualNetworkRule.VirtualNetworkResourceID", *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID, *actual.VirtualNetworkRule.VirtualNetworkResourceID)
-			}
+		if actual.VirtualNetworkRule != nil && v.Expected.VirtualNetworkRule != nil && !strings.EqualFold(*actual.VirtualNetworkRule.VirtualNetworkResourceID, *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID) {
+			t.Fatalf("Expected %+v but got %+v for VirtualNetworkRule.VirtualNetworkResourceID", *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID, *actual.VirtualNetworkRule.VirtualNetworkResourceID)
 		}
 
-		if actual.ResourceAccessRule != v.Expected.ResourceAccessRule {
+		if actual.ResourceAccessRule != nil && v.Expected.ResourceAccessRule != nil {
 			if !strings.EqualFold(*actual.ResourceAccessRule.ResourceID, *v.Expected.ResourceAccessRule.ResourceID) {
 				t.Fatalf("Expected %+v but got %+v for ResourceAccessRule.ResourceID", *v.Expected.ResourceAccessRule.ResourceID, *actual.ResourceAccessRule.ResourceID)
 			}

--- a/internal/services/storage/parse/storage_account_network_rule_test.go
+++ b/internal/services/storage/parse/storage_account_network_rule_test.go
@@ -1,0 +1,132 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+var _ resourceid.Formatter = StorageAccountNetworkRuleId{}
+
+func TestStorageAccountNetworkRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *StorageAccountNetworkRuleId
+	}{
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing value for StorageAccountID
+			Input: "ipRule/127.0.0.1",
+			Error: true,
+		},
+
+		{
+			// missing value for networkRuleId
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1",
+			Error: true,
+		},
+
+		{
+			// valid ipRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;ipRule/127.0.0.1",
+			Expected: &StorageAccountNetworkRuleId{
+				StorageAccountId: &StorageAccountId{
+					SubscriptionId: "12345678-1234-9876-4563-123456789012",
+					ResourceGroup:  "resGroup1",
+					Name:           "storageAccount1",
+				},
+				IPRule: &storage.IPRule{
+					IPAddressOrRange: utils.String("127.0.0.1"),
+				},
+			},
+		},
+
+		{
+			// valid virtualNetworkRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;virtualNetworkRule/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
+			Expected: &StorageAccountNetworkRuleId{
+				StorageAccountId: &StorageAccountId{
+					SubscriptionId: "12345678-1234-9876-4563-123456789012",
+					ResourceGroup:  "resGroup1",
+					Name:           "storageAccount1",
+				},
+				VirtualNetworkRule: &storage.VirtualNetworkRule{
+					VirtualNetworkResourceID: utils.String("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1"),
+				},
+			},
+		},
+
+		{
+			// valid resourceAccessRule
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1;resourceAccessRule/12345678-1234-9876-4563-123456789012/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2",
+			Expected: &StorageAccountNetworkRuleId{
+				StorageAccountId: &StorageAccountId{
+					SubscriptionId: "12345678-1234-9876-4563-123456789012",
+					ResourceGroup:  "resGroup1",
+					Name:           "storageAccount1",
+				},
+				ResourceAccessRule: &storage.ResourceAccessRule{
+					TenantID:   utils.String("12345678-1234-9876-4563-123456789012"),
+					ResourceID: utils.String("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2"),
+				},
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := StorageAccountNetworkRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.StorageAccountId != v.Expected.StorageAccountId {
+			if actual.StorageAccountId.SubscriptionId != v.Expected.StorageAccountId.SubscriptionId {
+				t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.StorageAccountId.SubscriptionId, actual.StorageAccountId.SubscriptionId)
+			}
+			if actual.StorageAccountId.ResourceGroup != v.Expected.StorageAccountId.ResourceGroup {
+				t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.StorageAccountId.ResourceGroup, actual.StorageAccountId.ResourceGroup)
+			}
+			if actual.StorageAccountId.Name != v.Expected.StorageAccountId.Name {
+				t.Fatalf("Expected %q but got %q for Name", v.Expected.StorageAccountId.Name, actual.StorageAccountId.Name)
+			}
+		}
+
+		if actual.IPRule != v.Expected.IPRule {
+			if !strings.EqualFold(*actual.IPRule.IPAddressOrRange, *v.Expected.IPRule.IPAddressOrRange) {
+				t.Fatalf("Expected %+v but got %+v for IPRule.IPAddressOrRange", *v.Expected.IPRule.IPAddressOrRange, *actual.IPRule.IPAddressOrRange)
+			}
+		}
+
+		if actual.VirtualNetworkRule != v.Expected.VirtualNetworkRule {
+			if !strings.EqualFold(*actual.VirtualNetworkRule.VirtualNetworkResourceID, *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID) {
+				t.Fatalf("Expected %+v but got %+v for VirtualNetworkRule.VirtualNetworkResourceID", *v.Expected.VirtualNetworkRule.VirtualNetworkResourceID, *actual.VirtualNetworkRule.VirtualNetworkResourceID)
+			}
+		}
+
+		if actual.ResourceAccessRule != v.Expected.ResourceAccessRule {
+			if !strings.EqualFold(*actual.ResourceAccessRule.ResourceID, *v.Expected.ResourceAccessRule.ResourceID) {
+				t.Fatalf("Expected %+v but got %+v for ResourceAccessRule.ResourceID", *v.Expected.ResourceAccessRule.ResourceID, *actual.ResourceAccessRule.ResourceID)
+			}
+			if !strings.EqualFold(*actual.ResourceAccessRule.TenantID, *v.Expected.ResourceAccessRule.TenantID) {
+				t.Fatalf("Expected %+v but got %+v for ResourceAccessRule.TenantID", *v.Expected.ResourceAccessRule.TenantID, *actual.ResourceAccessRule.TenantID)
+			}
+		}
+	}
+}

--- a/internal/services/storage/registration.go
+++ b/internal/services/storage/registration.go
@@ -41,6 +41,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_storage_account":                      resourceStorageAccount(),
 		"azurerm_storage_account_customer_managed_key": resourceStorageAccountCustomerManagedKey(),
+		"azurerm_storage_account_network_rule":         resourceStorageAccountNetworkRule(),
 		"azurerm_storage_account_network_rules":        resourceStorageAccountNetworkRules(),
 		"azurerm_storage_blob":                         resourceStorageBlob(),
 		"azurerm_storage_blob_inventory_policy":        resourceStorageBlobInventoryPolicy(),

--- a/internal/services/storage/storage_account_network_rule_resource.go
+++ b/internal/services/storage/storage_account_network_rule_resource.go
@@ -1,0 +1,323 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceStorageAccountNetworkRule() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceStorageAccountNetworkRuleCreate,
+		Read:   resourceStorageAccountNetworkRuleRead,
+		Delete: resourceStorageAccountNetworkRuleDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.StorageAccountNetworkRuleID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(10 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(10 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"storage_account_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageAccountID,
+			},
+
+			"ip_rule": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"virtual_network_rule", "resource_access_rule"},
+				ValidateFunc:  validate.StorageAccountIpRule,
+			},
+
+			"virtual_network_rule": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"ip_rule", "resource_access_rule"},
+				ValidateFunc:  networkValidate.SubnetID,
+			},
+
+			"resource_access_rule": {
+				Type:          pluginsdk.TypeSet,
+				Optional:      true,
+				ForceNew:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"ip_rule", "virtual_network_rule"},
+				Elem:          resourceAccessRuleResource(),
+			},
+		},
+	}
+}
+
+func resourceAccessRuleResource() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"resource_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+			"tenant_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+		},
+	}
+}
+
+func resourceStorageAccountNetworkRuleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	tenantID := meta.(*clients.Client).Account.TenantId
+	client := meta.(*clients.Client).Storage.AccountsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	storageAccountIDRaw := d.Get("storage_account_id").(string)
+	storageAccountID, err := parse.StorageAccountID(storageAccountIDRaw)
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(storageAccountID.Name, storageAccountResourceName)
+	defer locks.UnlockByName(storageAccountID.Name, storageAccountResourceName)
+
+	existing, err := client.GetProperties(ctx, storageAccountID.ResourceGroup, storageAccountID.Name, "")
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for the presence of %s: %s", storageAccountID, err)
+		}
+	}
+
+	rules := existing.NetworkRuleSet
+	if rules == nil {
+		rules = &storage.NetworkRuleSet{}
+	}
+
+	id := parse.StorageAccountNetworkRuleId{
+		StorageAccountId: storageAccountID,
+	}
+
+	if ipRange, ok := d.GetOk("ip_rule"); ok {
+		id.IPRule = &storage.IPRule{
+			IPAddressOrRange: utils.String(ipRange.(string)),
+			Action:           storage.ActionAllow,
+		}
+		*rules.IPRules = append(*rules.IPRules, *id.IPRule)
+	}
+
+	if subnetID, ok := d.GetOk("virtual_network_rule"); ok {
+		id.VirtualNetworkRule = &storage.VirtualNetworkRule{
+			VirtualNetworkResourceID: utils.String(subnetID.(string)),
+			Action:                   storage.ActionAllow,
+		}
+		*rules.VirtualNetworkRules = append(*rules.VirtualNetworkRules, *id.VirtualNetworkRule)
+	}
+
+	if resourceAccessRule, ok := d.GetOk("resource_access_rule"); ok {
+		id.ResourceAccessRule = expandStorageAccountNetworkRuleResourceAccessRule(resourceAccessRule.(*pluginsdk.Set).List(), tenantID)
+		if rules.ResourceAccessRules == nil {
+			r := make([]storage.ResourceAccessRule, 0)
+			rules.ResourceAccessRules = &r
+		}
+		*rules.ResourceAccessRules = append(*rules.ResourceAccessRules, *id.ResourceAccessRule)
+	}
+
+	opts := storage.AccountUpdateParameters{
+		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
+			NetworkRuleSet: rules,
+		},
+	}
+
+	if _, err := client.Update(ctx, storageAccountID.ResourceGroup, storageAccountID.Name, opts); err != nil {
+		return fmt.Errorf("creating %s: %+v", id.String(), err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceStorageAccountNetworkRuleRead(d, meta)
+}
+
+func resourceStorageAccountNetworkRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	tenantID := meta.(*clients.Client).Account.TenantId
+	client := meta.(*clients.Client).Storage.AccountsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.StorageAccountNetworkRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetProperties(ctx, id.StorageAccountId.ResourceGroup, id.StorageAccountId.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading the state of Storage Account %q: %+v", id.StorageAccountId.Name, err)
+	}
+
+	d.Set("storage_account_id", id.StorageAccountId.ID())
+	if rules := resp.NetworkRuleSet; rules != nil {
+		if ipRule, _, exists := FindStorageAccountNetworkIPRule(rules.IPRules, id.IPRule); exists {
+			if err := d.Set("ip_rule", ipRule.IPAddressOrRange); err != nil {
+				return fmt.Errorf("setting `ip_rule`: %+v", err)
+			}
+		}
+
+		if vnetRule, _, exists := FindStorageAccountVirtualNetworkRule(rules.VirtualNetworkRules, id.VirtualNetworkRule); exists {
+			if err := d.Set("virtual_network_rule", vnetRule.VirtualNetworkResourceID); err != nil {
+				return fmt.Errorf("setting `virtual_network_rule`: %+v", err)
+			}
+		}
+
+		if resourceAccessRule, _, exists := FindStorageAccountNetworkResourceAccessRule(rules.ResourceAccessRules, id.ResourceAccessRule); exists {
+			flattenedResourceAccessRule := flattenStorageAccountNetworkRuleResourceAccessRule(resourceAccessRule, tenantID)
+			if err := d.Set("resource_access_rule", pluginsdk.NewSet(pluginsdk.HashResource(resourceAccessRuleResource()), flattenedResourceAccessRule)); err != nil {
+				return fmt.Errorf("setting `resource_access_rule`: %+v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceStorageAccountNetworkRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Storage.AccountsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.StorageAccountNetworkRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.StorageAccountId.Name, storageAccountResourceName)
+	defer locks.UnlockByName(id.StorageAccountId.Name, storageAccountResourceName)
+
+	existing, err := client.GetProperties(ctx, id.StorageAccountId.ResourceGroup, id.StorageAccountId.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+		return fmt.Errorf("retrieving %+v: %+v", *id, err)
+	}
+
+	if rules := existing.NetworkRuleSet; rules != nil {
+		if _, index, exists := FindStorageAccountNetworkIPRule(rules.IPRules, id.IPRule); exists {
+			r := *rules.IPRules
+			r = append(r[:index], r[index+1:]...)
+			rules.IPRules = &r
+		}
+
+		if _, index, exists := FindStorageAccountVirtualNetworkRule(rules.VirtualNetworkRules, id.VirtualNetworkRule); exists {
+			r := *rules.VirtualNetworkRules
+			r = append(r[:index], r[index+1:]...)
+			rules.VirtualNetworkRules = &r
+		}
+
+		if _, index, exists := FindStorageAccountNetworkResourceAccessRule(rules.ResourceAccessRules, id.ResourceAccessRule); exists {
+			r := *rules.ResourceAccessRules
+			r = append(r[:index], r[index+1:]...)
+			rules.ResourceAccessRules = &r
+		}
+
+		opts := storage.AccountUpdateParameters{
+			AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
+				NetworkRuleSet: rules,
+			},
+		}
+
+		if _, err := client.Update(ctx, id.StorageAccountId.ResourceGroup, id.StorageAccountId.Name, opts); err != nil {
+			return fmt.Errorf("deleting %s: %+v", id.String(), err)
+		}
+	}
+
+	return nil
+}
+
+func FindStorageAccountNetworkIPRule(items *[]storage.IPRule, item *storage.IPRule) (*storage.IPRule, int, bool) {
+	if items != nil && item != nil {
+		for idx, rule := range *items {
+			if strings.EqualFold(*rule.IPAddressOrRange, *item.IPAddressOrRange) {
+				return &rule, idx, true
+			}
+		}
+	}
+	return nil, -1, false
+}
+
+func FindStorageAccountVirtualNetworkRule(items *[]storage.VirtualNetworkRule, item *storage.VirtualNetworkRule) (*storage.VirtualNetworkRule, int, bool) {
+	if items != nil && item != nil {
+		for idx, rule := range *items {
+			if strings.EqualFold(*rule.VirtualNetworkResourceID, *item.VirtualNetworkResourceID) {
+				return &rule, idx, true
+			}
+		}
+	}
+	return nil, -1, false
+}
+
+func FindStorageAccountNetworkResourceAccessRule(items *[]storage.ResourceAccessRule, item *storage.ResourceAccessRule) (*storage.ResourceAccessRule, int, bool) {
+	if items != nil && item != nil {
+		for idx, rule := range *items {
+			if strings.EqualFold(*rule.ResourceID, *item.ResourceID) && strings.EqualFold(*rule.TenantID, *item.TenantID) {
+				return &rule, idx, true
+			}
+		}
+	}
+	return nil, -1, false
+}
+
+func flattenStorageAccountNetworkRuleResourceAccessRule(input *storage.ResourceAccessRule, tenantId string) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	result := make(map[string]interface{})
+	if input.TenantID != nil {
+		tenantId = *input.TenantID
+	}
+	result["resource_id"] = *input.ResourceID
+	result["tenant_id"] = tenantId
+	return []interface{}{result}
+}
+
+func expandStorageAccountNetworkRuleResourceAccessRule(input []interface{}, tenantId string) *storage.ResourceAccessRule {
+	if len(input) == 0 {
+		return nil
+	}
+
+	item := input[0].(map[string]interface{})
+	if v := item["tenant_id"].(string); v != "" {
+		tenantId = v
+	}
+	return &storage.ResourceAccessRule{
+		ResourceID: utils.String(item["resource_id"].(string)),
+		TenantID:   utils.String(tenantId),
+	}
+}

--- a/internal/services/storage/storage_account_network_rule_resource_test.go
+++ b/internal/services/storage/storage_account_network_rule_resource_test.go
@@ -3,12 +3,12 @@ package storage_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/storage/storage_account_network_rule_resource_test.go
+++ b/internal/services/storage/storage_account_network_rule_resource_test.go
@@ -1,0 +1,190 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type StorageAccountNetworkRuleResource struct{}
+
+func TestAccStorageAccountNetworkRule_ipRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rule", "test")
+	r := StorageAccountNetworkRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipRule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule").HasValue("127.0.0.1"),
+				check.That(data.ResourceName).Key("virtual_network_rule").DoesNotExist(),
+				check.That(data.ResourceName).Key("resource_access_rule").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccountNetworkRule_virtualNetworkRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rule", "test")
+	r := StorageAccountNetworkRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.virtualNetworkRule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule").DoesNotExist(),
+				check.That(data.ResourceName).Key("virtual_network_rule").Exists(),
+				check.That(data.ResourceName).Key("resource_access_rule").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccountNetworkRule_resourceAccessRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rule", "test")
+	r := StorageAccountNetworkRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.resourceAccessRule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule").DoesNotExist(),
+				check.That(data.ResourceName).Key("virtual_network_rule").DoesNotExist(),
+				check.That(data.ResourceName).Key("resource_access_rule.0.resource_id").Exists(),
+				check.That(data.ResourceName).Key("resource_access_rule.0.tenant_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r StorageAccountNetworkRuleResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.StorageAccountNetworkRuleID(state.ID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %+v", state.ID, err)
+	}
+
+	resp, err := client.Storage.AccountsClient.GetProperties(ctx, id.StorageAccountId.ResourceGroup, id.StorageAccountId.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %q: %+v", id.StorageAccountId.ID(), err)
+	}
+
+	if rules := resp.NetworkRuleSet; rules != nil {
+		if _, _, exists := storage.FindStorageAccountNetworkIPRule(rules.IPRules, id.IPRule); exists {
+			return utils.Bool(true), nil
+		}
+		if _, _, exists := storage.FindStorageAccountVirtualNetworkRule(rules.VirtualNetworkRules, id.VirtualNetworkRule); exists {
+			return utils.Bool(true), nil
+		}
+		if _, _, exists := storage.FindStorageAccountNetworkResourceAccessRule(rules.ResourceAccessRules, id.ResourceAccessRule); exists {
+			return utils.Bool(true), nil
+		}
+	}
+	return utils.Bool(false), nil
+}
+
+func (r StorageAccountNetworkRuleResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}
+
+func (r StorageAccountNetworkRuleResource) ipRule(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account_network_rule" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+  ip_rule            = "127.0.0.1"
+}
+`, template)
+}
+
+func (r StorageAccountNetworkRuleResource) virtualNetworkRule(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account_network_rule" "test" {
+  storage_account_id   = azurerm_storage_account.test.id
+  virtual_network_rule = azurerm_subnet.test.id
+}
+`, template)
+}
+
+func (r StorageAccountNetworkRuleResource) resourceAccessRule(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "azurerm_storage_account_network_rule" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+
+  resource_access_rule {
+    resource_id = azurerm_private_endpoint.blob.id
+  }
+}
+`, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)
+}

--- a/website/docs/r/storage_account_network_rule.html.markdown
+++ b/website/docs/r/storage_account_network_rule.html.markdown
@@ -1,0 +1,108 @@
+---
+subcategory: "Storage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_account_network_rule"
+description: |-
+  Manages an Azure Storage Account Network Rule.
+---
+
+# azurerm_storage_account_network_rule
+
+Manages an Azure Storage Account Network Rule.
+
+~> **NOTE:** IP Network Rules, Virtual Network Rules and Resource Access Network Rules can be defined either directly on the [`azurerm_storage_account`](storage_account.html) resource, using the [`azurerm_storage_account_network_rules`](storage_account_network_rule.html) resource or using `azurerm_storage_account_network_rule` resources - but they cannot be used together. Spurious changes will occur if they are used against the same Storage Account.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_account_network_rule" "example" {
+  storage_account_id = azurerm_storage_account.example.id
+  ip_rule            = "127.0.0.1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created.
+
+* `ip_rule` - (Optional) Public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed. Changing this forces a new resource to be created. This field cannot be specified if `virtual_network_rule` or `resource_access_rule` is specified.
+
+-> **NOTE** Small address ranges using "/31" or "/32" prefix sizes are not supported. These ranges should be configured using individual IP address rules without prefix specified.
+
+-> **NOTE** IP network rules have no effect on requests originating from the same Azure region as the storage account. Use Virtual network rules to allow same-region requests. Services deployed in the same region as the storage account use private Azure IP addresses for communication. Thus, you cannot restrict access to specific Azure services based on their public outbound IP address range.
+
+* `virtual_network_rule` - (Optional) A virtual network subnet ids to secure the storage account. Changing this forces a new resource to be created. This field cannot be specified if `ip_rule` or `resource_access_rule` is specified.
+
+* `resource_access_rule` - (Optional) A `resource_access_rule` block as defined below. Changing this forces a new resource to be created. This field cannot be specified if `ip_rule` or `virtual_network_rule` is specified.
+
+---
+
+A `resource_access_rule` block supports the following:
+
+* `resource_id` - (Required) The resource id of the resource access rule to be granted access.
+
+* `tenant_id` - (Optional) The tenant id of the resource of the resource access rule to be granted access. Defaults to the current tenant id.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ID of the Storage Account Network Rule.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 minutes) Used when creating the Storage Account Network Rule.
+* `update` - (Defaults to 10 minutes) Used when updating the Storage Account Network Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Storage Account Network Rule.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Storage Account Network Rule.
+
+## Import
+
+Storage Account Network Rule can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_account_network_rule.ip_rule /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount;ipAddressOrRange/127.0.0.1
+terraform import azurerm_storage_account_network_rule.virtual_network_rule /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount;subnetId/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1
+terraform import azurerm_storage_account_network_rule.resource_access_rule /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount;tenantId/00000000-0000-0000-0000-000000000000/resourceId/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/privateEndpoints/myprivatelink
+```


### PR DESCRIPTION
Fixes: #10599

### Summary
This pull request adds a new resource for managing individual storage account network rules, equivalent of using the `az storage account network-rule add/remove` functionalities.

Not to be used w/ either `azurerm_storage_account_network_rules` or `azurerm_storage_account.network_rules`, except for `default_action` and `bypass` attributes.

### Terraform Configuration

```hcl
resource "azurerm_storage_account_network_rule" "ip_address_or_range" {
  storage_account_id = azurerm_storage_account.test.id
  ip_rule            = "127.0.0.1"
}

resource "azurerm_storage_account_network_rule" "subnet_id" {
  storage_account_id   = azurerm_storage_account.test.id
  virtual_network_rule = azurerm_subnet.test.id
}

resource "azurerm_storage_account_network_rule" "resource_access" {
  storage_account_id = azurerm_storage_account.test.id

  resource_access_rule {
    resource_id = azurerm_private_endpoint.blob.id
  }
}
```

### Acceptance tests
```
make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccountNetworkRule_ipRule' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageAccountNetworkRule_ipRule -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccountNetworkRule_ipRule
=== PAUSE TestAccStorageAccountNetworkRule_ipRule
=== CONT  TestAccStorageAccountNetworkRule_ipRule
--- PASS: TestAccStorageAccountNetworkRule_ipRule (131.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	132.409s
```
```
make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccountNetworkRule_virtualNetworkRule' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageAccountNetworkRule_virtualNetworkRule -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccountNetworkRule_virtualNetworkRule
=== PAUSE TestAccStorageAccountNetworkRule_virtualNetworkRule
=== CONT  TestAccStorageAccountNetworkRule_virtualNetworkRule
--- PASS: TestAccStorageAccountNetworkRule_virtualNetworkRule (138.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	139.555s
```
```
make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccountNetworkRule_resourceAccessRule' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageAccountNetworkRule_resourceAccessRule -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccountNetworkRule_resourceAccessRule
=== PAUSE TestAccStorageAccountNetworkRule_resourceAccessRule
=== CONT  TestAccStorageAccountNetworkRule_resourceAccessRule
--- PASS: TestAccStorageAccountNetworkRule_resourceAccessRule (182.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	183.368s
```
### TODOs:

- [x] Add documentation

