### PR TITLE
Added purge_protection to Databricks DBFS example

### DIFF
--- a/examples/databricks/customer-managed-key/dbfs/main.tf
+++ b/examples/databricks/customer-managed-key/dbfs/main.tf
@@ -37,6 +37,7 @@ resource "azurerm_key_vault" "example" {
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "premium"
 
+  purge_protection_enabled   = true
   soft_delete_retention_days = 7
 }
 


### PR DESCRIPTION
Currently, the Databricks DBFS example is broken because it's missing the `purge_protection_enabled = true` setting. This PR fixes that issue by adding that setting to the example.

Here is the [link](https://docs.microsoft.com/en-us/azure/databricks/security/keys/customer-managed-keys-dbfs/cmk-dbfs-powershell#create-a-new-key-vault) to the official Azure Databricks documentation that mentions that purge protection needs to be enabled on the keyvault. 