### PR TITLE
Firewall rule related resources change block type from `Set` to `List`

### DIFF
--- a/internal/services/firewall/firewall_application_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_application_rule_collection_resource_test.go
@@ -513,7 +513,7 @@ resource "azurerm_firewall_application_rule_collection" "test" {
   rule {
     name        = "rule1"
     description = "test description"
-    fqdn_tags   = ["WindowsDiagnostics"]
+    fqdn_tags   = ["WindowsDiagnostics", "AzureBackup"]
     source_addresses = [
       "10.0.0.0/16",
     ]
@@ -711,11 +711,13 @@ resource "azurerm_firewall_application_rule_collection" "test" {
     name = "rule1"
 
     source_addresses = [
+      "192.0.0.0/16",
       "10.0.0.0/16",
     ]
 
     target_fqdns = [
       "*.google.com",
+      "*.microsoft.com",
     ]
 
     protocol {
@@ -729,10 +731,12 @@ resource "azurerm_firewall_application_rule_collection" "test" {
 
     source_addresses = [
       "192.168.0.1",
+      "10.0.0.1",
     ]
 
     target_fqdns = [
       "*.microsoft.com",
+      "*.google.com",
     ]
 
     protocol {
@@ -851,11 +855,18 @@ func (FirewallApplicationRuleCollectionResource) ipGroups(data acceptance.TestDa
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_ip_group" "test" {
-  name                = "acctestIpGroupForFirewallAppRules"
+resource "azurerm_ip_group" "test1" {
+  name                = "acctestIpGroupForFirewallAppRules1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
+}
+
+resource "azurerm_ip_group" "test2" {
+  name                = "acctestIpGroupForFirewallAppRules2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["193.168.0.0/25", "193.168.0.192/26"]
 }
 
 resource "azurerm_firewall_application_rule_collection" "test" {
@@ -869,7 +880,8 @@ resource "azurerm_firewall_application_rule_collection" "test" {
     name = "rule1"
 
     source_ip_groups = [
-      azurerm_ip_group.test.id,
+      azurerm_ip_group.test1.id,
+      azurerm_ip_group.test2.id,
     ]
 
     target_fqdns = [

--- a/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
@@ -578,7 +578,6 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
     ]
 
     destination_addresses = [
-      "1.1.1.1",
       azurerm_public_ip.test.ip_address,
     ]
 
@@ -605,7 +604,6 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
     ]
 
     destination_addresses = [
-      "1.1.1.1",
       azurerm_public_ip.test.ip_address,
     ]
 

--- a/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
@@ -569,18 +569,22 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
 
     source_addresses = [
       "10.0.0.0/16",
+      "192.168.0.1",
     ]
 
     destination_ports = [
       "53",
+      "64",
     ]
 
     destination_addresses = [
+      "1.1.1.1",
       azurerm_public_ip.test.ip_address,
     ]
 
     protocols = [
       "TCP",
+      "UDP",
     ]
 
     translated_port    = 53
@@ -592,17 +596,21 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
 
     source_addresses = [
       "192.168.0.1",
+      "10.0.0.0/16",
     ]
 
     destination_ports = [
       "8888",
+      "9999",
     ]
 
     destination_addresses = [
+      "1.1.1.1",
       azurerm_public_ip.test.ip_address,
     ]
 
     protocols = [
+      "UDP",
       "TCP",
     ]
 
@@ -654,11 +662,18 @@ func (FirewallNatRuleCollectionResource) ipGroup(data acceptance.TestData) strin
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_ip_group" "test" {
-  name                = "acctestIpGroupForFirewallNatRules"
+resource "azurerm_ip_group" "test1" {
+  name                = "acctestIpGroupForFirewallNatRules1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
+}
+
+resource "azurerm_ip_group" "test2" {
+  name                = "acctestIpGroupForFirewallNatRules2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["193.168.0.0/25", "193.168.0.192/26"]
 }
 
 resource "azurerm_firewall_nat_rule_collection" "test" {
@@ -672,7 +687,8 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
     name = "rule1"
 
     source_ip_groups = [
-      azurerm_ip_group.test.id,
+      azurerm_ip_group.test1.id,
+      azurerm_ip_group.test2.id,
     ]
 
     destination_ports = [

--- a/internal/services/firewall/firewall_network_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_network_rule_collection_resource_test.go
@@ -664,18 +664,22 @@ resource "azurerm_firewall_network_rule_collection" "test" {
 
     source_addresses = [
       "10.0.0.0/16",
+      "192.0.0.0/16",
     ]
 
     destination_ports = [
       "53",
+      "64",
     ]
 
     destination_addresses = [
       "8.8.8.8",
+      "1.1.1.1",
     ]
 
     protocols = [
-      "Any",
+      "UDP",
+      "TCP",
     ]
   }
 
@@ -684,18 +688,22 @@ resource "azurerm_firewall_network_rule_collection" "test" {
 
     source_addresses = [
       "192.168.0.1",
+      "10.0.0.0/16",
     ]
 
     destination_ports = [
       "8888",
+      "9999",
     ]
 
     destination_addresses = [
       "1.1.1.1",
+      "8.8.8.8",
     ]
 
     protocols = [
       "TCP",
+      "UDP",
     ]
   }
 }
@@ -774,15 +782,28 @@ func (FirewallNetworkRuleCollectionResource) ipGroup(data acceptance.TestData) s
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_ip_group" "test_source" {
-  name                = "acctestIpGroupForFirewallNetworkRulesSource"
+resource "azurerm_ip_group" "test_source1" {
+  name                = "acctestIpGroupForFirewallNetworkRulesSource1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
 }
+resource "azurerm_ip_group" "test_source2" {
+  name                = "acctestIpGroupForFirewallNetworkRulesSource2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["4.3.2.1/32", "65.43.21.0/24"]
+}
 
-resource "azurerm_ip_group" "test_destination" {
-  name                = "acctestIpGroupForFirewallNetworkRulesDestination"
+resource "azurerm_ip_group" "test_destination1" {
+  name                = "acctestIpGroupForFirewallNetworkRulesDestination1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
+}
+
+resource "azurerm_ip_group" "test_destination2" {
+  name                = "acctestIpGroupForFirewallNetworkRulesDestination2"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
@@ -799,7 +820,8 @@ resource "azurerm_firewall_network_rule_collection" "test" {
     name = "rule1"
 
     source_ip_groups = [
-      azurerm_ip_group.test_source.id,
+      azurerm_ip_group.test_source1.id,
+      azurerm_ip_group.test_source2.id,
     ]
 
     destination_ports = [
@@ -807,7 +829,8 @@ resource "azurerm_firewall_network_rule_collection" "test" {
     ]
 
     destination_ip_groups = [
-      azurerm_ip_group.test_destination.id,
+      azurerm_ip_group.test_destination1.id,
+      azurerm_ip_group.test_destination2.id,
     ]
 
     protocols = [
@@ -837,7 +860,8 @@ resource "azurerm_firewall_network_rule_collection" "test" {
     ]
 
     destination_fqdns = [
-      "time.windows.com"
+      "time.windows.com",
+      "time.linux.com"
     ]
 
     destination_ports = [

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -61,7 +61,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 			},
 
 			"application_rule_collection": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
@@ -85,7 +85,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 							}, false),
 						},
 						"rule": {
-							Type:     pluginsdk.TypeSet,
+							Type:     pluginsdk.TypeList,
 							Required: true,
 							MinItems: 1,
 							Elem: &pluginsdk.Resource{
@@ -101,7 +101,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Resource{
 											Schema: map[string]*pluginsdk.Schema{
@@ -122,7 +122,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_addresses": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -134,7 +134,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_ip_groups": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -142,7 +142,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_addresses": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -154,7 +154,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_fqdns": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -162,7 +162,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_urls": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -170,7 +170,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_fqdn_tags": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -182,7 +182,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										Optional: true,
 									},
 									"web_categories": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -197,7 +197,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 			},
 
 			"network_rule_collection": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
@@ -221,7 +221,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 							}, false),
 						},
 						"rule": {
-							Type:     pluginsdk.TypeSet,
+							Type:     pluginsdk.TypeList,
 							Required: true,
 							MinItems: 1,
 							Elem: &pluginsdk.Resource{
@@ -232,7 +232,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -245,7 +245,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_addresses": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -257,7 +257,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_ip_groups": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -265,7 +265,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_addresses": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -274,7 +274,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_ip_groups": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -282,7 +282,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_fqdns": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -290,7 +290,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"destination_ports": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -308,7 +308,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 			},
 
 			"nat_rule_collection": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
@@ -329,13 +329,11 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								// Hardcode to using `Dnat` instead of the one defined in Swagger (i.e. network.DNAT) because of: https://github.com/Azure/azure-rest-api-specs/issues/9986
 								// Setting `StateFunc: state.IgnoreCase` will cause other issues, as tracked by: https://github.com/hashicorp/terraform-plugin-sdk/issues/485
-								// Another solution is to customize the hash function for the containing block, but as there are a couple of properties here, especially
-								// has property whose type is another nested block (Set), so the implementation is nontrivial and error-prone.
 								"Dnat",
 							}, false),
 						},
 						"rule": {
-							Type:     pluginsdk.TypeSet,
+							Type:     pluginsdk.TypeList,
 							Required: true,
 							MinItems: 1,
 							Elem: &pluginsdk.Resource{
@@ -346,7 +344,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"protocols": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -357,7 +355,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_addresses": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
@@ -369,7 +367,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										},
 									},
 									"source_ip_groups": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -385,7 +383,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 										),
 									},
 									"destination_ports": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
@@ -450,10 +448,10 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 		},
 	}
 	var rulesCollections []network.BasicFirewallPolicyRuleCollection
-	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionApplication(d.Get("application_rule_collection").(*pluginsdk.Set).List())...)
-	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionNetwork(d.Get("network_rule_collection").(*pluginsdk.Set).List())...)
+	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionApplication(d.Get("application_rule_collection").([]interface{}))...)
+	rulesCollections = append(rulesCollections, expandFirewallPolicyRuleCollectionNetwork(d.Get("network_rule_collection").([]interface{}))...)
 
-	natRules, err := expandFirewallPolicyRuleCollectionNat(d.Get("nat_rule_collection").(*pluginsdk.Set).List())
+	natRules, err := expandFirewallPolicyRuleCollectionNat(d.Get("nat_rule_collection").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding NAT rule collection: %w", err)
 	}
@@ -567,7 +565,7 @@ func expandFirewallPolicyRuleCollectionNat(input []interface{}) ([]network.Basic
 	result := make([]network.BasicFirewallPolicyRuleCollection, 0)
 	for _, e := range input {
 		rule := e.(map[string]interface{})
-		rules, err := expandFirewallPolicyRuleNat(rule["rule"].(*pluginsdk.Set).List())
+		rules, err := expandFirewallPolicyRuleNat(rule["rule"].([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -596,7 +594,7 @@ func expandFirewallPolicyFilterRuleCollection(input []interface{}, f func(input 
 			Name:               utils.String(rule["name"].(string)),
 			Priority:           utils.Int32(int32(rule["priority"].(int))),
 			RuleCollectionType: network.RuleCollectionTypeFirewallPolicyFilterRuleCollection,
-			Rules:              f(rule["rule"].(*pluginsdk.Set).List()),
+			Rules:              f(rule["rule"].([]interface{})),
 		}
 		result = append(result, output)
 	}
@@ -608,7 +606,7 @@ func expandFirewallPolicyRuleApplication(input []interface{}) *[]network.BasicFi
 	for _, e := range input {
 		condition := e.(map[string]interface{})
 		var protocols []network.FirewallPolicyRuleApplicationProtocol
-		for _, p := range condition["protocols"].(*pluginsdk.Set).List() {
+		for _, p := range condition["protocols"].([]interface{}) {
 			proto := p.(map[string]interface{})
 			protocols = append(protocols, network.FirewallPolicyRuleApplicationProtocol{
 				ProtocolType: network.FirewallPolicyRuleApplicationProtocolType(proto["type"].(string)),
@@ -620,14 +618,14 @@ func expandFirewallPolicyRuleApplication(input []interface{}) *[]network.BasicFi
 			Description:          utils.String(condition["description"].(string)),
 			RuleType:             network.RuleTypeApplicationRule,
 			Protocols:            &protocols,
-			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].(*pluginsdk.Set).List()),
-			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].(*pluginsdk.Set).List()),
-			DestinationAddresses: utils.ExpandStringSlice(condition["destination_addresses"].(*pluginsdk.Set).List()),
-			TargetFqdns:          utils.ExpandStringSlice(condition["destination_fqdns"].(*pluginsdk.Set).List()),
-			TargetUrls:           utils.ExpandStringSlice(condition["destination_urls"].(*pluginsdk.Set).List()),
-			FqdnTags:             utils.ExpandStringSlice(condition["destination_fqdn_tags"].(*pluginsdk.Set).List()),
+			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
+			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].([]interface{})),
+			DestinationAddresses: utils.ExpandStringSlice(condition["destination_addresses"].([]interface{})),
+			TargetFqdns:          utils.ExpandStringSlice(condition["destination_fqdns"].([]interface{})),
+			TargetUrls:           utils.ExpandStringSlice(condition["destination_urls"].([]interface{})),
+			FqdnTags:             utils.ExpandStringSlice(condition["destination_fqdn_tags"].([]interface{})),
 			TerminateTLS:         utils.Bool(condition["terminate_tls"].(bool)),
-			WebCategories:        utils.ExpandStringSlice(condition["web_categories"].(*pluginsdk.Set).List()),
+			WebCategories:        utils.ExpandStringSlice(condition["web_categories"].([]interface{})),
 		}
 		result = append(result, output)
 	}
@@ -639,19 +637,19 @@ func expandFirewallPolicyRuleNetwork(input []interface{}) *[]network.BasicFirewa
 	for _, e := range input {
 		condition := e.(map[string]interface{})
 		var protocols []network.FirewallPolicyRuleNetworkProtocol
-		for _, p := range condition["protocols"].(*pluginsdk.Set).List() {
+		for _, p := range condition["protocols"].([]interface{}) {
 			protocols = append(protocols, network.FirewallPolicyRuleNetworkProtocol(p.(string)))
 		}
 		output := &network.Rule{
 			Name:                 utils.String(condition["name"].(string)),
 			RuleType:             network.RuleTypeNetworkRule,
 			IPProtocols:          &protocols,
-			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].(*pluginsdk.Set).List()),
-			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].(*pluginsdk.Set).List()),
-			DestinationAddresses: utils.ExpandStringSlice(condition["destination_addresses"].(*pluginsdk.Set).List()),
-			DestinationIPGroups:  utils.ExpandStringSlice(condition["destination_ip_groups"].(*pluginsdk.Set).List()),
-			DestinationFqdns:     utils.ExpandStringSlice(condition["destination_fqdns"].(*pluginsdk.Set).List()),
-			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].(*pluginsdk.Set).List()),
+			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
+			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].([]interface{})),
+			DestinationAddresses: utils.ExpandStringSlice(condition["destination_addresses"].([]interface{})),
+			DestinationIPGroups:  utils.ExpandStringSlice(condition["destination_ip_groups"].([]interface{})),
+			DestinationFqdns:     utils.ExpandStringSlice(condition["destination_fqdns"].([]interface{})),
+			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].([]interface{})),
 		}
 		result = append(result, output)
 	}
@@ -663,7 +661,7 @@ func expandFirewallPolicyRuleNat(input []interface{}) (*[]network.BasicFirewallP
 	for _, e := range input {
 		condition := e.(map[string]interface{})
 		var protocols []network.FirewallPolicyRuleNetworkProtocol
-		for _, p := range condition["protocols"].(*pluginsdk.Set).List() {
+		for _, p := range condition["protocols"].([]interface{}) {
 			protocols = append(protocols, network.FirewallPolicyRuleNetworkProtocol(p.(string)))
 		}
 		destinationAddresses := []string{condition["destination_address"].(string)}
@@ -679,10 +677,10 @@ func expandFirewallPolicyRuleNat(input []interface{}) (*[]network.BasicFirewallP
 			Name:                 utils.String(condition["name"].(string)),
 			RuleType:             network.RuleTypeNatRule,
 			IPProtocols:          &protocols,
-			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].(*pluginsdk.Set).List()),
-			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].(*pluginsdk.Set).List()),
+			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
+			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].([]interface{})),
 			DestinationAddresses: &destinationAddresses,
-			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].(*pluginsdk.Set).List()),
+			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].([]interface{})),
 			TranslatedPort:       utils.String(strconv.Itoa(condition["translated_port"].(int))),
 		}
 		if condition["translated_address"].(string) != "" {

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -461,18 +461,34 @@ resource "azurerm_firewall_policy" "test" {
     proxy_enabled             = true
   }
 }
-resource "azurerm_ip_group" "test_source" {
-  name                = "acctestIpGroupForFirewallPolicySource"
+resource "azurerm_ip_group" "test_source1" {
+  name                = "acctestIpGroupForFirewallPolicySource1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
 }
-resource "azurerm_ip_group" "test_destination" {
-  name                = "acctestIpGroupForFirewallPolicyDest"
+
+resource "azurerm_ip_group" "test_source2" {
+  name                = "acctestIpGroupForFirewallPolicySource2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
+}
+
+resource "azurerm_ip_group" "test_destination1" {
+  name                = "acctestIpGroupForFirewallPolicyDest1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
 }
+
+resource "azurerm_ip_group" "test_destination2" {
+  name                = "acctestIpGroupForFirewallPolicyDest2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["193.168.0.0/25", "193.168.0.192/26"]
+}
+
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RCG-%[1]d"
   firewall_policy_id = azurerm_firewall_policy.test.id
@@ -509,7 +525,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
         type = "Https"
         port = 443
       }
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
       destination_addresses = ["10.0.0.1"]
       destination_fqdns     = ["pluginsdk.io"]
       terminate_tls         = true
@@ -533,6 +549,62 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
       web_categories        = ["News"]
     }
   }
+  application_rule_collection {
+    name     = "app_rule_collection2"
+    priority = 501
+    action   = "Deny"
+    rule {
+      name        = "app_rule_collection2_rule1"
+      description = "app_rule_collection2_rule1"
+      protocols {
+        type = "Http"
+        port = 80
+      }
+      protocols {
+        type = "Https"
+        port = 443
+      }
+      source_addresses      = ["10.0.0.1", "10.0.0.2"]
+      destination_addresses = ["10.0.0.1", "10.0.0.2"]
+      destination_urls      = ["www.google.com/en", "www.google.com/cn"]
+      terminate_tls         = true
+      web_categories        = ["News", "Arts"]
+    }
+    rule {
+      name        = "app_rule_collection2_rule2"
+      description = "app_rule_collection2_rule2"
+      protocols {
+        type = "Http"
+        port = 80
+      }
+      protocols {
+        type = "Https"
+        port = 443
+      }
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_addresses = ["10.0.0.1", "10.0.0.2"]
+      destination_fqdns     = ["pluginsdk.io", "pluginframework.io"]
+      terminate_tls         = true
+      web_categories        = ["News", "Arts"]
+    }
+    rule {
+      name        = "app_rule_collection2_rule3"
+      description = "app_rule_collection2_rule3"
+      protocols {
+        type = "Http"
+        port = 80
+      }
+      protocols {
+        type = "Https"
+        port = 443
+      }
+      source_addresses      = ["10.0.0.1", "10.0.0.2"]
+      destination_addresses = ["10.0.0.1", "10.0.0.2"]
+      destination_urls      = ["www.google.com/en", "www.google.com/cn"]
+      terminate_tls         = true
+      web_categories        = ["News", "Arts"]
+    }
+  }
   network_rule_collection {
     name     = "network_rule_collection1"
     priority = 400
@@ -554,16 +626,49 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
     rule {
       name                  = "network_rule_collection1_rule3"
       protocols             = ["TCP", "UDP"]
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
-      destination_ip_groups = [azurerm_ip_group.test_destination.id]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination1.id, azurerm_ip_group.test_destination2.id]
       destination_ports     = ["80", "1000-2000"]
     }
     rule {
       name                  = "network_rule_collection1_rule4"
       protocols             = ["ICMP"]
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
-      destination_ip_groups = [azurerm_ip_group.test_destination.id]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination1.id, azurerm_ip_group.test_destination2.id]
       destination_ports     = ["*"]
+    }
+  }
+  network_rule_collection {
+    name     = "network_rule_collection2"
+    priority = 401
+    action   = "Deny"
+    rule {
+      name                  = "network_rule_collection2_rule1"
+      protocols             = ["TCP", "UDP"]
+      source_addresses      = ["10.0.0.1", "10.0.0.2"]
+      destination_addresses = ["192.168.1.1", "ApiManagement"]
+      destination_ports     = ["80", "1000-2000"]
+    }
+    rule {
+      name              = "network_rule_collection2_rule2"
+      protocols         = ["TCP", "UDP"]
+      source_addresses  = ["10.0.0.1", "10.0.0.2"]
+      destination_fqdns = ["time.windows.com", "time.linux.com"]
+      destination_ports = ["80", "1000-2000"]
+    }
+    rule {
+      name                  = "network_rule_collection2_rule3"
+      protocols             = ["TCP", "UDP"]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination1.id, azurerm_ip_group.test_destination2.id]
+      destination_ports     = ["80", "1000-2000"]
+    }
+    rule {
+      name                  = "network_rule_collection2_rule4"
+      protocols             = ["ICMP", "TCP"]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination1.id, azurerm_ip_group.test_destination2.id]
+      destination_ports     = ["80", "1000-2000"]
     }
   }
   nat_rule_collection {
@@ -582,7 +687,30 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
     rule {
       name                = "nat_rule_collection1_rule2"
       protocols           = ["TCP", "UDP"]
-      source_ip_groups    = [azurerm_ip_group.test_source.id]
+      source_ip_groups    = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+      destination_address = "192.168.1.1"
+      destination_ports   = ["80"]
+      translated_address  = "192.168.0.1"
+      translated_port     = "8080"
+    }
+  }
+  nat_rule_collection {
+    name     = "nat_rule_collection2"
+    priority = 301
+    action   = "Dnat"
+    rule {
+      name                = "nat_rule_collection2_rule1"
+      protocols           = ["TCP", "UDP"]
+      source_addresses    = ["10.0.0.1", "10.0.0.2"]
+      destination_address = "192.168.1.1"
+      destination_ports   = ["80"]
+      translated_address  = "192.168.0.1"
+      translated_port     = "8080"
+    }
+    rule {
+      name                = "nat_rule_collection2_rule2"
+      protocols           = ["TCP", "UDP"]
+      source_ip_groups    = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
       destination_address = "192.168.1.1"
       destination_ports   = ["80"]
       translated_address  = "192.168.0.1"

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -739,17 +739,31 @@ resource "azurerm_firewall_policy" "test" {
     proxy_enabled             = true
   }
 }
-resource "azurerm_ip_group" "test_source" {
-  name                = "acctestIpGroupForFirewallPolicySource"
+resource "azurerm_ip_group" "test_source1" {
+  name                = "acctestIpGroupForFirewallPolicySource1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
 }
-resource "azurerm_ip_group" "test_destination" {
-  name                = "acctestIpGroupForFirewallPolicyDest"
+
+resource "azurerm_ip_group" "test_source2" {
+  name                = "acctestIpGroupForFirewallPolicySource2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
+}
+resource "azurerm_ip_group" "test_destination1" {
+  name                = "acctestIpGroupForFirewallPolicyDest1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["192.168.0.0/25", "192.168.0.192/26"]
+}
+
+resource "azurerm_ip_group" "test_destination2" {
+  name                = "acctestIpGroupForFirewallPolicyDest2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["193.168.0.0/25", "193.168.0.192/26"]
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RCG-%[1]d"
@@ -783,7 +797,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
         type = "Http"
         port = 80
       }
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id]
       destination_addresses = ["10.0.0.1"]
       destination_fqdns     = ["pluginsdk.io"]
       terminate_tls         = true
@@ -828,15 +842,15 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
     rule {
       name                  = "network_rule_collection1_rule3"
       protocols             = ["TCP"]
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
-      destination_ip_groups = [azurerm_ip_group.test_destination.id]
+      source_ip_groups      = [azurerm_ip_group.test_source1.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination1.id]
       destination_ports     = ["80", "1-65535"]
     }
     rule {
       name                  = "network_rule_collection1_rule4"
       protocols             = ["ICMP"]
-      source_ip_groups      = [azurerm_ip_group.test_source.id]
-      destination_ip_groups = [azurerm_ip_group.test_destination.id]
+      source_ip_groups      = [azurerm_ip_group.test_source2.id]
+      destination_ip_groups = [azurerm_ip_group.test_destination2.id]
       destination_ports     = ["*"]
     }
   }


### PR DESCRIPTION
There are typically two reasons to use the set type:

1. It allows users to reorder the elements inside the array, without getting a plan diff
2. Some API will return the elements without honoring its original order, in which case we have to use the set

It turns out (#11181, #10083), the first benefit is not more valuable than a readable plan. After contacting with the Azure firewall PM that he confirms the order of rules together with the other compound properties are reserved in turns of API, this PR changes the type of those blocks from `TypeSet` to `TypeList`.

Fixes #11181, fixes #10083.