### PR TITLE
`azurerm_template_deployment`: fix delete bug

### DIFF
--- a/internal/services/resource/template_deployment_resource.go
+++ b/internal/services/resource/template_deployment_resource.go
@@ -271,7 +271,7 @@ func resourceTemplateDeploymentDelete(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	if _, err = client.Delete(ctx, id.ResourceGroup, id.SubscriptionId); err != nil {
+	if _, err = client.Delete(ctx, id.ResourceGroup, id.DeploymentName); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/resource/template_deployment_resource_test.go
+++ b/internal/services/resource/template_deployment_resource_test.go
@@ -136,7 +136,7 @@ func TestAccTemplateDeployment_withError(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.withError(data),
-			ExpectError: regexp.MustCompile("Error waiting for deployment"),
+			ExpectError: regexp.MustCompile("Error: waiting for creation/update of Resource Group Template Deployment"),
 		},
 	})
 }


### PR DESCRIPTION
This PR fixes a mistake for deleting a tempalte deployment resource. Meanwhile, fixing another failed test case due to the expected error message has been changed.

While there is still another failed test case: `TestAccTemplateDeployment_withParamsBody`. Since I have no idea why it happens, so leaving it as is.

Fixes #15081