### PR TITLE
`azurerm_linux_function_app` fix #14812 by using length check for SiteConfig and ApplicationStack.

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -840,7 +840,7 @@ func (m *LinuxFunctionAppModel) unpackLinuxFunctionAppSettings(input web.StringD
 			}
 		case "WEBSITE_HTTPLOGGING_RETENTION_DAYS":
 		case "FUNCTIONS_WORKER_RUNTIME":
-			if m.SiteConfig[0].ApplicationStack != nil {
+			if len(m.SiteConfig) > 0 && len(m.SiteConfig[0].ApplicationStack) > 0 {
 				m.SiteConfig[0].ApplicationStack[0].CustomHandler = strings.EqualFold(*v, "custom")
 			}
 


### PR DESCRIPTION
fix #14812 by using length check for SiteConfig and ApplicationStack. 

Acc test:

=== RUN   TestAccLinuxFunctionApp_basicBasicPlan
=== PAUSE TestAccLinuxFunctionApp_basicBasicPlan
=== CONT  TestAccLinuxFunctionApp_basicBasicPlan
--- PASS: TestAccLinuxFunctionApp_basicBasicPlan (356.81s)
=== RUN   TestAccLinuxFunctionApp_basicConsumptionPlan
=== PAUSE TestAccLinuxFunctionApp_basicConsumptionPlan
=== CONT  TestAccLinuxFunctionApp_basicConsumptionPlan
--- PASS: TestAccLinuxFunctionApp_basicConsumptionPlan (310.72s)
=== RUN   TestAccLinuxFunctionApp_basicElasticPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_basicElasticPremiumPlan
=== CONT  TestAccLinuxFunctionApp_basicElasticPremiumPlan
--- PASS: TestAccLinuxFunctionApp_basicElasticPremiumPlan (317.92s)
=== RUN   TestAccLinuxFunctionApp_basicPremiumAppServicePlan
=== PAUSE TestAccLinuxFunctionApp_basicPremiumAppServicePlan
=== CONT  TestAccLinuxFunctionApp_basicPremiumAppServicePlan
--- PASS: TestAccLinuxFunctionApp_basicPremiumAppServicePlan (257.96s)
=== RUN   TestAccLinuxFunctionApp_basicStandardPlan
=== PAUSE TestAccLinuxFunctionApp_basicStandardPlan
=== CONT  TestAccLinuxFunctionApp_basicStandardPlan
--- PASS: TestAccLinuxFunctionApp_basicStandardPlan (372.58s)
=== RUN   TestAccLinuxFunctionApp_withAppSettingsBasic
=== PAUSE TestAccLinuxFunctionApp_withAppSettingsBasic
=== CONT  TestAccLinuxFunctionApp_withAppSettingsBasic
--- PASS: TestAccLinuxFunctionApp_withAppSettingsBasic (286.59s)
=== RUN   TestAccLinuxFunctionApp_withAppSettingsConsumption
=== PAUSE TestAccLinuxFunctionApp_withAppSettingsConsumption
=== CONT  TestAccLinuxFunctionApp_withAppSettingsConsumption
--- PASS: TestAccLinuxFunctionApp_withAppSettingsConsumption (326.33s)
=== RUN   TestAccLinuxFunctionApp_withAppSettingsElasticPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_withAppSettingsElasticPremiumPlan
=== CONT  TestAccLinuxFunctionApp_withAppSettingsElasticPremiumPlan
--- PASS: TestAccLinuxFunctionApp_withAppSettingsElasticPremiumPlan (335.97s)
=== RUN   TestAccLinuxFunctionApp_withAppSettingsPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_withAppSettingsPremiumPlan
=== CONT  TestAccLinuxFunctionApp_withAppSettingsPremiumPlan
--- PASS: TestAccLinuxFunctionApp_withAppSettingsPremiumPlan (345.07s)
=== RUN   TestAccLinuxFunctionApp_withAppSettingsStandardPlan
=== PAUSE TestAccLinuxFunctionApp_withAppSettingsStandardPlan
=== CONT  TestAccLinuxFunctionApp_withAppSettingsStandardPlan
--- PASS: TestAccLinuxFunctionApp_withAppSettingsStandardPlan (288.15s)
=== RUN   TestAccLinuxFunctionApp_withBackupElasticPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_withBackupElasticPremiumPlan
=== CONT  TestAccLinuxFunctionApp_withBackupElasticPremiumPlan
--- PASS: TestAccLinuxFunctionApp_withBackupElasticPremiumPlan (263.06s)
=== RUN   TestAccLinuxFunctionApp_withBackupPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_withBackupPremiumPlan
=== CONT  TestAccLinuxFunctionApp_withBackupPremiumPlan
--- PASS: TestAccLinuxFunctionApp_withBackupPremiumPlan (324.51s)
=== RUN   TestAccLinuxFunctionApp_withBackupStandardPlan
=== PAUSE TestAccLinuxFunctionApp_withBackupStandardPlan
=== CONT  TestAccLinuxFunctionApp_withBackupStandardPlan
--- PASS: TestAccLinuxFunctionApp_withBackupStandardPlan (345.43s)
=== RUN   TestAccLinuxFunctionApp_consumptionComplete
=== PAUSE TestAccLinuxFunctionApp_consumptionComplete
=== CONT  TestAccLinuxFunctionApp_consumptionComplete
--- PASS: TestAccLinuxFunctionApp_consumptionComplete (265.16s)
=== RUN   TestAccLinuxFunctionApp_consumptionCompleteUpdate
=== PAUSE TestAccLinuxFunctionApp_consumptionCompleteUpdate
=== CONT  TestAccLinuxFunctionApp_consumptionCompleteUpdate
--- PASS: TestAccLinuxFunctionApp_consumptionCompleteUpdate (579.87s)
=== RUN   TestAccLinuxFunctionApp_elasticPremiumComplete
=== PAUSE TestAccLinuxFunctionApp_elasticPremiumComplete
=== CONT  TestAccLinuxFunctionApp_elasticPremiumComplete
--- PASS: TestAccLinuxFunctionApp_elasticPremiumComplete (323.53s)
=== RUN   TestAccLinuxFunctionApp_standardComplete
=== PAUSE TestAccLinuxFunctionApp_standardComplete
=== CONT  TestAccLinuxFunctionApp_standardComplete
--- PASS: TestAccLinuxFunctionApp_standardComplete (387.84s)
=== RUN   TestAccLinuxFunctionApp_withAuthSettingsStandard
=== PAUSE TestAccLinuxFunctionApp_withAuthSettingsStandard
=== CONT  TestAccLinuxFunctionApp_withAuthSettingsStandard
--- PASS: TestAccLinuxFunctionApp_withAuthSettingsStandard (281.66s)
=== RUN   TestAccLinuxFunctionApp_withAuthSettingsConsumption
=== PAUSE TestAccLinuxFunctionApp_withAuthSettingsConsumption
=== CONT  TestAccLinuxFunctionApp_withAuthSettingsConsumption
--- PASS: TestAccLinuxFunctionApp_withAuthSettingsConsumption (249.88s)
=== RUN   TestAccLinuxFunctionApp_builtInLogging
=== PAUSE TestAccLinuxFunctionApp_builtInLogging
=== CONT  TestAccLinuxFunctionApp_builtInLogging
--- PASS: TestAccLinuxFunctionApp_builtInLogging (277.67s)
=== RUN   TestAccLinuxFunctionApp_withConnectionStrings
=== PAUSE TestAccLinuxFunctionApp_withConnectionStrings
=== CONT  TestAccLinuxFunctionApp_withConnectionStrings
--- PASS: TestAccLinuxFunctionApp_withConnectionStrings (286.29s)
=== RUN   TestAccLinuxFunctionApp_withUserIdentity
=== PAUSE TestAccLinuxFunctionApp_withUserIdentity
=== CONT  TestAccLinuxFunctionApp_withUserIdentity
--- PASS: TestAccLinuxFunctionApp_withUserIdentity (340.90s)
=== RUN   TestAccLinuxFunctionApp_withConnectionStringsUpdate
=== PAUSE TestAccLinuxFunctionApp_withConnectionStringsUpdate
=== CONT  TestAccLinuxFunctionApp_withConnectionStringsUpdate
--- PASS: TestAccLinuxFunctionApp_withConnectionStringsUpdate (814.11s)
=== RUN   TestAccLinuxFunctionApp_dailyTimeQuotaConsumptionPlan
=== PAUSE TestAccLinuxFunctionApp_dailyTimeQuotaConsumptionPlan
=== CONT  TestAccLinuxFunctionApp_dailyTimeQuotaConsumptionPlan
--- PASS: TestAccLinuxFunctionApp_dailyTimeQuotaConsumptionPlan (313.44s)
=== RUN   TestAccLinuxFunctionApp_dailyTimeQuotaElasticPremiumPlan
=== PAUSE TestAccLinuxFunctionApp_dailyTimeQuotaElasticPremiumPlan
=== CONT  TestAccLinuxFunctionApp_dailyTimeQuotaElasticPremiumPlan
--- PASS: TestAccLinuxFunctionApp_dailyTimeQuotaElasticPremiumPlan (327.49s)
=== RUN   TestAccLinuxFunctionApp_healthCheckPath
=== PAUSE TestAccLinuxFunctionApp_healthCheckPath
=== CONT  TestAccLinuxFunctionApp_healthCheckPath
--- PASS: TestAccLinuxFunctionApp_healthCheckPath (339.19s)
=== RUN   TestAccLinuxFunctionApp_healthCheckPathWithEviction
=== PAUSE TestAccLinuxFunctionApp_healthCheckPathWithEviction
=== CONT  TestAccLinuxFunctionApp_healthCheckPathWithEviction
--- PASS: TestAccLinuxFunctionApp_healthCheckPathWithEviction (343.52s)
=== RUN   TestAccLinuxFunctionApp_healthCheckPathWithEvictionUpdate
=== PAUSE TestAccLinuxFunctionApp_healthCheckPathWithEvictionUpdate
=== CONT  TestAccLinuxFunctionApp_healthCheckPathWithEvictionUpdate
--- PASS: TestAccLinuxFunctionApp_healthCheckPathWithEvictionUpdate (646.76s)
=== RUN   TestAccLinuxFunctionApp_appServiceLogging
=== PAUSE TestAccLinuxFunctionApp_appServiceLogging
=== CONT  TestAccLinuxFunctionApp_appServiceLogging
--- PASS: TestAccLinuxFunctionApp_appServiceLogging (353.26s)
=== RUN   TestAccLinuxFunctionApp_appServiceLoggingUpdate
=== PAUSE TestAccLinuxFunctionApp_appServiceLoggingUpdate
=== CONT  TestAccLinuxFunctionApp_appServiceLoggingUpdate
--- PASS: TestAccLinuxFunctionApp_appServiceLoggingUpdate (648.88s)
=== RUN   TestAccLinuxFunctionApp_appStackDotNet31
=== PAUSE TestAccLinuxFunctionApp_appStackDotNet31
=== CONT  TestAccLinuxFunctionApp_appStackDotNet31
--- PASS: TestAccLinuxFunctionApp_appStackDotNet31 (365.00s)
=== RUN   TestAccLinuxFunctionApp_appStackDotNet6
=== PAUSE TestAccLinuxFunctionApp_appStackDotNet6
=== CONT  TestAccLinuxFunctionApp_appStackDotNet6
--- PASS: TestAccLinuxFunctionApp_appStackDotNet6 (338.80s)
=== RUN   TestAccLinuxFunctionApp_appStackPython
=== PAUSE TestAccLinuxFunctionApp_appStackPython
=== CONT  TestAccLinuxFunctionApp_appStackPython
--- PASS: TestAccLinuxFunctionApp_appStackPython (362.41s)
=== RUN   TestAccLinuxFunctionApp_appStackPythonUpdate
=== PAUSE TestAccLinuxFunctionApp_appStackPythonUpdate
=== CONT  TestAccLinuxFunctionApp_appStackPythonUpdate
--- PASS: TestAccLinuxFunctionApp_appStackPythonUpdate (555.62s)
=== RUN   TestAccLinuxFunctionApp_appStackNode
=== PAUSE TestAccLinuxFunctionApp_appStackNode
=== CONT  TestAccLinuxFunctionApp_appStackNode
--- PASS: TestAccLinuxFunctionApp_appStackNode (348.15s)
=== RUN   TestAccLinuxFunctionApp_appStackNodeUpdate
=== PAUSE TestAccLinuxFunctionApp_appStackNodeUpdate
=== CONT  TestAccLinuxFunctionApp_appStackNodeUpdate
--- PASS: TestAccLinuxFunctionApp_appStackNodeUpdate (438.19s)
=== RUN   TestAccLinuxFunctionApp_appStackJava
=== PAUSE TestAccLinuxFunctionApp_appStackJava
=== CONT  TestAccLinuxFunctionApp_appStackJava
--- PASS: TestAccLinuxFunctionApp_appStackJava (294.01s)
=== RUN   TestAccLinuxFunctionApp_appStackJavaUpdate
=== PAUSE TestAccLinuxFunctionApp_appStackJavaUpdate
=== CONT  TestAccLinuxFunctionApp_appStackJavaUpdate
--- PASS: TestAccLinuxFunctionApp_appStackJavaUpdate (434.21s)
=== RUN   TestAccLinuxFunctionApp_appStackDocker
=== PAUSE TestAccLinuxFunctionApp_appStackDocker
=== CONT  TestAccLinuxFunctionApp_appStackDocker
--- PASS: TestAccLinuxFunctionApp_appStackDocker (343.84s)
=== RUN   TestAccLinuxFunctionApp_appStackDockerManagedServiceIdentity
=== PAUSE TestAccLinuxFunctionApp_appStackDockerManagedServiceIdentity
=== CONT  TestAccLinuxFunctionApp_appStackDockerManagedServiceIdentity
--- PASS: TestAccLinuxFunctionApp_appStackDockerManagedServiceIdentity (275.85s)
=== RUN   TestAccLinuxFunctionApp_appStackPowerShellCore
=== PAUSE TestAccLinuxFunctionApp_appStackPowerShellCore
=== CONT  TestAccLinuxFunctionApp_appStackPowerShellCore
--- PASS: TestAccLinuxFunctionApp_appStackPowerShellCore (345.33s)
=== RUN   TestAccLinuxFunctionApp_updateServicePlan
=== PAUSE TestAccLinuxFunctionApp_updateServicePlan
=== CONT  TestAccLinuxFunctionApp_updateServicePlan
--- PASS: TestAccLinuxFunctionApp_updateServicePlan (560.50s)
=== RUN   TestAccLinuxFunctionApp_updateStorageAccount
=== PAUSE TestAccLinuxFunctionApp_updateStorageAccount
=== CONT  TestAccLinuxFunctionApp_updateStorageAccount
--- PASS: TestAccLinuxFunctionApp_updateStorageAccount (474.39s)
=== RUN   TestAccLinuxFunctionApp_consumptionPlanBackupShouldError
=== PAUSE TestAccLinuxFunctionApp_consumptionPlanBackupShouldError
=== CONT  TestAccLinuxFunctionApp_consumptionPlanBackupShouldError
--- PASS: TestAccLinuxFunctionApp_consumptionPlanBackupShouldError (202.03s)
=== RUN   TestAccLinuxFunctionApp_basicPlanBackupShouldError
=== PAUSE TestAccLinuxFunctionApp_basicPlanBackupShouldError
=== CONT  TestAccLinuxFunctionApp_basicPlanBackupShouldError
--- PASS: TestAccLinuxFunctionApp_basicPlanBackupShouldError (220.52s)
PASS

Process finished with the exit code 0