### PR TITLE
servicebus related resources: reference parent resource ID

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_authorization_rule_resource.go
@@ -44,14 +44,37 @@ func resourceServiceBusNamespaceAuthorizationRule() *pluginsdk.Resource {
 				ValidateFunc: validate.AuthorizationRuleName(),
 			},
 
-			"namespace_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.NamespaceName,
+			// TODO 3.0 - Make it required
+			"namespace_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.NamespaceID,
+				ConflictsWith: []string{"namespace_name", "resource_group_name"},
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			// TODO 3.0 - Remove in favor of namespace_id
+			"namespace_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.NamespaceName,
+				Deprecated:    `Deprecated in favor of "namespace_id"`,
+				ConflictsWith: []string{"namespace_id"},
+			},
+
+			// TODO 3.0 - Remove in favor of namespace_id
+			"resource_group_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceGroupName,
+				Deprecated:    `Deprecated in favor of "namespace_id"`,
+				ConflictsWith: []string{"namespace_id"},
+			},
 		}),
 
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(authorizationRuleCustomizeDiff),
@@ -65,7 +88,15 @@ func resourceServiceBusNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.Resou
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for ServiceBus Namespace Authorization Rule create/update.")
-	resourceId := parse.NewNamespaceAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+
+	var resourceId parse.NamespaceAuthorizationRuleId
+	if namespaceIdLit := d.Get("namespace_id").(string); namespaceIdLit != "" {
+		namespaceId, _ := parse.NamespaceID(namespaceIdLit)
+		resourceId = parse.NewNamespaceAuthorizationRuleID(namespaceId.SubscriptionId, namespaceId.ResourceGroup, namespaceId.Name, d.Get("name").(string))
+	} else {
+		resourceId = parse.NewNamespaceAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+	}
+
 	if d.IsNewResource() {
 		existing, err := client.GetAuthorizationRule(ctx, resourceId.ResourceGroup, resourceId.NamespaceName, resourceId.AuthorizationRuleName)
 		if err != nil {
@@ -126,6 +157,7 @@ func resourceServiceBusNamespaceAuthorizationRuleRead(d *pluginsdk.ResourceData,
 	d.Set("name", id.AuthorizationRuleName)
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("namespace_id", parse.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName).ID())
 
 	if properties := resp.SBAuthorizationRuleProperties; properties != nil {
 		listen, send, manage := flattenAuthorizationRuleRights(properties.Rights)

--- a/internal/services/servicebus/servicebus_namespace_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_authorization_rule_resource_test.go
@@ -66,7 +66,7 @@ func TestAccServiceBusNamespaceAuthorizationRule_rightsUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("namespace_name").Exists(),
+				check.That(data.ResourceName).Key("namespace_id").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_key").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
@@ -136,9 +136,8 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctest-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 
   listen = %[3]t
   send   = %[4]t
@@ -152,9 +151,8 @@ func (r ServiceBusNamespaceAuthorizationRuleResource) requiresImport(data accept
 %s
 
 resource "azurerm_servicebus_namespace_authorization_rule" "import" {
-  name                = azurerm_servicebus_namespace_authorization_rule.test.name
-  namespace_name      = azurerm_servicebus_namespace_authorization_rule.test.namespace_name
-  resource_group_name = azurerm_servicebus_namespace_authorization_rule.test.resource_group_name
+  name         = azurerm_servicebus_namespace_authorization_rule.test.name
+  namespace_id = azurerm_servicebus_namespace_authorization_rule.test.namespace_id
 
   listen = azurerm_servicebus_namespace_authorization_rule.test.listen
   send   = azurerm_servicebus_namespace_authorization_rule.test.send
@@ -202,12 +200,11 @@ resource "azurerm_servicebus_namespace_disaster_recovery_config" "pairing_test" 
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "test" {
-  name                = "namespace_rule_test"
-  namespace_name      = azurerm_servicebus_namespace.primary_namespace_test.name
-  resource_group_name = azurerm_resource_group.primary.name
-  listen              = true
-  send                = true
-  manage              = true
+  name         = "namespace_rule_test"
+  namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
+  listen       = true
+  send         = true
+  manage       = true
 
   depends_on = [
     azurerm_servicebus_namespace_disaster_recovery_config.pairing_test

--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource_test.go
@@ -110,8 +110,7 @@ func (r ServiceBusNamespaceNetworkRuleSetResource) basic(data acceptance.TestDat
 %s
 
 resource "azurerm_servicebus_namespace_network_rule_set" "test" {
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  namespace_id = azurerm_servicebus_namespace.test.id
 
   default_action = "Deny"
 
@@ -128,8 +127,7 @@ func (r ServiceBusNamespaceNetworkRuleSetResource) complete(data acceptance.Test
 %s
 
 resource "azurerm_servicebus_namespace_network_rule_set" "test" {
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  namespace_id = azurerm_servicebus_namespace.test.id
 
   default_action           = "Deny"
   trusted_services_allowed = true
@@ -188,8 +186,7 @@ func (r ServiceBusNamespaceNetworkRuleSetResource) requiresImport(data acceptanc
 %s
 
 resource "azurerm_servicebus_namespace_network_rule_set" "import" {
-  namespace_name      = azurerm_servicebus_namespace_network_rule_set.test.namespace_name
-  resource_group_name = azurerm_servicebus_namespace_network_rule_set.test.resource_group_name
+  namespace_id = azurerm_servicebus_namespace_network_rule_set.test.namespace_id
 }
 `, r.basic(data))
 }

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource.go
@@ -43,21 +43,48 @@ func resourceServiceBusQueueAuthorizationRule() *pluginsdk.Resource {
 				ValidateFunc: validate.AuthorizationRuleName(),
 			},
 
-			"namespace_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.NamespaceName,
+			// TODO 3.0 - Make it required
+			"queue_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.QueueID,
+				ConflictsWith: []string{"queue_name", "namespace_name", "resource_group_name"},
 			},
 
+			// TODO 3.0 - Remove in favor of queue_id
 			"queue_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.QueueName(),
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.QueueName(),
+				Deprecated:    `Deprecated in favor of "queue_id"`,
+				ConflictsWith: []string{"queue_id"},
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			// TODO 3.0 - Remove in favor of queue_id
+			"namespace_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.NamespaceName,
+				Deprecated:    `Deprecated in favor of "queue_id"`,
+				ConflictsWith: []string{"queue_id"},
+			},
+
+			// TODO 3.0 - Remove in favor of queue_id
+			"resource_group_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceGroupName,
+				Deprecated:    `Deprecated in favor of "queue_id"`,
+				ConflictsWith: []string{"queue_id"},
+			},
 		}),
 
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(authorizationRuleCustomizeDiff),
@@ -72,7 +99,14 @@ func resourceServiceBusQueueAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 
 	log.Printf("[INFO] preparing arguments for ServiceBus Queue Authorization Rule creation.")
 
-	resourceId := parse.NewQueueAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("queue_name").(string), d.Get("name").(string))
+	var resourceId parse.QueueAuthorizationRuleId
+	if queueIdLit := d.Get("queue_id").(string); queueIdLit != "" {
+		queueId, _ := parse.QueueID(queueIdLit)
+		resourceId = parse.NewQueueAuthorizationRuleID(queueId.SubscriptionId, queueId.ResourceGroup, queueId.NamespaceName, queueId.Name, d.Get("name").(string))
+	} else {
+		resourceId = parse.NewQueueAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("queue_name").(string), d.Get("name").(string))
+	}
+
 	if d.IsNewResource() {
 		existing, err := client.GetAuthorizationRule(ctx, resourceId.ResourceGroup, resourceId.NamespaceName, resourceId.QueueName, resourceId.AuthorizationRuleName)
 		if err != nil {
@@ -135,6 +169,7 @@ func resourceServiceBusQueueAuthorizationRuleRead(d *pluginsdk.ResourceData, met
 	d.Set("queue_name", id.QueueName)
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("queue_id", parse.NewQueueID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.QueueName).ID())
 
 	if properties := resp.SBAuthorizationRuleProperties; properties != nil {
 		listen, send, manage := flattenAuthorizationRuleRights(properties.Rights)

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -43,8 +43,7 @@ func testAccServiceBusQueueAuthorizationRule(t *testing.T, listen, send, manage 
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("namespace_name").Exists(),
-				check.That(data.ResourceName).Key("queue_name").Exists(),
+				check.That(data.ResourceName).Key("queue_id").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_key").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
@@ -169,18 +168,15 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctest-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
+  name         = "acctest-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 
   enable_partitioning = true
 }
 
 resource "azurerm_servicebus_queue_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  queue_name          = azurerm_servicebus_queue.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name     = "acctest-%[1]d"
+  queue_id = azurerm_servicebus_queue.test.id
 
   listen = %[3]t
   send   = %[4]t
@@ -194,10 +190,8 @@ func (r ServiceBusQueueAuthorizationRuleResource) requiresImport(data acceptance
 %s
 
 resource "azurerm_servicebus_queue_authorization_rule" "import" {
-  name                = azurerm_servicebus_queue_authorization_rule.test.name
-  namespace_name      = azurerm_servicebus_queue_authorization_rule.test.namespace_name
-  queue_name          = azurerm_servicebus_queue_authorization_rule.test.queue_name
-  resource_group_name = azurerm_servicebus_queue_authorization_rule.test.resource_group_name
+  name     = azurerm_servicebus_queue_authorization_rule.test.name
+  queue_id = azurerm_servicebus_queue_authorization_rule.test.queue_id
 
   listen = azurerm_servicebus_queue_authorization_rule.test.listen
   send   = azurerm_servicebus_queue_authorization_rule.test.send
@@ -231,9 +225,8 @@ resource "azurerm_servicebus_namespace" "primary_namespace_test" {
 }
 
 resource "azurerm_servicebus_queue" "example" {
-  name                = "queue-test"
-  resource_group_name = azurerm_resource_group.primary.name
-  namespace_name      = azurerm_servicebus_namespace.primary_namespace_test.name
+  name         = "queue-test"
+  namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
 }
 
 resource "azurerm_servicebus_namespace" "secondary_namespace_test" {
@@ -251,13 +244,11 @@ resource "azurerm_servicebus_namespace_disaster_recovery_config" "pairing_test" 
 }
 
 resource "azurerm_servicebus_queue_authorization_rule" "test" {
-  name                = "example_queue_rule"
-  namespace_name      = azurerm_servicebus_namespace.primary_namespace_test.name
-  queue_name          = azurerm_servicebus_queue.example.name
-  resource_group_name = azurerm_resource_group.primary.name
-  manage              = true
-  listen              = true
-  send                = true
+  name     = "example_queue_rule"
+  queue_id = azurerm_servicebus_queue.example.id
+  manage   = true
+  listen   = true
+  send     = true
 
   depends_on = [
     azurerm_servicebus_namespace_disaster_recovery_config.pairing_test

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -46,14 +46,37 @@ func resourceServiceBusQueue() *pluginsdk.Resource {
 				ValidateFunc: azValidate.QueueName(),
 			},
 
-			"namespace_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azValidate.NamespaceName,
+			// TODO 3.0 - Make it required
+			"namespace_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azValidate.NamespaceID,
+				ConflictsWith: []string{"namespace_name", "resource_group_name"},
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			// TODO 3.0 - Remove in favor of namespace_id
+			"namespace_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azValidate.NamespaceName,
+				Deprecated:    `Deprecated in favor of "namespace_id"`,
+				ConflictsWith: []string{"namespace_id"},
+			},
+
+			// TODO 3.0 - Remove in favor of namespace_id
+			"resource_group_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceGroupName,
+				Deprecated:    `Deprecated in favor of "namespace_id"`,
+				ConflictsWith: []string{"namespace_id"},
+			},
 
 			// Optional
 			"auto_delete_on_idle": {
@@ -181,6 +204,14 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	defer cancel()
 	log.Printf("[INFO] preparing arguments for ServiceBus Queue creation/update.")
 
+	var resourceId parse.QueueId
+	if namespaceIdLit := d.Get("namespace_id").(string); namespaceIdLit != "" {
+		namespaceId, _ := parse.NamespaceID(namespaceIdLit)
+		resourceId = parse.NewQueueID(namespaceId.SubscriptionId, namespaceId.ResourceGroup, namespaceId.Name, d.Get("name").(string))
+	} else {
+		resourceId = parse.NewQueueID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+	}
+
 	deadLetteringOnMessageExpiration := d.Get("dead_lettering_on_message_expiration").(bool)
 	enableBatchedOperations := d.Get("enable_batched_operations").(bool)
 	enableExpress := d.Get("enable_express").(bool)
@@ -191,7 +222,6 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	requiresSession := d.Get("requires_session").(bool)
 	status := servicebus.EntityStatus(d.Get("status").(string))
 
-	resourceId := parse.NewQueueID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.NamespaceName, resourceId.Name)
 		if err != nil {
@@ -296,6 +326,7 @@ func resourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) er
 	d.Set("name", id.Name)
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("namespace_id", parse.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName).ID())
 
 	if props := resp.SBQueueProperties; props != nil {
 		d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -387,9 +387,8 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
+  name         = "acctestservicebusqueue-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -399,9 +398,8 @@ func (r ServiceBusQueueResource) requiresImport(data acceptance.TestData) string
 %s
 
 resource "azurerm_servicebus_queue" "import" {
-  name                = azurerm_servicebus_queue.test.name
-  resource_group_name = azurerm_servicebus_queue.test.resource_group_name
-  namespace_name      = azurerm_servicebus_queue.test.namespace_name
+  name         = azurerm_servicebus_queue.test.name
+  namespace_id = azurerm_servicebus_queue.test.namespace_id
 }
 `, r.basic(data))
 }
@@ -427,8 +425,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
+  namespace_id        = azurerm_servicebus_namespace.test.id
   enable_partitioning = false
   enable_express      = false
 
@@ -457,8 +454,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                      = "acctestservicebusqueue-%d"
-  resource_group_name       = azurerm_resource_group.test.name
-  namespace_name            = azurerm_servicebus_namespace.test.name
+  namespace_id              = azurerm_servicebus_namespace.test.id
   enable_express            = true
   max_size_in_megabytes     = 2048
   enable_batched_operations = false
@@ -486,8 +482,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                  = "acctestservicebusqueue-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  namespace_name        = azurerm_servicebus_namespace.test.name
+  namespace_id          = azurerm_servicebus_namespace.test.id
   enable_partitioning   = true
   max_size_in_megabytes = 5120
 }
@@ -514,8 +509,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                         = "acctestservicebusqueue-%d"
-  resource_group_name          = azurerm_resource_group.test.name
-  namespace_name               = azurerm_servicebus_namespace.test.name
+  namespace_id                 = azurerm_servicebus_namespace.test.id
   requires_duplicate_detection = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -541,10 +535,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  requires_session    = true
+  name             = "acctestservicebusqueue-%d"
+  namespace_id     = azurerm_servicebus_namespace.test.id
+  requires_session = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -570,8 +563,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                                 = "acctestservicebusqueue-%d"
-  resource_group_name                  = azurerm_resource_group.test.name
-  namespace_name                       = azurerm_servicebus_namespace.test.name
+  namespace_id                         = azurerm_servicebus_namespace.test.id
   dead_lettering_on_message_expiration = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -596,10 +588,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  lock_duration       = "PT40S"
+  name          = "acctestservicebusqueue-%d"
+  namespace_id  = azurerm_servicebus_namespace.test.id
+  lock_duration = "PT40S"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -623,10 +614,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  lock_duration       = "PT2M"
+  name          = "acctestservicebusqueue-%d"
+  namespace_id  = azurerm_servicebus_namespace.test.id
+  lock_duration = "PT2M"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -651,8 +641,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_queue" "test" {
   name                                    = "acctestservicebusqueue-%d"
-  resource_group_name                     = azurerm_resource_group.test.name
-  namespace_name                          = azurerm_servicebus_namespace.test.name
+  namespace_id                            = azurerm_servicebus_namespace.test.id
   auto_delete_on_idle                     = "PT10M"
   default_message_ttl                     = "PT30M"
   requires_duplicate_detection            = true
@@ -680,10 +669,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  max_delivery_count  = 20
+  name               = "acctestservicebusqueue-%d"
+  namespace_id       = azurerm_servicebus_namespace.test.id
+  max_delivery_count = 20
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -707,16 +695,14 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "forward_to" {
-  name                = "acctestservicebusqueue-forward_to-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
+  name         = "acctestservicebusqueue-forward_to-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  forward_to          = azurerm_servicebus_queue.forward_to.name
+  name         = "acctestservicebusqueue-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+  forward_to   = azurerm_servicebus_queue.forward_to.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -740,15 +726,13 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "forward_dl_messages_to" {
-  name                = "acctestservicebusqueue-forward_dl_messages_to-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
+  name         = "acctestservicebusqueue-forward_dl_messages_to-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 
 resource "azurerm_servicebus_queue" "test" {
   name                              = "acctestservicebusqueue-%d"
-  resource_group_name               = azurerm_resource_group.test.name
-  namespace_name                    = azurerm_servicebus_namespace.test.name
+  namespace_id                      = azurerm_servicebus_namespace.test.id
   forward_dead_lettered_messages_to = azurerm_servicebus_queue.forward_dl_messages_to.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
@@ -773,10 +757,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  status              = "%s"
+  name         = "acctestservicebusqueue-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+  status       = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, status)
 }

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -44,21 +44,48 @@ func resourceServiceBusSubscription() *pluginsdk.Resource {
 				ValidateFunc: validate.SubscriptionName(),
 			},
 
-			"namespace_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.NamespaceName,
+			// TODO 3.0 - Make it required
+			"topic_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.TopicID,
+				ConflictsWith: []string{"topic_name", "namespace_name", "resource_group_name"},
 			},
 
+			// TODO 3.0 - Remove in favor of topic_id
 			"topic_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.TopicName(),
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.TopicName(),
+				Deprecated:    `Deprecated in favor of "topic_id"`,
+				ConflictsWith: []string{"topic_id"},
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			// TODO 3.0 - Remove in favor of topic_id
+			"namespace_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.NamespaceName,
+				Deprecated:    `Deprecated in favor of "topic_id"`,
+				ConflictsWith: []string{"topic_id"},
+			},
+
+			// TODO 3.0 - Remove in favor of topic_id
+			"resource_group_name": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceGroupName,
+				Deprecated:    `Deprecated in favor of "topic_id"`,
+				ConflictsWith: []string{"topic_id"},
+			},
 
 			"auto_delete_on_idle": {
 				Type:     pluginsdk.TypeString,
@@ -137,7 +164,14 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 	defer cancel()
 	log.Printf("[INFO] preparing arguments for ServiceBus Subscription creation.")
 
-	resourceId := parse.NewSubscriptionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("topic_name").(string), d.Get("name").(string))
+	var resourceId parse.SubscriptionId
+	if topicIdLit := d.Get("topic_id").(string); topicIdLit != "" {
+		topicId, _ := parse.TopicID(topicIdLit)
+		resourceId = parse.NewSubscriptionID(topicId.SubscriptionId, topicId.ResourceGroup, topicId.NamespaceName, topicId.Name, d.Get("name").(string))
+	} else {
+		resourceId = parse.NewSubscriptionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("topic_name").(string), d.Get("name").(string))
+	}
+
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.NamespaceName, resourceId.TopicName, resourceId.Name)
 		if err != nil {
@@ -213,6 +247,7 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 	d.Set("topic_name", id.TopicName)
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("topic_id", parse.NewTopicID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.TopicName).ID())
 
 	if props := resp.SBSubscriptionProperties; props != nil {
 		d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -233,15 +233,12 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                = "acctestservicebustopic-%d"
-  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  namespace_id      = azurerm_servicebus_namespace.test.id
 }
 
 resource "azurerm_servicebus_subscription" "test" {
   name                = "_acctestservicebussubscription-%d_"
-  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-  topic_name          = "${azurerm_servicebus_topic.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  topic_id          = azurerm_servicebus_topic.test.id
   max_delivery_count  = 10
 	%s
 }
@@ -256,11 +253,9 @@ func (r ServiceBusSubscriptionResource) requiresImport(data acceptance.TestData)
 %s
 
 resource "azurerm_servicebus_subscription" "import" {
-  name                = azurerm_servicebus_subscription.test.name
-  namespace_name      = azurerm_servicebus_subscription.test.namespace_name
-  topic_name          = azurerm_servicebus_subscription.test.topic_name
-  resource_group_name = azurerm_servicebus_subscription.test.resource_group_name
-  max_delivery_count  = azurerm_servicebus_subscription.test.max_delivery_count
+  name               = azurerm_servicebus_subscription.test.name
+  topic_id           = azurerm_servicebus_subscription.test.topic_id
+  max_delivery_count = azurerm_servicebus_subscription.test.max_delivery_count
 }
 `, r.basic(data))
 }
@@ -286,8 +281,7 @@ func (ServiceBusSubscriptionResource) updateForwardTo(data acceptance.TestData) 
 
 resource "azurerm_servicebus_topic" "forward_to" {
   name                = "acctestservicebustopic-forward_to-%d"
-  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  namespace_id      = azurerm_servicebus_namespace.test.id
 }
 
 
@@ -302,8 +296,7 @@ func (ServiceBusSubscriptionResource) updateForwardDeadLetteredMessagesTo(data a
 
 resource "azurerm_servicebus_topic" "forward_dl_messages_to" {
   name                = "acctestservicebustopic-forward_dl_messages_to-%d"
-  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  namespace_id      = azurerm_servicebus_namespace.test.id
 }
 
 

--- a/internal/services/servicebus/servicebus_subscription_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource_test.go
@@ -172,13 +172,10 @@ func (r ServiceBusSubscriptionRuleResource) basicSqlFilter(data acceptance.TestD
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "SqlFilter"
-  sql_filter          = "2=2"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "SqlFilter"
+  sql_filter      = "2=2"
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -188,13 +185,10 @@ func (r ServiceBusSubscriptionRuleResource) requiresImport(data acceptance.TestD
 %s
 
 resource "azurerm_servicebus_subscription_rule" "import" {
-  name                = azurerm_servicebus_subscription_rule.test.name
-  namespace_name      = azurerm_servicebus_subscription_rule.test.namespace_name
-  topic_name          = azurerm_servicebus_subscription_rule.test.topic_name
-  subscription_name   = azurerm_servicebus_subscription_rule.test.subscription_name
-  resource_group_name = azurerm_servicebus_subscription_rule.test.resource_group_name
-  filter_type         = azurerm_servicebus_subscription_rule.test.filter_type
-  sql_filter          = azurerm_servicebus_subscription_rule.test.sql_filter
+  name            = azurerm_servicebus_subscription_rule.test.name
+  subscription_id = azurerm_servicebus_subscription_rule.test.subscription_id
+  filter_type     = azurerm_servicebus_subscription_rule.test.filter_type
+  sql_filter      = azurerm_servicebus_subscription_rule.test.sql_filter
 }
 `, r.basicSqlFilter(data))
 }
@@ -204,13 +198,10 @@ func (r ServiceBusSubscriptionRuleResource) basicSqlFilterUpdated(data acceptanc
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "SqlFilter"
-  sql_filter          = "3=3"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "SqlFilter"
+  sql_filter      = "3=3"
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -220,14 +211,11 @@ func (r ServiceBusSubscriptionRuleResource) sqlFilterWithAction(data acceptance.
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "SqlFilter"
-  sql_filter          = "2=2"
-  action              = "SET Test='true'"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "SqlFilter"
+  sql_filter      = "2=2"
+  action          = "SET Test='true'"
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -237,12 +225,9 @@ func (r ServiceBusSubscriptionRuleResource) basicCorrelationFilter(data acceptan
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "CorrelationFilter"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "CorrelationFilter"
 
   correlation_filter {
     correlation_id      = "test_correlation_id"
@@ -263,12 +248,9 @@ func (r ServiceBusSubscriptionRuleResource) correlationFilter(data acceptance.Te
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "CorrelationFilter"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "CorrelationFilter"
 
   correlation_filter {
     correlation_id = "test_correlation_id"
@@ -286,12 +268,9 @@ func (r ServiceBusSubscriptionRuleResource) correlationFilterUpdated(data accept
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  filter_type         = "CorrelationFilter"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  filter_type     = "CorrelationFilter"
 
   correlation_filter {
     correlation_id = "test_correlation_id"
@@ -310,13 +289,10 @@ func (r ServiceBusSubscriptionRuleResource) correlationFilterWithAction(data acc
 %s
 
 resource "azurerm_servicebus_subscription_rule" "test" {
-  name                = "acctestservicebusrule-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  subscription_name   = azurerm_servicebus_subscription.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  action              = "SET Test='true'"
-  filter_type         = "CorrelationFilter"
+  name            = "acctestservicebusrule-%d"
+  subscription_id = azurerm_servicebus_subscription.test.id
+  action          = "SET Test='true'"
+  filter_type     = "CorrelationFilter"
 
   correlation_filter {
     correlation_id = "test_correlation_id"
@@ -345,17 +321,14 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctestservicebustopic-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 
 resource "azurerm_servicebus_subscription" "test" {
-  name                = "acctestservicebussubscription-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  max_delivery_count  = 10
+  name               = "acctestservicebussubscription-%d"
+  topic_id           = azurerm_servicebus_topic.test.id
+  max_delivery_count = 10
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
@@ -43,7 +43,7 @@ func testAccServiceBusTopicAuthorizationRule(t *testing.T, listen, send, manage 
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("namespace_name").Exists(),
+				check.That(data.ResourceName).Key("topic_id").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_key").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
@@ -99,7 +99,7 @@ func TestAccServiceBusTopicAuthorizationRule_rightsUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("namespace_name").Exists(),
+				check.That(data.ResourceName).Key("topic_id").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_key").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
@@ -170,16 +170,13 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctestservicebustopic-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 
 resource "azurerm_servicebus_topic_authorization_rule" "test" {
-  name                = "acctest-%[1]d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  topic_name          = azurerm_servicebus_topic.test.name
+  name     = "acctest-%[1]d"
+  topic_id = azurerm_servicebus_topic.test.id
 
   listen = %[3]t
   send   = %[4]t
@@ -193,10 +190,8 @@ func (r ServiceBusTopicAuthorizationRuleResource) requiresImport(data acceptance
 %s
 
 resource "azurerm_servicebus_topic_authorization_rule" "import" {
-  name                = azurerm_servicebus_topic_authorization_rule.test.name
-  namespace_name      = azurerm_servicebus_topic_authorization_rule.test.namespace_name
-  resource_group_name = azurerm_servicebus_topic_authorization_rule.test.resource_group_name
-  topic_name          = azurerm_servicebus_topic_authorization_rule.test.topic_name
+  name     = azurerm_servicebus_topic_authorization_rule.test.name
+  topic_id = azurerm_servicebus_topic_authorization_rule.test.topic_id
 
   listen = azurerm_servicebus_topic_authorization_rule.test.listen
   send   = azurerm_servicebus_topic_authorization_rule.test.send
@@ -230,9 +225,8 @@ resource "azurerm_servicebus_namespace" "primary_namespace_test" {
 }
 
 resource "azurerm_servicebus_topic" "example" {
-  name                = "topic-test"
-  resource_group_name = azurerm_resource_group.primary.name
-  namespace_name      = azurerm_servicebus_namespace.primary_namespace_test.name
+  name         = "topic-test"
+  namespace_id = azurerm_servicebus_namespace.primary_namespace_test.id
 }
 
 resource "azurerm_servicebus_namespace" "secondary_namespace_test" {
@@ -250,13 +244,11 @@ resource "azurerm_servicebus_namespace_disaster_recovery_config" "pairing_test" 
 }
 
 resource "azurerm_servicebus_topic_authorization_rule" "test" {
-  name                = "example_topic_rule"
-  namespace_name      = azurerm_servicebus_namespace.primary_namespace_test.name
-  topic_name          = azurerm_servicebus_topic.example.name
-  resource_group_name = azurerm_resource_group.primary.name
-  manage              = true
-  listen              = true
-  send                = true
+  name     = "example_topic_rule"
+  topic_id = azurerm_servicebus_topic.example.id
+  manage   = true
+  listen   = true
+  send     = true
 
   depends_on = [
     azurerm_servicebus_namespace_disaster_recovery_config.pairing_test

--- a/internal/services/servicebus/servicebus_topic_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_resource_test.go
@@ -244,9 +244,8 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctestservicebustopic-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -256,9 +255,8 @@ func (r ServiceBusTopicResource) requiresImport(data acceptance.TestData) string
 %s
 
 resource "azurerm_servicebus_topic" "import" {
-  name                = azurerm_servicebus_topic.test.name
-  namespace_name      = azurerm_servicebus_topic.test.namespace_name
-  resource_group_name = azurerm_servicebus_topic.test.resource_group_name
+  name         = azurerm_servicebus_topic.test.name
+  namespace_id = azurerm_servicebus_topic.test.namespace_id
 }
 `, r.basic(data))
 }
@@ -282,10 +280,9 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  status              = "disabled"
+  name         = "acctestservicebustopic-%d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+  status       = "disabled"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -310,8 +307,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                      = "acctestservicebustopic-%d"
-  namespace_name            = azurerm_servicebus_namespace.test.name
-  resource_group_name       = azurerm_resource_group.test.name
+  namespace_id              = azurerm_servicebus_namespace.test.id
   enable_batched_operations = true
   enable_express            = true
 }
@@ -339,8 +335,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                = "acctestservicebustopic-%d"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  namespace_id        = azurerm_servicebus_namespace.test.id
   enable_partitioning = false
 
   max_message_size_in_kilobytes = 102400
@@ -368,8 +363,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                  = "acctestservicebustopic-%d"
-  namespace_name        = azurerm_servicebus_namespace.test.name
-  resource_group_name   = azurerm_resource_group.test.name
+  namespace_id          = azurerm_servicebus_namespace.test.id
   enable_partitioning   = true
   max_size_in_megabytes = 5120
 }
@@ -397,8 +391,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                  = "acctestservicebustopic-%d"
-  namespace_name        = azurerm_servicebus_namespace.test.name
-  resource_group_name   = azurerm_resource_group.test.name
+  namespace_id          = azurerm_servicebus_namespace.test.id
   enable_partitioning   = false
   max_size_in_megabytes = 81920
 }
@@ -425,8 +418,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                         = "acctestservicebustopic-%d"
-  namespace_name               = azurerm_servicebus_namespace.test.name
-  resource_group_name          = azurerm_resource_group.test.name
+  namespace_id                 = azurerm_servicebus_namespace.test.id
   requires_duplicate_detection = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -452,8 +444,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_topic" "test" {
   name                                    = "acctestservicebustopic-%d"
-  namespace_name                          = azurerm_servicebus_namespace.test.name
-  resource_group_name                     = azurerm_resource_group.test.name
+  namespace_id                            = azurerm_servicebus_namespace.test.id
   auto_delete_on_idle                     = "PT10M"
   default_message_ttl                     = "PT30M"
   requires_duplicate_detection            = true

--- a/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
@@ -30,9 +30,8 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "example" {
-  name                = "examplerule"
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  name         = "examplerule"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   listen = true
   send   = true
@@ -46,9 +45,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Namespace Authorization Rule resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) Specifies the name of the ServiceBus Namespace. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which the ServiceBus Namespace exists. Changing this forces a new resource to be created.
+* `namespace_id` - (Required) Specifies the ID of the ServiceBus Namespace. Changing this forces a new resource to be created.
 
 ~> **NOTE** At least one of the 3 permissions below needs to be set.
 

--- a/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
+++ b/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
@@ -49,8 +49,7 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_servicebus_namespace_network_rule_set" "example" {
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   default_action = "Deny"
 
@@ -67,9 +66,7 @@ resource "azurerm_servicebus_namespace_network_rule_set" "example" {
 
 The following arguments are supported:
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the ServiceBus Namespace Network Rule Set should exist. Changing this forces a new resource to be created.
-
-* `namespace_name` - (Required) Specifies the ServiceBus Namespace name to which to attach the ServiceBus Namespace Network Rule Set. Changing this forces a new resource to be created.
+* `namespace_id` - (Required) Specifies the ServiceBus Namespace ID to which to attach the ServiceBus Namespace Network Rule Set. Changing this forces a new resource to be created.
 
 ~> **NOTE:** The ServiceBus Namespace must be `Premium` in order to attach a ServiceBus Namespace Network Rule Set.
 

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -30,9 +30,8 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_queue" "example" {
-  name                = "tfex_servicebus_queue"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_queue"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   enable_partitioning = true
 }
@@ -44,9 +43,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Queue resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace to create this queue in. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
+* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create this queue in. Changing this forces a new resource to be created.
 
 * `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute (`PT1M`).
 

--- a/website/docs/r/servicebus_queue_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_queue_authorization_rule.html.markdown
@@ -30,18 +30,15 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_queue" "example" {
-  name                = "tfex_servicebus_queue"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_queue"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   enable_partitioning = true
 }
 
 resource "azurerm_servicebus_queue_authorization_rule" "example" {
-  name                = "examplerule"
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  queue_name          = azurerm_servicebus_queue.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  name     = "examplerule"
+  queue_id = azurerm_servicebus_queue.example.id
 
   listen = true
   send   = true
@@ -55,11 +52,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Authorization Rule. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) Specifies the name of the ServiceBus Namespace in which the Queue exists. Changing this forces a new resource to be created.
-
-* `queue_name` - (Required) Specifies the name of the ServiceBus Queue. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group in which the ServiceBus Namespace exists. Changing this forces a new resource to be created.
+* `queue_id` - (Required) Specifies the ID of the ServiceBus Queue. Changing this forces a new resource to be created.
 
 ~> **NOTE** At least one of the 3 permissions below needs to be set.
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -30,19 +30,16 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_topic" "example" {
-  name                = "tfex_servicebus_topic"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_topic"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   enable_partitioning = true
 }
 
 resource "azurerm_servicebus_subscription" "example" {
-  name                = "tfex_servicebus_subscription"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  topic_name          = azurerm_servicebus_topic.example.name
-  max_delivery_count  = 1
+  name               = "tfex_servicebus_subscription"
+  topic_id           = azurerm_servicebus_topic.example.id
+  max_delivery_count = 1
 }
 ```
 
@@ -52,11 +49,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Subscription resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace to create this Subscription in. Changing this forces a new resource to be created.
-
-* `topic_name` - (Required) The name of the ServiceBus Topic to create this Subscription in. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
+* `topic_id` - (Required) The ID of the ServiceBus Topic to create this Subscription in. Changing this forces a new resource to be created.
 
 * `max_delivery_count` - (Required) The maximum number of deliveries.
 

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -76,28 +76,22 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_topic" "example" {
-  name                = "tfex_servicebus_topic"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_topic"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   enable_partitioning = true
 }
 
 resource "azurerm_servicebus_subscription" "example" {
-  name                = "tfex_servicebus_subscription"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  topic_name          = azurerm_servicebus_topic.example.name
-  max_delivery_count  = 1
+  name               = "tfex_servicebus_subscription"
+  topic_id           = azurerm_servicebus_topic.example.id
+  max_delivery_count = 1
 }
 
 resource "azurerm_servicebus_subscription_rule" "example" {
-  name                = "tfex_servicebus_rule"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  topic_name          = azurerm_servicebus_topic.example.name
-  subscription_name   = azurerm_servicebus_subscription.example.name
-  filter_type         = "CorrelationFilter"
+  name            = "tfex_servicebus_rule"
+  subscription_id = azurerm_servicebus_subscription.example.id
+  filter_type     = "CorrelationFilter"
 
   correlation_filter {
     correlation_id = "high"
@@ -115,13 +109,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Subscription Rule. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace in which the ServiceBus Topic exists. Changing this forces a new resource to be created.
-
-* `topic_name` - (Required) The name of the ServiceBus Topic in which the ServiceBus Subscription exists. Changing this forces a new resource to be created.
-
-* `subscription_name` - (Required) The name of the ServiceBus Subscription in which this Rule should be created. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in the ServiceBus Namespace exists. Changing this forces a new resource to be created.
+* `subscription_id` - (Required) The ID of the ServiceBus Subscription in which this Rule should be created. Changing this forces a new resource to be created.
 
 * `filter_type` - (Required) Type of filter to be applied to a BrokeredMessage. Possible values are `SqlFilter` and `CorrelationFilter`.
 

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -32,9 +32,8 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_topic" "example" {
-  name                = "tfex_servicebus_topic"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_topic"
+  namespace_id = azurerm_servicebus_namespace.example.id
 
   enable_partitioning = true
 }
@@ -47,11 +46,8 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the ServiceBus Topic resource. Changing this forces a
     new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace to create
+* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create
     this topic in. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the namespace. Changing this forces a new resource to be created.
 
 * `status` - (Optional) The Status of the Service Bus Topic. Acceptable values are `Active` or `Disabled`. Defaults to `Active`.
 

--- a/website/docs/r/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_topic_authorization_rule.html.markdown
@@ -30,19 +30,16 @@ resource "azurerm_servicebus_namespace" "example" {
 }
 
 resource "azurerm_servicebus_topic" "example" {
-  name                = "tfex_servicebus_topic"
-  resource_group_name = azurerm_resource_group.example.name
-  namespace_name      = azurerm_servicebus_namespace.example.name
+  name         = "tfex_servicebus_topic"
+  namespace_id = azurerm_servicebus_namespace.example.id
 }
 
 resource "azurerm_servicebus_topic_authorization_rule" "example" {
-  name                = "tfex_servicebus_topic_sasPolicy"
-  namespace_name      = azurerm_servicebus_namespace.example.name
-  topic_name          = azurerm_servicebus_topic.example.name
-  resource_group_name = azurerm_resource_group.example.name
-  listen              = true
-  send                = false
-  manage              = false
+  name     = "tfex_servicebus_topic_sasPolicy"
+  topic_id = azurerm_servicebus_topic.example.id
+  listen   = true
+  send     = false
+  manage   = false
 }
 ```
 
@@ -52,11 +49,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the ServiceBus Topic Authorization Rule resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) Specifies the name of the ServiceBus Namespace. Changing this forces a new resource to be created.
-
-* `topic_name` - (Required) Specifies the name of the ServiceBus Topic. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which the ServiceBus Namespace exists. Changing this forces a new resource to be created.
+* `topic_id` - (Required) Specifies the ID of the ServiceBus Topic. Changing this forces a new resource to be created.
 
 ~> **NOTE** At least one of the 3 permissions below needs to be set.
 


### PR DESCRIPTION
Deprecating the original ways to reference parent resources via its
scopes (e.g. resource group name, parent resource name, grand parent
resource name, etc) - instead use the parent resource ID.

The benefit is to allow the force new on parent resource can be
propagate to its child resources.

Fixes #14748