### PR TITLE
d/azurerm_public_ips: Update the "Example Usage"

### DIFF
--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -15,7 +15,7 @@ Use this data source to access information about a set of existing Public IP Add
 ```hcl
 data "azurerm_public_ips" "example" {
   resource_group_name = "pip-test"
-  attached            = false
+  attachment_status   = "Attached"
 }
 ```
 


### PR DESCRIPTION
Switch deprecated `attached` with `attachment_status` in the "Example Usage"