### PR TITLE
`azurerm_container_group`: fix parallel provision failure given the same `network_profile_id`

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -19,6 +19,7 @@ import (
 	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
 	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -74,7 +75,7 @@ func resourceContainerGroup() *pluginsdk.Resource {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ValidateFunc:  validation.StringIsNotEmpty,
+				ValidateFunc:  networkValidate.NetworkProfileID,
 				ConflictsWith: []string{"dns_name_label"},
 			},
 
@@ -598,16 +599,18 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet#virtual-network-deployment-limitations
 	// https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet#preview-limitations
 	if networkProfileID := d.Get("network_profile_id").(string); networkProfileID != "" {
+		id, _ := networkParse.NetworkProfileID(networkProfileID)
+		networkProfileIDNorm := id.ID()
 		// Avoid parallel provisioning if "network_profile_id" is given.
 		// See: https://github.com/hashicorp/terraform-provider-azurerm/issues/15025
-		locks.ByID(networkProfileID)
-		defer locks.UnlockByID(networkProfileID)
+		locks.ByID(networkProfileIDNorm)
+		defer locks.UnlockByID(networkProfileIDNorm)
 
 		if strings.ToLower(OSType) != "linux" {
 			return fmt.Errorf("Currently only Linux containers can be deployed to virtual networks")
 		}
 		containerGroup.ContainerGroupProperties.NetworkProfile = &containerinstance.ContainerGroupNetworkProfile{
-			ID: &networkProfileID,
+			ID: &networkProfileIDNorm,
 		}
 	}
 
@@ -763,8 +766,16 @@ func resourceContainerGroupDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	if props := existing.ContainerGroupProperties; props != nil {
 		if profile := props.NetworkProfile; profile != nil {
 			if profile.ID != nil {
-				networkProfileId = *profile.ID
+				id, err := networkParse.NetworkProfileID(*profile.ID)
+				if err != nil {
+					return err
+				}
+				networkProfileId = id.ID()
 			}
+			// Avoid parallel deletion if "network_profile_id" is given. (not sure whether this is necessary)
+			// See: https://github.com/hashicorp/terraform-provider-azurerm/issues/15025
+			locks.ByID(networkProfileId)
+			defer locks.UnlockByID(networkProfileId)
 		}
 	}
 


### PR DESCRIPTION
Fixes #15025 

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run='TestAccContainerGroup_virtualNetworkParallel'
=== RUN   TestAccContainerGroup_virtualNetworkParallel
=== PAUSE TestAccContainerGroup_virtualNetworkParallel
=== CONT  TestAccContainerGroup_virtualNetworkParallel
--- PASS: TestAccContainerGroup_virtualNetworkParallel (668.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    668.057s
```