### PR TITLE
dependencies: upgrading to v61.0.0 of github.com/Azure/azure-sdk-for-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-azurerm
 
 require (
 	cloud.google.com/go/storage v1.16.0 // indirect
-	github.com/Azure/azure-sdk-for-go v60.2.0+incompatible
+	github.com/Azure/azure-sdk-for-go v61.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.22
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Azure/azure-sdk-for-go v56.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v59.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v60.2.0+incompatible h1:twJOQQl3um6o+1q5SSyAdLr2GCX8dJPVRNS1eKOnv54=
 github.com/Azure/azure-sdk-for-go v60.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v61.0.0+incompatible h1:6RxU1YOzXgfowurlZA/OjUdVMIPavRmmotUcbb3wc/w=
+github.com/Azure/azure-sdk-for-go v61.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.3/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=

--- a/internal/services/notificationhub/notification_hub_authorization_rule_resource.go
+++ b/internal/services/notificationhub/notification_hub_authorization_rule_resource.go
@@ -210,15 +210,15 @@ func expandNotificationHubAuthorizationRuleRights(manage bool, send bool, listen
 	rights := make([]notificationhubs.AccessRights, 0)
 
 	if manage {
-		rights = append(rights, notificationhubs.Manage)
+		rights = append(rights, notificationhubs.AccessRightsManage)
 	}
 
 	if send {
-		rights = append(rights, notificationhubs.SendEnumValue)
+		rights = append(rights, notificationhubs.AccessRightsSend)
 	}
 
 	if listen {
-		rights = append(rights, notificationhubs.Listen)
+		rights = append(rights, notificationhubs.AccessRightsListen)
 	}
 
 	return &rights
@@ -231,13 +231,13 @@ func flattenNotificationHubAuthorizationRuleRights(input *[]notificationhubs.Acc
 
 	for _, right := range *input {
 		switch right {
-		case notificationhubs.Manage:
+		case notificationhubs.AccessRightsManage:
 			manage = true
 			continue
-		case notificationhubs.SendEnumValue:
+		case notificationhubs.AccessRightsSend:
 			send = true
 			continue
-		case notificationhubs.Listen:
+		case notificationhubs.AccessRightsListen:
 			listen = true
 			continue
 		}

--- a/internal/services/notificationhub/notification_hub_namespace_resource.go
+++ b/internal/services/notificationhub/notification_hub_namespace_resource.go
@@ -63,9 +63,9 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(notificationhubs.Basic),
-					string(notificationhubs.Free),
-					string(notificationhubs.Standard),
+					string(notificationhubs.SkuNameBasic),
+					string(notificationhubs.SkuNameFree),
+					string(notificationhubs.SkuNameStandard),
 				}, false),
 			},
 
@@ -79,8 +79,8 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(notificationhubs.Messaging),
-					string(notificationhubs.NotificationHub),
+					string(notificationhubs.NamespaceTypeMessaging),
+					string(notificationhubs.NamespaceTypeNotificationHub),
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 			},

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/CHANGELOG.md
@@ -1,2 +1,40 @@
 # Change History
 
+## Breaking Changes
+
+### Removed Constants
+
+1. AccessRights.Listen
+1. AccessRights.Manage
+1. AccessRights.SendEnumValue
+1. NamespaceType.Messaging
+1. NamespaceType.NotificationHub
+1. SkuName.Basic
+1. SkuName.Free
+1. SkuName.Standard
+
+### Signature Changes
+
+#### Funcs
+
+1. NamespacesClient.ListKeys
+	- Returns
+		- From: SharedAccessAuthorizationRuleListResult, error
+		- To: ResourceListKeys, error
+1. NamespacesClient.ListKeysResponder
+	- Returns
+		- From: SharedAccessAuthorizationRuleListResult, error
+		- To: ResourceListKeys, error
+
+## Additive Changes
+
+### New Constants
+
+1. AccessRights.AccessRightsListen
+1. AccessRights.AccessRightsManage
+1. AccessRights.AccessRightsSend
+1. NamespaceType.NamespaceTypeMessaging
+1. NamespaceType.NamespaceTypeNotificationHub
+1. SkuName.SkuNameBasic
+1. SkuName.SkuNameFree
+1. SkuName.SkuNameStandard

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/_meta.json
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/_meta.json
@@ -1,11 +1,11 @@
 {
-  "commit": "3c764635e7d442b3e74caf593029fcd440b3ef82",
+  "commit": "81ab10cd9d46a85258b710c6150ec48021c6d202",
   "readme": "/_/azure-rest-api-specs/specification/notificationhubs/resource-manager/readme.md",
   "tag": "package-2017-04",
   "use": "@microsoft.azure/autorest.go@2.1.187",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
-  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.187 --tag=package-2017-04 --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION /_/azure-rest-api-specs/specification/notificationhubs/resource-manager/readme.md",
+  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.187 --tag=package-2017-04 --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix /_/azure-rest-api-specs/specification/notificationhubs/resource-manager/readme.md",
   "additional_properties": {
-    "additional_options": "--go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION"
+    "additional_options": "--go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix"
   }
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/enums.go
@@ -10,47 +10,47 @@ package notificationhubs
 type AccessRights string
 
 const (
-	// Listen ...
-	Listen AccessRights = "Listen"
-	// Manage ...
-	Manage AccessRights = "Manage"
-	// SendEnumValue ...
-	SendEnumValue AccessRights = "Send"
+	// AccessRightsListen ...
+	AccessRightsListen AccessRights = "Listen"
+	// AccessRightsManage ...
+	AccessRightsManage AccessRights = "Manage"
+	// AccessRightsSend ...
+	AccessRightsSend AccessRights = "Send"
 )
 
 // PossibleAccessRightsValues returns an array of possible values for the AccessRights const type.
 func PossibleAccessRightsValues() []AccessRights {
-	return []AccessRights{Listen, Manage, SendEnumValue}
+	return []AccessRights{AccessRightsListen, AccessRightsManage, AccessRightsSend}
 }
 
 // NamespaceType enumerates the values for namespace type.
 type NamespaceType string
 
 const (
-	// Messaging ...
-	Messaging NamespaceType = "Messaging"
-	// NotificationHub ...
-	NotificationHub NamespaceType = "NotificationHub"
+	// NamespaceTypeMessaging ...
+	NamespaceTypeMessaging NamespaceType = "Messaging"
+	// NamespaceTypeNotificationHub ...
+	NamespaceTypeNotificationHub NamespaceType = "NotificationHub"
 )
 
 // PossibleNamespaceTypeValues returns an array of possible values for the NamespaceType const type.
 func PossibleNamespaceTypeValues() []NamespaceType {
-	return []NamespaceType{Messaging, NotificationHub}
+	return []NamespaceType{NamespaceTypeMessaging, NamespaceTypeNotificationHub}
 }
 
 // SkuName enumerates the values for sku name.
 type SkuName string
 
 const (
-	// Basic ...
-	Basic SkuName = "Basic"
-	// Free ...
-	Free SkuName = "Free"
-	// Standard ...
-	Standard SkuName = "Standard"
+	// SkuNameBasic ...
+	SkuNameBasic SkuName = "Basic"
+	// SkuNameFree ...
+	SkuNameFree SkuName = "Free"
+	// SkuNameStandard ...
+	SkuNameStandard SkuName = "Standard"
 )
 
 // PossibleSkuNameValues returns an array of possible values for the SkuName const type.
 func PossibleSkuNameValues() []SkuName {
-	return []SkuName{Basic, Free, Standard}
+	return []SkuName{SkuNameBasic, SkuNameFree, SkuNameStandard}
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/models.go
@@ -1080,7 +1080,7 @@ type NamespaceProperties struct {
 	Critical *bool `json:"critical,omitempty"`
 	// DataCenter - Data center for the namespace
 	DataCenter *string `json:"dataCenter,omitempty"`
-	// NamespaceType - The namespace type. Possible values include: 'Messaging', 'NotificationHub'
+	// NamespaceType - The namespace type. Possible values include: 'NamespaceTypeMessaging', 'NamespaceTypeNotificationHub'
 	NamespaceType NamespaceType `json:"namespaceType,omitempty"`
 }
 
@@ -2230,7 +2230,7 @@ func (saarr *SharedAccessAuthorizationRuleResource) UnmarshalJSON(body []byte) e
 
 // Sku the Sku description for a namespace
 type Sku struct {
-	// Name - Name of the notification hub sku. Possible values include: 'Free', 'Basic', 'Standard'
+	// Name - Name of the notification hub sku. Possible values include: 'SkuNameFree', 'SkuNameBasic', 'SkuNameStandard'
 	Name SkuName `json:"name,omitempty"`
 	// Tier - The tier of particular sku
 	Tier *string `json:"tier,omitempty"`

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/namespaces.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs/namespaces.go
@@ -945,7 +945,7 @@ func (client NamespacesClient) ListAuthorizationRulesComplete(ctx context.Contex
 // resourceGroupName - the name of the resource group.
 // namespaceName - the namespace name.
 // authorizationRuleName - the connection string of the namespace for the specified authorizationRule.
-func (client NamespacesClient) ListKeys(ctx context.Context, resourceGroupName string, namespaceName string, authorizationRuleName string) (result SharedAccessAuthorizationRuleListResult, err error) {
+func (client NamespacesClient) ListKeys(ctx context.Context, resourceGroupName string, namespaceName string, authorizationRuleName string) (result ResourceListKeys, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/NamespacesClient.ListKeys")
 		defer func() {
@@ -1008,7 +1008,7 @@ func (client NamespacesClient) ListKeysSender(req *http.Request) (*http.Response
 
 // ListKeysResponder handles the response to the ListKeys request. The method always
 // closes the http.Response Body.
-func (client NamespacesClient) ListKeysResponder(resp *http.Response) (result SharedAccessAuthorizationRuleListResult, err error) {
+func (client NamespacesClient) ListKeysResponder(resp *http.Response) (result ResourceListKeys, err error) {
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -4,4 +4,4 @@ package version
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 // Number contains the semantic version of this SDK.
-const Number = "v60.2.0"
+const Number = "v61.0.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # cloud.google.com/go/storage v1.16.0
 ## explicit
-# github.com/Azure/azure-sdk-for-go v60.2.0+incompatible
+# github.com/Azure/azure-sdk-for-go v61.0.0+incompatible
 ## explicit
 github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
 github.com/Azure/azure-sdk-for-go/services/aad/mgmt/2017-04-01/aad


### PR DESCRIPTION
Prepare for new compute sdk version 2021-08-01
Resolving breaking change in notificationhubs