### PR TITLE
Clarify what the endpoint_uri property should be in iothub_endpoint_storage_container

### DIFF
--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 -> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If not specified when `authentication_type` is `identityBased`, System Assigned Managed Identity of the Iot Hub will be used.
 
-* `endpoint_uri` - (Optional) URI of the Storage Container endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
+* `endpoint_uri` - (Optional) URI of the Storage Container endpoint. This corresponds to the `primary_blob_endpoint` of the parent storage account. This attribute can only be specified and is mandatory when `authentication_type` is `identityBased`.
 
 * `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 


### PR DESCRIPTION
I did not find it intuitive that it should be the endpoint of the storage account, and hope this can help others.