### PR TITLE
`azurerm_log_analytics_workspace` - update docs and check for `daily_quota_gb` on free sku

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -219,7 +219,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	dailyQuotaGb, ok := d.GetOk("daily_quota_gb")
-	if ok && strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumFree)) {
+	if ok && strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumFree)) && dailyQuotaGb != -1 {
 		return fmt.Errorf("`Free` tier SKU quota is not configurable and is hard set to 0.5GB")
 	} else if !strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumFree)) {
 		parameters.WorkspaceProperties.WorkspaceCapping = &operationalinsights.WorkspaceCapping{

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `daily_quota_gb` - (Optional) The workspace daily quota for ingestion in GB.  Defaults to -1 (unlimited) if omitted.
 
-~> **NOTE:** When `sku` is set to `Free` this field can be set to a maximum of `0.5` (GB), and has a default value of `0.5`. 
+~> **NOTE:** When `sku` is set to `Free` this field should not be set and has a default value of `0.5`. 
 
 * `internet_ingestion_enabled ` - (Optional) Should the Log Analytics Workflow support ingestion over the Public Internet? Defaults to `true`.
 


### PR DESCRIPTION
possible fix for #10573

Note: It is not possible for me to fully test this as it requires using free sku tier which is only available to those with an existing free resource before pricing tiers were changed in 2018.