### PR TITLE
`azurerm_app_service_environment_v3` - fix for default value of `allow_new_private_endpoint_connections`

### DIFF
--- a/internal/services/web/app_service_environment_v3_resource.go
+++ b/internal/services/web/app_service_environment_v3_resource.go
@@ -310,15 +310,13 @@ func (r AppServiceEnvironmentV3Resource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for the creation of %s: %+v", id, err)
 			}
 
-			if !model.AllowNewPrivateEndpointConnections {
-				aseNetworkConfig := web.AseV3NetworkingConfiguration{
-					AseV3NetworkingConfigurationProperties: &web.AseV3NetworkingConfigurationProperties{
-						AllowNewPrivateEndpointConnections: utils.Bool(model.AllowNewPrivateEndpointConnections),
-					},
-				}
-				if _, err := client.UpdateAseNetworkingConfiguration(ctx, id.ResourceGroup, id.HostingEnvironmentName, aseNetworkConfig); err != nil {
-					return fmt.Errorf("setting Allow New Private Endpoint Connections on %s: %+v", id, err)
-				}
+			aseNetworkConfig := web.AseV3NetworkingConfiguration{
+				AseV3NetworkingConfigurationProperties: &web.AseV3NetworkingConfigurationProperties{
+					AllowNewPrivateEndpointConnections: utils.Bool(model.AllowNewPrivateEndpointConnections),
+				},
+			}
+			if _, err := client.UpdateAseNetworkingConfiguration(ctx, id.ResourceGroup, id.HostingEnvironmentName, aseNetworkConfig); err != nil {
+				return fmt.Errorf("setting Allow New Private Endpoint Connections on %s: %+v", id, err)
 			}
 
 			metadata.SetID(id)
@@ -375,7 +373,7 @@ func (r AppServiceEnvironmentV3Resource) Read() sdk.ResourceFunc {
 				model.LinuxOutboundIPAddresses = *props.LinuxOutboundIPAddresses
 				model.InternalInboundIPAddresses = *props.InternalInboundIPAddresses
 				model.ExternalInboundIPAddresses = *props.ExternalInboundIPAddresses
-				model.AllowNewPrivateEndpointConnections = *props.AllowNewPrivateEndpointConnections
+				model.AllowNewPrivateEndpointConnections = utils.NormaliseNilableBool(props.AllowNewPrivateEndpointConnections)
 			}
 
 			inboundNetworkDependencies, err := flattenInboundNetworkDependencies(ctx, client, id)
@@ -454,15 +452,13 @@ func (r AppServiceEnvironmentV3Resource) Update() sdk.ResourceFunc {
 				existing.Tags = tags.FromTypedObject(state.Tags)
 			}
 
-			if metadata.ResourceData.HasChange("allow_new_private_endpoint_connections") {
-				aseNetworkConfig := web.AseV3NetworkingConfiguration{
-					AseV3NetworkingConfigurationProperties: &web.AseV3NetworkingConfigurationProperties{
-						AllowNewPrivateEndpointConnections: utils.Bool(state.AllowNewPrivateEndpointConnections),
-					},
-				}
-				if _, err := client.UpdateAseNetworkingConfiguration(ctx, id.ResourceGroup, id.HostingEnvironmentName, aseNetworkConfig); err != nil {
-					return fmt.Errorf("setting Allow New Private Endpoint Connections on %s: %+v", id, err)
-				}
+			aseNetworkConfig := web.AseV3NetworkingConfiguration{
+				AseV3NetworkingConfigurationProperties: &web.AseV3NetworkingConfigurationProperties{
+					AllowNewPrivateEndpointConnections: utils.Bool(state.AllowNewPrivateEndpointConnections),
+				},
+			}
+			if _, err := client.UpdateAseNetworkingConfiguration(ctx, id.ResourceGroup, id.HostingEnvironmentName, aseNetworkConfig); err != nil {
+				return fmt.Errorf("setting Allow New Private Endpoint Connections on %s: %+v", id, err)
 			}
 
 			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.HostingEnvironmentName, existing); err != nil {


### PR DESCRIPTION
update for apparent default value change in service (circa 2021-12-20?)
fixes potential nil crash while passing

![image](https://user-images.githubusercontent.com/11830746/148204000-78dbe582-081c-412c-bcca-d5ba28bfaf68.png)
