### PR TITLE
`azurerm_[linux|windows]_virtual_machine`: Add support for `dedicated_host_group_id`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -138,9 +138,25 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: computeValidate.DedicatedHostID,
 				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				// same for `dedicated_host_group_id`
 				DiffSuppressFunc: suppress.CaseDifference,
+				ConflictsWith: []string{
+					"dedicated_host_group_id",
+				},
 				// TODO: raise a GH issue for the broken API
 				// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TOM-MANUAL/providers/Microsoft.Compute/hostGroups/tom-hostgroup/hosts/tom-manual-host
+
+			},
+
+			"dedicated_host_group_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: computeValidate.DedicatedHostGroupID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE
+				DiffSuppressFunc: suppress.CaseDifference,
+				ConflictsWith: []string{
+					"dedicated_host_id",
+				},
 			},
 
 			"disable_password_authentication": {
@@ -502,6 +518,12 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
+	if v, ok := d.GetOk("dedicated_host_group_id"); ok {
+		params.HostGroup = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
 	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
 		if params.Priority != compute.VirtualMachinePriorityTypesSpot {
 			return fmt.Errorf("An `eviction_policy` can only be specified when `priority` is set to `Spot`")
@@ -679,6 +701,12 @@ func resourceLinuxVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 		dedicatedHostId = *props.Host.ID
 	}
 	d.Set("dedicated_host_id", dedicatedHostId)
+
+	dedicatedHostGroupId := ""
+	if props.HostGroup != nil && props.HostGroup.ID != nil {
+		dedicatedHostGroupId = *props.HostGroup.ID
+	}
+	d.Set("dedicated_host_group_id", dedicatedHostGroupId)
 
 	virtualMachineScaleSetId := ""
 	if props.VirtualMachineScaleSet != nil && props.VirtualMachineScaleSet.ID != nil {
@@ -897,6 +925,21 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			}
 		} else {
 			update.Host = &compute.SubResource{}
+		}
+	}
+
+	if d.HasChange("dedicated_host_group_id") {
+		shouldUpdate = true
+
+		// Code="PropertyChangeNotAllowed" Message="Updating Host of VM 'VMNAME' is not allowed as the VM is currently allocated. Please Deallocate the VM and retry the operation."
+		shouldDeallocate = true
+
+		if v, ok := d.GetOk("dedicated_host_group_id"); ok {
+			update.HostGroup = &compute.SubResource{
+				ID: utils.String(v.(string)),
+			}
+		} else {
+			update.HostGroup = &compute.SubResource{}
 		}
 	}
 

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -687,6 +687,22 @@ func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupRemoved(data accep
 	return fmt.Sprintf(`
 %s
 
+resource "azurerm_dedicated_host_group" "second" {
+  name                        = "acctestDHG2-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "second" {
+  name                    = "acctestDH2-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -714,7 +730,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -527,14 +527,6 @@ func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupInitial(data accep
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  platform_fault_domain_count = 2
-  automatic_placement_enabled = true
-}
-
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -562,7 +554,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingDedicatedHostGroup(data acceptance.TestData) string {
@@ -575,6 +567,14 @@ resource "azurerm_dedicated_host_group" "test" {
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
   automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
@@ -605,7 +605,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupUpdate(data acceptance.TestData) string {
@@ -620,12 +620,28 @@ resource "azurerm_dedicated_host_group" "test" {
   automatic_placement_enabled = true
 }
 
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
 resource "azurerm_dedicated_host_group" "second" {
   name                        = "acctestDHG2-%d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
   automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "second" {
+  name                    = "acctestDH2-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
@@ -656,20 +672,12 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupRemoved(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  platform_fault_domain_count = 2
-  automatic_placement_enabled = true
-}
 
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
@@ -698,7 +706,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -604,6 +604,10 @@ resource "azurerm_linux_virtual_machine" "test" {
     sku       = "16.04-LTS"
     version   = "latest"
   }
+
+  depends_on = [
+    azurerm_dedicated_host.test
+  ]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -671,6 +675,10 @@ resource "azurerm_linux_virtual_machine" "test" {
     sku       = "16.04-LTS"
     version   = "latest"
   }
+
+  depends_on = [
+    azurerm_dedicated_host.second
+  ]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -578,12 +578,12 @@ resource "azurerm_dedicated_host_group" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
-  admin_username      = "adminuser"
-  dedicated_host_id   = azurerm_dedicated_host_group.test.id
+  name                    = "acctestVM-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  size                    = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username          = "adminuser"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -629,12 +629,12 @@ resource "azurerm_dedicated_host_group" "second" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
-  admin_username      = "adminuser"
-  dedicated_host_id   = azurerm_dedicated_host_group.second.id
+  name                    = "acctestVM-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  size                    = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username          = "adminuser"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -90,6 +90,57 @@ func TestAccLinuxVirtualMachine_scalingDedicatedHostUpdate(t *testing.T) {
 	})
 }
 
+func TestAccLinuxVirtualMachine_scalingDedicatedHostGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingDedicatedHostGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingDedicatedHostGroupUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingDedicatedHostGroupInitial(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingDedicatedHostGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingDedicatedHostGroupUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingDedicatedHostGroupRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxVirtualMachine_scalingProximityPlacementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
@@ -470,6 +521,184 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupInitial(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) scalingDedicatedHostGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  dedicated_host_id   = azurerm_dedicated_host_group.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host_group" "second" {
+  name                        = "acctestDHG2-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  dedicated_host_id   = azurerm_dedicated_host_group.second.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) scalingDedicatedHostGroupRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -139,9 +139,24 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: computeValidate.DedicatedHostID,
 				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				// same for `dedicated_host_group_id`
 				DiffSuppressFunc: suppress.CaseDifference,
+				ConflictsWith: []string{
+					"dedicated_host_group_id",
+				},
 				// TODO: raise a GH issue for the broken API
 				// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TOM-MANUAL/providers/Microsoft.Compute/hostGroups/tom-hostgroup/hosts/tom-manual-host
+			},
+
+			"dedicated_host_group_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: computeValidate.DedicatedHostGroupID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE
+				DiffSuppressFunc: suppress.CaseDifference,
+				ConflictsWith: []string{
+					"dedicated_host_id",
+				},
 			},
 
 			"enable_automatic_updates": {
@@ -497,6 +512,12 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if v, ok := d.GetOk("dedicated_host_group_id"); ok {
+		params.HostGroup = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
 	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
 		if params.SecurityProfile == nil {
 			params.SecurityProfile = &compute.SecurityProfile{}
@@ -705,6 +726,12 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 		dedicatedHostId = *props.Host.ID
 	}
 	d.Set("dedicated_host_id", dedicatedHostId)
+
+	dedicatedHostGroupId := ""
+	if props.HostGroup != nil && props.HostGroup.ID != nil {
+		dedicatedHostGroupId = *props.HostGroup.ID
+	}
+	d.Set("dedicated_host_group_id", dedicatedHostGroupId)
 
 	virtualMachineScaleSetId := ""
 	if props.VirtualMachineScaleSet != nil && props.VirtualMachineScaleSet.ID != nil {
@@ -945,6 +972,21 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			}
 		} else {
 			update.Host = &compute.SubResource{}
+		}
+	}
+
+	if d.HasChange("dedicated_host_group_id") {
+		shouldUpdate = true
+
+		// Code="PropertyChangeNotAllowed" Message="Updating Host of VM 'VMNAME' is not allowed as the VM is currently allocated. Please Deallocate the VM and retry the operation."
+		shouldDeallocate = true
+
+		if v, ok := d.GetOk("dedicated_host_group_id"); ok {
+			update.HostGroup = &compute.SubResource{
+				ID: utils.String(v.(string)),
+			}
+		} else {
+			update.HostGroup = &compute.SubResource{}
 		}
 	}
 

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -597,13 +597,13 @@ resource "azurerm_dedicated_host_group" "second" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-  dedicated_host_id   = azurerm_dedicated_host_group.second.id
+  name                    = local.vm_name
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  size                    = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username          = "adminuser"
+  admin_password          = "P@$$w0rd1234!"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -572,6 +572,10 @@ resource "azurerm_windows_virtual_machine" "test" {
     sku       = "2016-Datacenter"
     version   = "latest"
   }
+
+  depends_on = [
+    azurerm_dedicated_host.test
+  ]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
@@ -635,6 +639,10 @@ resource "azurerm_windows_virtual_machine" "test" {
     sku       = "2016-Datacenter"
     version   = "latest"
   }
+
+  depends_on = [
+    azurerm_dedicated_host.second
+  ]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -503,14 +503,6 @@ func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupInitial(data acc
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  platform_fault_domain_count = 2
-  automatic_placement_enabled = true
-}
-
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -534,7 +526,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r WindowsVirtualMachineResource) scalingDedicatedHostGroup(data acceptance.TestData) string {
@@ -547,6 +539,14 @@ resource "azurerm_dedicated_host_group" "test" {
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
   automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
@@ -573,7 +573,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupUpdate(data acceptance.TestData) string {
@@ -588,12 +588,28 @@ resource "azurerm_dedicated_host_group" "test" {
   automatic_placement_enabled = true
 }
 
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
 resource "azurerm_dedicated_host_group" "second" {
   name                        = "acctestDHG2-%d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
   automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "second" {
+  name                    = "acctestDH2-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
@@ -620,20 +636,12 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupRemoved(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  platform_fault_domain_count = 2
-  automatic_placement_enabled = true
-}
 
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
@@ -658,7 +666,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
 func (r WindowsVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -90,6 +90,57 @@ func TestAccWindowsVirtualMachine_scalingDedicatedHostUpdate(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_scalingDedicatedHostGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingDedicatedHostGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingDedicatedHostGroupUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingDedicatedHostGroupInitial(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingDedicatedHostGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingDedicatedHostGroupUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingDedicatedHostGroupRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_scalingProximityPlacementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -429,7 +480,6 @@ resource "azurerm_windows_virtual_machine" "test" {
   size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
-  dedicated_host_id   = azurerm_dedicated_host.second.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -447,6 +497,168 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupInitial(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) scalingDedicatedHostGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                    = local.vm_name
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  size                    = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username          = "adminuser"
+  admin_password          = "P@$$w0rd1234!"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host_group" "second" {
+  name                        = "acctestDHG2-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  dedicated_host_id   = azurerm_dedicated_host_group.second.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r WindowsVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -651,6 +651,22 @@ func (r WindowsVirtualMachineResource) scalingDedicatedHostGroupRemoved(data acc
 	return fmt.Sprintf(`
 %s
 
+resource "azurerm_dedicated_host_group" "second" {
+  name                        = "acctestDHG2-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+  automatic_placement_enabled = true
+}
+
+resource "azurerm_dedicated_host" "second" {
+  name                    = "acctestDH2-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.second.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -674,7 +690,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, r.template(data))
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r WindowsVirtualMachineResource) scalingProximityPlacementGroup(data acceptance.TestData) string {

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
 
-* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group where this machine should be run on. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Linux Virtual Machine should be run within. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
 
 * `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
 
-* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Linux Virtual Machine should be run within. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Linux Virtual Machine should be run within. Conflicts with `dedicated_host_id`.
 
 * `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -134,7 +134,9 @@ The following arguments are supported:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
 
-* `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on.
+* `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
+
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group where this machine should be run on. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
 
 * `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
 
-* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Windows Virtual Machine should be run within. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Windows Virtual Machine should be run within. Conflicts with `dedicated_host_id`.
 
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
 
-* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group where this machine should be run on. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group that this Windows Virtual Machine should be run within. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
 
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -123,7 +123,9 @@ The following arguments are supported:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
 
-* `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on.
+* `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Conflicts with `dedicated_host_group_id`.
+
+* `dedicated_host_group_id` - (Optional) The ID of a Dedicated Host Group where this machine should be run on. The target Host Group must have automatic placement enabled. Conflicts with `dedicated_host_id`.
 
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
 - Implement [Host Group Automatic Placement](https://docs.microsoft.com/en-us/azure/virtual-machines/dedicated-hosts#manual-vs-automatic-placement)
- The new property `dedicated_host_group_id` is similar to `dedicated_host_id`, it puts the VM on a Host Group instead, the Host Group needs to have automatic placement enabled.
- Minor fix for a test case config `func (r WindowsVirtualMachineResource) scalingDedicatedHostRemoved` which didn't remove the `dedicated_host_id`

Test result:
![image](https://user-images.githubusercontent.com/10579712/149344456-23197b63-5343-43f4-8590-31c9ec51b4a4.png)
