### PR TITLE
azurerm_aadb2c_directory: fix broken import support

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource.go
@@ -60,7 +60,8 @@ func (r AadB2cDirectoryResource) Arguments() map[string]*pluginsdk.Schema {
 		"country_code": {
 			Description:  "Country code of the B2C tenant. See https://aka.ms/B2CDataResidency for valid country codes.",
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
+			Computed:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
@@ -82,7 +83,8 @@ func (r AadB2cDirectoryResource) Arguments() map[string]*pluginsdk.Schema {
 		"display_name": {
 			Description:  "The initial display name of the B2C tenant.",
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
+			Computed:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
@@ -134,6 +136,13 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 			var model AadB2cDirectoryModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			if model.CountryCode == "" {
+				return fmt.Errorf("`country_code` is required when creating a new AADB2C directory")
+			}
+			if model.DisplayName == "" {
+				return fmt.Errorf("`display_name` is required when creating a new AADB2C directory")
 			}
 
 			id := tenants.NewB2CDirectoryID(subscriptionId, model.ResourceGroup, model.DomainName)

--- a/website/docs/r/aadb2c_directory.html.markdown
+++ b/website/docs/r/aadb2c_directory.html.markdown
@@ -27,11 +27,11 @@ resource "azurerm_aadb2c_directory" "example" {
 
 The following arguments are supported:
 
-* `country_code` - (Required) Country code of the B2C tenant. The `country_code` should be valid for the specified `data_residency_location`. See [official docs](https://aka.ms/B2CDataResidency) for valid country codes. Changing this forces a new AAD B2C Directory to be created.
+* `country_code` - (Optional) Country code of the B2C tenant. The `country_code` should be valid for the specified `data_residency_location`. See [official docs](https://aka.ms/B2CDataResidency) for valid country codes. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.
 
 * `data_residency_location` - (Required) Location in which the B2C tenant is hosted and data resides. The `data_residency_location` should be valid for the specified `country_code`. See [official docs](https://aka.ms/B2CDataResidenc) for more information. Changing this forces a new AAD B2C Directory to be created.
 
-* `display_name` - (Required) The initial display name of the B2C tenant. Changing this forces a new AAD B2C Directory to be created.
+* `display_name` - (Optional) The initial display name of the B2C tenant. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.
 
 * `domain_name` - (Required) Domain name of the B2C tenant, including the `.onmicrosoft.com` suffix. Changing this forces a new AAD B2C Directory to be created.
 


### PR DESCRIPTION
Fixes: #14855

This makes `country_code` and `display_name` optional+computed instead of required, and checks that they are set at create time. Tested by creating a tenant in portal, importing it and attempting a plan:

![Screenshot 2022-01-10 at 17 06 38](https://user-images.githubusercontent.com/251987/148808659-a516c9db-35d6-42b6-a97a-2ea949178f80.png)

