### PR TITLE
Importer normalize

### DIFF
--- a/internal/sdk/wrapper_helpers.go
+++ b/internal/sdk/wrapper_helpers.go
@@ -1,10 +1,12 @@
 package sdk
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
 
 // combineSchema combines the arguments (user-configurable) and attributes (read-only) schema fields
@@ -54,4 +56,17 @@ func runArgs(d *schema.ResourceData, meta interface{}, logger Logger) ResourceMe
 	}
 
 	return metaData
+}
+
+// NormalizeIdImporter is a helper function which returns a ResourceRunFunc.
+// This function is intended to be used as the CustomImporter for a ResourceWithCustomImporter.
+func NormalizeIdImporter(parser func(string) (resourceid.Formatter, error)) ResourceRunFunc {
+	return func(ctx context.Context, metadata ResourceMetaData) error {
+		id, err := parser(metadata.ResourceData.Id())
+		if err != nil {
+			return err
+		}
+		metadata.SetID(id)
+		return nil
+	}
 }

--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -39,9 +40,8 @@ func resourceCdnEndpoint() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.EndpointID(id)
-			return err
+		Importer: pluginsdk.ImporterValidatingThenNormalizeId(func(input string) (resourceids.Id, error) {
+			return parse.EndpointID(input)
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/containers/container_registry_task_resource.go
+++ b/internal/services/containers/container_registry_task_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
@@ -25,6 +26,7 @@ type ContainerRegistryTaskResource struct{}
 
 var _ sdk.ResourceWithUpdate = ContainerRegistryTaskResource{}
 var _ sdk.ResourceWithCustomizeDiff = ContainerRegistryTaskResource{}
+var _ sdk.ResourceWithCustomImporter = ContainerRegistryTaskResource{}
 
 type AgentConfig struct {
 	CPU int `tfschema:"cpu"`
@@ -674,6 +676,12 @@ func (r ContainerRegistryTaskResource) CustomizeDiff() sdk.ResourceFunc {
 			return nil
 		},
 	}
+}
+
+func (r ContainerRegistryTaskResource) CustomImporter() sdk.ResourceRunFunc {
+	return sdk.NormalizeIdImporter(func(input string) (resourceid.Formatter, error) {
+		return parse.ContainerRegistryTaskID(input)
+	})
 }
 
 func (r ContainerRegistryTaskResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -44,6 +45,24 @@ func ImporterValidatingResourceIdThen(validateFunc IDValidationFunc, thenFunc Im
 			}
 
 			return thenFunc(ctx, d, meta)
+		},
+	}
+}
+
+type IDParseFunc func(string) (resourceids.Id, error)
+
+func ImporterValidatingThenNormalizeId(parser IDParseFunc) *schema.ResourceImporter {
+	return &schema.ResourceImporter{
+		StateContext: func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
+			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
+
+			id, err := parser(d.Id())
+			if err != nil {
+				return []*ResourceData{d}, fmt.Errorf("parsing Resource ID %q: %+v", d.Id(), err)
+			}
+
+			d.SetId(id.ID())
+			return []*ResourceData{d}, nil
 		},
 	}
 }


### PR DESCRIPTION
Normalize the ID using the importer function to conform to what is
defined in the ID formatter.

This is to mitigate cases like users import resource ID with lowercase
'g' for the resource group. In this case, the current validation in the
importer raise no error, which results into the incorrect cased ID leak
into terraform state. This will cause the other referencing resource get
unexpected plan diff (see #14854).

This commit adds the helper function for both untyped and typed sdk. The
users are expected to pass in a wrapper function around the parse
function generated via the resource id tool. While this wrapper might be
eliminated once we have generic in Go.

Together with this PR comes with two real world examples (one for typed sdk and one for the untyped sdk). If this makes sense, then we can move on refactoring for the remaing resources.