### PR TITLE
`lintignore`ing current lint errors 

### DIFF
--- a/internal/services/disks/disk_pool_resource.go
+++ b/internal/services/disks/disk_pool_resource.go
@@ -124,6 +124,7 @@ func (r DiskPoolResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
+			// lintignore:R006
 			return pluginsdk.Retry(metadata.ResourceData.Timeout(pluginsdk.TimeoutCreate), func() *resource.RetryError {
 				if err := r.retryError(future.Poller.PollUntilDone()); err != nil {
 					return err
@@ -190,6 +191,7 @@ func (r DiskPoolResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 
+			// lintignore:R006
 			return pluginsdk.Retry(metadata.ResourceData.Timeout(pluginsdk.TimeoutDelete), func() *resource.RetryError {
 				return r.retryError(future.Poller.PollUntilDone())
 			})
@@ -232,6 +234,7 @@ func (r DiskPoolResource) Update() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
+			// lintignore:R006
 			return pluginsdk.Retry(metadata.ResourceData.Timeout(pluginsdk.TimeoutUpdate), func() *resource.RetryError {
 				return r.retryError(future.Poller.PollUntilDone())
 			})


### PR DESCRIPTION
There are a few lint errors happening because there isn't a "top level" RetryError call. Instead that is happening in the `retryError` function. This PR ignores these linting errors