### PR TITLE
r/consumption_budget_subscription: adding a v2 state migration

### DIFF
--- a/internal/services/consumption/consumption_budget_subscription_resource.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource.go
@@ -83,9 +83,10 @@ func (r SubscriptionConsumptionBudget) CustomImporter() sdk.ResourceRunFunc {
 
 func (r SubscriptionConsumptionBudget) StateUpgraders() sdk.StateUpgradeData {
 	return sdk.StateUpgradeData{
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		Upgraders: map[int]pluginsdk.StateUpgrade{
 			0: migration.SubscriptionConsumptionBudgetV0ToV1{},
+			1: migration.SubscriptionConsumptionBudgetV1ToV2{},
 		},
 	}
 }

--- a/internal/services/consumption/migration/consumption_budget_subscription.go
+++ b/internal/services/consumption/migration/consumption_budget_subscription.go
@@ -2,7 +2,10 @@ package migration
 
 import (
 	"context"
+	"fmt"
 	"log"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/parse"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -17,16 +20,243 @@ func (SubscriptionConsumptionBudgetV0ToV1) UpgradeFunc() pluginsdk.StateUpgrader
 		// The previous validation behaviour of subscription_id meant that we were only accepting this format 00000000-0000-0000-0000-000000000000,
 		// but we should be accepting /subscriptions/00000000-0000-0000-0000-000000000000
 
-		subscription_id := rawState["subscription_id"].(string)
-		newID := commonids.NewSubscriptionID(subscription_id).ID()
-		log.Printf("[DEBUG] Updating subscription_id from %q to %q", subscription_id, newID)
-
-		rawState["subscription_id"] = newID
+		// NOTE: this is an intentional bug which is fixed in v2 of the state migration
+		rawState["subscription_id"] = commonids.NewSubscriptionID(rawState["subscription_id"].(string))
 		return rawState, nil
 	}
 }
 
 func (SubscriptionConsumptionBudgetV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"subscription_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"etag": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+
+		"amount": {
+			Type:     pluginsdk.TypeFloat,
+			Required: true,
+		},
+
+		"filter": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"dimension": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"operator": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"tag": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"operator": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"not": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"dimension": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"name": {
+												Type:     pluginsdk.TypeString,
+												Required: true,
+											},
+											"operator": {
+												Type:     pluginsdk.TypeString,
+												Optional: true,
+											},
+											"values": {
+												Type:     pluginsdk.TypeList,
+												Required: true,
+												Elem: &pluginsdk.Schema{
+													Type: pluginsdk.TypeString,
+												},
+											},
+										},
+									},
+								},
+								"tag": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"name": {
+												Type:     pluginsdk.TypeString,
+												Required: true,
+											},
+											"operator": {
+												Type:     pluginsdk.TypeString,
+												Optional: true,
+											},
+											"values": {
+												Type:     pluginsdk.TypeList,
+												Required: true,
+												Elem: &pluginsdk.Schema{
+													Type: pluginsdk.TypeString,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"notification": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+					"threshold": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+					"threshold_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"operator": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"contact_emails": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"contact_groups": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"contact_roles": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"time_grain": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"time_period": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"start_date": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"end_date": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ pluginsdk.StateUpgrade = SubscriptionConsumptionBudgetV1ToV2{}
+
+type SubscriptionConsumptionBudgetV1ToV2 struct{}
+
+func (SubscriptionConsumptionBudgetV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// since the `subscription_id` field gets incorrectly mutated in the V0 -> V1 upgrade
+		// we have to parse it from the ID instead to correct this
+		idRaw := rawState["id"].(string)
+		id, err := parse.ConsumptionBudgetSubscriptionID(idRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", idRaw, err)
+		}
+
+		oldSubscriptionId := rawState["subscription_id"].(string)
+		newSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId).ID()
+		log.Printf("[DEBUG] Updating subscription_id from %q to %q", oldSubscriptionId, newSubscriptionId)
+		rawState["subscription_id"] = newSubscriptionId
+
+		return rawState, nil
+	}
+}
+
+func (SubscriptionConsumptionBudgetV1ToV2) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,


### PR DESCRIPTION
Whilst #14687 attempted to fix the issue in the original state migration unfortunately doing so would lead to multiple possible values for this field (the "fixed" value for users who skipped releases containing this bug, and a "broken" value for users who didn't).

As such this commit introduces a new state migration from v1 -> v2 which parses the Subscription ID from the Resource ID, meaning that value will be the same (and correct) in both cases.