### PR TITLE
Fix #14869

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_resource.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource.go
@@ -205,12 +205,18 @@ func resourceApiManagementApiOperationRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("method", props.Method)
 		d.Set("url_template", props.URLTemplate)
 
-		flattenedRequest := flattenApiManagementOperationRequestContract(props.Request)
+		flattenedRequest, err := flattenApiManagementOperationRequestContract(props.Request)
+		if err != nil {
+			return fmt.Errorf("flattening `request`: %+v", err)
+		}
 		if err := d.Set("request", flattenedRequest); err != nil {
 			return fmt.Errorf("flattening `request`: %+v", err)
 		}
 
-		flattenedResponse := flattenApiManagementOperationResponseContract(props.Responses)
+		flattenedResponse, err := flattenApiManagementOperationResponseContract(props.Responses)
+		if err != nil {
+			return fmt.Errorf("flattening `response`: %+v", err)
+		}
 		if err := d.Set("response", flattenedResponse); err != nil {
 			return fmt.Errorf("flattening `response`: %+v", err)
 		}
@@ -284,9 +290,9 @@ func expandApiManagementOperationRequestContract(d *pluginsdk.ResourceData, sche
 	}, nil
 }
 
-func flattenApiManagementOperationRequestContract(input *apimanagement.RequestContract) []interface{} {
+func flattenApiManagementOperationRequestContract(input *apimanagement.RequestContract) ([]interface{}, error) {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{}, nil
 	}
 
 	output := make(map[string]interface{})
@@ -297,9 +303,12 @@ func flattenApiManagementOperationRequestContract(input *apimanagement.RequestCo
 
 	output["header"] = schemaz.FlattenApiManagementOperationParameterContract(input.Headers)
 	output["query_parameter"] = schemaz.FlattenApiManagementOperationParameterContract(input.QueryParameters)
-	output["representation"] = schemaz.FlattenApiManagementOperationRepresentation(input.Representations)
-
-	return []interface{}{output}
+	representation, err := schemaz.FlattenApiManagementOperationRepresentation(input.Representations)
+	if err != nil {
+		return []interface{}{}, err
+	}
+	output["representation"] = representation
+	return []interface{}{output}, nil
 }
 
 func expandApiManagementOperationResponseContract(d *pluginsdk.ResourceData, schemaPath string, input []interface{}) (*[]apimanagement.ResponseContract, error) {
@@ -337,9 +346,9 @@ func expandApiManagementOperationResponseContract(d *pluginsdk.ResourceData, sch
 	return &outputs, nil
 }
 
-func flattenApiManagementOperationResponseContract(input *[]apimanagement.ResponseContract) []interface{} {
+func flattenApiManagementOperationResponseContract(input *[]apimanagement.ResponseContract) ([]interface{}, error) {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{}, nil
 	}
 
 	outputs := make([]interface{}, 0)
@@ -356,10 +365,13 @@ func flattenApiManagementOperationResponseContract(input *[]apimanagement.Respon
 		}
 
 		output["header"] = schemaz.FlattenApiManagementOperationParameterContract(v.Headers)
-		output["representation"] = schemaz.FlattenApiManagementOperationRepresentation(v.Representations)
-
+		representation, err := schemaz.FlattenApiManagementOperationRepresentation(v.Representations)
+		if err != nil {
+			return []interface{}{}, err
+		}
+		output["representation"] = representation
 		outputs = append(outputs, output)
 	}
 
-	return outputs
+	return outputs, nil
 }

--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -432,17 +432,16 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]*api
 			output["description"] = *v.Description
 		}
 
-		value := v.Value
-		if value != nil {
-			switch value.(type) {
+		if v.Value != nil {
+			switch v := v.Value.(type) {
 			case map[string]interface{}:
-				valueBytes, err := json.Marshal(value)
+				valueBytes, err := json.Marshal(v)
 				if err != nil {
 					return []interface{}{}, fmt.Errorf("unable to serialize `request.representation.example.value` %+v", err)
 				}
 				output["value"] = string(valueBytes)
 			case string:
-				output["value"] = value.(string)
+				output["value"] = v
 			}
 		}
 


### PR DESCRIPTION
Fix #14869 and #14707 by determining `request.representation.example.value`'s type.

The panic was caused by [type cast](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/apimanagement/schemaz/api_management.go#L423) for `request.representation.example.value`.

According to [rest-api spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2021-08-01/definitions.json#L3760), the value field could be a string or an object.

 If we're facing a `map[string]interface{}`, then we use json marshal to convert it into string. And we added extra pluginsdk.SuppressJsonDiff to the schema to suppress any json format diff.

Acc tests:
=== RUN   TestAccApiManagementApiOperation_basic
=== PAUSE TestAccApiManagementApiOperation_basic
=== CONT  TestAccApiManagementApiOperation_basic
--- PASS: TestAccApiManagementApiOperation_basic (415.87s)
=== RUN   TestAccApiManagementApiOperation_requiresImport
=== PAUSE TestAccApiManagementApiOperation_requiresImport
=== CONT  TestAccApiManagementApiOperation_requiresImport
--- PASS: TestAccApiManagementApiOperation_requiresImport (446.10s)
=== RUN   TestAccApiManagementApiOperation_customMethod
=== PAUSE TestAccApiManagementApiOperation_customMethod
=== CONT  TestAccApiManagementApiOperation_customMethod
--- PASS: TestAccApiManagementApiOperation_customMethod (414.24s)
=== RUN   TestAccApiManagementApiOperation_headers
=== PAUSE TestAccApiManagementApiOperation_headers
=== CONT  TestAccApiManagementApiOperation_headers
--- PASS: TestAccApiManagementApiOperation_headers (412.00s)
=== RUN   TestAccApiManagementApiOperation_requestRepresentations
=== PAUSE TestAccApiManagementApiOperation_requestRepresentations
=== CONT  TestAccApiManagementApiOperation_requestRepresentations
--- PASS: TestAccApiManagementApiOperation_requestRepresentations (507.64s)
=== RUN   TestAccApiManagementApiOperation_representations
=== PAUSE TestAccApiManagementApiOperation_representations
=== CONT  TestAccApiManagementApiOperation_representations
--- PASS: TestAccApiManagementApiOperation_representations (519.47s)
PASS


Process finished with the exit code 0