### PR TITLE
Update schema for kubernetes addons

### DIFF
--- a/internal/services/containers/kubernetes_cluster_addons.go
+++ b/internal/services/containers/kubernetes_cluster_addons.go
@@ -592,7 +592,7 @@ func expandKubernetesAddOnProfiles(d *pluginsdk.ResourceData, input []interface{
 			props := &containerservice.ManagedClusterAddonProfile{
 				Enabled: utils.Bool(v),
 			}
-			if v != false {
+			if v {
 				props.Config = map[string]*string{
 					"version": utils.String("v2"),
 				}

--- a/internal/services/containers/kubernetes_cluster_addons.go
+++ b/internal/services/containers/kubernetes_cluster_addons.go
@@ -52,7 +52,8 @@ var unsupportedAddonsForEnvironment = map[string][]string{
 }
 
 func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
-	if features.ThreePointOh() {
+	// TODO 3.0 - Remove this block
+	if !features.ThreePointOh() {
 		return &pluginsdk.Schema{
 			Type:     pluginsdk.TypeList,
 			MaxItems: 1,
@@ -66,6 +67,11 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+
 								"subnet_name": {
 									Type:         pluginsdk.TypeString,
 									Optional:     true,
@@ -75,16 +81,32 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						},
 					},
 
-					"azure_policy_enabled": {
-						Type:     pluginsdk.TypeBool,
+					"azure_policy": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
 						Optional: true,
-						Default:  false,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
 					},
 
-					"kube_dashboard_enabled": {
-						Type:     pluginsdk.TypeBool,
+					"kube_dashboard": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
 						Optional: true,
-						Default:  false,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
 					},
 
 					"http_application_routing": {
@@ -93,6 +115,10 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
 								"http_application_routing_zone_name": {
 									Type:     pluginsdk.TypeString,
 									Computed: true,
@@ -107,6 +133,10 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
 								"log_analytics_workspace_id": {
 									Type:         pluginsdk.TypeString,
 									Optional:     true,
@@ -142,11 +172,18 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
 								"gateway_id": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
-									ValidateFunc:  applicationGatewayValidate.ApplicationGatewayID,
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ConflictsWith: []string{
+										"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+										"addon_profile.0.ingress_application_gateway.0.subnet_id",
+									},
+									ValidateFunc: applicationGatewayValidate.ApplicationGatewayID,
 								},
 								"gateway_name": {
 									Type:         pluginsdk.TypeString,
@@ -154,16 +191,22 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								"subnet_cidr": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
-									ValidateFunc:  commonValidate.CIDR,
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ConflictsWith: []string{
+										"addon_profile.0.ingress_application_gateway.0.gateway_id",
+										"addon_profile.0.ingress_application_gateway.0.subnet_id",
+									},
+									ValidateFunc: commonValidate.CIDR,
 								},
 								"subnet_id": {
-									Type:          pluginsdk.TypeString,
-									Optional:      true,
-									ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_cidr"},
-									ValidateFunc:  subnetValidate.SubnetID,
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ConflictsWith: []string{
+										"addon_profile.0.ingress_application_gateway.0.gateway_id",
+										"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+									},
+									ValidateFunc: subnetValidate.SubnetID,
 								},
 								"effective_gateway_id": {
 									Type:     pluginsdk.TypeString,
@@ -193,10 +236,18 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						},
 					},
 
-					"open_service_mesh_enabled": {
-						Type:     pluginsdk.TypeBool,
+					"open_service_mesh": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
 						Optional: true,
-						Default: false,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
+							},
+						},
 					},
 					"azure_keyvault_secrets_provider": {
 						Type:     pluginsdk.TypeList,
@@ -204,6 +255,10 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Required: true,
+								},
 								"secret_rotation_enabled": {
 									Type:     pluginsdk.TypeBool,
 									Default:  false,
@@ -242,7 +297,6 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 			},
 		}
 	}
-	//lintignore:XS003
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		MaxItems: 1,
@@ -256,64 +310,33 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 					Optional: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
-
 							"subnet_name": {
 								Type:         pluginsdk.TypeString,
-								Optional:     true,
+								Required:     true,
 								ValidateFunc: validation.StringIsNotEmpty,
 							},
 						},
 					},
 				},
 
-				"azure_policy": {
-					Type:     pluginsdk.TypeList,
-					MaxItems: 1,
+				"azure_policy_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Elem: &pluginsdk.Resource{
-						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
-						},
-					},
+
 				},
 
-				"kube_dashboard": {
-					Type:     pluginsdk.TypeList,
-					MaxItems: 1,
+				"kube_dashboard_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Elem: &pluginsdk.Resource{
-						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
-						},
-					},
 				},
 
-				"http_application_routing": {
-					Type:     pluginsdk.TypeList,
-					MaxItems: 1,
+				"http_application_routing_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Elem: &pluginsdk.Resource{
-						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
-							"http_application_routing_zone_name": {
-								Type:     pluginsdk.TypeString,
-								Computed: true,
-							},
-						},
-					},
+				},
+				"http_application_routing_zone_name": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
 				},
 
 				"oms_agent": {
@@ -322,13 +345,9 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 					Optional: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
 							"log_analytics_workspace_id": {
 								Type:         pluginsdk.TypeString,
-								Optional:     true,
+								Required:     true,
 								ValidateFunc: logAnalyticsValidate.LogAnalyticsWorkspaceID,
 							},
 							"oms_agent_identity": {
@@ -361,15 +380,19 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 					Optional: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
 							"gateway_id": {
-								Type:          pluginsdk.TypeString,
-								Optional:      true,
-								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
-								ValidateFunc:  applicationGatewayValidate.ApplicationGatewayID,
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								ConflictsWith: []string{
+									"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+									"addon_profile.0.ingress_application_gateway.0.subnet_id",
+								},
+								AtLeastOneOf: []string{
+									"addon_profile.0.ingress_application_gateway.0.gateway_id",
+									"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+									"addon_profile.0.ingress_application_gateway.0.subnet_id",
+								},
+								ValidateFunc: applicationGatewayValidate.ApplicationGatewayID,
 							},
 							"gateway_name": {
 								Type:         pluginsdk.TypeString,
@@ -377,16 +400,32 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 								ValidateFunc: validation.StringIsNotEmpty,
 							},
 							"subnet_cidr": {
-								Type:          pluginsdk.TypeString,
-								Optional:      true,
-								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
-								ValidateFunc:  commonValidate.CIDR,
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								ConflictsWith: []string{
+									"addon_profile.0.ingress_application_gateway.0.gateway_id",
+									"addon_profile.0.ingress_application_gateway.0.subnet_id",
+								},
+								AtLeastOneOf: []string{
+									"addon_profile.0.ingress_application_gateway.0.gateway_id",
+									"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+									"addon_profile.0.ingress_application_gateway.0.subnet_id",
+								},
+								ValidateFunc: commonValidate.CIDR,
 							},
 							"subnet_id": {
-								Type:          pluginsdk.TypeString,
-								Optional:      true,
-								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_cidr"},
-								ValidateFunc:  subnetValidate.SubnetID,
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								ConflictsWith: []string{
+									"addon_profile.0.ingress_application_gateway.0.gateway_id",
+									"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+								},
+								AtLeastOneOf: []string{
+									"addon_profile.0.ingress_application_gateway.0.gateway_id",
+									"addon_profile.0.ingress_application_gateway.0.subnet_cidr",
+									"addon_profile.0.ingress_application_gateway.0.subnet_id",
+								},
+								ValidateFunc: subnetValidate.SubnetID,
 							},
 							"effective_gateway_id": {
 								Type:     pluginsdk.TypeString,
@@ -416,38 +455,34 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 					},
 				},
 
-				"open_service_mesh": {
-					Type:     pluginsdk.TypeList,
-					MaxItems: 1,
+				"open_service_mesh_enabled": {
+					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Elem: &pluginsdk.Resource{
-						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
-						},
-					},
 				},
+
 				"azure_keyvault_secrets_provider": {
 					Type:     pluginsdk.TypeList,
 					MaxItems: 1,
 					Optional: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
-							"enabled": {
-								Type:     pluginsdk.TypeBool,
-								Required: true,
-							},
 							"secret_rotation_enabled": {
 								Type:     pluginsdk.TypeBool,
 								Default:  false,
 								Optional: true,
+								AtLeastOneOf: []string{
+									"addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_enabled",
+									"addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_interval",
+								},
 							},
 							"secret_rotation_interval": {
-								Type:         pluginsdk.TypeString,
-								Optional:     true,
-								Default:      "2m",
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								Default:  "2m",
+								AtLeastOneOf: []string{
+									"addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_enabled",
+									"addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_interval",
+								},
 								ValidateFunc: containerValidate.Duration,
 							},
 							"secret_identity": {
@@ -478,7 +513,7 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 	}
 }
 
-func expandKubernetesAddOnProfiles(input []interface{}, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
+func expandKubernetesAddOnProfiles(d *pluginsdk.ResourceData, input []interface{}, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
 	disabled := containerservice.ManagedClusterAddonProfile{
 		Enabled: utils.Bool(false),
 	}
@@ -501,134 +536,251 @@ func expandKubernetesAddOnProfiles(input []interface{}, env azure.Environment) (
 	profile := input[0].(map[string]interface{})
 	addonProfiles := map[string]*containerservice.ManagedClusterAddonProfile{}
 
-	httpApplicationRouting := profile["http_application_routing"].([]interface{})
-	if len(httpApplicationRouting) > 0 && httpApplicationRouting[0] != nil {
-		value := httpApplicationRouting[0].(map[string]interface{})
-		enabled := value["enabled"].(bool)
-		addonProfiles[httpApplicationRoutingKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-		}
-	}
-
-	omsAgent := profile["oms_agent"].([]interface{})
-	if len(omsAgent) > 0 && omsAgent[0] != nil {
-		value := omsAgent[0].(map[string]interface{})
-		config := make(map[string]*string)
-		enabled := value["enabled"].(bool)
-
-		if workspaceID, ok := value["log_analytics_workspace_id"]; ok && workspaceID != "" {
-			lawid, err := laparse.LogAnalyticsWorkspaceID(workspaceID.(string))
-			if err != nil {
-				return nil, fmt.Errorf("parsing Log Analytics Workspace ID: %+v", err)
+	if features.ThreePointOh() {
+		if raw, ok := d.GetOkExists("addon_profile.0.http_application_routing_enabled"); ok {
+			addonProfiles[httpApplicationRoutingKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(raw.(bool)),
 			}
-			config["logAnalyticsWorkspaceResourceID"] = utils.String(lawid.ID())
 		}
 
-		addonProfiles[omsAgentKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  config,
+		omsAgent := profile["oms_agent"].([]interface{})
+		if len(omsAgent) > 0 && omsAgent[0] != nil {
+			value := omsAgent[0].(map[string]interface{})
+			config := make(map[string]*string)
+
+			if workspaceID, ok := value["log_analytics_workspace_id"]; ok && workspaceID != "" {
+				lawid, err := laparse.LogAnalyticsWorkspaceID(workspaceID.(string))
+				if err != nil {
+					return nil, fmt.Errorf("parsing Log Analytics Workspace ID: %+v", err)
+				}
+				config["logAnalyticsWorkspaceResourceID"] = utils.String(lawid.ID())
+			}
+
+			addonProfiles[omsAgentKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(true),
+				Config:  config,
+			}
 		}
+
+		aciConnector := profile["aci_connector_linux"].([]interface{})
+		if len(aciConnector) > 0 && aciConnector[0] != nil {
+			value := aciConnector[0].(map[string]interface{})
+			config := make(map[string]*string)
+
+			if subnetName, ok := value["subnet_name"]; ok && subnetName != "" {
+				config["SubnetName"] = utils.String(subnetName.(string))
+			}
+
+			addonProfiles[aciConnectorKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(true),
+				Config:  config,
+			}
+		}
+
+		if raw, ok := d.GetOkExists("addon_profile.0.kube_dashboard_enabled"); ok {
+			addonProfiles[kubernetesDashboardKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(raw.(bool)),
+				Config:  nil,
+			}
+		}
+
+		if raw, ok := d.GetOkExists("addon_profile.0.azure_policy_enabled"); ok {
+			v := raw.(bool)
+			props := &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(v),
+			}
+			if v != false {
+				props.Config = map[string]*string{
+					"version": utils.String("v2"),
+				}
+			}
+			addonProfiles[azurePolicyKey] = props
+		}
+
+		ingressApplicationGateway := profile["ingress_application_gateway"].([]interface{})
+		if len(ingressApplicationGateway) > 0 && ingressApplicationGateway[0] != nil {
+			value := ingressApplicationGateway[0].(map[string]interface{})
+			config := make(map[string]*string)
+
+			if gatewayId, ok := value["gateway_id"]; ok && gatewayId != "" {
+				config["applicationGatewayId"] = utils.String(gatewayId.(string))
+			}
+
+			if gatewayName, ok := value["gateway_name"]; ok && gatewayName != "" {
+				config["applicationGatewayName"] = utils.String(gatewayName.(string))
+			}
+
+			if subnetCIDR, ok := value["subnet_cidr"]; ok && subnetCIDR != "" {
+				config["subnetCIDR"] = utils.String(subnetCIDR.(string))
+			}
+
+			if subnetId, ok := value["subnet_id"]; ok && subnetId != "" {
+				config["subnetId"] = utils.String(subnetId.(string))
+			}
+
+			addonProfiles[ingressApplicationGatewayKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(true),
+				Config:  config,
+			}
+		}
+
+		if raw, ok := d.GetOkExists("addon_profile.0.open_service_mesh_enabled"); ok {
+			addonProfiles[openServiceMeshKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(raw.(bool)),
+				Config:  nil,
+			}
+		}
+
+		azureKeyVaultSecretsProvider := profile["azure_keyvault_secrets_provider"].([]interface{})
+		if len(azureKeyVaultSecretsProvider) > 0 && azureKeyVaultSecretsProvider[0] != nil {
+			value := azureKeyVaultSecretsProvider[0].(map[string]interface{})
+			config := make(map[string]*string)
+
+			enableSecretRotation := "false"
+			if value["secret_rotation_enabled"].(bool) {
+				enableSecretRotation = "true"
+			}
+			config["enableSecretRotation"] = utils.String(enableSecretRotation)
+			config["rotationPollInterval"] = utils.String(value["secret_rotation_interval"].(string))
+
+			addonProfiles[azureKeyvaultSecretsProviderKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(true),
+				Config:  config,
+			}
+		}
+
+		return filterUnsupportedKubernetesAddOns(addonProfiles, env)
+	} else {
+		// TODO 3.0 - Remove this block
+		httpApplicationRouting := profile["http_application_routing"].([]interface{})
+		if len(httpApplicationRouting) > 0 && httpApplicationRouting[0] != nil {
+			value := httpApplicationRouting[0].(map[string]interface{})
+			enabled := value["enabled"].(bool)
+			addonProfiles[httpApplicationRoutingKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+			}
+		}
+
+		omsAgent := profile["oms_agent"].([]interface{})
+		if len(omsAgent) > 0 && omsAgent[0] != nil {
+			value := omsAgent[0].(map[string]interface{})
+			config := make(map[string]*string)
+			enabled := value["enabled"].(bool)
+
+			if workspaceID, ok := value["log_analytics_workspace_id"]; ok && workspaceID != "" {
+				lawid, err := laparse.LogAnalyticsWorkspaceID(workspaceID.(string))
+				if err != nil {
+					return nil, fmt.Errorf("parsing Log Analytics Workspace ID: %+v", err)
+				}
+				config["logAnalyticsWorkspaceResourceID"] = utils.String(lawid.ID())
+			}
+
+			addonProfiles[omsAgentKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  config,
+			}
+		}
+
+		aciConnector := profile["aci_connector_linux"].([]interface{})
+		if len(aciConnector) > 0 && aciConnector[0] != nil {
+			value := aciConnector[0].(map[string]interface{})
+			config := make(map[string]*string)
+			enabled := value["enabled"].(bool)
+
+			if subnetName, ok := value["subnet_name"]; ok && subnetName != "" {
+				config["SubnetName"] = utils.String(subnetName.(string))
+			}
+
+			addonProfiles[aciConnectorKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  config,
+			}
+		}
+
+		kubeDashboard := profile["kube_dashboard"].([]interface{})
+		if len(kubeDashboard) > 0 && kubeDashboard[0] != nil {
+			value := kubeDashboard[0].(map[string]interface{})
+			enabled := value["enabled"].(bool)
+
+			addonProfiles[kubernetesDashboardKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  nil,
+			}
+		}
+
+		azurePolicy := profile["azure_policy"].([]interface{})
+		if len(azurePolicy) > 0 && azurePolicy[0] != nil {
+			value := azurePolicy[0].(map[string]interface{})
+			enabled := value["enabled"].(bool)
+
+			addonProfiles[azurePolicyKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config: map[string]*string{
+					"version": utils.String("v2"),
+				},
+			}
+		}
+
+		ingressApplicationGateway := profile["ingress_application_gateway"].([]interface{})
+		if len(ingressApplicationGateway) > 0 && ingressApplicationGateway[0] != nil {
+			value := ingressApplicationGateway[0].(map[string]interface{})
+			config := make(map[string]*string)
+			enabled := value["enabled"].(bool)
+
+			if gatewayId, ok := value["gateway_id"]; ok && gatewayId != "" {
+				config["applicationGatewayId"] = utils.String(gatewayId.(string))
+			}
+
+			if gatewayName, ok := value["gateway_name"]; ok && gatewayName != "" {
+				config["applicationGatewayName"] = utils.String(gatewayName.(string))
+			}
+
+			if subnetCIDR, ok := value["subnet_cidr"]; ok && subnetCIDR != "" {
+				config["subnetCIDR"] = utils.String(subnetCIDR.(string))
+			}
+
+			if subnetId, ok := value["subnet_id"]; ok && subnetId != "" {
+				config["subnetId"] = utils.String(subnetId.(string))
+			}
+
+			addonProfiles[ingressApplicationGatewayKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  config,
+			}
+		}
+
+		openServiceMesh := profile["open_service_mesh"].([]interface{})
+		if len(openServiceMesh) > 0 && openServiceMesh[0] != nil {
+			value := openServiceMesh[0].(map[string]interface{})
+			enabled := value["enabled"].(bool)
+
+			addonProfiles[openServiceMeshKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  nil,
+			}
+		}
+
+		azureKeyvaultSecretsProvider := profile["azure_keyvault_secrets_provider"].([]interface{})
+		if len(azureKeyvaultSecretsProvider) > 0 && azureKeyvaultSecretsProvider[0] != nil {
+			value := azureKeyvaultSecretsProvider[0].(map[string]interface{})
+			config := make(map[string]*string)
+			enabled := value["enabled"].(bool)
+
+			enableSecretRotation := "false"
+			if value["secret_rotation_enabled"].(bool) {
+				enableSecretRotation = "true"
+			}
+			config["enableSecretRotation"] = utils.String(enableSecretRotation)
+			config["rotationPollInterval"] = utils.String(value["secret_rotation_interval"].(string))
+
+			addonProfiles[azureKeyvaultSecretsProviderKey] = &containerservice.ManagedClusterAddonProfile{
+				Enabled: utils.Bool(enabled),
+				Config:  config,
+			}
+		}
+
+		return filterUnsupportedKubernetesAddOns(addonProfiles, env)
 	}
-
-	aciConnector := profile["aci_connector_linux"].([]interface{})
-	if len(aciConnector) > 0 && aciConnector[0] != nil {
-		value := aciConnector[0].(map[string]interface{})
-		config := make(map[string]*string)
-		enabled := value["enabled"].(bool)
-
-		if subnetName, ok := value["subnet_name"]; ok && subnetName != "" {
-			config["SubnetName"] = utils.String(subnetName.(string))
-		}
-
-		addonProfiles[aciConnectorKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  config,
-		}
-	}
-
-	kubeDashboard := profile["kube_dashboard"].([]interface{})
-	if len(kubeDashboard) > 0 && kubeDashboard[0] != nil {
-		value := kubeDashboard[0].(map[string]interface{})
-		enabled := value["enabled"].(bool)
-
-		addonProfiles[kubernetesDashboardKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  nil,
-		}
-	}
-
-	azurePolicy := profile["azure_policy"].([]interface{})
-	if len(azurePolicy) > 0 && azurePolicy[0] != nil {
-		value := azurePolicy[0].(map[string]interface{})
-		enabled := value["enabled"].(bool)
-
-		addonProfiles[azurePolicyKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config: map[string]*string{
-				"version": utils.String("v2"),
-			},
-		}
-	}
-
-	ingressApplicationGateway := profile["ingress_application_gateway"].([]interface{})
-	if len(ingressApplicationGateway) > 0 && ingressApplicationGateway[0] != nil {
-		value := ingressApplicationGateway[0].(map[string]interface{})
-		config := make(map[string]*string)
-		enabled := value["enabled"].(bool)
-
-		if gatewayId, ok := value["gateway_id"]; ok && gatewayId != "" {
-			config["applicationGatewayId"] = utils.String(gatewayId.(string))
-		}
-
-		if gatewayName, ok := value["gateway_name"]; ok && gatewayName != "" {
-			config["applicationGatewayName"] = utils.String(gatewayName.(string))
-		}
-
-		if subnetCIDR, ok := value["subnet_cidr"]; ok && subnetCIDR != "" {
-			config["subnetCIDR"] = utils.String(subnetCIDR.(string))
-		}
-
-		if subnetId, ok := value["subnet_id"]; ok && subnetId != "" {
-			config["subnetId"] = utils.String(subnetId.(string))
-		}
-
-		addonProfiles[ingressApplicationGatewayKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  config,
-		}
-	}
-
-	openServiceMesh := profile["open_service_mesh"].([]interface{})
-	if len(openServiceMesh) > 0 && openServiceMesh[0] != nil {
-		value := openServiceMesh[0].(map[string]interface{})
-		enabled := value["enabled"].(bool)
-
-		addonProfiles[openServiceMeshKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  nil,
-		}
-	}
-
-	azureKeyvaultSecretsProvider := profile["azure_keyvault_secrets_provider"].([]interface{})
-	if len(azureKeyvaultSecretsProvider) > 0 && azureKeyvaultSecretsProvider[0] != nil {
-		value := azureKeyvaultSecretsProvider[0].(map[string]interface{})
-		config := make(map[string]*string)
-		enabled := value["enabled"].(bool)
-
-		enableSecretRotation := "false"
-		if value["secret_rotation_enabled"].(bool) {
-			enableSecretRotation = "true"
-		}
-		config["enableSecretRotation"] = utils.String(enableSecretRotation)
-		config["rotationPollInterval"] = utils.String(value["secret_rotation_interval"].(string))
-
-		addonProfiles[azureKeyvaultSecretsProviderKey] = &containerservice.ManagedClusterAddonProfile{
-			Enabled: utils.Bool(enabled),
-			Config:  config,
-		}
-	}
-
-	return filterUnsupportedKubernetesAddOns(addonProfiles, env)
 }
 
 func filterUnsupportedKubernetesAddOns(input map[string]*containerservice.ManagedClusterAddonProfile, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
@@ -661,187 +813,343 @@ func filterUnsupportedKubernetesAddOns(input map[string]*containerservice.Manage
 }
 
 func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.ManagedClusterAddonProfile) []interface{} {
-	aciConnectors := make([]interface{}, 0)
-	if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
-		enabled := false
-		if enabledVal := aciConnector.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
+	if features.ThreePointOh() {
+		result := make(map[string]interface{})
 
-		subnetName := ""
-		if v := aciConnector.Config["SubnetName"]; v != nil {
-			subnetName = *v
-		}
-
-		aciConnectors = append(aciConnectors, map[string]interface{}{
-			"enabled":     enabled,
-			"subnet_name": subnetName,
-		})
-	}
-
-	azurePolicies := make([]interface{}, 0)
-	if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
-		enabled := false
-		if enabledVal := azurePolicy.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
-
-		azurePolicies = append(azurePolicies, map[string]interface{}{
-			"enabled": enabled,
-		})
-	}
-
-	httpApplicationRoutes := make([]interface{}, 0)
-	if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
-		enabled := false
-		if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
-
-		zoneName := ""
-		if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
-			zoneName = *v
-		}
-
-		httpApplicationRoutes = append(httpApplicationRoutes, map[string]interface{}{
-			"enabled":                            enabled,
-			"http_application_routing_zone_name": zoneName,
-		})
-	}
-
-	kubeDashboards := make([]interface{}, 0)
-	if kubeDashboard := kubernetesAddonProfileLocate(profile, kubernetesDashboardKey); kubeDashboard != nil {
-		enabled := false
-		if enabledVal := kubeDashboard.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
-
-		kubeDashboards = append(kubeDashboards, map[string]interface{}{
-			"enabled": enabled,
-		})
-	}
-
-	omsAgents := make([]interface{}, 0)
-	if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
-		enabled := false
-		if enabledVal := omsAgent.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
-
-		workspaceID := ""
-		if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
-			if lawid, err := laparse.LogAnalyticsWorkspaceID(*v); err == nil {
-				workspaceID = lawid.ID()
+		aciConnectors := make([]interface{}, 0)
+		if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
+			subnetName := ""
+			if v := aciConnector.Config["SubnetName"]; v != nil {
+				subnetName = *v
 			}
+
+			aciConnectors = append(aciConnectors, map[string]interface{}{
+				"subnet_name": subnetName,
+			})
+
+			result["aci_connector_linux"] = aciConnectors
 		}
 
-		omsagentIdentity := flattenKubernetesClusterAddOnIdentityProfile(omsAgent.Identity)
+		if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
+			enabled := false
+			if enabledVal := azurePolicy.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
 
-		omsAgents = append(omsAgents, map[string]interface{}{
-			"enabled":                    enabled,
-			"log_analytics_workspace_id": workspaceID,
-			"oms_agent_identity":         omsagentIdentity,
-		})
-	}
-
-	ingressApplicationGateways := make([]interface{}, 0)
-	if ingressApplicationGateway := kubernetesAddonProfileLocate(profile, ingressApplicationGatewayKey); ingressApplicationGateway != nil {
-		enabled := false
-		if enabledVal := ingressApplicationGateway.Enabled; enabledVal != nil {
-			enabled = *enabledVal
+			result["azure_policy_enabled"] = enabled
 		}
 
-		gatewayId := ""
-		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayId"); v != nil {
-			gatewayId = *v
+		if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
+			enabled := false
+			if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			routingZoneName := ""
+			if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
+				routingZoneName = *v
+			}
+
+			result["http_application_routing_enabled"] = enabled
+			result["http_application_routing_zone_name"] = routingZoneName
 		}
 
-		gatewayName := ""
-		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayName"); v != nil {
-			gatewayName = *v
+		if kubeDashboard := kubernetesAddonProfileLocate(profile, kubernetesDashboardKey); kubeDashboard != nil {
+			enabled := false
+			if enabledVal := kubeDashboard.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			result["kube_dashboard_enabled"] = enabled
 		}
 
-		effectiveGatewayId := ""
-		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "effectiveApplicationGatewayId"); v != nil {
-			effectiveGatewayId = *v
+		omsAgents := make([]interface{}, 0)
+		if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
+			workspaceID := ""
+			if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
+				if lawid, err := laparse.LogAnalyticsWorkspaceID(*v); err == nil {
+					workspaceID = lawid.ID()
+				}
+			}
+
+			omsAgentIdentity := flattenKubernetesClusterAddOnIdentityProfile(omsAgent.Identity)
+
+			omsAgents = append(omsAgents, map[string]interface{}{
+				"log_analytics_workspace_id": workspaceID,
+				"oms_agent_identity":         omsAgentIdentity,
+			})
+
+			result["oms_agent"] = omsAgents
 		}
 
-		subnetCIDR := ""
-		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetCIDR"); v != nil {
-			subnetCIDR = *v
+		ingressApplicationGateways := make([]interface{}, 0)
+		if ingressApplicationGateway := kubernetesAddonProfileLocate(profile, ingressApplicationGatewayKey); ingressApplicationGateway != nil {
+			gatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayId"); v != nil {
+				gatewayId = *v
+			}
+
+			gatewayName := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayName"); v != nil {
+				gatewayName = *v
+			}
+
+			effectiveGatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "effectiveApplicationGatewayId"); v != nil {
+				effectiveGatewayId = *v
+			}
+
+			subnetCIDR := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetCIDR"); v != nil {
+				subnetCIDR = *v
+			}
+
+			subnetId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetId"); v != nil {
+				subnetId = *v
+			}
+
+			ingressApplicationGatewayIdentity := flattenKubernetesClusterAddOnIdentityProfile(ingressApplicationGateway.Identity)
+
+			ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
+				"gateway_id":                           gatewayId,
+				"gateway_name":                         gatewayName,
+				"effective_gateway_id":                 effectiveGatewayId,
+				"subnet_cidr":                          subnetCIDR,
+				"subnet_id":                            subnetId,
+				"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
+			})
+
+			result["ingress_application_gateway"] = ingressApplicationGateways
 		}
 
-		subnetId := ""
-		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetId"); v != nil {
-			subnetId = *v
+		if openServiceMesh := kubernetesAddonProfileLocate(profile, openServiceMeshKey); openServiceMesh != nil {
+			enabled := false
+			if enabledVal := openServiceMesh.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			result["open_service_mesh_enabled"] = enabled
 		}
 
-		ingressApplicationGatewayIdentity := flattenKubernetesClusterAddOnIdentityProfile(ingressApplicationGateway.Identity)
+		azureKeyVaultSecretsProviders := make([]interface{}, 0)
+		if azureKeyVaultSecretsProvider := kubernetesAddonProfileLocate(profile, azureKeyvaultSecretsProviderKey); azureKeyVaultSecretsProvider != nil {
+			enableSecretRotation := false
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyVaultSecretsProvider.Config, "enableSecretRotation"); v != nil && *v != "false" {
+				enableSecretRotation = true
+			}
 
-		ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
-			"enabled":                              enabled,
-			"gateway_id":                           gatewayId,
-			"gateway_name":                         gatewayName,
-			"effective_gateway_id":                 effectiveGatewayId,
-			"subnet_cidr":                          subnetCIDR,
-			"subnet_id":                            subnetId,
-			"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
-		})
-	}
+			rotationPollInterval := ""
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyVaultSecretsProvider.Config, "rotationPollInterval"); v != nil {
+				rotationPollInterval = *v
+			}
 
-	openServiceMeshes := make([]interface{}, 0)
-	if openServiceMesh := kubernetesAddonProfileLocate(profile, openServiceMeshKey); openServiceMesh != nil {
-		enabled := false
-		if enabledVal := openServiceMesh.Enabled; enabledVal != nil {
-			enabled = *enabledVal
+			azureKeyvaultSecretsProviderIdentity := flattenKubernetesClusterAddOnIdentityProfile(azureKeyVaultSecretsProvider.Identity)
+
+			azureKeyVaultSecretsProviders = append(azureKeyVaultSecretsProviders, map[string]interface{}{
+				"secret_rotation_enabled":  enableSecretRotation,
+				"secret_rotation_interval": rotationPollInterval,
+				"secret_identity":          azureKeyvaultSecretsProviderIdentity,
+			})
+
+			result["azure_keyvault_secrets_provider"] = azureKeyVaultSecretsProviders
 		}
 
-		openServiceMeshes = append(openServiceMeshes, map[string]interface{}{
-			"enabled": enabled,
-		})
-	}
+		azurePoliciesEnabled := result["azure_policy_enabled"]
+		httpApplicationRoutesEnabled := result["http_application_routing_enabled"]
+		kubeDashboardsEnabled := result["kube_dashboard_enabled"]
+		openServiceMeshesEnabled := result["open_service_mesh_enabled"]
 
-	azureKeyvaultSecretsProviders := make([]interface{}, 0)
-	if azureKeyvaultSecretsProvider := kubernetesAddonProfileLocate(profile, azureKeyvaultSecretsProviderKey); azureKeyvaultSecretsProvider != nil {
-		enabled := false
-		if enabledVal := azureKeyvaultSecretsProvider.Enabled; enabledVal != nil {
-			enabled = *enabledVal
-		}
-		enableSecretRotation := false
-		if v := kubernetesAddonProfilelocateInConfig(azureKeyvaultSecretsProvider.Config, "enableSecretRotation"); v != nil && *v != "false" {
-			enableSecretRotation = true
-		}
-		rotationPollInterval := ""
-		if v := kubernetesAddonProfilelocateInConfig(azureKeyvaultSecretsProvider.Config, "rotationPollInterval"); v != nil {
-			rotationPollInterval = *v
+		// this is a UX hack, since if the top level block isn't defined everything should be turned off
+		if len(aciConnectors) == 0 && azurePoliciesEnabled == false && httpApplicationRoutesEnabled == false && kubeDashboardsEnabled == false && len(omsAgents) == 0 && len(ingressApplicationGateways) == 0 && openServiceMeshesEnabled == false && len(azureKeyVaultSecretsProviders) == 0 {
+			return []interface{}{}
 		}
 
-		azureKeyvaultSecretsProviderIdentity := flattenKubernetesClusterAddOnIdentityProfile(azureKeyvaultSecretsProvider.Identity)
+		return []interface{}{result}
+	} else {
+		// TODO 3.0 - Remove this block
+		aciConnectors := make([]interface{}, 0)
+		if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
+			enabled := false
+			if enabledVal := aciConnector.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
 
-		azureKeyvaultSecretsProviders = append(azureKeyvaultSecretsProviders, map[string]interface{}{
-			"enabled":                  enabled,
-			"secret_rotation_enabled":  enableSecretRotation,
-			"secret_rotation_interval": rotationPollInterval,
-			"secret_identity":          azureKeyvaultSecretsProviderIdentity,
-		})
-	}
+			subnetName := ""
+			if v := aciConnector.Config["SubnetName"]; v != nil {
+				subnetName = *v
+			}
 
-	// this is a UX hack, since if the top level block isn't defined everything should be turned off
-	if len(aciConnectors) == 0 && len(azurePolicies) == 0 && len(httpApplicationRoutes) == 0 && len(kubeDashboards) == 0 && len(omsAgents) == 0 && len(ingressApplicationGateways) == 0 && len(openServiceMeshes) == 0 && len(azureKeyvaultSecretsProviders) == 0 {
-		return []interface{}{}
-	}
+			aciConnectors = append(aciConnectors, map[string]interface{}{
+				"enabled":     enabled,
+				"subnet_name": subnetName,
+			})
+		}
 
-	return []interface{}{
-		map[string]interface{}{
-			"aci_connector_linux":             aciConnectors,
-			"azure_policy":                    azurePolicies,
-			"http_application_routing":        httpApplicationRoutes,
-			"kube_dashboard":                  kubeDashboards,
-			"oms_agent":                       omsAgents,
-			"ingress_application_gateway":     ingressApplicationGateways,
-			"open_service_mesh":               openServiceMeshes,
-			"azure_keyvault_secrets_provider": azureKeyvaultSecretsProviders,
-		},
+		azurePolicies := make([]interface{}, 0)
+		if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
+			enabled := false
+			if enabledVal := azurePolicy.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			azurePolicies = append(azurePolicies, map[string]interface{}{
+				"enabled": enabled,
+			})
+		}
+
+		httpApplicationRoutes := make([]interface{}, 0)
+		if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
+			enabled := false
+			if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			zoneName := ""
+			if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
+				zoneName = *v
+			}
+
+			httpApplicationRoutes = append(httpApplicationRoutes, map[string]interface{}{
+				"enabled":                            enabled,
+				"http_application_routing_zone_name": zoneName,
+			})
+		}
+
+		kubeDashboards := make([]interface{}, 0)
+		if kubeDashboard := kubernetesAddonProfileLocate(profile, kubernetesDashboardKey); kubeDashboard != nil {
+			enabled := false
+			if enabledVal := kubeDashboard.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			kubeDashboards = append(kubeDashboards, map[string]interface{}{
+				"enabled": enabled,
+			})
+		}
+
+		omsAgents := make([]interface{}, 0)
+		if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
+			enabled := false
+			if enabledVal := omsAgent.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			workspaceID := ""
+			if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
+				if lawid, err := laparse.LogAnalyticsWorkspaceID(*v); err == nil {
+					workspaceID = lawid.ID()
+				}
+			}
+
+			omsagentIdentity := flattenKubernetesClusterAddOnIdentityProfile(omsAgent.Identity)
+
+			omsAgents = append(omsAgents, map[string]interface{}{
+				"enabled":                    enabled,
+				"log_analytics_workspace_id": workspaceID,
+				"oms_agent_identity":         omsagentIdentity,
+			})
+		}
+
+		ingressApplicationGateways := make([]interface{}, 0)
+		if ingressApplicationGateway := kubernetesAddonProfileLocate(profile, ingressApplicationGatewayKey); ingressApplicationGateway != nil {
+			enabled := false
+			if enabledVal := ingressApplicationGateway.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			gatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayId"); v != nil {
+				gatewayId = *v
+			}
+
+			gatewayName := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayName"); v != nil {
+				gatewayName = *v
+			}
+
+			effectiveGatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "effectiveApplicationGatewayId"); v != nil {
+				effectiveGatewayId = *v
+			}
+
+			subnetCIDR := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetCIDR"); v != nil {
+				subnetCIDR = *v
+			}
+
+			subnetId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetId"); v != nil {
+				subnetId = *v
+			}
+
+			ingressApplicationGatewayIdentity := flattenKubernetesClusterAddOnIdentityProfile(ingressApplicationGateway.Identity)
+
+			ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
+				"enabled":                              enabled,
+				"gateway_id":                           gatewayId,
+				"gateway_name":                         gatewayName,
+				"effective_gateway_id":                 effectiveGatewayId,
+				"subnet_cidr":                          subnetCIDR,
+				"subnet_id":                            subnetId,
+				"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
+			})
+		}
+
+		openServiceMeshes := make([]interface{}, 0)
+		if openServiceMesh := kubernetesAddonProfileLocate(profile, openServiceMeshKey); openServiceMesh != nil {
+			enabled := false
+			if enabledVal := openServiceMesh.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+
+			openServiceMeshes = append(openServiceMeshes, map[string]interface{}{
+				"enabled": enabled,
+			})
+		}
+
+		azureKeyvaultSecretsProviders := make([]interface{}, 0)
+		if azureKeyvaultSecretsProvider := kubernetesAddonProfileLocate(profile, azureKeyvaultSecretsProviderKey); azureKeyvaultSecretsProvider != nil {
+			enabled := false
+			if enabledVal := azureKeyvaultSecretsProvider.Enabled; enabledVal != nil {
+				enabled = *enabledVal
+			}
+			enableSecretRotation := false
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyvaultSecretsProvider.Config, "enableSecretRotation"); v != nil && *v != "false" {
+				enableSecretRotation = true
+			}
+			rotationPollInterval := ""
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyvaultSecretsProvider.Config, "rotationPollInterval"); v != nil {
+				rotationPollInterval = *v
+			}
+
+			azureKeyvaultSecretsProviderIdentity := flattenKubernetesClusterAddOnIdentityProfile(azureKeyvaultSecretsProvider.Identity)
+
+			azureKeyvaultSecretsProviders = append(azureKeyvaultSecretsProviders, map[string]interface{}{
+				"enabled":                  enabled,
+				"secret_rotation_enabled":  enableSecretRotation,
+				"secret_rotation_interval": rotationPollInterval,
+				"secret_identity":          azureKeyvaultSecretsProviderIdentity,
+			})
+		}
+
+		// this is a UX hack, since if the top level block isn't defined everything should be turned off
+		if len(aciConnectors) == 0 && len(azurePolicies) == 0 && len(httpApplicationRoutes) == 0 && len(kubeDashboards) == 0 && len(omsAgents) == 0 && len(ingressApplicationGateways) == 0 && len(openServiceMeshes) == 0 && len(azureKeyvaultSecretsProviders) == 0 {
+			return []interface{}{}
+		}
+
+		return []interface{}{
+			map[string]interface{}{
+				"aci_connector_linux":             aciConnectors,
+				"azure_policy":                    azurePolicies,
+				"http_application_routing":        httpApplicationRoutes,
+				"kube_dashboard":                  kubeDashboards,
+				"oms_agent":                       omsAgents,
+				"ingress_application_gateway":     ingressApplicationGateways,
+				"open_service_mesh":               openServiceMeshes,
+				"azure_keyvault_secrets_provider": azureKeyvaultSecretsProviders,
+			},
+		}
 	}
 }
 
@@ -899,4 +1207,3 @@ func kubernetesAddonProfilelocateInConfig(config map[string]*string, key string)
 
 	return nil
 }
-

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -2,6 +2,7 @@ package containers_test
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -10,6 +11,7 @@ import (
 
 var addOnAppGatewaySubnetCIDR string = "10.241.0.0/16" // AKS will use 10.240.0.0/16 for the aks subnet so use 10.241.0.0/16 for the app gateway subnet
 
+// passes
 func TestAccKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -18,10 +20,6 @@ func TestAccKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
 		{
 			Config: r.addonProfileAciConnectorLinuxConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.subnet_name").HasValue(fmt.Sprintf("acctestsubnet-aci%d", data.RandomInteger)),
 			),
 		},
@@ -38,11 +36,6 @@ func TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled(t *testing.T
 			Config: r.addonProfileAciConnectorLinuxDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.subnet_name").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -59,8 +52,6 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -69,8 +60,6 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -79,8 +68,6 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -96,8 +83,6 @@ func TestAccKubernetesCluster_addonProfileKubeDashboard(t *testing.T) {
 			Config: r.addonProfileKubeDashboardConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -113,13 +98,6 @@ func TestAccKubernetesCluster_addonProfileOMS(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.client_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.object_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -135,23 +113,6 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.addonProfileOMSDisabledConfig(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -159,11 +120,6 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSScaleWithoutBlockConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("2"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -171,11 +127,6 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -191,10 +142,6 @@ func TestAccKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
 			Config: r.addonProfileRoutingConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.http_application_routing_zone_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -202,10 +149,6 @@ func TestAccKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
 			Config: r.addonProfileRoutingConfigDisabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.http_application_routing_zone_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -221,13 +164,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
 			Config: r.addonProfileIngressApplicationGatewayAppGatewayConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").MatchesOtherKey(
-					check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_id"),
-				),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.client_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.object_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -253,8 +189,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR(t
 			Config: r.addonProfileIngressApplicationGatewayDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -270,8 +204,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId(t *
 			Config: r.addonProfileIngressApplicationGatewaySubnetIdConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -288,8 +220,6 @@ func TestAccKubernetesCluster_addonProfileOpenServiceMesh(t *testing.T) {
 			Config: r.addonProfileOpenServiceMeshConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -298,15 +228,13 @@ func TestAccKubernetesCluster_addonProfileOpenServiceMesh(t *testing.T) {
 			Config: r.addonProfileOpenServiceMeshConfig(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testing.T) {
+func TestAccKubernetesCluster_addonProfileAzureKeyVaultSecretsProvider(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
@@ -316,10 +244,6 @@ func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testin
 			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, true, true, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_interval").HasValue("2m"),
 			),
 		},
 		data.ImportStep(),
@@ -328,8 +252,6 @@ func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testin
 			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, false, false, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -337,846 +259,1633 @@ func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testin
 }
 
 func (KubernetesClusterResource) addonProfileAciConnectorLinuxConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["172.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+name                = "acctestvirtnet%d"
+address_space       = ["172.0.0.0/16"]
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "172.0.2.0/24"
+name                 = "acctestsubnet%d"
+resource_group_name  = azurerm_resource_group.test.name
+virtual_network_name = azurerm_virtual_network.test.name
+address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_subnet" "test-aci" {
-  name                 = "acctestsubnet-aci%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "172.0.3.0/24"
+name                 = "acctestsubnet-aci%d"
+resource_group_name  = azurerm_resource_group.test.name
+virtual_network_name = azurerm_virtual_network.test.name
+address_prefix       = "172.0.3.0/24"
 
-  delegation {
-    name = "aciDelegation"
+delegation {
+  name = "aciDelegation"
 
-    service_delegation {
-      name    = "Microsoft.ContainerInstance/containerGroups"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-    }
+  service_delegation {
+    name    = "Microsoft.ContainerInstance/containerGroups"
+    actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
   }
+}
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name           = "default"
-    node_count     = 1
-    vm_size        = "Standard_DS2_v2"
-    vnet_subnet_id = azurerm_subnet.test.id
-  }
+default_node_pool {
+  name           = "default"
+  node_count     = 1
+  vm_size        = "Standard_DS2_v2"
+  vnet_subnet_id = azurerm_subnet.test.id
+}
 
-  addon_profile {
-    aci_connector_linux {
-      enabled     = true
-      subnet_name = azurerm_subnet.test-aci.name
-    }
+addon_profile {
+  aci_connector_linux {
+    enabled     = true
+    subnet_name = azurerm_subnet.test-aci.name
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
 
-  network_profile {
-    network_plugin = "azure"
-  }
+network_profile {
+  network_plugin = "azure"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+ name                = "acctestvirtnet%d"
+ address_space       = ["172.0.0.0/16"]
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+ name                 = "acctestsubnet%d"
+ resource_group_name  = azurerm_resource_group.test.name
+ virtual_network_name = azurerm_virtual_network.test.name
+ address_prefix       = "172.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test-aci" {
+ name                 = "acctestsubnet-aci%d"
+ resource_group_name  = azurerm_resource_group.test.name
+ virtual_network_name = azurerm_virtual_network.test.name
+ address_prefix       = "172.0.3.0/24"
+
+ delegation {
+   name = "aciDelegation"
+
+   service_delegation {
+     name    = "Microsoft.ContainerInstance/containerGroups"
+     actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+   }
+ }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name           = "default"
+   node_count     = 1
+   vm_size        = "Standard_DS2_v2"
+   vnet_subnet_id = azurerm_subnet.test.id
+ }
+
+ addon_profile {
+   aci_connector_linux {
+     subnet_name = azurerm_subnet.test-aci.name
+   }
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
+
+ network_profile {
+   network_plugin = "azure"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileAciConnectorLinuxDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["172.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+name                = "acctestvirtnet%d"
+address_space       = ["172.0.0.0/16"]
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "172.0.2.0/24"
+name                 = "acctestsubnet%d"
+resource_group_name  = azurerm_resource_group.test.name
+virtual_network_name = azurerm_virtual_network.test.name
+address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name           = "default"
-    node_count     = 1
-    vm_size        = "Standard_DS2_v2"
-    vnet_subnet_id = azurerm_subnet.test.id
-  }
+default_node_pool {
+  name           = "default"
+  node_count     = 1
+  vm_size        = "Standard_DS2_v2"
+  vnet_subnet_id = azurerm_subnet.test.id
+}
 
-  addon_profile {
-    aci_connector_linux {
-      enabled = false
-    }
+addon_profile {
+  aci_connector_linux {
+    enabled = false
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
 
-  network_profile {
-    network_plugin = "azure"
-  }
+network_profile {
+  network_plugin = "azure"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+ name                = "acctestvirtnet%d"
+ address_space       = ["172.0.0.0/16"]
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+ name                 = "acctestsubnet%d"
+ resource_group_name  = azurerm_resource_group.test.name
+ virtual_network_name = azurerm_virtual_network.test.name
+ address_prefix       = "172.0.2.0/24"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name           = "default"
+   node_count     = 1
+   vm_size        = "Standard_DS2_v2"
+   vnet_subnet_id = azurerm_subnet.test.id
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
+
+ network_profile {
+   network_plugin = "azure"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileAzurePolicyConfig(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    azure_policy {
-      enabled = %t
-    }
+addon_profile {
+  azure_policy {
+    enabled = %t
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   azure_policy_enabled = %t
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 }
 
 func (KubernetesClusterResource) addonProfileKubeDashboardConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  kube_dashboard {
+    enabled = false
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   kube_dashboard_enabled = false
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOMSConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctest-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
+name                = "acctest-%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "ContainerInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
+solution_name         = "ContainerInsights"
+location              = azurerm_resource_group.test.location
+resource_group_name   = azurerm_resource_group.test.name
+workspace_resource_id = azurerm_log_analytics_workspace.test.id
+workspace_name        = azurerm_log_analytics_workspace.test.name
 
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/ContainerInsights"
-  }
+plan {
+  publisher = "Microsoft"
+  product   = "OMSGallery/ContainerInsights"
+}
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    oms_agent {
-      enabled                    = true
-      log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-    }
+addon_profile {
+  oms_agent {
+    enabled                    = true
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+ name                = "acctest-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+ solution_name         = "ContainerInsights"
+ location              = azurerm_resource_group.test.location
+ resource_group_name   = azurerm_resource_group.test.name
+ workspace_resource_id = azurerm_log_analytics_workspace.test.id
+ workspace_name        = azurerm_log_analytics_workspace.test.name
+
+ plan {
+   publisher = "Microsoft"
+   product   = "OMSGallery/ContainerInsights"
+ }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   oms_agent {
+     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+   }
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOMSDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    oms_agent {
-      enabled = false
-    }
+addon_profile {
+  oms_agent {
+    enabled = false
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {}
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOMSScaleWithoutBlockConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 2
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 2
+  vm_size    = "Standard_DS2_v2"
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 2
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileRoutingConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    http_application_routing {
-      enabled = true
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  http_application_routing {
+    enabled = true
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   http_application_routing_enabled = true
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileRoutingConfigDisabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    http_application_routing {
-      enabled = false
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  http_application_routing {
+    enabled = false
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   http_application_routing_enabled = false
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayAppGatewayConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["172.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+name                = "acctestvirtnet%d"
+address_space       = ["172.0.0.0/16"]
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["172.0.2.0/24"]
+name                 = "acctestsubnet%d"
+resource_group_name  = azurerm_resource_group.test.name
+virtual_network_name = azurerm_virtual_network.test.name
+address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "test" {
-  name                = "acctestpublicip%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard"
-  allocation_method   = "Static"
+name                = "acctestpublicip%d"
+resource_group_name = azurerm_resource_group.test.name
+location            = azurerm_resource_group.test.location
+sku                 = "Standard"
+allocation_method   = "Static"
 }
 
 resource "azurerm_application_gateway" "test" {
-  name                = "acctestappgw%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+name                = "acctestappgw%d"
+resource_group_name = azurerm_resource_group.test.name
+location            = azurerm_resource_group.test.location
 
-  sku {
-    name     = "Standard_V2"
-    tier     = "Standard_V2"
-    capacity = 2
-  }
+sku {
+  name     = "Standard_V2"
+  tier     = "Standard_V2"
+  capacity = 2
+}
 
-  gateway_ip_configuration {
-    name      = "gwipcfg"
-    subnet_id = azurerm_subnet.test.id
-  }
+gateway_ip_configuration {
+  name      = "gwipcfg"
+  subnet_id = azurerm_subnet.test.id
+}
 
-  frontend_port {
-    name = "frontendport"
-    port = 80
-  }
+frontend_port {
+  name = "frontendport"
+  port = 80
+}
 
-  frontend_ip_configuration {
-    name                 = "frontendipcfg"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
+frontend_ip_configuration {
+  name                 = "frontendipcfg"
+  public_ip_address_id = azurerm_public_ip.test.id
+}
 
-  backend_address_pool {
-    name = "backendaddresspool"
-  }
+backend_address_pool {
+  name = "backendaddresspool"
+}
 
-  backend_http_settings {
-    name                  = "backendhttpsettings"
-    cookie_based_affinity = "Disabled"
-    port                  = 80
-    protocol              = "Http"
-    request_timeout       = 60
-  }
+backend_http_settings {
+  name                  = "backendhttpsettings"
+  cookie_based_affinity = "Disabled"
+  port                  = 80
+  protocol              = "Http"
+  request_timeout       = 60
+}
 
-  http_listener {
-    name                           = "httplistener"
-    frontend_ip_configuration_name = "frontendipcfg"
-    frontend_port_name             = "frontendport"
-    protocol                       = "Http"
-  }
+http_listener {
+  name                           = "httplistener"
+  frontend_ip_configuration_name = "frontendipcfg"
+  frontend_port_name             = "frontendport"
+  protocol                       = "Http"
+}
 
-  request_routing_rule {
-    name                       = "requestroutingrule"
-    rule_type                  = "Basic"
-    http_listener_name         = "httplistener"
-    backend_address_pool_name  = "backendaddresspool"
-    backend_http_settings_name = "backendhttpsettings"
-  }
+request_routing_rule {
+  name                       = "requestroutingrule"
+  rule_type                  = "Basic"
+  http_listener_name         = "httplistener"
+  backend_address_pool_name  = "backendaddresspool"
+  backend_http_settings_name = "backendhttpsettings"
+}
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    ingress_application_gateway {
-      enabled    = true
-      gateway_id = azurerm_application_gateway.test.id
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  ingress_application_gateway {
+    enabled    = true
+    gateway_id = azurerm_application_gateway.test.id
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+ name                = "acctestvirtnet%d"
+ address_space       = ["172.0.0.0/16"]
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+ name                 = "acctestsubnet%d"
+ resource_group_name  = azurerm_resource_group.test.name
+ virtual_network_name = azurerm_virtual_network.test.name
+ address_prefixes     = ["172.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+ name                = "acctestpublicip%d"
+ resource_group_name = azurerm_resource_group.test.name
+ location            = azurerm_resource_group.test.location
+ sku                 = "Standard"
+ allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+ name                = "acctestappgw%d"
+ resource_group_name = azurerm_resource_group.test.name
+ location            = azurerm_resource_group.test.location
+
+ sku {
+   name     = "Standard_V2"
+   tier     = "Standard_V2"
+   capacity = 2
+ }
+
+ gateway_ip_configuration {
+   name      = "gwipcfg"
+   subnet_id = azurerm_subnet.test.id
+ }
+
+ frontend_port {
+   name = "frontendport"
+   port = 80
+ }
+
+ frontend_ip_configuration {
+   name                 = "frontendipcfg"
+   public_ip_address_id = azurerm_public_ip.test.id
+ }
+
+ backend_address_pool {
+   name = "backendaddresspool"
+ }
+
+ backend_http_settings {
+   name                  = "backendhttpsettings"
+   cookie_based_affinity = "Disabled"
+   port                  = 80
+   protocol              = "Http"
+   request_timeout       = 60
+ }
+
+ http_listener {
+   name                           = "httplistener"
+   frontend_ip_configuration_name = "frontendipcfg"
+   frontend_port_name             = "frontendport"
+   protocol                       = "Http"
+ }
+
+ request_routing_rule {
+   name                       = "requestroutingrule"
+   rule_type                  = "Basic"
+   http_listener_name         = "httplistener"
+   backend_address_pool_name  = "backendaddresspool"
+   backend_http_settings_name = "backendhttpsettings"
+ }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   ingress_application_gateway {
+     gateway_id = azurerm_application_gateway.test.id
+   }
+   kube_dashboard_enabled = false
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetCIDRConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    ingress_application_gateway {
-      enabled      = true
-      gateway_name = "acctestgwn%d"
-      subnet_cidr  = "%s"
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  ingress_application_gateway {
+    enabled      = true
+    gateway_name = "acctestgwn%d"
+    subnet_cidr  = "%s"
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   ingress_application_gateway {
+     gateway_name = "acctestgwn%d"
+     subnet_cidr  = "%s"
+   }
+   kube_dashboard_enabled = false
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    ingress_application_gateway {
-      enabled = false
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  ingress_application_gateway {
+    enabled = false
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {}
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetIdConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["172.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+name                = "acctestvirtnet%d"
+address_space       = ["172.0.0.0/16"]
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["172.0.2.0/24"]
+name                 = "acctestsubnet%d"
+resource_group_name  = azurerm_resource_group.test.name
+virtual_network_name = azurerm_virtual_network.test.name
+address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    ingress_application_gateway {
-      enabled      = true
-      gateway_name = "acctestgwn%d"
-      subnet_id    = azurerm_subnet.test.id
-    }
-    kube_dashboard {
-      enabled = false
-    }
+addon_profile {
+  ingress_application_gateway {
+    enabled      = true
+    gateway_name = "acctestgwn%d"
+    subnet_id    = azurerm_subnet.test.id
   }
+  kube_dashboard {
+    enabled = false
+  }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+ name                = "acctestvirtnet%d"
+ address_space       = ["172.0.0.0/16"]
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+ name                 = "acctestsubnet%d"
+ resource_group_name  = azurerm_resource_group.test.name
+ virtual_network_name = azurerm_virtual_network.test.name
+ address_prefixes     = ["172.0.2.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   ingress_application_gateway {
+     gateway_name = "acctestgwn%d"
+     subnet_id    = azurerm_subnet.test.id
+   }
+   kube_dashboard_enabled = false
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOpenServiceMeshConfig(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
+}
 
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
 
-  addon_profile {
-    open_service_mesh {
-      enabled = %t
-    }
+addon_profile {
+  open_service_mesh {
+    enabled = %t
   }
+}
 
-  identity {
-    type = "SystemAssigned"
-  }
+identity {
+  type = "SystemAssigned"
+}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   open_service_mesh_enabled = %t
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 }
 
 func (KubernetesClusterResource) addonProfileAzureKeyvaultSecretsProviderConfig(data acceptance.TestData, enabled bool, secretRotation bool, rotationInterval string) string {
-	return fmt.Sprintf(`
+	if features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
+name     = "acctestRG-aks-%d"
+location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
+name                = "acctestaks%d"
+location            = azurerm_resource_group.test.location
+resource_group_name = azurerm_resource_group.test.name
+dns_prefix          = "acctestaks%d"
 
-  linux_profile {
-    admin_username = "acctestuser%d"
+linux_profile {
+  admin_username = "acctestuser%d"
 
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
-  }
-
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-  }
-
-  addon_profile {
-    azure_keyvault_secrets_provider {
-      enabled                  = %t
-      secret_rotation_enabled  = %t
-      secret_rotation_interval = "%s"
-    }
-  }
-
-  identity {
-    type = "SystemAssigned"
+  ssh_key {
+    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
   }
 }
+
+default_node_pool {
+  name       = "default"
+  node_count = 1
+  vm_size    = "Standard_DS2_v2"
+}
+
+addon_profile {
+  azure_keyvault_secrets_provider {
+    enabled                  = %t
+    secret_rotation_enabled  = %t
+    secret_rotation_interval = "%s"
+  }
+}
+
+identity {
+  type = "SystemAssigned"
+}
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled, secretRotation, rotationInterval)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {}
+}
+
+resource "azurerm_resource_group" "test" {
+ name     = "acctestRG-aks-%d"
+ location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+ name                = "acctestaks%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+ dns_prefix          = "acctestaks%d"
+
+ linux_profile {
+   admin_username = "acctestuser%d"
+
+   ssh_key {
+     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+   }
+ }
+
+ default_node_pool {
+   name       = "default"
+   node_count = 1
+   vm_size    = "Standard_DS2_v2"
+ }
+
+ addon_profile {
+   azure_keyvault_secrets_provider {
+     secret_rotation_enabled  = %t
+     secret_rotation_interval = "%s"
+   }
+ }
+
+ identity {
+   type = "SystemAssigned"
+ }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, secretRotation, rotationInterval)
 }

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -11,7 +11,6 @@ import (
 
 var addOnAppGatewaySubnetCIDR string = "10.241.0.0/16" // AKS will use 10.240.0.0/16 for the aks subnet so use 10.241.0.0/16 for the app gateway subnet
 
-// passes
 func TestAccKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -2,11 +2,11 @@ package containers_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 var addOnAppGatewaySubnetCIDR string = "10.241.0.0/16" // AKS will use 10.240.0.0/16 for the aks subnet so use 10.241.0.0/16 for the app gateway subnet
@@ -117,14 +117,14 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.addonProfileOMSScaleWithoutBlockConfig(data),
+			Config: r.addonProfileOMSDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.addonProfileOMSConfig(data),
+			Config: r.addonProfileOMSScaleWithoutBlockConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -240,16 +240,16 @@ func TestAccKubernetesCluster_addonProfileAzureKeyVaultSecretsProvider(t *testin
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			// Enable AzureKeyvaultSecretsProvider
-			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, true, true, "2m"),
+			// Enable AzureKeyVaultSecretsProvider
+			Config: r.addonProfileAzureKeyVaultSecretsProviderConfig(data, true, true, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			// Disable AzureKeyvaultSecretsProvider
-			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, false, false, "2m"),
+			// Disable AzureKeyVaultSecretsProvider
+			Config: r.addonProfileAzureKeyVaultSecretsProviderConfig(data, false, false, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -262,157 +262,157 @@ func (KubernetesClusterResource) addonProfileAciConnectorLinuxConfig(data accept
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-name                = "acctestvirtnet%d"
-address_space       = ["172.0.0.0/16"]
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-name                 = "acctestsubnet%d"
-resource_group_name  = azurerm_resource_group.test.name
-virtual_network_name = azurerm_virtual_network.test.name
-address_prefix       = "172.0.2.0/24"
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_subnet" "test-aci" {
-name                 = "acctestsubnet-aci%d"
-resource_group_name  = azurerm_resource_group.test.name
-virtual_network_name = azurerm_virtual_network.test.name
-address_prefix       = "172.0.3.0/24"
+  name                 = "acctestsubnet-aci%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.3.0/24"
 
-delegation {
-  name = "aciDelegation"
+  delegation {
+    name = "aciDelegation"
 
-  service_delegation {
-    name    = "Microsoft.ContainerInstance/containerGroups"
-    actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
   }
-}
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name           = "default"
-  node_count     = 1
-  vm_size        = "Standard_DS2_v2"
-  vnet_subnet_id = azurerm_subnet.test.id
-}
-
-addon_profile {
-  aci_connector_linux {
-    enabled     = true
-    subnet_name = azurerm_subnet.test-aci.name
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    aci_connector_linux {
+      enabled     = true
+      subnet_name = azurerm_subnet.test-aci.name
+    }
+  }
 
-network_profile {
-  network_plugin = "azure"
-}
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
- name                = "acctestvirtnet%d"
- address_space       = ["172.0.0.0/16"]
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
- name                 = "acctestsubnet%d"
- resource_group_name  = azurerm_resource_group.test.name
- virtual_network_name = azurerm_virtual_network.test.name
- address_prefix       = "172.0.2.0/24"
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_subnet" "test-aci" {
- name                 = "acctestsubnet-aci%d"
- resource_group_name  = azurerm_resource_group.test.name
- virtual_network_name = azurerm_virtual_network.test.name
- address_prefix       = "172.0.3.0/24"
+  name                 = "acctestsubnet-aci%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.3.0/24"
 
- delegation {
-   name = "aciDelegation"
+  delegation {
+    name = "aciDelegation"
 
-   service_delegation {
-     name    = "Microsoft.ContainerInstance/containerGroups"
-     actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-   }
- }
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name           = "default"
-   node_count     = 1
-   vm_size        = "Standard_DS2_v2"
-   vnet_subnet_id = azurerm_subnet.test.id
- }
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+  }
 
- addon_profile {
-   aci_connector_linux {
-     subnet_name = azurerm_subnet.test-aci.name
-   }
- }
+  addon_profile {
+    aci_connector_linux {
+      subnet_name = azurerm_subnet.test-aci.name
+    }
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 
- network_profile {
-   network_plugin = "azure"
- }
+  network_profile {
+    network_plugin = "azure"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -421,118 +421,118 @@ func (KubernetesClusterResource) addonProfileAciConnectorLinuxDisabledConfig(dat
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-name                = "acctestvirtnet%d"
-address_space       = ["172.0.0.0/16"]
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-name                 = "acctestsubnet%d"
-resource_group_name  = azurerm_resource_group.test.name
-virtual_network_name = azurerm_virtual_network.test.name
-address_prefix       = "172.0.2.0/24"
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name           = "default"
-  node_count     = 1
-  vm_size        = "Standard_DS2_v2"
-  vnet_subnet_id = azurerm_subnet.test.id
-}
-
-addon_profile {
-  aci_connector_linux {
-    enabled = false
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    aci_connector_linux {
+      enabled = false
+    }
+  }
 
-network_profile {
-  network_plugin = "azure"
-}
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
- name                = "acctestvirtnet%d"
- address_space       = ["172.0.0.0/16"]
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
- name                 = "acctestsubnet%d"
- resource_group_name  = azurerm_resource_group.test.name
- virtual_network_name = azurerm_virtual_network.test.name
- address_prefix       = "172.0.2.0/24"
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name           = "default"
-   node_count     = 1
-   vm_size        = "Standard_DS2_v2"
-   vnet_subnet_id = azurerm_subnet.test.id
- }
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 
- network_profile {
-   network_plugin = "azure"
- }
+  network_profile {
+    network_plugin = "azure"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -541,83 +541,83 @@ func (KubernetesClusterResource) addonProfileAzurePolicyConfig(data acceptance.T
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  azure_policy {
-    enabled = %t
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    azure_policy {
+      enabled = %t
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   azure_policy_enabled = %t
- }
+  addon_profile {
+    azure_policy_enabled = %t
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 }
@@ -626,83 +626,83 @@ func (KubernetesClusterResource) addonProfileKubeDashboardConfig(data acceptance
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  kube_dashboard {
-    enabled = false
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   kube_dashboard_enabled = false
- }
+  addon_profile {
+    kube_dashboard_enabled = false
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -711,126 +711,126 @@ func (KubernetesClusterResource) addonProfileOMSConfig(data acceptance.TestData)
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-name                = "acctest-%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-sku                 = "PerGB2018"
+  name                = "acctest-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {
-solution_name         = "ContainerInsights"
-location              = azurerm_resource_group.test.location
-resource_group_name   = azurerm_resource_group.test.name
-workspace_resource_id = azurerm_log_analytics_workspace.test.id
-workspace_name        = azurerm_log_analytics_workspace.test.name
+  solution_name         = "ContainerInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
 
-plan {
-  publisher = "Microsoft"
-  product   = "OMSGallery/ContainerInsights"
-}
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/ContainerInsights"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  oms_agent {
-    enabled                    = true
-    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    oms_agent {
+      enabled                    = true
+      log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
- name                = "acctest-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- sku                 = "PerGB2018"
+  name                = "acctest-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {
- solution_name         = "ContainerInsights"
- location              = azurerm_resource_group.test.location
- resource_group_name   = azurerm_resource_group.test.name
- workspace_resource_id = azurerm_log_analytics_workspace.test.id
- workspace_name        = azurerm_log_analytics_workspace.test.name
+  solution_name         = "ContainerInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
 
- plan {
-   publisher = "Microsoft"
-   product   = "OMSGallery/ContainerInsights"
- }
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/ContainerInsights"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   oms_agent {
-     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-   }
- }
+  addon_profile {
+    oms_agent {
+      log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+    }
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -839,81 +839,79 @@ func (KubernetesClusterResource) addonProfileOMSDisabledConfig(data acceptance.T
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  oms_agent {
-    enabled = false
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    oms_agent {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {}
-
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -922,73 +920,73 @@ func (KubernetesClusterResource) addonProfileOMSScaleWithoutBlockConfig(data acc
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 2
-  vm_size    = "Standard_DS2_v2"
-}
+  default_node_pool {
+    name       = "default"
+    node_count = 2
+    vm_size    = "Standard_DS2_v2"
+  }
 
-identity {
-  type = "SystemAssigned"
-}
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 2
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 2
+    vm_size    = "Standard_DS2_v2"
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -997,86 +995,86 @@ func (KubernetesClusterResource) addonProfileRoutingConfig(data acceptance.TestD
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  http_application_routing {
-    enabled = true
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    http_application_routing {
+      enabled = true
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   http_application_routing_enabled = true
- }
+  addon_profile {
+    http_application_routing_enabled = true
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1085,86 +1083,86 @@ func (KubernetesClusterResource) addonProfileRoutingConfigDisabled(data acceptan
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  http_application_routing {
-    enabled = false
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    http_application_routing {
+      enabled = false
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   http_application_routing_enabled = false
- }
+  addon_profile {
+    http_application_routing_enabled = false
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1173,242 +1171,242 @@ func (KubernetesClusterResource) addonProfileIngressApplicationGatewayAppGateway
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-name                = "acctestvirtnet%d"
-address_space       = ["172.0.0.0/16"]
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-name                 = "acctestsubnet%d"
-resource_group_name  = azurerm_resource_group.test.name
-virtual_network_name = azurerm_virtual_network.test.name
-address_prefixes     = ["172.0.2.0/24"]
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "test" {
-name                = "acctestpublicip%d"
-resource_group_name = azurerm_resource_group.test.name
-location            = azurerm_resource_group.test.location
-sku                 = "Standard"
-allocation_method   = "Static"
+  name                = "acctestpublicip%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_application_gateway" "test" {
-name                = "acctestappgw%d"
-resource_group_name = azurerm_resource_group.test.name
-location            = azurerm_resource_group.test.location
+  name                = "acctestappgw%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 
-sku {
-  name     = "Standard_V2"
-  tier     = "Standard_V2"
-  capacity = 2
-}
+  sku {
+    name     = "Standard_V2"
+    tier     = "Standard_V2"
+    capacity = 2
+  }
 
-gateway_ip_configuration {
-  name      = "gwipcfg"
-  subnet_id = azurerm_subnet.test.id
-}
+  gateway_ip_configuration {
+    name      = "gwipcfg"
+    subnet_id = azurerm_subnet.test.id
+  }
 
-frontend_port {
-  name = "frontendport"
-  port = 80
-}
+  frontend_port {
+    name = "frontendport"
+    port = 80
+  }
 
-frontend_ip_configuration {
-  name                 = "frontendipcfg"
-  public_ip_address_id = azurerm_public_ip.test.id
-}
+  frontend_ip_configuration {
+    name                 = "frontendipcfg"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
 
-backend_address_pool {
-  name = "backendaddresspool"
-}
+  backend_address_pool {
+    name = "backendaddresspool"
+  }
 
-backend_http_settings {
-  name                  = "backendhttpsettings"
-  cookie_based_affinity = "Disabled"
-  port                  = 80
-  protocol              = "Http"
-  request_timeout       = 60
-}
+  backend_http_settings {
+    name                  = "backendhttpsettings"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 60
+  }
 
-http_listener {
-  name                           = "httplistener"
-  frontend_ip_configuration_name = "frontendipcfg"
-  frontend_port_name             = "frontendport"
-  protocol                       = "Http"
-}
+  http_listener {
+    name                           = "httplistener"
+    frontend_ip_configuration_name = "frontendipcfg"
+    frontend_port_name             = "frontendport"
+    protocol                       = "Http"
+  }
 
-request_routing_rule {
-  name                       = "requestroutingrule"
-  rule_type                  = "Basic"
-  http_listener_name         = "httplistener"
-  backend_address_pool_name  = "backendaddresspool"
-  backend_http_settings_name = "backendhttpsettings"
-}
+  request_routing_rule {
+    name                       = "requestroutingrule"
+    rule_type                  = "Basic"
+    http_listener_name         = "httplistener"
+    backend_address_pool_name  = "backendaddresspool"
+    backend_http_settings_name = "backendhttpsettings"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  ingress_application_gateway {
-    enabled    = true
-    gateway_id = azurerm_application_gateway.test.id
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    ingress_application_gateway {
+      enabled    = true
+      gateway_id = azurerm_application_gateway.test.id
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
- name                = "acctestvirtnet%d"
- address_space       = ["172.0.0.0/16"]
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
- name                 = "acctestsubnet%d"
- resource_group_name  = azurerm_resource_group.test.name
- virtual_network_name = azurerm_virtual_network.test.name
- address_prefixes     = ["172.0.2.0/24"]
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "test" {
- name                = "acctestpublicip%d"
- resource_group_name = azurerm_resource_group.test.name
- location            = azurerm_resource_group.test.location
- sku                 = "Standard"
- allocation_method   = "Static"
+  name                = "acctestpublicip%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_application_gateway" "test" {
- name                = "acctestappgw%d"
- resource_group_name = azurerm_resource_group.test.name
- location            = azurerm_resource_group.test.location
+  name                = "acctestappgw%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 
- sku {
-   name     = "Standard_V2"
-   tier     = "Standard_V2"
-   capacity = 2
- }
+  sku {
+    name     = "Standard_V2"
+    tier     = "Standard_V2"
+    capacity = 2
+  }
 
- gateway_ip_configuration {
-   name      = "gwipcfg"
-   subnet_id = azurerm_subnet.test.id
- }
+  gateway_ip_configuration {
+    name      = "gwipcfg"
+    subnet_id = azurerm_subnet.test.id
+  }
 
- frontend_port {
-   name = "frontendport"
-   port = 80
- }
+  frontend_port {
+    name = "frontendport"
+    port = 80
+  }
 
- frontend_ip_configuration {
-   name                 = "frontendipcfg"
-   public_ip_address_id = azurerm_public_ip.test.id
- }
+  frontend_ip_configuration {
+    name                 = "frontendipcfg"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
 
- backend_address_pool {
-   name = "backendaddresspool"
- }
+  backend_address_pool {
+    name = "backendaddresspool"
+  }
 
- backend_http_settings {
-   name                  = "backendhttpsettings"
-   cookie_based_affinity = "Disabled"
-   port                  = 80
-   protocol              = "Http"
-   request_timeout       = 60
- }
+  backend_http_settings {
+    name                  = "backendhttpsettings"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 60
+  }
 
- http_listener {
-   name                           = "httplistener"
-   frontend_ip_configuration_name = "frontendipcfg"
-   frontend_port_name             = "frontendport"
-   protocol                       = "Http"
- }
+  http_listener {
+    name                           = "httplistener"
+    frontend_ip_configuration_name = "frontendipcfg"
+    frontend_port_name             = "frontendport"
+    protocol                       = "Http"
+  }
 
- request_routing_rule {
-   name                       = "requestroutingrule"
-   rule_type                  = "Basic"
-   http_listener_name         = "httplistener"
-   backend_address_pool_name  = "backendaddresspool"
-   backend_http_settings_name = "backendhttpsettings"
- }
+  request_routing_rule {
+    name                       = "requestroutingrule"
+    rule_type                  = "Basic"
+    http_listener_name         = "httplistener"
+    backend_address_pool_name  = "backendaddresspool"
+    backend_http_settings_name = "backendhttpsettings"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   ingress_application_gateway {
-     gateway_id = azurerm_application_gateway.test.id
-   }
-   kube_dashboard_enabled = false
- }
+  addon_profile {
+    ingress_application_gateway {
+      gateway_id = azurerm_application_gateway.test.id
+    }
+    kube_dashboard_enabled = false
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1417,92 +1415,92 @@ func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetCIDR
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  ingress_application_gateway {
-    enabled      = true
-    gateway_name = "acctestgwn%d"
-    subnet_cidr  = "%s"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    ingress_application_gateway {
+      enabled      = true
+      gateway_name = "acctestgwn%d"
+      subnet_cidr  = "%s"
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   ingress_application_gateway {
-     gateway_name = "acctestgwn%d"
-     subnet_cidr  = "%s"
-   }
-   kube_dashboard_enabled = false
- }
+  addon_profile {
+    ingress_application_gateway {
+      gateway_name = "acctestgwn%d"
+      subnet_cidr  = "%s"
+    }
+    kube_dashboard_enabled = false
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
 }
@@ -1511,84 +1509,84 @@ func (KubernetesClusterResource) addonProfileIngressApplicationGatewayDisabledCo
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  ingress_application_gateway {
-    enabled = false
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    ingress_application_gateway {
+      enabled = false
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {}
+  addon_profile {}
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1597,120 +1595,120 @@ func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetIdCo
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-name                = "acctestvirtnet%d"
-address_space       = ["172.0.0.0/16"]
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
-name                 = "acctestsubnet%d"
-resource_group_name  = azurerm_resource_group.test.name
-virtual_network_name = azurerm_virtual_network.test.name
-address_prefixes     = ["172.0.2.0/24"]
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  ingress_application_gateway {
-    enabled      = true
-    gateway_name = "acctestgwn%d"
-    subnet_id    = azurerm_subnet.test.id
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-  kube_dashboard {
-    enabled = false
-  }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    ingress_application_gateway {
+      enabled      = true
+      gateway_name = "acctestgwn%d"
+      subnet_id    = azurerm_subnet.test.id
+    }
+    kube_dashboard {
+      enabled = false
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
- name                = "acctestvirtnet%d"
- address_space       = ["172.0.0.0/16"]
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test" {
- name                 = "acctestsubnet%d"
- resource_group_name  = azurerm_resource_group.test.name
- virtual_network_name = azurerm_virtual_network.test.name
- address_prefixes     = ["172.0.2.0/24"]
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   ingress_application_gateway {
-     gateway_name = "acctestgwn%d"
-     subnet_id    = azurerm_subnet.test.id
-   }
-   kube_dashboard_enabled = false
- }
+  addon_profile {
+    ingress_application_gateway {
+      gateway_name = "acctestgwn%d"
+      subnet_id    = azurerm_subnet.test.id
+    }
+    kube_dashboard_enabled = false
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1719,173 +1717,173 @@ func (KubernetesClusterResource) addonProfileOpenServiceMeshConfig(data acceptan
 	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  open_service_mesh {
-    enabled = %t
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    open_service_mesh {
+      enabled = %t
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   open_service_mesh_enabled = %t
- }
+  addon_profile {
+    open_service_mesh_enabled = %t
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 }
 
-func (KubernetesClusterResource) addonProfileAzureKeyvaultSecretsProviderConfig(data acceptance.TestData, enabled bool, secretRotation bool, rotationInterval string) string {
-	if features.ThreePointOh() {
+func (KubernetesClusterResource) addonProfileAzureKeyVaultSecretsProviderConfig(data acceptance.TestData, enabled bool, secretRotation bool, rotationInterval string) string {
+	if !features.ThreePointOh() {
 		return fmt.Sprintf(`
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
-name     = "acctestRG-aks-%d"
-location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-name                = "acctestaks%d"
-location            = azurerm_resource_group.test.location
-resource_group_name = azurerm_resource_group.test.name
-dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
-linux_profile {
-  admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-  ssh_key {
-    key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
   }
-}
 
-default_node_pool {
-  name       = "default"
-  node_count = 1
-  vm_size    = "Standard_DS2_v2"
-}
-
-addon_profile {
-  azure_keyvault_secrets_provider {
-    enabled                  = %t
-    secret_rotation_enabled  = %t
-    secret_rotation_interval = "%s"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
-}
 
-identity {
-  type = "SystemAssigned"
-}
+  addon_profile {
+    azure_keyvault_secrets_provider {
+      enabled                  = %t
+      secret_rotation_enabled  = %t
+      secret_rotation_interval = "%s"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled, secretRotation, rotationInterval)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-aks-%d"
- location = "%s"
+  name     = "acctestRG-aks-%d"
+  location = "%s"
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
- name                = "acctestaks%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- dns_prefix          = "acctestaks%d"
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
 
- linux_profile {
-   admin_username = "acctestuser%d"
+  linux_profile {
+    admin_username = "acctestuser%d"
 
-   ssh_key {
-     key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-   }
- }
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
 
- default_node_pool {
-   name       = "default"
-   node_count = 1
-   vm_size    = "Standard_DS2_v2"
- }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
 
- addon_profile {
-   azure_keyvault_secrets_provider {
-     secret_rotation_enabled  = %t
-     secret_rotation_interval = "%s"
-   }
- }
+  addon_profile {
+    azure_keyvault_secrets_provider {
+      secret_rotation_enabled  = %t
+      secret_rotation_interval = "%s"
+    }
+  }
 
- identity {
-   type = "SystemAssigned"
- }
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, secretRotation, rotationInterval)
 }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -444,7 +444,7 @@ func TestAccDataSourceKubernetesCluster_addOnProfileAzureKeyvaultSecretsProvider
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.addOnProfileAzureKeyvaultSecretsProviderConfig(data),
+			Config: r.addOnProfileAzureKeyVaultSecretsProviderConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.#").HasValue("1"),
 				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.enabled").HasValue("true"),
@@ -754,7 +754,7 @@ data "azurerm_kubernetes_cluster" "test" {
 `, KubernetesClusterResource{}.addonProfileOpenServiceMeshConfig(data, true))
 }
 
-func (KubernetesClusterDataSource) addOnProfileAzureKeyvaultSecretsProviderConfig(data acceptance.TestData) string {
+func (KubernetesClusterDataSource) addOnProfileAzureKeyVaultSecretsProviderConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -762,7 +762,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.addonProfileAzureKeyvaultSecretsProviderConfig(data, true, true, "2m"))
+`, KubernetesClusterResource{}.addonProfileAzureKeyVaultSecretsProviderConfig(data, true, true, "2m"))
 }
 
 func (KubernetesClusterDataSource) autoScalingNoAvailabilityZonesConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1084,7 +1084,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	addOnProfilesRaw := d.Get("addon_profile").([]interface{})
-	addonProfiles, err := expandKubernetesAddOnProfiles(addOnProfilesRaw, env)
+	addonProfiles, err := expandKubernetesAddOnProfiles(d, addOnProfilesRaw, env)
 	if err != nil {
 		return err
 	}
@@ -1370,7 +1370,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("addon_profile") {
 		updateCluster = true
 		addOnProfilesRaw := d.Get("addon_profile").([]interface{})
-		addonProfiles, err := expandKubernetesAddOnProfiles(addOnProfilesRaw, env)
+		addonProfiles, err := expandKubernetesAddOnProfiles(d, addOnProfilesRaw, env)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Thanks to @jackofallops for helping with this 🙂

For better behavioural consistency across this resource and the provider the schema for the addons has been updated. The main change is the removal of the `enabled` field for all addons. This change is feature flagged and the new schema will be documented when the release is open for beta. .

Test results when `ThreePointOh()` returns `true`
```
--- PASS: TestAccKubernetesCluster_addonProfileOMS (755.32s)
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled (774.25s)
--- PASS: TestAccKubernetesCluster_addonProfileKubeDashboard (779.22s)
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinux (784.32s)
--- PASS: TestAccKubernetesCluster_addonProfileRoutingToggle (856.47s)
--- PASS: TestAccKubernetesCluster_addonProfileAzureKeyVaultSecretsProvider (885.39s)
--- PASS: TestAccKubernetesCluster_addonProfileOMSToggle (958.45s)
--- PASS: TestAccKubernetesCluster_addonProfileOpenServiceMesh (965.06s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId (1083.80s)
--- FAIL: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR (1177.99s)
--- PASS: TestAccKubernetesCluster_addonProfileAzurePolicy (1197.14s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId (1419.14s)
```

The failing test is known and also fails on main.