### PR TITLE
`azurerm_bastion_host` - support for `scale_units`

### DIFF
--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -50,6 +50,16 @@ func resourceBastionHost() *pluginsdk.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			"copy_paste_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"file_copy_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"ip_configuration": {
 				Type:     pluginsdk.TypeList,
 				ForceNew: true,
@@ -69,6 +79,15 @@ func resourceBastionHost() *pluginsdk.Resource {
 							ForceNew:     true,
 							ValidateFunc: azure.ValidateResourceID,
 						},
+						"private_ip_allocation_method": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.IPAllocationMethodDynamic),
+								string(network.IPAllocationMethodStatic),
+							}, false),
+							Default: string(network.IPAllocationMethodDynamic),
+						},
 						"public_ip_address_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
@@ -79,6 +98,23 @@ func resourceBastionHost() *pluginsdk.Resource {
 				},
 			},
 
+			"ip_connect_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"scale_units": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(2, 50),
+				Default:      2,
+			},
+
+			"shareable_link_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -87,6 +123,11 @@ func resourceBastionHost() *pluginsdk.Resource {
 					string(network.BastionHostSkuNameStandard),
 				}, false),
 				Default: string(network.BastionHostSkuNameBasic),
+			},
+
+			"tunneling_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
 			},
 
 			"dns_name": {
@@ -133,6 +174,30 @@ func resourceBastionHostCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 			Name: network.BastionHostSkuName(d.Get("sku").(string)),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("scale_units"); ok {
+		parameters.BastionHostPropertiesFormat.ScaleUnits = utils.Int32(int32(v.(int)))
+	}
+
+	if v, ok := d.GetOk("copy_paste_enabled"); ok {
+		parameters.BastionHostPropertiesFormat.DisableCopyPaste = utils.Bool(!v.(bool))
+	}
+
+	if v, ok := d.GetOk("file_copy_enabled"); ok {
+		parameters.BastionHostPropertiesFormat.EnableFileCopy = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("ip_connect_enabled"); ok {
+		parameters.BastionHostPropertiesFormat.EnableIPConnect = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("shareable_link_enabled"); ok {
+		parameters.BastionHostPropertiesFormat.EnableShareableLink = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("tunneling_enabled"); ok {
+		parameters.BastionHostPropertiesFormat.EnableTunneling = utils.Bool(v.(bool))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, parameters)
@@ -182,6 +247,12 @@ func resourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	if props := resp.BastionHostPropertiesFormat; props != nil {
 		d.Set("dns_name", props.DNSName)
+		d.Set("scale_units", props.ScaleUnits)
+		d.Set("copy_paste_enabled", !*props.DisableCopyPaste)
+		d.Set("file_copy_enabled", props.EnableFileCopy)
+		d.Set("ip_connect_enabled", props.EnableIPConnect)
+		d.Set("shareable_link_enabled", props.EnableShareableLink)
+		d.Set("tunneling_enabled", props.EnableTunneling)
 
 		if ipConfigs := props.IPConfigurations; ipConfigs != nil {
 			if err := d.Set("ip_configuration", flattenBastionHostIPConfiguration(ipConfigs)); err != nil {
@@ -222,24 +293,32 @@ func expandBastionHostIPConfiguration(input []interface{}) (ipConfigs *[]network
 		return nil
 	}
 
+	results := make([]network.BastionHostIPConfiguration, 0)
 	property := input[0].(map[string]interface{})
 	ipConfName := property["name"].(string)
 	subID := property["subnet_id"].(string)
 	pipID := property["public_ip_address_id"].(string)
+	privateIPAllocationMethod := property["private_ip_allocation_method"].(string)
 
-	return &[]network.BastionHostIPConfiguration{
-		{
-			Name: &ipConfName,
-			BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
-				Subnet: &network.SubResource{
-					ID: &subID,
-				},
-				PublicIPAddress: &network.SubResource{
-					ID: &pipID,
-				},
+	result := network.BastionHostIPConfiguration{
+		Name: &ipConfName,
+		BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
+			Subnet: &network.SubResource{
+				ID: &subID,
+			},
+			PublicIPAddress: &network.SubResource{
+				ID: &pipID,
 			},
 		},
 	}
+
+	if privateIPAllocationMethod != "" {
+		result.PrivateIPAllocationMethod = network.IPAllocationMethod(privateIPAllocationMethod)
+	}
+
+	results = append(results, result)
+
+	return &results
 }
 
 func flattenBastionHostIPConfiguration(ipConfigs *[]network.BastionHostIPConfiguration) []interface{} {
@@ -262,6 +341,10 @@ func flattenBastionHostIPConfiguration(ipConfigs *[]network.BastionHostIPConfigu
 
 			if pip := props.PublicIPAddress; pip != nil {
 				ipConfig["public_ip_address_id"] = *pip.ID
+			}
+
+			if ipAllocationMethod := props.PrivateIPAllocationMethod; ipAllocationMethod != "" {
+				ipConfig["private_ip_allocation_method"] = string(ipAllocationMethod)
 			}
 		}
 

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -135,15 +135,12 @@ func resourceBastionHostCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 		Location: &location,
 		BastionHostPropertiesFormat: &network.BastionHostPropertiesFormat{
 			IPConfigurations: expandBastionHostIPConfiguration(d.Get("ip_configuration").([]interface{})),
+			ScaleUnits:       utils.Int32(int32(d.Get("scale_units").(int))),
 		},
 		Sku: &network.Sku{
 			Name: network.BastionHostSkuName(d.Get("sku").(string)),
 		},
 		Tags: tags.Expand(t),
-	}
-
-	if v, ok := d.GetOk("scale_units"); ok {
-		parameters.BastionHostPropertiesFormat.ScaleUnits = utils.Int32(int32(v.(int)))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, parameters)

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -79,6 +79,26 @@ func TestAccBastionHost_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccBastionHost_scaleUnits(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
+	r := BastionHostResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scaleUnits(data, 3),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.scaleUnits(data, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (BastionHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.BastionHostID(state.ID)
 	if err != nil {
@@ -254,4 +274,53 @@ resource "azurerm_bastion_host" "import" {
   }
 }
 `, r.basic(data))
+}
+
+func (BastionHostResource) scaleUnits(data acceptance.TestData, scaleUnits int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-bastion-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestVNet%s"
+  address_space       = ["192.168.1.0/24"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "192.168.1.224/27"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestBastionPIP%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_bastion_host" "test" {
+  name                = "acctestBastion%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  scale_units         = %d
+
+  ip_configuration {
+    name                 = "ip-configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomString, scaleUnits)
 }

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -66,9 +66,21 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  Review [Azure Bastion Host FAQ](https://docs.microsoft.com/en-us/azure/bastion/bastion-faq) for supported locations.
 
+* `copy_paste_enabled` - (Optional) Is Copy/Paste feature enabled for the Bastion Host.
+
+* `file_copy_enabled` - (Optional) Is File Copy feature enabled for the Bastion Host.
+
 * `sku` - (Optional) The SKU of the Bastion Host. Accepted values are `Basic` and `Standard`. Defaults to `Basic`.
 
 * `ip_configuration` - (Required) A `ip_configuration` block as defined below.
+
+* `ip_connect_enabled` - (Optional) Is IP Connect feature enabled for the Bastion Host.
+
+* `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
+
+* `shareable_link_enabled` - (Optional) Is Shareable Link feature enabled for the Bastion Host.
+
+* `tunneling_enabled` - (Optional) Is Tunneling feature enabled for the Bastion Host.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -81,6 +93,8 @@ A `ip_configuration` block supports the following:
 * `subnet_id` - (Required) Reference to a subnet in which this Bastion Host has been created.
 
 * `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host.
+
+* `private_ip_allocation_method` (Required)  The private IP address allocation method for the Bastion Host. Possible values are `Static` and `Dynamic`. Defaults to `Dynamic`.
 
 ## Attributes Reference
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
-**Note:** `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`.
+~> **Note:** `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
-**Note:** `scale_units` is only supported when `sku` is `Standard`.
+**Note:** `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -66,21 +66,13 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  Review [Azure Bastion Host FAQ](https://docs.microsoft.com/en-us/azure/bastion/bastion-faq) for supported locations.
 
-* `copy_paste_enabled` - (Optional) Is Copy/Paste feature enabled for the Bastion Host.
-
-* `file_copy_enabled` - (Optional) Is File Copy feature enabled for the Bastion Host.
-
 * `sku` - (Optional) The SKU of the Bastion Host. Accepted values are `Basic` and `Standard`. Defaults to `Basic`.
 
 * `ip_configuration` - (Required) A `ip_configuration` block as defined below.
 
-* `ip_connect_enabled` - (Optional) Is IP Connect feature enabled for the Bastion Host.
-
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
-* `shareable_link_enabled` - (Optional) Is Shareable Link feature enabled for the Bastion Host.
-
-* `tunneling_enabled` - (Optional) Is Tunneling feature enabled for the Bastion Host.
+**Note:** `scale_units` is only supported when `sku` is `Standard`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -93,8 +85,6 @@ A `ip_configuration` block supports the following:
 * `subnet_id` - (Required) Reference to a subnet in which this Bastion Host has been created.
 
 * `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host.
-
-* `private_ip_allocation_method` (Required)  The private IP address allocation method for the Bastion Host. Possible values are `Static` and `Dynamic`. Defaults to `Dynamic`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is to support new feature `scale_units`.

--- PASS: TestAccBastionHost_standardSku (866.41s)
--- PASS: TestAccBastionHost_requiresImport (904.70s)
--- PASS: TestAccBastionHost_basic (1021.07s)
--- PASS: TestAccBastionHost_complete (1153.08s)
--- PASS: TestAccBastionHost_scaleUnits (1714.74s)