### PR TITLE
fix typo in `azurerm_log_analytics_workspace` argument: reservation_capcity_in_gb_per_day to reservation_capacity_in_gb_per_day

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -89,10 +89,21 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				DiffSuppressFunc: logAnalyticsLinkedServiceSkuChangeCaseDifference,
 			},
 
+			"reservation_capcity_in_gb_per_day": {
+				Type:          pluginsdk.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.All(validation.IntBetween(100, 5000), validation.IntDivisibleBy(100)),
+				Deprecated:    "As this property name contained a typo originally, please switch to using 'reservation_capacity_in_gb_per_day' instead.",
+				ConflictsWith: []string{"reservation_capacity_in_gb_per_day"},
+			},
+
 			"reservation_capacity_in_gb_per_day": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.All(validation.IntBetween(100, 5000), validation.IntDivisibleBy(100)),
+				Type:          pluginsdk.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.All(validation.IntBetween(100, 5000), validation.IntDivisibleBy(100)),
+				ConflictsWith: []string{"reservation_capcity_in_gb_per_day"},
 			},
 
 			"retention_in_days": {
@@ -216,16 +227,23 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		}
 	}
 
-	capacityReservationLevel, ok := d.GetOk("reservation_capacity_in_gb_per_day")
+	// Handle typoed property name
+	propName := "reservation_capacity_in_gb_per_day"
+	capacityReservationLevel, ok := d.GetOk(propName)
+	if !ok {
+		propName := "reservation_capcity_in_gb_per_day"
+		capacityReservationLevel, ok = d.GetOk(propName)
+	}
+
 	if ok {
 		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
 			parameters.WorkspaceProperties.Sku.CapacityReservationLevel = utils.Int32((int32(capacityReservationLevel.(int))))
 		} else {
-			return fmt.Errorf("`reservation_capacity_in_gb_per_day` can only be used with the `CapacityReservation` SKU")
+			return fmt.Errorf("`%s` can only be used with the `CapacityReservation` SKU", propName)
 		}
 	} else {
 		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
-			return fmt.Errorf("`reservation_capacity_in_gb_per_day` must be set when using the `CapacityReservation` SKU")
+			return fmt.Errorf("`%s` must be set when using the `CapacityReservation` SKU", propName)
 		}
 	}
 
@@ -278,6 +296,8 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 
 		if capacityReservationLevel := sku.CapacityReservationLevel; capacityReservationLevel != nil {
 			d.Set("reservation_capacity_in_gb_per_day", capacityReservationLevel)
+			// Handle typoed property name
+			d.Set("reservation_capcity_in_gb_per_day", capacityReservationLevel)
 		}
 	}
 	d.Set("retention_in_days", resp.RetentionInDays)

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -89,7 +89,7 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				DiffSuppressFunc: logAnalyticsLinkedServiceSkuChangeCaseDifference,
 			},
 
-			"reservation_capcity_in_gb_per_day": {
+			"reservation_capacity_in_gb_per_day": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.All(validation.IntBetween(100, 5000), validation.IntDivisibleBy(100)),
@@ -216,16 +216,16 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		}
 	}
 
-	capacityReservationLevel, ok := d.GetOk("reservation_capcity_in_gb_per_day")
+	capacityReservationLevel, ok := d.GetOk("reservation_capacity_in_gb_per_day")
 	if ok {
 		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
 			parameters.WorkspaceProperties.Sku.CapacityReservationLevel = utils.Int32((int32(capacityReservationLevel.(int))))
 		} else {
-			return fmt.Errorf("`reservation_capcity_in_gb_per_day` can only be used with the `CapacityReservation` SKU")
+			return fmt.Errorf("`reservation_capacity_in_gb_per_day` can only be used with the `CapacityReservation` SKU")
 		}
 	} else {
 		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
-			return fmt.Errorf("`reservation_capcity_in_gb_per_day` must be set when using the `CapacityReservation` SKU")
+			return fmt.Errorf("`reservation_capacity_in_gb_per_day` must be set when using the `CapacityReservation` SKU")
 		}
 	}
 
@@ -277,7 +277,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 		d.Set("sku", sku.Name)
 
 		if capacityReservationLevel := sku.CapacityReservationLevel; capacityReservationLevel != nil {
-			d.Set("reservation_capcity_in_gb_per_day", capacityReservationLevel)
+			d.Set("reservation_capacity_in_gb_per_day", capacityReservationLevel)
 		}
 	}
 	d.Set("retention_in_days", resp.RetentionInDays)

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -184,7 +184,7 @@ func TestAccLogAnalyticsWorkspace_withCapacityReservation(t *testing.T) {
 			Config: r.withCapacityReservation(data, 2300),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("reservation_capcity_in_gb_per_day").HasValue("2300"),
+				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("2300"),
 			),
 		},
 		data.ImportStep(),
@@ -471,12 +471,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name                              = "acctestLAW-%d"
-  location                          = azurerm_resource_group.test.location
-  resource_group_name               = azurerm_resource_group.test.name
-  internet_query_enabled            = false
-  sku                               = "CapacityReservation"
-  reservation_capcity_in_gb_per_day = %d
+  name                               = "acctestLAW-%d"
+  location                           = azurerm_resource_group.test.location
+  resource_group_name                = azurerm_resource_group.test.name
+  internet_query_enabled             = false
+  sku                                = "CapacityReservation"
+  reservation_capacity_in_gb_per_day = %d
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, capacityReservation)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -175,6 +175,7 @@ func TestAccLogAnalyticsWorkspace_withInternetQueryEnabled(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+
 func TestAccLogAnalyticsWorkspace_withCapacityReservation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
 	r := LogAnalyticsWorkspaceResource{}
@@ -185,6 +186,14 @@ func TestAccLogAnalyticsWorkspace_withCapacityReservation(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("2300"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withCapacityReservationTypo(data, 2300),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("reservation_capcity_in_gb_per_day").HasValue("2300"),
 			),
 		},
 		data.ImportStep(),
@@ -477,6 +486,28 @@ resource "azurerm_log_analytics_workspace" "test" {
   internet_query_enabled             = false
   sku                                = "CapacityReservation"
   reservation_capacity_in_gb_per_day = %d
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, capacityReservation)
+}
+
+func (LogAnalyticsWorkspaceResource) withCapacityReservationTypo(data acceptance.TestData, capacityReservation int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                              = "acctestLAW-%d"
+  location                          = azurerm_resource_group.test.location
+  resource_group_name               = azurerm_resource_group.test.name
+  internet_query_enabled            = false
+  sku                               = "CapacityReservation"
+  reservation_capcity_in_gb_per_day = %d
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, capacityReservation)
 }

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -53,9 +53,9 @@ The following arguments are supported:
 
 * `internet_query_enabled` - (Optional) Should the Log Analytics Workflow support querying over the Public Internet? Defaults to `true`.
 
-* `reservation_capcity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace.  Must be in increments of 100  between 100 and 5000.
+* `reservation_capacity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace.  Must be in increments of 100  between 100 and 5000.
 
-~> **NOTE:** `reservation_capcity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
+~> **NOTE:** `reservation_capacity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Updates argument name `reservation_capcity_in_gb_per_day` to `reservation_capacity_in_gb_per_day`.