### PR TITLE
azurerm_network_interface_security_group_association: fix terraform azurerm crashing on import of specific resource type

### DIFF
--- a/internal/services/network/network_interface_network_security_group_association_resource.go
+++ b/internal/services/network/network_interface_network_security_group_association_resource.go
@@ -26,7 +26,7 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			splitId := strings.Split(id, "|")
 			if len(splitId) != 2 {
-				return fmt.Errorf("expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", id)
+				return fmt.Errorf("expect ID to be the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", id)
 			}
 			if _, err := parse.NetworkInterfaceID(splitId[0]); err != nil {
 				return err

--- a/internal/services/network/network_interface_network_security_group_association_resource.go
+++ b/internal/services/network/network_interface_network_security_group_association_resource.go
@@ -25,6 +25,9 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 		Delete: resourceNetworkInterfaceSecurityGroupAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			splitId := strings.Split(id, "|")
+			if len(splitId) != 2 {
+				return fmt.Errorf("expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", id)
+			}
 			if _, err := parse.NetworkInterfaceID(splitId[0]); err != nil {
 				return err
 			}


### PR DESCRIPTION
The purpose of this PR:

> The azurerm_network_interface_security_group_association resource can be imported using the resource id. The resource id is specific to Terraform - and is of the format {networkInterfaceId}|{networkSecurityGroupId}. Terrafrom azurerm crashes when the resource id only contains the {networkInterfaceId} due to the error "index out of range [1] length 1". So, add length verification to improve user experience.

Fix [#14730](https://github.com/hashicorp/terraform-provider-azurerm/issues/14730).

Test results:
PASS: TestAccNetworkInterfaceSecurityGroupAssociation_deleted (290.88s)
PASS: TestAccNetworkInterfaceSecurityGroupAssociation_basic (316.56s)
PASS: TestAccNetworkInterfaceSecurityGroupAssociation_requiresImport (327.93s)
PASS: TestAccNetworkInterfaceSecurityGroupAssociation_updateNIC (401.48s)