### PR TITLE
azurerm_bastion_host - support new properties `copy_paste_enabled`, `file_copy_enabled`, `ip_connect_enabled`, `shareable_link_enabled` and `tunneling_enabled`

### DIFF
--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -158,19 +158,19 @@ func resourceBastionHostCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("`scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`")
 	}
 
-	if fileCopyEnabled == true && sku == string(network.BastionHostSkuNameBasic) {
+	if fileCopyEnabled && sku == string(network.BastionHostSkuNameBasic) {
 		return fmt.Errorf("`file_copy_enabled` is only supported when `sku` is `Standard`")
 	}
 
-	if ipConnectEnabled == true && sku == string(network.BastionHostSkuNameBasic) {
+	if ipConnectEnabled && sku == string(network.BastionHostSkuNameBasic) {
 		return fmt.Errorf("`ip_connect_enabled` is only supported when `sku` is `Standard`")
 	}
 
-	if shareableLinkEnabled == true && sku == string(network.BastionHostSkuNameBasic) {
+	if shareableLinkEnabled && sku == string(network.BastionHostSkuNameBasic) {
 		return fmt.Errorf("`shareable_link_enabled` is only supported when `sku` is `Standard`")
 	}
 
-	if tunnelingEnabled == true && sku == string(network.BastionHostSkuNameBasic) {
+	if tunnelingEnabled && sku == string(network.BastionHostSkuNameBasic) {
 		return fmt.Errorf("`tunneling_enabled` is only supported when `sku` is `Standard`")
 	}
 

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -297,27 +297,24 @@ func expandBastionHostIPConfiguration(input []interface{}) (ipConfigs *[]network
 		return nil
 	}
 
-	results := make([]network.BastionHostIPConfiguration, 0)
 	property := input[0].(map[string]interface{})
 	ipConfName := property["name"].(string)
 	subID := property["subnet_id"].(string)
 	pipID := property["public_ip_address_id"].(string)
 
-	result := network.BastionHostIPConfiguration{
-		Name: &ipConfName,
-		BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
-			Subnet: &network.SubResource{
-				ID: &subID,
-			},
-			PublicIPAddress: &network.SubResource{
-				ID: &pipID,
+	return &[]network.BastionHostIPConfiguration{
+		{
+			Name: &ipConfName,
+			BastionHostIPConfigurationPropertiesFormat: &network.BastionHostIPConfigurationPropertiesFormat{
+				Subnet: &network.SubResource{
+					ID: &subID,
+				},
+				PublicIPAddress: &network.SubResource{
+					ID: &pipID,
+				},
 			},
 		},
 	}
-
-	results = append(results, result)
-
-	return &results
 }
 
 func flattenBastionHostIPConfiguration(ipConfigs *[]network.BastionHostIPConfiguration) []interface{} {

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -194,10 +194,14 @@ resource "azurerm_public_ip" "test" {
 }
 
 resource "azurerm_bastion_host" "test" {
-  name                = "acctestBastion%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
+  name                   = "acctestBastion%s"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  sku                    = "Standard"
+  file_copy_enabled      = true
+  ip_connect_enabled     = true
+  shareable_link_enabled = true
+  tunneling_enabled      = true
 
   ip_configuration {
     name                 = "ip-configuration"
@@ -245,6 +249,7 @@ resource "azurerm_bastion_host" "test" {
   name                = "acctestBastion%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  copy_paste_enabled  = false
 
   ip_configuration {
     name                 = "ip-configuration"

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -66,13 +66,31 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  Review [Azure Bastion Host FAQ](https://docs.microsoft.com/en-us/azure/bastion/bastion-faq) for supported locations.
 
+* `copy_paste_enabled` - (Optional) Is Copy/Paste feature enabled for the Bastion Host. Defaults to `true`.
+
+* `file_copy_enabled` - (Optional) Is File Copy feature enabled for the Bastion Host. Defaults to `false`.
+
+~> **Note:** `file_copy_enabled` is only supported when `sku` is `Standard`.
+
 * `sku` - (Optional) The SKU of the Bastion Host. Accepted values are `Basic` and `Standard`. Defaults to `Basic`.
 
 * `ip_configuration` - (Required) A `ip_configuration` block as defined below.
 
+* `ip_connect_enabled` - (Optional) Is IP Connect feature enabled for the Bastion Host. Defaults to `false`.
+
+~> **Note:** `ip_connect_enabled` is only supported when `sku` is `Standard`.
+
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
 ~> **Note:** `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`.
+
+* `shareable_link_enabled` - (Optional) Is Shareable Link feature enabled for the Bastion Host. Defaults to `false`.
+
+~> **Note:** `shareable_link_enabled` is only supported when `sku` is `Standard`.
+
+* `tunneling_enabled` - (Optional) Is Tunneling feature enabled for the Bastion Host. Defaults to `false`.
+
+~> **Note:** `tunneling_enabled` is only supported when `sku` is `Standard`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
This PR is to support new properties `copy_paste_enabled`, `file_copy_enabled`, `ip_connect_enabled`, `shareable_link_enabled` and `tunneling_enabled`

--- PASS: TestAccBastionHost_standardSku (1079.79s)
--- PASS: TestAccBastionHost_complete (1193.83s)
--- PASS: TestAccBastionHost_requiresImport (1218.74s)
--- PASS: TestAccBastionHost_basic (1259.21s)
--- PASS: TestAccBastionHost_scaleUnits (1843.80s)
