### PR TITLE
fix(services/storage/file): change at the `content_md5` attribute will now trigger recreation; set content length of share file when updating properties to prevent clearing of byte range.

### DIFF
--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -169,7 +169,6 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %+v", fileName, storageShareID.Name, storageShareID.AccountName, err)
 		}
 
-		d.Set("content_length", int(info.Size()))
 		input.ContentLength = info.Size()
 	}
 
@@ -311,6 +310,12 @@ func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("content_encoding", props.ContentEncoding)
 	d.Set("content_md5", props.ContentMD5)
 	d.Set("content_disposition", props.ContentDisposition)
+
+	if props.ContentLength == nil {
+		return fmt.Errorf("file share file properties %q returned no information about the content-length", id.FileName)
+	}
+
+	d.Set("content_length", int(*props.ContentLength))
 
 	return nil
 }

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -68,6 +68,7 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 			"content_md5": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -82,6 +83,11 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 				ForceNew:     true,
+			},
+
+			"content_length": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
 			},
 
 			"metadata": MetaDataSchema(),
@@ -163,6 +169,7 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %+v", fileName, storageShareID.Name, storageShareID.AccountName, err)
 		}
 
+		d.Set("content_length", int(info.Size()))
 		input.ContentLength = info.Size()
 	}
 
@@ -225,11 +232,12 @@ func resourceStorageShareFileUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("content_type") || d.HasChange("content_encoding") || d.HasChange("content_disposition") || d.HasChange("content_md5") {
+	if d.HasChange("content_type") || d.HasChange("content_encoding") || d.HasChange("content_disposition") {
 		input := files.SetPropertiesInput{
 			ContentType:        utils.String(d.Get("content_type").(string)),
 			ContentEncoding:    utils.String(d.Get("content_encoding").(string)),
 			ContentDisposition: utils.String(d.Get("content_disposition").(string)),
+			ContentLength:      int64(d.Get("content_length").(int)),
 			MetaData:           ExpandMetaData(d.Get("metadata").(map[string]interface{})),
 		}
 

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -71,6 +71,7 @@ func TestAccAzureRMStorageShareFile_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("content_length").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -108,6 +109,7 @@ func TestAccAzureRMStorageShareFile_withFile(t *testing.T) {
 			Config: r.withFile(data, sourceBlob.Name()),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("content_length").Exists(),
 			),
 		},
 		data.ImportStep("source"),

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `content_type` - (Optional) The content type of the share file. Defaults to `application/octet-stream`.
 
-* `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.   
+* `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.
 
 * `content_encoding` - (Optional) Specifies which content encodings have been applied to the file.
 
@@ -66,6 +66,7 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ID of the file within the File Share.
+* `content_length` - The length in bytes of the file content
 
 ## Timeouts
 


### PR DESCRIPTION
Hey,

I debugged the the issue #11507 and found two bugs:

- The resourceStorageShareFileUpdate function does check for changes on the resource, but should not check on content_md5 due to the file should be recreated (as the docs states). Furthermore the client.SetProperties will delete the files content.
- When updating the properties of the share file, the content length does not get set and erases all bytes above the default value (0) in azure. This behaviour is also documented in the azure api docs for the `x-ms-content-length`: https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties#request-headers


My PR changes the following:

- The `content_md5` property is now marked for replacement when change occur (as stated in the provider docs).
- The `content_length` is added as a new `Computed` property in order to track the content.