### PR TITLE
`d/azurerm_virtual_machine_scale_set`: Add scale set instances details

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_identity_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_identity_resource_test.go
@@ -141,6 +141,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
+  overprovision       = false
 
   disable_password_authentication = false
 

--- a/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -1,13 +1,17 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -36,12 +40,84 @@ func dataSourceVirtualMachineScaleSet() *pluginsdk.Resource {
 			"network_interface": VirtualMachineScaleSetNetworkInterfaceSchemaForDataSource(),
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
+			"instances": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"computer_name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"instance_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"latest_model_applied": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"private_ip_address": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"private_ip_addresses": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"public_ip_address": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"public_ip_addresses": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"provisioning_state": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"virtual_machine_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"zone": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	instancesClient := meta.(*clients.Client).Compute.VMScaleSetVMsClient
+	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
+	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -82,5 +158,143 @@ func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interf
 		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 
+	instances := make([]interface{}, 0)
+	result, err := instancesClient.ListComplete(ctx, id.ResourceGroup, id.Name, "", "", "")
+	if err != nil {
+		return fmt.Errorf("listing VM Instances for Virtual Machine Scale Set %q (Resource Group %q): %+v", id.ResourceGroup, id.Name, err)
+	}
+
+	for result.NotDone() {
+		instance := result.Value()
+		if err := result.NextWithContext(ctx); err != nil {
+			return fmt.Errorf("listing next page VM Instances for Virtual Machine Scale Set %q (Resource Group %q): %+v", id.ResourceGroup, id.Name, err)
+		}
+
+		nics, err := networkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id.ResourceGroup, id.Name, *instance.InstanceID)
+		if err != nil {
+			return fmt.Errorf("listing Network Interfaces for VM Instance %q for Virtual Machine Scale Set %q (Resource Group %q): %+v", *instance.InstanceID, id.ResourceGroup, id.Name, err)
+		}
+
+		networkInterfaces := make([]network.Interface, 0)
+		for nics.NotDone() {
+			networkInterfaces = append(networkInterfaces, nics.Value())
+			if err := nics.NextWithContext(ctx); err != nil {
+				return fmt.Errorf("listing next page of Network Interfaces for VM Instance %q of Virtual Machine Scale Set %q (Resource Group %q): %v", *instance.InstanceID, id.ResourceGroup, id.Name, err)
+			}
+		}
+
+		connectionInfo, err := getVirtualMachineScaleSetVMConnectionInfo(ctx, networkInterfaces, id.ResourceGroup, id.Name, *instance.InstanceID, publicIPAddressesClient)
+		if err != nil {
+			return err
+		}
+
+		flattenedInstances := flattenVirtualMachineScaleSetVM(instance, connectionInfo)
+		instances = append(instances, flattenedInstances)
+	}
+	if err := d.Set("instances", instances); err != nil {
+		return fmt.Errorf("setting `instances`: %+v", err)
+	}
+
 	return nil
+}
+
+func getVirtualMachineScaleSetVMConnectionInfo(ctx context.Context, networkInterfaces []network.Interface, resourceGroupName string, virtualMachineScaleSetName string, instanceID string, publicIPAddressesClient *network.PublicIPAddressesClient) (*connectionInfo, error) {
+	if len(networkInterfaces) == 0 {
+		return nil, nil
+	}
+
+	primaryPublicAddress := ""
+	primaryPrivateAddress := ""
+	publicIPAddresses := make([]string, 0)
+	privateIPAddresses := make([]string, 0)
+
+	for _, nic := range networkInterfaces {
+		for _, config := range *nic.IPConfigurations {
+			if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
+				if pip := props.PublicIPAddress; pip != nil {
+					pipID, err := networkParse.VirtualMachineScaleSetPublicIPAddressID(*pip.ID)
+					if err != nil {
+						return nil, err
+					}
+
+					publicIPAddress, err := publicIPAddressesClient.GetVirtualMachineScaleSetPublicIPAddress(ctx, resourceGroupName, virtualMachineScaleSetName, instanceID, pipID.NetworkInterfaceName, pipID.IpConfigurationName, pipID.PublicIPAddressName, "")
+					if err != nil {
+						return nil, fmt.Errorf("reading Public IP Address for VM Instance %q for Virtual Machine Scale Set %q (Resource Group %q): %+v", instanceID, virtualMachineScaleSetName, resourceGroupName, err)
+					}
+
+					if *nic.Primary && *props.Primary {
+						primaryPublicAddress = *publicIPAddress.IPAddress
+					}
+					publicIPAddresses = append(publicIPAddresses, *publicIPAddress.IPAddress)
+				}
+
+				if props.PrivateIPAddress != nil {
+					if *nic.Primary && *props.Primary {
+						primaryPrivateAddress = *props.PrivateIPAddress
+					}
+					privateIPAddresses = append(privateIPAddresses, *props.PrivateIPAddress)
+				}
+			}
+		}
+	}
+
+	if primaryPublicAddress == "" && len(publicIPAddresses) > 0 {
+		primaryPublicAddress = publicIPAddresses[0]
+	}
+
+	if primaryPrivateAddress == "" && len(privateIPAddresses) > 0 {
+		primaryPrivateAddress = privateIPAddresses[0]
+	}
+
+	return &connectionInfo{
+		primaryPublicAddress:  primaryPublicAddress,
+		publicAddresses:       publicIPAddresses,
+		primaryPrivateAddress: primaryPrivateAddress,
+		privateAddresses:      privateIPAddresses,
+	}, nil
+}
+
+func flattenVirtualMachineScaleSetVM(input compute.VirtualMachineScaleSetVM, connectionInfo *connectionInfo) map[string]interface{} {
+	output := make(map[string]interface{})
+	if input.Name != nil {
+		output["name"] = *input.Name
+	}
+
+	if input.InstanceID != nil {
+		output["instance_id"] = *input.InstanceID
+	}
+
+	if input.LatestModelApplied != nil {
+		output["latest_model_applied"] = *input.LatestModelApplied
+	}
+
+	if input.ProvisioningState != nil {
+		output["provisioning_state"] = *input.ProvisioningState
+	}
+
+	if input.VMID != nil {
+		output["virtual_machine_id"] = *input.VMID
+	}
+
+	props := *input.VirtualMachineScaleSetVMProperties
+	if profile := props.OsProfile; profile != nil {
+		output["computer_name"] = profile.ComputerName
+	}
+
+	zone := ""
+	if input.Zones != nil {
+		if zones := *input.Zones; len(zones) > 0 {
+			zone = zones[0]
+		}
+	}
+	output["zone"] = zone
+
+	if connectionInfo != nil {
+		output["private_ip_address"] = connectionInfo.primaryPrivateAddress
+		output["private_ip_addresses"] = connectionInfo.privateAddresses
+		output["public_ip_address"] = connectionInfo.primaryPublicAddress
+		output["public_ip_addresses"] = connectionInfo.publicAddresses
+	}
+
+	return output
 }

--- a/internal/services/compute/virtual_machine_scale_set_data_source_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source_test.go
@@ -21,6 +21,9 @@ func TestAccDataSourceVirtualMachineScaleSet_basicLinux(t *testing.T) {
 				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
 				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+				check.That(data.ResourceName).Key("instances.#").HasValue("1"),
+				check.That(data.ResourceName).Key("instances.0.instance_id").HasValue("0"),
+				check.That(data.ResourceName).Key("instances.0.private_ip_address").HasValue("10.0.2.4"),
 			),
 		},
 	})

--- a/internal/services/network/parse/virtual_machine_scale_set_public_ip_address.go
+++ b/internal/services/network/parse/virtual_machine_scale_set_public_ip_address.go
@@ -45,7 +45,7 @@ func (id VirtualMachineScaleSetPublicIPAddressId) String() string {
 }
 
 func (id VirtualMachineScaleSetPublicIPAddressId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/%s/publicIPAddresses/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/%s/publicIPAddresses/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.VirtualMachineName, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIPAddressName)
 }
 

--- a/internal/services/network/parse/virtual_machine_scale_set_public_ip_address.go
+++ b/internal/services/network/parse/virtual_machine_scale_set_public_ip_address.go
@@ -1,0 +1,93 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type VirtualMachineScaleSetPublicIPAddressId struct {
+	SubscriptionId             string
+	ResourceGroup              string
+	VirtualMachineScaleSetName string
+	VirtualMachineName         string
+	NetworkInterfaceName       string
+	IpConfigurationName        string
+	PublicIPAddressName        string
+}
+
+func NewVirtualMachineScaleSetPublicIPAddressID(subscriptionId, resourceGroup, virtualMachineScaleSetName, virtualMachineName, networkInterfaceName, ipConfigurationName, publicIPAddressName string) VirtualMachineScaleSetPublicIPAddressId {
+	return VirtualMachineScaleSetPublicIPAddressId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroup:              resourceGroup,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+		VirtualMachineName:         virtualMachineName,
+		NetworkInterfaceName:       networkInterfaceName,
+		IpConfigurationName:        ipConfigurationName,
+		PublicIPAddressName:        publicIPAddressName,
+	}
+}
+
+func (id VirtualMachineScaleSetPublicIPAddressId) String() string {
+	segments := []string{
+		fmt.Sprintf("Public I P Address Name %q", id.PublicIPAddressName),
+		fmt.Sprintf("Ip Configuration Name %q", id.IpConfigurationName),
+		fmt.Sprintf("Network Interface Name %q", id.NetworkInterfaceName),
+		fmt.Sprintf("Virtual Machine Name %q", id.VirtualMachineName),
+		fmt.Sprintf("Virtual Machine Scale Set Name %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Machine Scale Set Public I P Address", segmentsStr)
+}
+
+func (id VirtualMachineScaleSetPublicIPAddressId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/%s/publicIPAddresses/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.VirtualMachineName, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIPAddressName)
+}
+
+// VirtualMachineScaleSetPublicIPAddressID parses a VirtualMachineScaleSetPublicIPAddress ID into an VirtualMachineScaleSetPublicIPAddressId struct
+func VirtualMachineScaleSetPublicIPAddressID(input string) (*VirtualMachineScaleSetPublicIPAddressId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualMachineScaleSetPublicIPAddressId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VirtualMachineScaleSetName, err = id.PopSegment("virtualMachineScaleSets"); err != nil {
+		return nil, err
+	}
+	if resourceId.VirtualMachineName, err = id.PopSegment("virtualMachines"); err != nil {
+		return nil, err
+	}
+	if resourceId.NetworkInterfaceName, err = id.PopSegment("networkInterfaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.IpConfigurationName, err = id.PopSegment("ipConfigurations"); err != nil {
+		return nil, err
+	}
+	if resourceId.PublicIPAddressName, err = id.PopSegment("publicIPAddresses"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/virtual_machine_scale_set_public_ip_address_test.go
+++ b/internal/services/network/parse/virtual_machine_scale_set_public_ip_address_test.go
@@ -12,7 +12,7 @@ var _ resourceids.Id = VirtualMachineScaleSetPublicIPAddressId{}
 
 func TestVirtualMachineScaleSetPublicIPAddressIDFormatter(t *testing.T) {
 	actual := NewVirtualMachineScaleSetPublicIPAddressID("12345678-1234-9876-4563-123456789012", "resGroup1", "scaleSet1", "virtualMachine1", "networkInterface1", "ipConfiguration1", "publicIpAddress1").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -57,67 +57,67 @@ func TestVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
 
 		{
 			// missing VirtualMachineScaleSetName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
 			Error: true,
 		},
 
 		{
 			// missing value for VirtualMachineScaleSetName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/",
 			Error: true,
 		},
 
 		{
 			// missing VirtualMachineName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
 			Error: true,
 		},
 
 		{
 			// missing value for VirtualMachineName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
 			Error: true,
 		},
 
 		{
 			// missing NetworkInterfaceName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
 			Error: true,
 		},
 
 		{
 			// missing value for NetworkInterfaceName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
 			Error: true,
 		},
 
 		{
 			// missing IpConfigurationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
 			Error: true,
 		},
 
 		{
 			// missing value for IpConfigurationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
 			Error: true,
 		},
 
 		{
 			// missing PublicIPAddressName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
 			Error: true,
 		},
 
 		{
 			// missing value for PublicIPAddressName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
 			Expected: &VirtualMachineScaleSetPublicIPAddressId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:              "resGroup1",

--- a/internal/services/network/parse/virtual_machine_scale_set_public_ip_address_test.go
+++ b/internal/services/network/parse/virtual_machine_scale_set_public_ip_address_test.go
@@ -1,0 +1,176 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = VirtualMachineScaleSetPublicIPAddressId{}
+
+func TestVirtualMachineScaleSetPublicIPAddressIDFormatter(t *testing.T) {
+	actual := NewVirtualMachineScaleSetPublicIPAddressID("12345678-1234-9876-4563-123456789012", "resGroup1", "scaleSet1", "virtualMachine1", "networkInterface1", "ipConfiguration1", "publicIpAddress1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualMachineScaleSetPublicIPAddressId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VirtualMachineScaleSetName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/",
+			Error: true,
+		},
+
+		{
+			// missing value for VirtualMachineScaleSetName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/",
+			Error: true,
+		},
+
+		{
+			// missing VirtualMachineName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
+			Error: true,
+		},
+
+		{
+			// missing value for VirtualMachineName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
+			Error: true,
+		},
+
+		{
+			// missing NetworkInterfaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
+			Error: true,
+		},
+
+		{
+			// missing value for NetworkInterfaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
+			Error: true,
+		},
+
+		{
+			// missing IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
+			Error: true,
+		},
+
+		{
+			// missing value for IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
+			Error: true,
+		},
+
+		{
+			// missing PublicIPAddressName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
+			Error: true,
+		},
+
+		{
+			// missing value for PublicIPAddressName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
+			Expected: &VirtualMachineScaleSetPublicIPAddressId{
+				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:              "resGroup1",
+				VirtualMachineScaleSetName: "scaleSet1",
+				VirtualMachineName:         "virtualMachine1",
+				NetworkInterfaceName:       "networkInterface1",
+				IpConfigurationName:        "ipConfiguration1",
+				PublicIPAddressName:        "publicIpAddress1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINESCALESETS/SCALESET1/VIRTUALMACHINES/VIRTUALMACHINE1/NETWORKINTERFACES/NETWORKINTERFACE1/IPCONFIGURATIONS/IPCONFIGURATION1/PUBLICIPADDRESSES/PUBLICIPADDRESS1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualMachineScaleSetPublicIPAddressID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {
+			t.Fatalf("Expected %q but got %q for VirtualMachineScaleSetName", v.Expected.VirtualMachineScaleSetName, actual.VirtualMachineScaleSetName)
+		}
+		if actual.VirtualMachineName != v.Expected.VirtualMachineName {
+			t.Fatalf("Expected %q but got %q for VirtualMachineName", v.Expected.VirtualMachineName, actual.VirtualMachineName)
+		}
+		if actual.NetworkInterfaceName != v.Expected.NetworkInterfaceName {
+			t.Fatalf("Expected %q but got %q for NetworkInterfaceName", v.Expected.NetworkInterfaceName, actual.NetworkInterfaceName)
+		}
+		if actual.IpConfigurationName != v.Expected.IpConfigurationName {
+			t.Fatalf("Expected %q but got %q for IpConfigurationName", v.Expected.IpConfigurationName, actual.IpConfigurationName)
+		}
+		if actual.PublicIPAddressName != v.Expected.PublicIPAddressName {
+			t.Fatalf("Expected %q but got %q for PublicIPAddressName", v.Expected.PublicIPAddressName, actual.PublicIPAddressName)
+		}
+	}
+}

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -107,4 +107,4 @@ package network
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=LoadBalancerBackendAddressPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/loadBalancers/loadBalancer1/backendAddressPools/backendAddressPool1
 
 // Virtual Machine Scale Set
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualMachineScaleSetPublicIPAddress -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualMachineScaleSetPublicIPAddress -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -105,3 +105,6 @@ package network
 // Load balancer
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=InboundNatRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/loadBalancers/loadBalancer1/inboundNatRules/natrule1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=LoadBalancerBackendAddressPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/loadBalancers/loadBalancer1/backendAddressPools/backendAddressPool1
+
+// Virtual Machine Scale Set
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualMachineScaleSetPublicIPAddress -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1

--- a/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id.go
+++ b/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func VirtualMachineScaleSetPublicIPAddressID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualMachineScaleSetPublicIPAddressID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id_test.go
+++ b/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id_test.go
@@ -1,0 +1,124 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VirtualMachineScaleSetName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VirtualMachineScaleSetName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/",
+			Valid: false,
+		},
+
+		{
+			// missing VirtualMachineName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VirtualMachineName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
+			Valid: false,
+		},
+
+		{
+			// missing NetworkInterfaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for NetworkInterfaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
+			Valid: false,
+		},
+
+		{
+			// missing IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
+			Valid: false,
+		},
+
+		{
+			// missing PublicIPAddressName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PublicIPAddressName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINESCALESETS/SCALESET1/VIRTUALMACHINES/VIRTUALMACHINE1/NETWORKINTERFACES/NETWORKINTERFACE1/IPCONFIGURATIONS/IPCONFIGURATION1/PUBLICIPADDRESSES/PUBLICIPADDRESS1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualMachineScaleSetPublicIPAddressID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id_test.go
+++ b/internal/services/network/validate/virtual_machine_scale_set_public_ip_address_id_test.go
@@ -42,67 +42,67 @@ func TestVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
 
 		{
 			// missing VirtualMachineScaleSetName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
 			Valid: false,
 		},
 
 		{
 			// missing value for VirtualMachineScaleSetName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/",
 			Valid: false,
 		},
 
 		{
 			// missing VirtualMachineName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/",
 			Valid: false,
 		},
 
 		{
 			// missing value for VirtualMachineName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/",
 			Valid: false,
 		},
 
 		{
 			// missing NetworkInterfaceName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/",
 			Valid: false,
 		},
 
 		{
 			// missing value for NetworkInterfaceName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/",
 			Valid: false,
 		},
 
 		{
 			// missing IpConfigurationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/",
 			Valid: false,
 		},
 
 		{
 			// missing value for IpConfigurationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/",
 			Valid: false,
 		},
 
 		{
 			// missing PublicIPAddressName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/",
 			Valid: false,
 		},
 
 		{
 			// missing value for PublicIPAddressName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1",
 			Valid: true,
 		},
 

--- a/website/docs/d/virtual_machine_scale_set.html.markdown
+++ b/website/docs/d/virtual_machine_scale_set.html.markdown
@@ -37,7 +37,11 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Virtual Machine Scale Set.
 
+* `location` - The Azure Region in which this Virtual Machine Scale Set exists.
+
 * `identity` - A `identity` block as defined below.
+
+* `instances` - A list of `instances` blocks as defined below.
 
 * `network_interface` - A list of `network_interface` blocks as defined below.
 
@@ -52,6 +56,22 @@ An `identity` block exports the following:
 * `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Virtual Machine Scale Set.
 
 * `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Virtual Machine Scale Set.
+
+---
+
+`instances` exports the following:
+
+* `computer_name` - The Hostname of this Virtual Machine.
+* `instance_id` - The Instance ID of this Virtual Machine.
+* `latest_model_applied` - Whether the latest model has been applied to this Virtual Machine.
+* `name` - The name of the this Virtual Machine.
+* `private_ip_address` - The Primary Private IP Address assigned to this Virtual Machine.
+* `private_ip_addresses` - A list of Private IP Addresses assigned to this Virtual Machine.
+* `public_ip_address` - The Primary Public IP Address assigned to this Virtual Machine.
+* `public_ip_addresses` - A list of the Public IP Addresses assigned to this Virtual Machine.
+* `provisioning_state` - The provisioning state of the virtual machine.
+* `virtual_machine_id` - The unique ID of the virtual machine.
+* `zone` - The zones of the virtual machine.
 
 ---
 


### PR DESCRIPTION
### Summary

Outputs the list of virtual machine instance currently in the scale set w/ details including private/public ip adresses, computer name, etc. Useful when using auto scaling...

Supersede #14031

### Acceptance tests
```
make acctests SERVICE='compute' TESTARGS='-run=TestAccDataSourceVirtualMachineScaleSet_basicLinux' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/compute -run=TestAccDataSourceVirtualMachineScaleSet_basicLinux -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceVirtualMachineScaleSet_basicLinux
=== PAUSE TestAccDataSourceVirtualMachineScaleSet_basicLinux
=== CONT  TestAccDataSourceVirtualMachineScaleSet_basicLinux
--- PASS: TestAccDataSourceVirtualMachineScaleSet_basicLinux (245.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/compute	247.273s
```