### PR TITLE
support storage_resource_id for azurerm_hdinsight_hbase_cluster, azurerm_hdinsight_hadoop_cluster,azurerm_hdinsight_spark_cluster and azurerm_hdinsight_interactive_query_cluster resources

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -990,8 +990,13 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   storage_account {
     storage_container_id = azurerm_storage_container.test.id
+    storage_resource_id  = azurerm_storage_account.test.id
     storage_account_key  = azurerm_storage_account.test.primary_access_key
     is_default           = true
+  }
+
+  network {
+    connection_direction = "Outbound"
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -992,8 +992,13 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
 
   storage_account {
     storage_container_id = azurerm_storage_container.test.id
+    storage_resource_id  = azurerm_storage_account.test.id
     storage_account_key  = azurerm_storage_account.test.primary_access_key
     is_default           = true
+  }
+
+  network {
+    connection_direction = "Outbound"
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1031,8 +1031,13 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
 
   storage_account {
     storage_container_id = azurerm_storage_container.test.id
+    storage_resource_id  = azurerm_storage_account.test.id
     storage_account_key  = azurerm_storage_account.test.primary_access_key
     is_default           = true
+  }
+
+  network {
+    connection_direction = "Outbound"
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1031,8 +1031,13 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   storage_account {
     storage_container_id = azurerm_storage_container.test.id
+    storage_resource_id  = azurerm_storage_account.test.id
     storage_account_key  = azurerm_storage_account.test.primary_access_key
     is_default           = true
+  }
+
+  network {
+    connection_direction = "Outbound"
   }
 
   roles {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -612,6 +612,12 @@ func SchemaHDInsightsStorageAccounts() *pluginsdk.Schema {
 					ForceNew:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
+				"storage_resource_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: azure.ValidateResourceID,
+				},
 				"is_default": {
 					Type:     pluginsdk.TypeBool,
 					Required: true,
@@ -670,6 +676,7 @@ func ExpandHDInsightsStorageAccounts(storageAccounts []interface{}, gen2storageA
 
 		storageAccountKey := v["storage_account_key"].(string)
 		storageContainerID := v["storage_container_id"].(string)
+		storageResourceID := v["storage_resource_id"].(string)
 		isDefault := v["is_default"].(bool)
 
 		uri, err := url.Parse(storageContainerID)
@@ -678,10 +685,11 @@ func ExpandHDInsightsStorageAccounts(storageAccounts []interface{}, gen2storageA
 		}
 
 		result := hdinsight.StorageAccount{
-			Name:      utils.String(uri.Host),
-			Container: utils.String(strings.TrimPrefix(uri.Path, "/")),
-			Key:       utils.String(storageAccountKey),
-			IsDefault: utils.Bool(isDefault),
+			Name:       utils.String(uri.Host),
+			ResourceID: utils.String(storageResourceID),
+			Container:  utils.String(strings.TrimPrefix(uri.Path, "/")),
+			Key:        utils.String(storageAccountKey),
+			IsDefault:  utils.Bool(isDefault),
 		}
 		results = append(results, result)
 	}

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -192,6 +192,10 @@ A `storage_account` block supports the following:
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
 
+* `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
+
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -194,8 +194,6 @@ A `storage_account` block supports the following:
 
 * `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
 
--> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
-
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -192,8 +192,6 @@ A `storage_account` block supports the following:
 
 * `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
 
--> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
-
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -190,6 +190,10 @@ A `storage_account` block supports the following:
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
 
+* `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
+
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -195,8 +195,6 @@ A `storage_account` block supports the following:
 
 * `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
 
--> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
-
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -193,6 +193,10 @@ A `storage_account` block supports the following:
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
 
+* `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
+
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -192,6 +192,10 @@ A `storage_account` block supports the following:
 
 -> **NOTE:** This can be obtained from the `id` of the `azurerm_storage_container` resource.
 
+* `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
+
 ---
 
 A `storage_account_gen2` block supports the following:

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -194,8 +194,6 @@ A `storage_account` block supports the following:
 
 * `storage_resource_id` - (Optional) The ID of the Storage Account. Changing this forces a new resource to be created.
 
--> **NOTE:** The `storage_resource_id` takes format like "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME".
-
 ---
 
 A `storage_account_gen2` block supports the following:


### PR DESCRIPTION
The purpose of this PR:

> Fix issue #14780. When creating a cluster with network properties, missing storage account id  error is returned. As confirmed with service team, the description of resourceID of storage account in [API ](https://github.com/Azure/azure-rest-api-specs/blob/d29e6eb4894005c52e67cb4b5ac3faf031113e7d/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2021-06-01/cluster.json#L1176)is "The resource ID of storage account, only to be specified for Azure Data Lake Storage Gen 2." which is an incorrect description. Actually resource is required not matter it is  ADLSGen2 or not for some features. So, I added the resource id of storage account to fix this issue.

Test results:

> PASS: TestAccHDInsightRServerCluster_basic (1906.96s)
> PASS: TestAccHDInsightHadoopCluster_basic (1168.71s)
> PASS: TestAccHDInsightSparkCluster_basic (2072.57s)
> PASS: TestAccHDInsightHBaseCluster_basic (1166.09s)
> PASS: TestAccHDInsightInteractiveQueryCluster_basic (1152.35s)
> PASS: TestAccHDInsightHBaseCluster_complete (2422.96s)
> PASS: TestAccHDInsightInteractiveQueryCluster_complete (2004.88s)
> PASS: TestAccHDInsightSparkCluster_complete (3085.73s)
> PASS: TestAccHDInsightHadoopCluster_complete (2272.83s)