### PR TITLE
`r\windows_virtual_machine`: Add support for `hot_patching_enabled`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -83,6 +83,35 @@ func TestAccWindowsVirtualMachine_otherPatchModeUpdate(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_otherHotPatchingEnabledUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherHotPatchingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherHotPatchingDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherHotPatchingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_otherAdditionalUnattendContent(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -920,6 +949,73 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   patch_mode = "AutomaticByPlatform"
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherHotPatchingDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_DS1_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-azure-edition-core"
+    version   = "latest"
+  }
+
+  patch_mode = "AutomaticByPlatform"
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherHotPatchingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_DS1_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-azure-edition-core"
+    version   = "latest"
+  }
+
+  patch_mode           = "AutomaticByPlatform"
+  hot_patching_enabled = true
 }
 `, r.template(data))
 }

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -145,6 +145,12 @@ The following arguments are supported:
 
 * `patch_mode` - (Optional) Specifies the mode of in-guest patching to this Windows Virtual Machine. Possible values are `Manual`, `AutomaticByOS` and `AutomaticByPlatform`. Defaults to `AutomaticByOS`.
 
+* `hot_patching_enabled` - (Optional) Specifies if Hot Patching is enabled for the Virtual Machine. Defaults to `false`
+
+-> **NOTE:** This can only be set to `true` when `patch_mode` is `AutomaticByPlatform`
+
+-> **NOTE:** This is a preview feature, see [here](https://docs.microsoft.com/en-us/azure/automanage/automanage-hotpatch) for more details
+
 * `plan` - (Optional) A `plan` block as defined below. Changing this forces a new resource to be created.
 
 * `platform_fault_domain` - (Optional) Specifies the Platform Fault Domain in which this Windows Virtual Machine should be created. Defaults to `-1`, which means this will be automatically assigned to a fault domain that best maintains balance across the available fault domains. Changing this forces a new Windows Virtual Machine to be created.


### PR DESCRIPTION
- [hot patching](https://docs.microsoft.com/en-us/azure/automanage/automanage-hotpatch) is used for automatically install patch in windows vm without restarting, it is a supplementary of `patch_mode`.
- It can only be enabled with `patch_mode`: `AutomaticByPlatform`
- `patch_mode` is now in GA state, and `hot_patching_enabled` is in public preview, removing the preview comment of `patch_mode`, and adding the preview doc link in the document of the new property
