### PR TITLE
update markdown for azurerm_api_management_identity_provider_aadb2c

### DIFF
--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -40,14 +40,14 @@ resource "azuread_application_password" "example" {
 }
 
 resource "azurerm_api_management_identity_provider_aadb2c" "example" {
-  api_management_id = azurerm_api_management.example.id
-  client_id         = azuread_application.example.application_id
-  client_secret     = "P@55w0rD!%[7]s"
-  allowed_tenant    = "myb2ctenant.onmicrosoft.com"
-  signin_tenant     = "myb2ctenant.onmicrosoft.com"
-  authority         = "myb2ctenant.b2clogin.com"
-  signin_policy     = "B2C_1_Login"
-  signup_policy     = "B2C_1_Signup"
+  api_management_name = azurerm_api_management.example.name
+  client_id           = azuread_application.example.application_id
+  client_secret       = "P@55w0rD!%[7]s"
+  allowed_tenant      = "myb2ctenant.onmicrosoft.com"
+  signin_tenant       = "myb2ctenant.onmicrosoft.com"
+  authority           = "myb2ctenant.b2clogin.com"
+  signin_policy       = "B2C_1_Login"
+  signup_policy       = "B2C_1_Signup"
 
   depends_on = [azuread_application_password.example]
 }


### PR DESCRIPTION
update markdown for `azurerm_api_management_identity_provider_aadb2c` to reference `api_management_name` instead of `api_management_id`

Ref: https://github.com/hashicorp/terraform-provider-azurerm/blob/5b973d62ad25fa893090e6e1d2ef72023ce3cc33/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go#L39