### PR TITLE
`azurerm_iothub` - export `event_hub_events_namespace` and add a fallback route by default

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -390,12 +391,12 @@ func resourceIotHub() *pluginsdk.Resource {
 							Optional: true,
 							Default:  "DeviceMessages",
 							ValidateFunc: validation.StringInSlice([]string{
-								"DeviceConnectionStateEvents",
-								"DeviceJobLifecycleEvents",
-								"DeviceLifecycleEvents",
-								"DeviceMessages",
-								"Invalid",
-								"TwinChangeEvents",
+								string(devices.RoutingSourceDeviceConnectionStateEvents),
+								string(devices.RoutingSourceDeviceJobLifecycleEvents),
+								string(devices.RoutingSourceDeviceLifecycleEvents),
+								string(devices.RoutingSourceDeviceMessages),
+								string(devices.RoutingSourceInvalid),
+								string(devices.RoutingSourceTwinChangeEvents),
 							}, false),
 						},
 						"condition": {
@@ -524,6 +525,10 @@ func resourceIotHub() *pluginsdk.Resource {
 			},
 
 			"event_hub_events_endpoint": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"event_hub_events_namespace": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -726,6 +731,14 @@ func resourceIotHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 			if k == "events" {
 				d.Set("event_hub_events_endpoint", v.Endpoint)
+
+				if *v.Endpoint != "" {
+					uri, err := url.Parse(*v.Endpoint)
+					if err == nil {
+						d.Set("event_hub_events_namespace", strings.Split(uri.Hostname(), ".")[0])
+					}
+				}
+
 				d.Set("event_hub_events_path", v.Path)
 				d.Set("event_hub_partition_count", v.PartitionCount)
 				d.Set("event_hub_retention_in_days", v.RetentionTimeInDays)

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
@@ -602,6 +603,13 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if _, ok := d.GetOk("fallback_route"); ok {
 		routingProperties.FallbackRoute = expandIoTHubFallbackRoute(d)
+	} else if features.ThreePointOh() {
+		routingProperties.FallbackRoute = &devices.FallbackRouteProperties{
+			Source:        utils.String(string(devices.RoutingSourceDeviceMessages)),
+			Condition:     utils.String("true"),
+			EndpointNames: &[]string{"events"},
+			IsEnabled:     utils.Bool(true),
+		}
 	}
 
 	if _, ok := d.GetOk("endpoint"); ok {

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -389,7 +389,7 @@ func resourceIotHub() *pluginsdk.Resource {
 						"source": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  "DeviceMessages",
+							Default:  string(devices.RoutingSourceDeviceMessages),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(devices.RoutingSourceDeviceConnectionStateEvents),
 								string(devices.RoutingSourceDeviceJobLifecycleEvents),

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -299,6 +299,7 @@ The following attributes are exported:
 * `id` - The ID of the IoTHub.
 
 * `event_hub_events_endpoint` -  The EventHub compatible endpoint for events data
+* `event_hub_events_namespace` - The EventHub namespace for events data   
 * `event_hub_events_path` -  The EventHub compatible path for events data
 * `event_hub_operations_endpoint` -  The EventHub compatible endpoint for operational data
 * `event_hub_operations_path` -  The EventHub compatible path for operational data


### PR DESCRIPTION
fixes #7571, #10146