### PR TITLE
`azurerm_monitor_activity_log_alert` - update - dynamic validation for `service_health`

### DIFF
--- a/internal/services/monitor/client/client.go
+++ b/internal/services/monitor/client/client.go
@@ -33,7 +33,7 @@ type Client struct {
 	PrivateLinkScopedResourcesClient *classic.PrivateLinkScopedResourcesClient
 	ScheduledQueryRulesClient        *classic.ScheduledQueryRulesClient
 
-	//Resourcehealth custom client
+	// Resourcehealth custom client
 	ResourceHealthMetadataClient *resourcehealth.ResourceHealthMetadataClient
 }
 

--- a/internal/services/monitor/client/client.go
+++ b/internal/services/monitor/client/client.go
@@ -7,6 +7,7 @@ import (
 	classic "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2021-07-01-preview/insights"
 	newActionGroupClient "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2021-09-01-preview/insights"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/sdk/resourcehealth"
 )
 
 type Client struct {
@@ -31,6 +32,9 @@ type Client struct {
 	PrivateLinkScopesClient          *classic.PrivateLinkScopesClient
 	PrivateLinkScopedResourcesClient *classic.PrivateLinkScopedResourcesClient
 	ScheduledQueryRulesClient        *classic.ScheduledQueryRulesClient
+
+	//Resourcehealth custom client
+	ResourceHealthMetadataClient *resourcehealth.ResourceHealthMetadataClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -76,6 +80,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	ScheduledQueryRulesClient := classic.NewScheduledQueryRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&ScheduledQueryRulesClient.Client, o.ResourceManagerAuthorizer)
 
+	ResourceHealthMetadataClient := resourcehealth.NewResourceHealthMetadataClientWithBaseURI(resourcehealth.DefaultBaseURI, o.SubscriptionId)
+	o.ConfigureClient(&ResourceHealthMetadataClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		AADDiagnosticSettingsClient:      &AADDiagnosticSettingsClient,
 		AutoscaleSettingsClient:          &AutoscaleSettingsClient,
@@ -91,5 +98,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		PrivateLinkScopesClient:          &PrivateLinkScopesClient,
 		PrivateLinkScopedResourcesClient: &PrivateLinkScopedResourcesClient,
 		ScheduledQueryRulesClient:        &ScheduledQueryRulesClient,
+		ResourceHealthMetadataClient:     &ResourceHealthMetadataClient,
 	}
 }

--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -250,8 +250,8 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 						return err
 					}
 
-					supportedEventTypes := make(map[string]string, 0)
-					supportedServiceTypes := make(map[string]string, 0)
+					supportedEventTypes := make(map[string]string)
+					supportedServiceTypes := make(map[string]string)
 
 					for _, data := range fetchedValues.Value {
 						if data.Name == "supportedEventTypes" {

--- a/internal/services/monitor/sdk/resourcehealth/client.go
+++ b/internal/services/monitor/sdk/resourcehealth/client.go
@@ -1,0 +1,85 @@
+package resourcehealth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+const (
+	// DefaultBaseURI is the default URI used for the service Resourcehealth
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+// BaseClient is the base client for Resourcehealth.
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type ResourceHealthMetadataClient struct {
+	BaseClient
+}
+
+func NewResourceHealthMetadataClientWithBaseURI(baseURI string, subscriptionID string) ResourceHealthMetadataClient {
+	return ResourceHealthMetadataClient{BaseClient: BaseClient{
+		Client:         autorest.NewClientWithUserAgent(""),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}}
+}
+
+func (client ResourceHealthMetadataClient) GetMetaData(ctx context.Context) (result ResourceHealthMetadataResource, err error) {
+	req, err := client.GetPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "providers/Microsoft.ResourceHealthMetadataClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "providers/Microsoft.ResourceHealthMetadataClient", "Get", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "providers/Microsoft.ResourceHealthMetadataClient", "Get", resp, "Failure responding to request")
+		return
+	}
+
+	return result, nil
+}
+
+// GetPreparer prepares the Get request.
+func (client ResourceHealthMetadataClient) GetPreparer(ctx context.Context) (*http.Request, error) {
+	const APIVersion = "2018-07-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/providers/Microsoft.ResourceHealth/metadata"),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client ResourceHealthMetadataClient) GetSender(req *http.Request) (*http.Response, error) {
+	return client.Send(req, azure.DoRetryWithRegistration(client.Client))
+}
+
+func (client ResourceHealthMetadataClient) GetResponder(resp *http.Response) (result ResourceHealthMetadataResource, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}

--- a/internal/services/monitor/sdk/resourcehealth/model.go
+++ b/internal/services/monitor/sdk/resourcehealth/model.go
@@ -1,0 +1,21 @@
+package resourcehealth
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ResourceHealthMetadataResource struct {
+	autorest.Response `json:"-"`
+	Value             []struct {
+		ID         string `json:"id"`
+		Type       string `json:"type"`
+		Name       string `json:"name"`
+		Properties struct {
+			DisplayName         string   `json:"displayName"`
+			ApplicableScenarios []string `json:"applicableScenarios,omitempty"`
+			SupportedValues     []struct {
+				ID            string   `json:"id"`
+				DisplayName   string   `json:"displayName,omitempty"`
+				ResourceTypes []string `json:"resourceTypes,omitempty"`
+			} `json:"supportedValues"`
+		} `json:"properties,omitempty"`
+	} `json:"value"`
+}


### PR DESCRIPTION
Hi all,

just a small pr to add a better validation (based on Azure API) to validate the user / terraform input for "ServiceHealth" alerts.

Reason:
The API behind the Service Health feature was case sensitive, each input that was not 100% correct types will be pushed to the api (also shown in some views of the azure portal) but the action didn't work correct.
With the new dynamic validation each input will be validated with the service response that contains all possible input values. 
Also new Services can be handled in that way.


What I have changed / added

Add custom REST Client (api was not part of the azure sdk atm)
Add Validation errors
Add CustomDiff validation for `service_health` fields: `events` and `services`

resource "azurerm_monitor_activity_log_alert" "main" {
  name                = "example-activitylogalert"
  resource_group_name = azurerm_resource_group.main.name
  scopes              = [azurerm_resource_group.main.id]
  description         = "This alert will monitor a specific storage account updates."

  criteria {
    category = "ServiceHealth"    
    servicehealth {
      events   = ["Incident", "Maintenance"]
      regions  = ["Global", "West Europe"]
      services = ["App Service (Linux)", "Network Infrastructure"]
    }
  }

  action {
    action_group_id = azurerm_monitor_action_group.main.id
  }
}

Please provide some feedback what you think about and if I have to change something

Regards,
Tobi