### PR TITLE
`azurerm_iothub_dps` - updating default `allocation_weight` 

### DIFF
--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -108,6 +108,7 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Optional: true,
 							Default:  features.ThreePointOh(),
 						},
+						// TODO update docs with new default for 3.0
 						"allocation_weight": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -109,9 +109,14 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Default:  features.ThreePointOh(),
 						},
 						"allocation_weight": {
-							Type:         pluginsdk.TypeInt,
-							Optional:     true,
-							Default:      0,
+							Type:     pluginsdk.TypeInt,
+							Optional: true,
+							Default: func() interface{} {
+								if features.ThreePointOh() {
+									return 1
+								}
+								return 0
+							}(),
 							ValidateFunc: validation.IntBetween(0, 1000),
 						},
 						"hostname": {


### PR DESCRIPTION
fixes #7443 

This brings the default in line with azure. 