### PR TITLE
dox fix: remove the wrong description of index_policy for resource azurerm_cosmosdb_gremlin_graph

### DIFF
--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
-* `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
+* `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below.
 
 * `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
 


### PR DESCRIPTION
The purpose of this PR:

Fix issue [#14995](https://github.com/hashicorp/terraform-provider-azurerm/issues/14995). In fact, updating azurerm_cosmosdb_gremlin_graph index policy does not cause the resource re-created. This is the documentation description error. Also, there is no `forcenew` is not set in index_policy` property of [terraform code](https://github.com/hashicorp/terraform-provider-azurerm/blob/fa9c32542a75982a58c68dab171fcf9f9bea59fa/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go#L100). So, I removed the "Changing this forces a new resource to be created." description in the doc.
