### PR TITLE
Fix bug that missing eTag when updating azurerm_resource_group_cost_management_export and azurerm_subscription_cost_management_export resource

### DIFF
--- a/internal/services/costmanagement/export_base_resource.go
+++ b/internal/services/costmanagement/export_base_resource.go
@@ -232,7 +232,9 @@ func (br costManagementExportBaseResource) updateFunc() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("reading %s: %+v", *id, err)
 			}
-
+			if resp.ETag == nil {
+				return fmt.Errorf("add %s: etag was nil", *id)
+			}
 			if err := createOrUpdateCostManagementExport(ctx, client, metadata, *id, resp.ETag); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/costmanagement/export_base_resource.go
+++ b/internal/services/costmanagement/export_base_resource.go
@@ -133,7 +133,7 @@ func (br costManagementExportBaseResource) createFunc(resourceName, scopeFieldNa
 				return tf.ImportAsExistsError(resourceName, id.ID())
 			}
 
-			if err := createOrUpdateCostManagementExport(ctx, client, metadata, id); err != nil {
+			if err := createOrUpdateCostManagementExport(ctx, client, metadata, id, nil); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -227,7 +227,13 @@ func (br costManagementExportBaseResource) updateFunc() sdk.ResourceFunc {
 				return err
 			}
 
-			if err := createOrUpdateCostManagementExport(ctx, client, metadata, *id); err != nil {
+			// Update operation requires latest eTag to be set in the request.
+			resp, err := client.Get(ctx, id.Scope, id.Name, "")
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			if err := createOrUpdateCostManagementExport(ctx, client, metadata, *id, resp.ETag); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
@@ -236,7 +242,7 @@ func (br costManagementExportBaseResource) updateFunc() sdk.ResourceFunc {
 	}
 }
 
-func createOrUpdateCostManagementExport(ctx context.Context, client *costmanagement.ExportsClient, metadata sdk.ResourceMetaData, id parse.CostManagementExportId) error {
+func createOrUpdateCostManagementExport(ctx context.Context, client *costmanagement.ExportsClient, metadata sdk.ResourceMetaData, id parse.CostManagementExportId, etag *string) error {
 	from, _ := time.Parse(time.RFC3339, metadata.ResourceData.Get("recurrence_period_start_date").(string))
 	to, _ := time.Parse(time.RFC3339, metadata.ResourceData.Get("recurrence_period_end_date").(string))
 
@@ -251,6 +257,7 @@ func createOrUpdateCostManagementExport(ctx context.Context, client *costmanagem
 	}
 
 	props := costmanagement.Export{
+		ETag: etag,
 		ExportProperties: &costmanagement.ExportProperties{
 			Schedule: &costmanagement.ExportSchedule{
 				Recurrence: costmanagement.RecurrenceType(metadata.ResourceData.Get("recurrence_type").(string)),


### PR DESCRIPTION
The purpose of this PR:

> Fix issue [#15010](https://github.com/hashicorp/terraform-provider-azurerm/issues/15010). The issue is caused by missing eTag when updating azurerm_resource_group_cost_management_export and azurerm_subscription_cost_management_export resource in current terraform code. The latest eTag should be set in the update request as described in the [API](https://github.com/Azure/azure-rest-api-specs/blob/1b0a465061c68175898f8f5d27f0301f42ce994c/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2020-06-01/costmanagement.exports.json#L165). So, I added the eTag to fix this issue.

Test results:

> PASS: TestAccSubscriptionCostManagementExport_basic (266.51s)
> PASS: TestAccSubscriptionCostManagementExport_requiresImport (288.51s)
> PASS: TestAccSubscriptionCostManagementExport_update (463.30s)
> PASS: TestAccResourceGroupCostManagementExport_basic (256.56s)
> PASS: TestAccResourceGroupCostManagementExport_requiresImport (282.96s)
> PASS: TestAccResourceGroupCostManagementExport_update (444.04s)