### PR TITLE
[Bug Fix - azurerm_api_management_api_operation] -  Handling example.value none-string types

### DIFF
--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -204,7 +204,7 @@ func FlattenApiManagementOperationRepresentation(input *[]apimanagement.Represen
 			output["example"] = example
 
 			if !features.ThreePointOhBeta() && v.Examples["default"] != nil && v.Examples["default"].Value != nil {
-				value, err := convert2String(v.Examples["default"].Value)
+				value, err := convert2Json(v.Examples["default"].Value)
 				if err != nil {
 					return nil, err
 				}
@@ -438,7 +438,7 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]*api
 		// value can be any type, may be a primitive value or an object
 		// https://github.com/Azure/azure-sdk-for-go/blob/main/services/apimanagement/mgmt/2021-08-01/apimanagement/models.go#L10236
 		if v.Value != nil {
-			value, err := convert2String(v.Value)
+			value, err := convert2Json(v.Value)
 			if err != nil {
 				return nil, err
 			}
@@ -472,7 +472,7 @@ func CopyCertificateAndPassword(vals []interface{}, hostName string, output map[
 	}
 }
 
-func convert2String(rawVal interface{}) (string, error) {
+func convert2Json(rawVal interface{}) (string, error) {
 	value := ""
 	if val, ok := rawVal.(string); ok {
 		value = val

--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -1,12 +1,12 @@
 package schemaz
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -180,9 +180,9 @@ func ExpandApiManagementOperationRepresentation(d *pluginsdk.ResourceData, schem
 	return &outputs, nil
 }
 
-func FlattenApiManagementOperationRepresentation(input *[]apimanagement.RepresentationContract) []interface{} {
+func FlattenApiManagementOperationRepresentation(input *[]apimanagement.RepresentationContract) ([]interface{}, error) {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{}, nil
 	}
 
 	outputs := make([]interface{}, 0)
@@ -197,10 +197,18 @@ func FlattenApiManagementOperationRepresentation(input *[]apimanagement.Represen
 		output["form_parameter"] = FlattenApiManagementOperationParameterContract(v.FormParameters)
 
 		if v.Examples != nil {
-			output["example"] = FlattenApiManagementOperationParameterExampleContract(v.Examples)
+			example, err := FlattenApiManagementOperationParameterExampleContract(v.Examples)
+			if err != nil {
+				return nil, err
+			}
+			output["example"] = example
 
-			if features.ThreePointOhBeta() && v.Examples["default"] != nil && v.Examples["default"].Value != nil {
-				output["sample"] = v.Examples["default"].Value.(string)
+			if !features.ThreePointOhBeta() && v.Examples["default"] != nil && v.Examples["default"].Value != nil {
+				value, err := convert2String(v.Examples["default"].Value)
+				if err != nil {
+					return nil, err
+				}
+				output["sample"] = value
 			}
 		}
 
@@ -215,7 +223,7 @@ func FlattenApiManagementOperationRepresentation(input *[]apimanagement.Represen
 		outputs = append(outputs, output)
 	}
 
-	return outputs
+	return outputs, nil
 }
 
 func SchemaApiManagementOperationParameterContract() *pluginsdk.Schema {
@@ -392,7 +400,12 @@ func ExpandApiManagementOperationParameterExampleContract(input []interface{}) m
 		}
 
 		if vs["value"] != nil {
-			outputs[name].Value = utils.String(vs["value"].(string))
+			var js interface{}
+			if json.Unmarshal([]byte(vs["value"].(string)), &js) != nil {
+				outputs[name].Value = js
+			} else {
+				outputs[name].Value = utils.String(vs["value"].(string))
+			}
 		}
 
 		if vs["external_value"] != nil {
@@ -403,9 +416,9 @@ func ExpandApiManagementOperationParameterExampleContract(input []interface{}) m
 	return outputs
 }
 
-func FlattenApiManagementOperationParameterExampleContract(input map[string]*apimanagement.ParameterExampleContract) []interface{} {
+func FlattenApiManagementOperationParameterExampleContract(input map[string]*apimanagement.ParameterExampleContract) ([]interface{}, error) {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{}, nil
 	}
 
 	outputs := make([]interface{}, 0)
@@ -422,8 +435,14 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]*api
 			output["description"] = *v.Description
 		}
 
+		// value can be any type, may be a primitive value or an object
+		// https://github.com/Azure/azure-sdk-for-go/blob/main/services/apimanagement/mgmt/2021-08-01/apimanagement/models.go#L10236
 		if v.Value != nil {
-			output["value"] = v.Value.(string)
+			value, err := convert2String(v.Value)
+			if err != nil {
+				return nil, err
+			}
+			output["value"] = value
 		}
 
 		if v.ExternalValue != nil {
@@ -433,7 +452,7 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]*api
 		outputs = append(outputs, output)
 	}
 
-	return outputs
+	return outputs, nil
 }
 
 // CopyCertificateAndPassword copies any certificate and password attributes
@@ -451,4 +470,18 @@ func CopyCertificateAndPassword(vals []interface{}, hostName string, output map[
 			break
 		}
 	}
+}
+
+func convert2String(rawVal interface{}) (string, error) {
+	value := ""
+	if val, ok := rawVal.(string); ok {
+		value = val
+	} else {
+		val, err := json.Marshal(rawVal)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal `representations.examples.value` to json: %+v", err)
+		}
+		value = string(val)
+	}
+	return value, nil
 }

--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -3,6 +3,7 @@ package schemaz
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement"
@@ -363,8 +364,9 @@ func SchemaApiManagementOperationParameterExampleContract() *pluginsdk.Schema {
 				},
 
 				"value": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
+					Type:             pluginsdk.TypeString,
+					Optional:         true,
+					DiffSuppressFunc: exampleSuppressEquivalentJSONDiffs,
 				},
 
 				"external_value": {
@@ -401,7 +403,7 @@ func ExpandApiManagementOperationParameterExampleContract(input []interface{}) m
 
 		if vs["value"] != nil {
 			var js interface{}
-			if json.Unmarshal([]byte(vs["value"].(string)), &js) != nil {
+			if json.Unmarshal([]byte(vs["value"].(string)), &js) == nil {
 				outputs[name].Value = js
 			} else {
 				outputs[name].Value = utils.String(vs["value"].(string))
@@ -484,4 +486,18 @@ func convert2Json(rawVal interface{}) (string, error) {
 		value = string(val)
 	}
 	return value, nil
+}
+
+func exampleSuppressEquivalentJSONDiffs(k, old, new string, d *pluginsdk.ResourceData) bool {
+	var ojs interface{}
+	if json.Unmarshal([]byte(old), &ojs) != nil {
+		return strings.Compare(old, new) == 0
+	}
+
+	var njs interface{}
+	if json.Unmarshal([]byte(new), &njs) != nil {
+		return strings.Compare(old, new) == 0
+	}
+
+	return reflect.DeepEqual(ojs, njs)
 }

--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -3,7 +3,6 @@ package schemaz
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement"
@@ -366,7 +365,7 @@ func SchemaApiManagementOperationParameterExampleContract() *pluginsdk.Schema {
 				"value": {
 					Type:             pluginsdk.TypeString,
 					Optional:         true,
-					DiffSuppressFunc: exampleSuppressEquivalentJSONDiffs,
+					DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
 				},
 
 				"external_value": {
@@ -444,6 +443,7 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]*api
 			if err != nil {
 				return nil, err
 			}
+
 			output["value"] = value
 		}
 
@@ -486,18 +486,4 @@ func convert2Json(rawVal interface{}) (string, error) {
 		value = string(val)
 	}
 	return value, nil
-}
-
-func exampleSuppressEquivalentJSONDiffs(k, old, new string, d *pluginsdk.ResourceData) bool {
-	var ojs interface{}
-	if json.Unmarshal([]byte(old), &ojs) != nil {
-		return strings.Compare(old, new) == 0
-	}
-
-	var njs interface{}
-	if json.Unmarshal([]byte(new), &njs) != nil {
-		return strings.Compare(old, new) == 0
-	}
-
-	return reflect.DeepEqual(ojs, njs)
 }


### PR DESCRIPTION

Fix issue #14707 
`example.value` can be any type, may be a primitive value or an object, parse non-string type values to JSON string

Models definition: https://github.com/Azure/azure-sdk-for-go/blob/main/services/apimanagement/mgmt/2021-08-01/apimanagement/models.go#L10236

AccTests:
```log
=== RUN   TestAccApiManagementApiOperation_basic
=== PAUSE TestAccApiManagementApiOperation_basic
=== RUN   TestAccApiManagementApiOperation_requiresImport
=== PAUSE TestAccApiManagementApiOperation_requiresImport
=== RUN   TestAccApiManagementApiOperation_customMethod
=== RUN   TestAccApiManagementApiOperationTag_requiresImport
=== PAUSE TestAccApiManagementApiOperationTag_requiresImport
=== RUN   TestAccApiManagementApiOperationTag_update
=== PAUSE TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperation_basic
=== CONT  TestAccApiManagementApiOperation_representations
=== CONT  TestAccApiManagementApiOperationTag_requiresImport
=== CONT  TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperation_requestRepresentations
=== CONT  TestAccApiManagementApiOperationTag_basic
=== CONT  TestAccApiManagementApiOperation_customMethod
=== CONT  TestAccApiManagementApiOperation_headers
--- PASS: TestAccApiManagementApiOperation_basic (418.13s)
=== CONT  TestAccApiManagementApiOperation_requiresImport
--- PASS: TestAccApiManagementApiOperation_customMethod (419.67s)
--- PASS: TestAccApiManagementApiOperationTag_basic (421.82s)
--- PASS: TestAccApiManagementApiOperation_headers (432.89s)
--- PASS: TestAccApiManagementApiOperationTag_requiresImport (448.78s)
--- PASS: TestAccApiManagementApiOperation_requestRepresentations (497.60s)
--- PASS: TestAccApiManagementApiOperation_representations (508.32s)
--- PASS: TestAccApiManagementApiOperationTag_update (597.76s)
--- PASS: TestAccApiManagementApiOperation_requiresImport (415.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 838.375s

```