### PR TITLE
`azurerm_mysql_server_key` - Fix issue when checking for existing resource on create

### DIFF
--- a/internal/services/mysql/mysql_server_key_resource.go
+++ b/internal/services/mysql/mysql_server_key_resource.go
@@ -105,7 +105,7 @@ func resourceMySQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 				return fmt.Errorf("missing ID for existing MySQL Server Key")
 			}
 
-			id, err := parse.ServerID(*keys[0].ID)
+			id, err := parse.KeyID(*keys[0].ID)
 			if err != nil {
 				return err
 			}

--- a/internal/services/mysql/mysql_server_key_resource.go
+++ b/internal/services/mysql/mysql_server_key_resource.go
@@ -101,7 +101,7 @@ func resourceMySQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			if len(keys) > 1 {
 				return fmt.Errorf("expecting at most one MySQL Server Key, but got %q", len(keys))
 			}
-			if keys[0].ID == nil || *keys[0].ID != "" {
+			if keys[0].ID == nil || *keys[0].ID == "" {
 				return fmt.Errorf("missing ID for existing MySQL Server Key")
 			}
 


### PR DESCRIPTION
```
--- PASS: TestAccMySQLServerKey_requiresImport (812.01s)
```