### PR TITLE
azurerm_mssql_database_vulnerability_assessment_rule_baseline: fix the resource is being replaced every new tf apply issue

### DIFF
--- a/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
+++ b/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
@@ -153,8 +153,7 @@ func resourceMsSqlDatabaseVulnerabilityAssessmentRuleBaselineRead(d *pluginsdk.R
 	d.Set("rule_id", id.RuleName)
 	d.Set("baseline_name", id.BaselineName)
 
-	// TODO: replace "Default" with "default" after the issue(https://github.com/Azure/azure-rest-api-specs/issues/17192) is fixed.
-	vulnerabilityAssessmentId := parse.NewServerVulnerabilityAssessmentID(id.SubscriptionId, id.ResourceGroup, id.ServerName, "Default")
+	vulnerabilityAssessmentId := parse.NewServerVulnerabilityAssessmentID(id.SubscriptionId, id.ResourceGroup, id.ServerName, id.VulnerabilityAssessmentName)
 	d.Set("server_vulnerability_assessment_id", vulnerabilityAssessmentId.ID())
 
 	if baselineResults := result.BaselineResults; baselineResults != nil {

--- a/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
+++ b/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
@@ -153,7 +153,8 @@ func resourceMsSqlDatabaseVulnerabilityAssessmentRuleBaselineRead(d *pluginsdk.R
 	d.Set("rule_id", id.RuleName)
 	d.Set("baseline_name", id.BaselineName)
 
-	vulnerabilityAssessmentId := parse.NewServerVulnerabilityAssessmentID(id.SubscriptionId, id.ResourceGroup, id.ServerName, "default")
+	// TODO: replace "Default" with "default" after the issue(https://github.com/Azure/azure-rest-api-specs/issues/17192) is fixed.
+	vulnerabilityAssessmentId := parse.NewServerVulnerabilityAssessmentID(id.SubscriptionId, id.ResourceGroup, id.ServerName, "Default")
 	d.Set("server_vulnerability_assessment_id", vulnerabilityAssessmentId.ID())
 
 	if baselineResults := result.BaselineResults; baselineResults != nil {


### PR DESCRIPTION
The purpose of this PR:

> Fix Issue [#14695](https://github.com/hashicorp/terraform-provider-azurerm/issues/14695). The issue is that the resource azurerm_mssql_database_vulnerability_assessment_rule_baseline is always created when the "terraform apply" runs every time, even if the tf config is not changed. The server_vulnerability_assessment_id property is ForceNew in terraform. So, when the value of the property is changed, the resource would be re-created. In this case, the root cause is that the [DatabaseVulnerabilityAssessments ](https://github.com/Azure/azure-rest-api-specs/blob/0fe46ea84880c3232c7a86db0c73f30975b11b0b/specification/sql/resource-manager/Microsoft.Sql/preview/2021-05-01-preview/DatabaseVulnerabilityAssessments.json#L83)API returns the VulnerabilityAssessmentName of id in uppercase, which changes the property value. So, I submitted this PR as a workaround for the issue. And I created an [issue ](https://github.com/Azure/azure-rest-api-specs/issues/17192)for Azure API to fix it completely. And this PR should be reverted after the API issue is fixed.



Test results:
PASS: TestAccMsSqlDatabaseVulnerabilityAssessmentRuleBaseline_basic (461.71s)
PASS: TestAccMsSqlDatabaseVulnerabilityAssessmentRuleBaseline_primary (550.76s)