### PR TITLE
`azurerm_bastion_host` - Fix crash by adding nil check for `copy_paste_enabled

### DIFF
--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -252,11 +252,16 @@ func resourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	if props := resp.BastionHostPropertiesFormat; props != nil {
 		d.Set("dns_name", props.DNSName)
 		d.Set("scale_units", props.ScaleUnits)
-		d.Set("copy_paste_enabled", !*props.DisableCopyPaste)
 		d.Set("file_copy_enabled", props.EnableFileCopy)
 		d.Set("ip_connect_enabled", props.EnableIPConnect)
 		d.Set("shareable_link_enabled", props.EnableShareableLink)
 		d.Set("tunneling_enabled", props.EnableTunneling)
+
+		copyPasteEnabled := true
+		if props.DisableCopyPaste != nil {
+			copyPasteEnabled = !*props.DisableCopyPaste
+		}
+		d.Set("copy_paste_enabled", copyPasteEnabled)
 
 		if ipConfigs := props.IPConfigurations; ipConfigs != nil {
 			if err := d.Set("ip_configuration", flattenBastionHostIPConfiguration(ipConfigs)); err != nil {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15058

As older api version doesn't include copy_paste_enabled, so it has to add nil check for api upgrading.

![image](https://user-images.githubusercontent.com/19754191/150640139-c95445e7-93c8-4428-839e-583c19a489c6.png)