### PR TITLE
Updated error message to provide the solution

### DIFF
--- a/internal/services/keyvault/validate/nested_item_id.go
+++ b/internal/services/keyvault/validate/nested_item_id.go
@@ -44,7 +44,7 @@ func VersionlessNestedItemId(i interface{}, k string) (warnings []string, errors
 	}
 
 	if id.Version != "" {
-		errors = append(errors, fmt.Errorf("expected %s to not have a version", k))
+		errors = append(errors, fmt.Errorf("expected %s to not have a version, please use the versionless ID", k))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
The error message when supplying a key ID when a versionless ID is expected does not provide any kind of context to explain the solution. This error message will provide the solution, rather than just state the error. 

This directly addresses https://github.com/hashicorp/terraform-provider-azurerm/issues/13147

Fixes #13147