### PR TITLE
azurerm_dev_test_lab: normalize the `key_vault_id`

### DIFF
--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -3,6 +3,7 @@ package devtestlabs
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
@@ -184,7 +185,13 @@ func resourceDevTestLabRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("artifacts_storage_account_id", props.ArtifactsStorageAccount)
 		d.Set("default_storage_account_id", props.DefaultStorageAccount)
 		d.Set("default_premium_storage_account_id", props.DefaultPremiumStorageAccount)
-		d.Set("key_vault_id", props.VaultName)
+
+		// TODO: remove the replacement until the issue(https://github.com/Azure/azure-rest-api-specs/issues/17422) is fixed.
+		// The lowercase "resourcegroups" and "microsoft.keyvault" in key value id are returned by Labs_Get API.
+		// This will cause the resource which referencing the key vault id to be re-created after running terraform apply command even though nothing has changed.
+		// Hence replace them as a workaround in terraform.
+		vaultId := strings.Replace(*props.VaultName, "resourcegroups", "resourceGroups", 1)
+		d.Set("key_vault_id", strings.Replace(vaultId, "microsoft.keyvault", "Microsoft.KeyVault", 1))
 		d.Set("premium_data_disk_storage_account_id", props.PremiumDataDiskStorageAccount)
 		d.Set("unique_identifier", props.UniqueIdentifier)
 	}

--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -187,15 +187,15 @@ func resourceDevTestLabRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("default_storage_account_id", props.DefaultStorageAccount)
 		d.Set("default_premium_storage_account_id", props.DefaultPremiumStorageAccount)
 
-		// TODO: remove the following workaround until the issue(https://github.com/Azure/azure-rest-api-specs/issues/17422) is fixed.
-		// The lowercase "resourcegroups" and "microsoft.keyvault" in key value id are returned by Labs_Get API.
-		// This will cause the azurerm_dev_test_lab resource which referencing the key vault id to be re-created after running terraform apply command even though nothing has changed.
-		// Hence, re-build the key vault id as a workaround in terraform.
-		id, err := keyvaultParse.VaultID(*props.VaultName)
-		if err != nil {
-			return fmt.Errorf("parsing %q: %+v", *props.VaultName, err)
+		kvId := ""
+		if props.VaultName != nil {
+			id, err := keyvaultParse.VaultID(*props.VaultName)
+			if err != nil {
+				return fmt.Errorf("parsing %q: %+v", *props.VaultName, err)
+			}
+			kvId = id.ID()
 		}
-		d.Set("key_vault_id", id.ID())
+		d.Set("key_vault_id", kvId)
 		d.Set("premium_data_disk_storage_account_id", props.PremiumDataDiskStorageAccount)
 		d.Set("unique_identifier", props.UniqueIdentifier)
 	}


### PR DESCRIPTION
The purpose of this PR:

Fix issue #15013. The lowercase "resourcegroups" and "microsoft.keyvault" in key vault id are returned by [Labs_Get API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/DTL.json#L7446).  This will cause the azurerm_dev_test_lab resource which referencing the key vault id to be re-created after running terraform apply command, even though without any changes. I have filed an [issue ](https://github.com/Azure/azure-rest-api-specs/issues/17422)to track it.  And submitted this PR to fix it in terraform.
 

 
Test results:

```
PASS: TestAccDevTestLab_basic (427.39s)
PASS: TestAccDevTestLab_requiresImport (427.94s)
PASS: TestAccDevTestLab_complete (453.59s)
```