### PR TITLE
Update schema for AKS add-ons

### DIFF
--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -1422,5 +1422,3 @@ func kubernetesAddonProfilelocateInConfig(config map[string]*string, key string)
 
 	return nil
 }
-
-

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -354,7 +354,7 @@ func schemaKubernetesAddOnProfilesDeprecated() *pluginsdk.Schema {
 					Type:       pluginsdk.TypeList,
 					MaxItems:   1,
 					Optional:   true,
-					Deprecated: "`http_application_routing_enabled` has been deprecated in favour of `http_application_routing_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
+					Deprecated: "`http_application_routing` has been deprecated in favour of `http_application_routing_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"enabled": {
@@ -473,7 +473,7 @@ func schemaKubernetesAddOnProfilesDeprecated() *pluginsdk.Schema {
 					Type:       pluginsdk.TypeList,
 					MaxItems:   1,
 					Optional:   true,
-					Deprecated: "`open_service_mesh_enabled` has been deprecated in favour of `open_service_mesh_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
+					Deprecated: "`open_service_mesh` has been deprecated in favour of `open_service_mesh_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"enabled": {

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -50,6 +50,7 @@ var unsupportedAddonsForEnvironment = map[string][]string{
 	},
 }
 
+// TODO 3.0 - Remove this schema as it's deprecated
 func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 	//lintignore:XS003
 	return &pluginsdk.Schema{
@@ -238,6 +239,7 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 						},
 					},
 				},
+
 				"azure_keyvault_secrets_provider": {
 					Type:     pluginsdk.TypeList,
 					MaxItems: 1,
@@ -287,6 +289,451 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 	}
 }
 
+// TODO 3.0 - Duplicate of the old schema with deprecation messages that should only be displayed when the release is open for beta
+func schemaKubernetesAddOnProfilesDeprecated() *pluginsdk.Schema {
+	//lintignore:XS003
+	return &pluginsdk.Schema{
+		Type:       pluginsdk.TypeList,
+		MaxItems:   1,
+		Optional:   true,
+		Computed:   true,
+		Deprecated: "`addon_profile` block has been deprecated and will be removed in version 3.0 of the AzureRM Provider.",
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"aci_connector_linux": {
+					Type:     pluginsdk.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+
+							"subnet_name": {
+								Type:         pluginsdk.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+					},
+				},
+
+				"azure_policy": {
+					Type:       pluginsdk.TypeList,
+					MaxItems:   1,
+					Optional:   true,
+					Deprecated: "`azure_policy` has been deprecated in favour of `azure_policy_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
+
+				"kube_dashboard": {
+					Type:       pluginsdk.TypeList,
+					MaxItems:   1,
+					Optional:   true,
+					Deprecated: "`kube_dashboard` has been deprecated since it is no longer supported by Kubernetes versions 1.19 or above, this property will be removed in version 3.0 of the AzureRM Provider.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
+
+				"http_application_routing": {
+					Type:       pluginsdk.TypeList,
+					MaxItems:   1,
+					Optional:   true,
+					Deprecated: "`http_application_routing_enabled` has been deprecated in favour of `http_application_routing_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+							"http_application_routing_zone_name": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+
+				"oms_agent": {
+					Type:     pluginsdk.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+							"log_analytics_workspace_id": {
+								Type:         pluginsdk.TypeString,
+								Optional:     true,
+								ValidateFunc: logAnalyticsValidate.LogAnalyticsWorkspaceID,
+							},
+							"oms_agent_identity": {
+								Type:     pluginsdk.TypeList,
+								Computed: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"client_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"object_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"user_assigned_identity_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+
+				"ingress_application_gateway": {
+					Type:     pluginsdk.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+							"gateway_id": {
+								Type:          pluginsdk.TypeString,
+								Optional:      true,
+								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+								ValidateFunc:  applicationGatewayValidate.ApplicationGatewayID,
+							},
+							"gateway_name": {
+								Type:         pluginsdk.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							"subnet_cidr": {
+								Type:          pluginsdk.TypeString,
+								Optional:      true,
+								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
+								ValidateFunc:  commonValidate.CIDR,
+							},
+							"subnet_id": {
+								Type:          pluginsdk.TypeString,
+								Optional:      true,
+								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.gateway_id", "addon_profile.0.ingress_application_gateway.0.subnet_cidr"},
+								ValidateFunc:  subnetValidate.SubnetID,
+							},
+							"effective_gateway_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"ingress_application_gateway_identity": {
+								Type:     pluginsdk.TypeList,
+								Computed: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"client_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"object_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"user_assigned_identity_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+
+				"open_service_mesh": {
+					Type:       pluginsdk.TypeList,
+					MaxItems:   1,
+					Optional:   true,
+					Deprecated: "`open_service_mesh_enabled` has been deprecated in favour of `open_service_mesh_enabled` and will be removed in version 3.0 of the AzureRM Provider.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
+
+				"azure_keyvault_secrets_provider": {
+					Type:     pluginsdk.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:     pluginsdk.TypeBool,
+								Required: true,
+							},
+							"secret_rotation_enabled": {
+								Type:     pluginsdk.TypeBool,
+								Default:  false,
+								Optional: true,
+							},
+							"secret_rotation_interval": {
+								Type:         pluginsdk.TypeString,
+								Optional:     true,
+								Default:      "2m",
+								ValidateFunc: containerValidate.Duration,
+							},
+							"secret_identity": {
+								Type:     pluginsdk.TypeList,
+								Computed: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"client_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"object_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"user_assigned_identity_id": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaKubernetesAddOns(resource *pluginsdk.Resource) pluginsdk.Resource {
+	resource.Schema["aci_connector_linux"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"subnet_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+	resource.Schema["azure_policy_enabled"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+	resource.Schema["http_application_routing_enabled"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+	resource.Schema["http_application_routing_zone_name"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeString,
+		Computed: true,
+	}
+	resource.Schema["oms_agent"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"log_analytics_workspace_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: logAnalyticsValidate.LogAnalyticsWorkspaceID,
+				},
+				"oms_agent_identity": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"client_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"object_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"user_assigned_identity_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resource.Schema["ingress_application_gateway"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"gateway_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ConflictsWith: []string{
+						"ingress_application_gateway.0.subnet_cidr",
+						"ingress_application_gateway.0.subnet_id",
+					},
+					AtLeastOneOf: []string{
+						"ingress_application_gateway.0.gateway_id",
+						"ingress_application_gateway.0.subnet_cidr",
+						"ingress_application_gateway.0.subnet_id",
+					},
+					ValidateFunc: applicationGatewayValidate.ApplicationGatewayID,
+				},
+				"gateway_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"subnet_cidr": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ConflictsWith: []string{
+						"ingress_application_gateway.0.gateway_id",
+						"ingress_application_gateway.0.subnet_id",
+					},
+					AtLeastOneOf: []string{
+						"ingress_application_gateway.0.gateway_id",
+						"ingress_application_gateway.0.subnet_cidr",
+						"ingress_application_gateway.0.subnet_id",
+					},
+					ValidateFunc: commonValidate.CIDR,
+				},
+				"subnet_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ConflictsWith: []string{
+						"ingress_application_gateway.0.gateway_id",
+						"ingress_application_gateway.0.subnet_cidr",
+					},
+					AtLeastOneOf: []string{
+						"ingress_application_gateway.0.gateway_id",
+						"ingress_application_gateway.0.subnet_cidr",
+						"ingress_application_gateway.0.subnet_id",
+					},
+					ValidateFunc: subnetValidate.SubnetID,
+				},
+				"effective_gateway_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"ingress_application_gateway_identity": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"client_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"object_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"user_assigned_identity_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resource.Schema["open_service_mesh_enabled"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+	resource.Schema["azure_keyvault_secrets_provider"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"secret_rotation_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Default:  false,
+					Optional: true,
+					AtLeastOneOf: []string{
+						"azure_keyvault_secrets_provider.0.secret_rotation_enabled",
+						"azure_keyvault_secrets_provider.0.secret_rotation_interval",
+					},
+				},
+				"secret_rotation_interval": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "2m",
+					AtLeastOneOf: []string{
+						"azure_keyvault_secrets_provider.0.secret_rotation_enabled",
+						"azure_keyvault_secrets_provider.0.secret_rotation_interval",
+					},
+					ValidateFunc: containerValidate.Duration,
+				},
+				"secret_identity": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"client_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"object_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"user_assigned_identity_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return *resource
+}
+
+// TODO 3.0 - Remove this function
 func expandKubernetesAddOnProfiles(input []interface{}, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
 	disabled := containerservice.ManagedClusterAddonProfile{
 		Enabled: utils.Bool(false),
@@ -440,6 +887,126 @@ func expandKubernetesAddOnProfiles(input []interface{}, env azure.Environment) (
 	return filterUnsupportedKubernetesAddOns(addonProfiles, env)
 }
 
+func expandKubernetesAddOn(d *pluginsdk.ResourceData, input map[string]interface{}, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
+	disabled := containerservice.ManagedClusterAddonProfile{
+		Enabled: utils.Bool(false),
+	}
+
+	addonProfiles := map[string]*containerservice.ManagedClusterAddonProfile{}
+	if d.HasChange("http_application_routing_enabled") {
+		addonProfiles[httpApplicationRoutingKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(input["http_application_routing_enabled"].(bool)),
+		}
+	}
+
+	omsAgent := input["oms_agent"].([]interface{})
+	if len(omsAgent) > 0 && omsAgent[0] != nil {
+		value := omsAgent[0].(map[string]interface{})
+		config := make(map[string]*string)
+
+		if workspaceID, ok := value["log_analytics_workspace_id"]; ok && workspaceID != "" {
+			lawid, err := laparse.LogAnalyticsWorkspaceID(workspaceID.(string))
+			if err != nil {
+				return nil, fmt.Errorf("parsing Log Analytics Workspace ID: %+v", err)
+			}
+			config["logAnalyticsWorkspaceResourceID"] = utils.String(lawid.ID())
+		}
+
+		addonProfiles[omsAgentKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(true),
+			Config:  config,
+		}
+	} else if len(omsAgent) == 0 && d.HasChange("oms_agent") {
+		addonProfiles[omsAgentKey] = &disabled
+	}
+
+	aciConnector := input["aci_connector_linux"].([]interface{})
+	if len(aciConnector) > 0 && aciConnector[0] != nil {
+		value := aciConnector[0].(map[string]interface{})
+		config := make(map[string]*string)
+
+		if subnetName, ok := value["subnet_name"]; ok && subnetName != "" {
+			config["SubnetName"] = utils.String(subnetName.(string))
+		}
+
+		addonProfiles[aciConnectorKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(true),
+			Config:  config,
+		}
+	} else if len(aciConnector) == 0 && d.HasChange("aci_connector_linux") {
+		addonProfiles[aciConnectorKey] = &disabled
+	}
+
+	if ok := d.HasChange("azure_policy_enabled"); ok {
+		v := input["azure_policy_enabled"].(bool)
+		props := &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(v),
+			Config: map[string]*string{
+				"version": utils.String("v2"),
+			},
+		}
+		addonProfiles[azurePolicyKey] = props
+	}
+
+	ingressApplicationGateway := input["ingress_application_gateway"].([]interface{})
+	if len(ingressApplicationGateway) > 0 && ingressApplicationGateway[0] != nil {
+		value := ingressApplicationGateway[0].(map[string]interface{})
+		config := make(map[string]*string)
+
+		if gatewayId, ok := value["gateway_id"]; ok && gatewayId != "" {
+			config["applicationGatewayId"] = utils.String(gatewayId.(string))
+		}
+
+		if gatewayName, ok := value["gateway_name"]; ok && gatewayName != "" {
+			config["applicationGatewayName"] = utils.String(gatewayName.(string))
+		}
+
+		if subnetCIDR, ok := value["subnet_cidr"]; ok && subnetCIDR != "" {
+			config["subnetCIDR"] = utils.String(subnetCIDR.(string))
+		}
+
+		if subnetId, ok := value["subnet_id"]; ok && subnetId != "" {
+			config["subnetId"] = utils.String(subnetId.(string))
+		}
+
+		addonProfiles[ingressApplicationGatewayKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(true),
+			Config:  config,
+		}
+	} else if len(ingressApplicationGateway) == 0 && d.HasChange("ingress_application_gateway") {
+		addonProfiles[ingressApplicationGatewayKey] = &disabled
+	}
+
+	if ok := d.HasChange("open_service_mesh_enabled"); ok {
+		addonProfiles[openServiceMeshKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(input["open_service_mesh_enabled"].(bool)),
+			Config:  nil,
+		}
+	}
+
+	azureKeyVaultSecretsProvider := input["azure_keyvault_secrets_provider"].([]interface{})
+	if len(azureKeyVaultSecretsProvider) > 0 && azureKeyVaultSecretsProvider[0] != nil {
+		value := azureKeyVaultSecretsProvider[0].(map[string]interface{})
+		config := make(map[string]*string)
+
+		enableSecretRotation := "false"
+		if value["secret_rotation_enabled"].(bool) {
+			enableSecretRotation = "true"
+		}
+		config["enableSecretRotation"] = utils.String(enableSecretRotation)
+		config["rotationPollInterval"] = utils.String(value["secret_rotation_interval"].(string))
+
+		addonProfiles[azureKeyvaultSecretsProviderKey] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: utils.Bool(true),
+			Config:  config,
+		}
+	} else if len(azureKeyVaultSecretsProvider) == 0 && d.HasChange("azure_keyvault_secrets_provider") {
+		addonProfiles[azureKeyvaultSecretsProviderKey] = &disabled
+	}
+
+	return filterUnsupportedKubernetesAddOns(addonProfiles, env)
+}
+
 func filterUnsupportedKubernetesAddOns(input map[string]*containerservice.ManagedClusterAddonProfile, env azure.Environment) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
 	filter := func(input map[string]*containerservice.ManagedClusterAddonProfile, key string) (*map[string]*containerservice.ManagedClusterAddonProfile, error) {
 		output := input
@@ -469,6 +1036,7 @@ func filterUnsupportedKubernetesAddOns(input map[string]*containerservice.Manage
 	return &output, nil
 }
 
+// TODO 3.0 - Remove this function
 func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.ManagedClusterAddonProfile) []interface{} {
 	aciConnectors := make([]interface{}, 0)
 	if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
@@ -651,6 +1219,143 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			"open_service_mesh":               openServiceMeshes,
 			"azure_keyvault_secrets_provider": azureKeyvaultSecretsProviders,
 		},
+	}
+}
+
+func flattenKubernetesAddOn(profile map[string]*containerservice.ManagedClusterAddonProfile) map[string]interface{} {
+	aciConnectors := make([]interface{}, 0)
+	if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
+		if enabled := aciConnector.Enabled; enabled != nil && *enabled {
+			subnetName := ""
+			if v := aciConnector.Config["SubnetName"]; v != nil {
+				subnetName = *v
+			}
+
+			aciConnectors = append(aciConnectors, map[string]interface{}{
+				"subnet_name": subnetName,
+			})
+		}
+
+	}
+
+	azurePolicyEnabled := false
+	if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
+		if enabledVal := azurePolicy.Enabled; enabledVal != nil {
+			azurePolicyEnabled = *enabledVal
+		}
+	}
+
+	httpApplicationRoutingEnabled := false
+	httpApplicationRoutingZone := ""
+	if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
+		if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
+			httpApplicationRoutingEnabled = *enabledVal
+		}
+
+		if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
+			httpApplicationRoutingZone = *v
+		}
+	}
+
+	omsAgents := make([]interface{}, 0)
+	if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
+		if enabled := omsAgent.Enabled; enabled != nil && *enabled {
+			workspaceID := ""
+			if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
+				if lawid, err := laparse.LogAnalyticsWorkspaceID(*v); err == nil {
+					workspaceID = lawid.ID()
+				}
+			}
+
+			omsAgentIdentity := flattenKubernetesClusterAddOnIdentityProfile(omsAgent.Identity)
+
+			omsAgents = append(omsAgents, map[string]interface{}{
+				"log_analytics_workspace_id": workspaceID,
+				"oms_agent_identity":         omsAgentIdentity,
+			})
+		}
+	}
+
+	ingressApplicationGateways := make([]interface{}, 0)
+	if ingressApplicationGateway := kubernetesAddonProfileLocate(profile, ingressApplicationGatewayKey); ingressApplicationGateway != nil {
+		if enabled := ingressApplicationGateway.Enabled; enabled != nil && *enabled {
+			gatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayId"); v != nil {
+				gatewayId = *v
+			}
+
+			gatewayName := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayName"); v != nil {
+				gatewayName = *v
+			}
+
+			effectiveGatewayId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "effectiveApplicationGatewayId"); v != nil {
+				effectiveGatewayId = *v
+			}
+
+			subnetCIDR := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetCIDR"); v != nil {
+				subnetCIDR = *v
+			}
+
+			subnetId := ""
+			if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "subnetId"); v != nil {
+				subnetId = *v
+			}
+
+			ingressApplicationGatewayIdentity := flattenKubernetesClusterAddOnIdentityProfile(ingressApplicationGateway.Identity)
+
+			ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
+				"gateway_id":                           gatewayId,
+				"gateway_name":                         gatewayName,
+				"effective_gateway_id":                 effectiveGatewayId,
+				"subnet_cidr":                          subnetCIDR,
+				"subnet_id":                            subnetId,
+				"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
+			})
+		}
+	}
+
+	openServiceMeshEnabled := false
+	if openServiceMesh := kubernetesAddonProfileLocate(profile, openServiceMeshKey); openServiceMesh != nil {
+		if enabledVal := openServiceMesh.Enabled; enabledVal != nil {
+			openServiceMeshEnabled = *enabledVal
+		}
+	}
+
+	azureKeyVaultSecretsProviders := make([]interface{}, 0)
+	if azureKeyVaultSecretsProvider := kubernetesAddonProfileLocate(profile, azureKeyvaultSecretsProviderKey); azureKeyVaultSecretsProvider != nil {
+		if enabled := azureKeyVaultSecretsProvider.Enabled; enabled != nil && *enabled {
+			enableSecretRotation := false
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyVaultSecretsProvider.Config, "enableSecretRotation"); v != nil && *v != "false" {
+				enableSecretRotation = true
+			}
+
+			rotationPollInterval := ""
+			if v := kubernetesAddonProfilelocateInConfig(azureKeyVaultSecretsProvider.Config, "rotationPollInterval"); v != nil {
+				rotationPollInterval = *v
+			}
+
+			azureKeyvaultSecretsProviderIdentity := flattenKubernetesClusterAddOnIdentityProfile(azureKeyVaultSecretsProvider.Identity)
+
+			azureKeyVaultSecretsProviders = append(azureKeyVaultSecretsProviders, map[string]interface{}{
+				"secret_rotation_enabled":  enableSecretRotation,
+				"secret_rotation_interval": rotationPollInterval,
+				"secret_identity":          azureKeyvaultSecretsProviderIdentity,
+			})
+		}
+	}
+
+	return map[string]interface{}{
+		"aci_connector_linux":                aciConnectors,
+		"azure_policy_enabled":               azurePolicyEnabled,
+		"http_application_routing_enabled":   httpApplicationRoutingEnabled,
+		"http_application_routing_zone_name": httpApplicationRoutingZone,
+		"oms_agent":                          omsAgents,
+		"ingress_application_gateway":        ingressApplicationGateways,
+		"open_service_mesh_enabled":          openServiceMeshEnabled,
+		"azure_keyvault_secrets_provider":    azureKeyVaultSecretsProviders,
 	}
 }
 

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -73,7 +73,7 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 	})
 }
 
-// TODO 3.0 - Remove this test since Kube Dashboard will be removed along with Kubernetes version 1.19
+// TODO 3.0 - Remove this test since Kube Dashboard isn't supported with Kubernetes versions >= 1.19
 func TestAccKubernetesCluster_addonProfileKubeDashboard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 var addOnAppGatewaySubnetCIDR string = "10.241.0.0/16" // AKS will use 10.240.0.0/16 for the aks subnet so use 10.241.0.0/16 for the app gateway subnet
@@ -19,10 +20,6 @@ func TestAccKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
 			Config: r.addonProfileAciConnectorLinuxConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.subnet_name").HasValue(fmt.Sprintf("acctestsubnet-aci%d", data.RandomInteger)),
 			),
 		},
 		data.ImportStep(),
@@ -38,11 +35,6 @@ func TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled(t *testing.T
 			Config: r.addonProfileAciConnectorLinuxDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.aci_connector_linux.0.subnet_name").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -59,8 +51,6 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -69,8 +59,6 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -79,29 +67,30 @@ func TestAccKubernetesCluster_addonProfileAzurePolicy(t *testing.T) {
 			Config: r.addonProfileAzurePolicyConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_policy.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
+// TODO 3.0 - Remove this test since Kube Dashboard will be removed along with Kubernetes version 1.19
 func TestAccKubernetesCluster_addonProfileKubeDashboard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.addonProfileKubeDashboardConfig(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.0.enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-	})
+	if !features.ThreePointOh() {
+		data.ResourceTest(t, r, []acceptance.TestStep{
+			{
+				Config: r.addonProfileKubeDashboardConfig(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.#").HasValue("1"),
+					check.That(data.ResourceName).Key("addon_profile.0.kube_dashboard.0.enabled").HasValue("false"),
+				),
+			},
+			data.ImportStep(),
+		})
+	}
 }
 
 func TestAccKubernetesCluster_addonProfileOMS(t *testing.T) {
@@ -113,13 +102,6 @@ func TestAccKubernetesCluster_addonProfileOMS(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.client_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.object_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.oms_agent_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -135,11 +117,6 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -147,23 +124,14 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
+		// TODO 3.0 - Remove this step since this config will be identical to the one provided in the step above
 		{
 			Config: r.addonProfileOMSScaleWithoutBlockConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("2"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -171,11 +139,6 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 			Config: r.addonProfileOMSConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("0"),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.0.log_analytics_workspace_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -188,24 +151,16 @@ func TestAccKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.addonProfileRoutingConfig(data),
+			Config: r.addonProfileRoutingConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.http_application_routing_zone_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.addonProfileRoutingConfigDisabled(data),
+			Config: r.addonProfileRoutingConfig(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("addon_profile.0.http_application_routing.0.http_application_routing_zone_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.oms_agent.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -221,13 +176,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
 			Config: r.addonProfileIngressApplicationGatewayAppGatewayConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").MatchesOtherKey(
-					check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_id"),
-				),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.client_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.object_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -243,9 +191,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR(t
 			Config: r.addonProfileIngressApplicationGatewaySubnetCIDRConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.subnet_cidr").HasValue(addOnAppGatewaySubnetCIDR),
 			),
 		},
 		data.ImportStep(),
@@ -253,8 +198,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR(t
 			Config: r.addonProfileIngressApplicationGatewayDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -270,8 +213,6 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId(t *
 			Config: r.addonProfileIngressApplicationGatewaySubnetIdConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_name").Exists(),
-				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -288,8 +229,6 @@ func TestAccKubernetesCluster_addonProfileOpenServiceMesh(t *testing.T) {
 			Config: r.addonProfileOpenServiceMeshConfig(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -298,38 +237,30 @@ func TestAccKubernetesCluster_addonProfileOpenServiceMesh(t *testing.T) {
 			Config: r.addonProfileOpenServiceMeshConfig(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.open_service_mesh.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testing.T) {
+func TestAccKubernetesCluster_addonProfileAzureKeyVaultSecretsProvider(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			// Enable AzureKeyvaultSecretsProvider
-			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, true, true, "2m"),
+			Config: r.addonProfileAzureKeyVaultSecretsProviderConfig(data, true, true, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.secret_rotation_interval").HasValue("2m"),
 			),
 		},
 		data.ImportStep(),
 		{
 			// Disable AzureKeyvaultSecretsProvider
-			Config: r.addonProfileAzureKeyvaultSecretsProviderConfig(data, false, false, "2m"),
+			Config: r.addonProfileAzureKeyVaultSecretsProviderConfig(data, false, false, "2m"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.#").HasValue("1"),
-				check.That(data.ResourceName).Key("addon_profile.0.azure_keyvault_secrets_provider.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -337,7 +268,8 @@ func TestAccKubernetesCluster_addonProfileAzureKeyvaultSecretsProvider(t *testin
 }
 
 func (KubernetesClusterResource) addonProfileAciConnectorLinuxConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -414,10 +346,86 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test-aci" {
+  name                 = "acctestsubnet-aci%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.3.0/24"
+
+  delegation {
+    name = "aciDelegation"
+
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+  }
+
+  aci_connector_linux {
+    subnet_name = azurerm_subnet.test-aci.name
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileAciConnectorLinuxDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -477,10 +485,65 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "172.0.2.0/24"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileAzurePolicyConfig(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -521,10 +584,50 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
 }
 
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  azure_policy_enabled = %t
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+}
+
+// TODO 3.0 - Remove this test since Kube Dashboard will be removed along with Kubernetes version 1.19
 func (KubernetesClusterResource) addonProfileKubeDashboardConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -565,10 +668,47 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOMSConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -630,10 +770,71 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "ContainerInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/ContainerInsights"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  oms_agent {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOMSDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -674,9 +875,83 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
 }
 
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+// TODO 3.0 - Remove this since OMS Agent can only be disabled by omitting the config
 func (KubernetesClusterResource) addonProfileOMSScaleWithoutBlockConfig(data acceptance.TestData) string {
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 2
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -714,8 +989,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (KubernetesClusterResource) addonProfileRoutingConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+func (KubernetesClusterResource) addonProfileRoutingConfig(data acceptance.TestData, enabled bool) string {
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -747,7 +1023,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   addon_profile {
     http_application_routing {
-      enabled = true
+      enabled = %t
     }
     kube_dashboard {
       enabled = false
@@ -758,10 +1034,8 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (KubernetesClusterResource) addonProfileRoutingConfigDisabled(data acceptance.TestData) string {
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -792,24 +1066,18 @@ resource "azurerm_kubernetes_cluster" "test" {
     vm_size    = "Standard_DS2_v2"
   }
 
-  addon_profile {
-    http_application_routing {
-      enabled = false
-    }
-    kube_dashboard {
-      enabled = false
-    }
-  }
+  http_application_routing_enabled = %t
 
   identity {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayAppGatewayConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -930,10 +1198,127 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestappgw%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_V2"
+    tier     = "Standard_V2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gwipcfg"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = "frontendport"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "frontendipcfg"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  backend_address_pool {
+    name = "backendaddresspool"
+  }
+
+  backend_http_settings {
+    name                  = "backendhttpsettings"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 60
+  }
+
+  http_listener {
+    name                           = "httplistener"
+    frontend_ip_configuration_name = "frontendipcfg"
+    frontend_port_name             = "frontendport"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "requestroutingrule"
+    rule_type                  = "Basic"
+    http_listener_name         = "httplistener"
+    backend_address_pool_name  = "backendaddresspool"
+    backend_http_settings_name = "backendhttpsettings"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  ingress_application_gateway {
+    gateway_id = azurerm_application_gateway.test.id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetCIDRConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -979,10 +1364,52 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  ingress_application_gateway {
+    gateway_name = "acctestgwn%d"
+    subnet_cidr  = "%s"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayDisabledConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -1026,10 +1453,47 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetIdConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -1089,10 +1553,66 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  ingress_application_gateway {
+    gateway_name = "acctestgwn%d"
+    subnet_id    = azurerm_subnet.test.id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) addonProfileOpenServiceMeshConfig(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -1133,10 +1653,49 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
 }
 
-func (KubernetesClusterResource) addonProfileAzureKeyvaultSecretsProviderConfig(data acceptance.TestData, enabled bool, secretRotation bool, rotationInterval string) string {
-	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  open_service_mesh_enabled = %t
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled)
+}
+
+func (KubernetesClusterResource) addonProfileAzureKeyVaultSecretsProviderConfig(data acceptance.TestData, enabled bool, secretRotation bool, rotationInterval string) string {
+	if !features.ThreePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -1179,4 +1738,45 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabled, secretRotation, rotationInterval)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  azure_keyvault_secrets_provider {
+    secret_rotation_enabled  = %t
+    secret_rotation_interval = "%s"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, secretRotation, rotationInterval)
 }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -707,7 +707,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.addonProfileRoutingConfig(data))
+`, KubernetesClusterResource{}.addonProfileRoutingConfig(data, true))
 }
 
 func (KubernetesClusterDataSource) addOnProfileIngressApplicationGatewayAppGatewayConfig(data acceptance.TestData) string {
@@ -762,7 +762,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.addonProfileAzureKeyvaultSecretsProviderConfig(data, true, true, "2m"))
+`, KubernetesClusterResource{}.addonProfileAzureKeyVaultSecretsProviderConfig(data, true, true, "2m"))
 }
 
 func (KubernetesClusterDataSource) autoScalingNoAvailabilityZonesConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -958,6 +958,13 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if features.ThreePointOh() {
+		schemaKubernetesAddOns(resource)
+		// Overwrite old schema with version containing the deprecation messages
+		resource.Schema["addon_profile"] = schemaKubernetesAddOnProfilesDeprecated()
+	}
+
 	if features.KubeConfigsAreSensitive() {
 		resource.Schema["kube_config"] = &pluginsdk.Schema{
 			Type:      pluginsdk.TypeList,
@@ -1083,10 +1090,28 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("expanding `default_node_pool`: %+v", err)
 	}
 
+	// TODO clean this up
+	var addonProfiles *map[string]*containerservice.ManagedClusterAddonProfile
 	addOnProfilesRaw := d.Get("addon_profile").([]interface{})
-	addonProfiles, err := expandKubernetesAddOnProfiles(addOnProfilesRaw, env)
+	addonProfiles, err = expandKubernetesAddOnProfiles(addOnProfilesRaw, env)
 	if err != nil {
 		return err
+	}
+
+	if features.ThreePointOh() {
+		addOns := map[string]interface{}{
+			"aci_connector_linux":              d.Get("aci_connector_linux").([]interface{}),
+			"azure_policy_enabled":             d.Get("azure_policy_enabled").(bool),
+			"http_application_routing_enabled": d.Get("http_application_routing_enabled").(bool),
+			"oms_agent":                        d.Get("oms_agent").([]interface{}),
+			"ingress_application_gateway":      d.Get("ingress_application_gateway").([]interface{}),
+			"open_service_mesh_enabled":        d.Get("open_service_mesh_enabled").(bool),
+			"azure_keyvault_secrets_provider":  d.Get("azure_keyvault_secrets_provider").([]interface{}),
+		}
+		addonProfiles, err = expandKubernetesAddOn(d, addOns, env)
+		if err != nil {
+			return err
+		}
 	}
 
 	networkProfileRaw := d.Get("network_profile").([]interface{})
@@ -1367,6 +1392,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
+	// TODO cleanup
 	if d.HasChange("addon_profile") {
 		updateCluster = true
 		addOnProfilesRaw := d.Get("addon_profile").([]interface{})
@@ -1376,6 +1402,27 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		existing.ManagedClusterProperties.AddonProfiles = *addonProfiles
+	}
+
+	if features.ThreePointOh() {
+		if d.HasChange("aci_connector_linux") || d.HasChange("azure_policy_enabled") || d.HasChange("http_application_routing_enabled") || d.HasChange("oms_agent") || d.HasChange("ingress_application_gateway") || d.HasChange("open_service_mesh_enabled") || d.HasChange("azure_keyvault_secrets_provider") {
+			updateCluster = true
+			addOns := map[string]interface{}{
+				"aci_connector_linux":              d.Get("aci_connector_linux").([]interface{}),
+				"azure_policy_enabled":             d.Get("azure_policy_enabled").(bool),
+				"http_application_routing_enabled": d.Get("http_application_routing_enabled").(bool),
+				"oms_agent":                        d.Get("oms_agent").([]interface{}),
+				"ingress_application_gateway":      d.Get("ingress_application_gateway").([]interface{}),
+				"open_service_mesh_enabled":        d.Get("open_service_mesh_enabled").(bool),
+				"azure_keyvault_secrets_provider":  d.Get("azure_keyvault_secrets_provider").([]interface{}),
+			}
+			addonProfiles, err := expandKubernetesAddOn(d, addOns, env)
+			if err != nil {
+				return err
+			}
+
+			existing.ManagedClusterProperties.AddonProfiles = *addonProfiles
+		}
 	}
 
 	if d.HasChange("api_server_authorized_ip_ranges") {
@@ -1717,9 +1764,22 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 		}
 
+		// TODO 3.0 - clean up
 		addonProfiles := flattenKubernetesAddOnProfiles(props.AddonProfiles)
 		if err := d.Set("addon_profile", addonProfiles); err != nil {
 			return fmt.Errorf("setting `addon_profile`: %+v", err)
+		}
+
+		if features.ThreePointOh() {
+			addOns := flattenKubernetesAddOn(props.AddonProfiles)
+			d.Set("aci_connector_linux", addOns["aci_connector_linux"])
+			d.Set("azure_policy_enabled", addOns["azure_policy_enabled"].(bool))
+			d.Set("http_application_routing_enabled", addOns["http_application_routing_enabled"].(bool))
+			d.Set("http_application_routing_zone_name", addOns["http_application_routing_zone_name"])
+			d.Set("oms_agent", addOns["oms_agent"])
+			d.Set("ingress_application_gateway", addOns["ingress_application_gateway"])
+			d.Set("open_service_mesh_enabled", addOns["open_service_mesh_enabled"].(bool))
+			d.Set("azure_keyvault_secrets_provider", addOns["azure_keyvault_secrets_provider"])
 		}
 
 		autoScalerProfile, err := flattenKubernetesClusterAutoScalerProfile(props.AutoScalerProfile)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -961,7 +961,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 
 	if features.ThreePointOh() {
 		schemaKubernetesAddOns(resource)
-		// Overwrite old schema with version containing the deprecation messages
+		// Overwrite old schema with version containing the deprecation messages for beta,
+		// TODO 3.0 - Remove this
 		resource.Schema["addon_profile"] = schemaKubernetesAddOnProfilesDeprecated()
 	}
 
@@ -1090,7 +1091,6 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("expanding `default_node_pool`: %+v", err)
 	}
 
-	// TODO clean this up
 	var addonProfiles *map[string]*containerservice.ManagedClusterAddonProfile
 	addOnProfilesRaw := d.Get("addon_profile").([]interface{})
 	addonProfiles, err = expandKubernetesAddOnProfiles(addOnProfilesRaw, env)
@@ -1099,16 +1099,8 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if features.ThreePointOh() {
-		addOns := map[string]interface{}{
-			"aci_connector_linux":              d.Get("aci_connector_linux").([]interface{}),
-			"azure_policy_enabled":             d.Get("azure_policy_enabled").(bool),
-			"http_application_routing_enabled": d.Get("http_application_routing_enabled").(bool),
-			"oms_agent":                        d.Get("oms_agent").([]interface{}),
-			"ingress_application_gateway":      d.Get("ingress_application_gateway").([]interface{}),
-			"open_service_mesh_enabled":        d.Get("open_service_mesh_enabled").(bool),
-			"azure_keyvault_secrets_provider":  d.Get("azure_keyvault_secrets_provider").([]interface{}),
-		}
-		addonProfiles, err = expandKubernetesAddOn(d, addOns, env)
+		addOns := collectKubernetesAddons(d)
+		addonProfiles, err = expandKubernetesAddOns(d, addOns, env)
 		if err != nil {
 			return err
 		}
@@ -1407,16 +1399,8 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if features.ThreePointOh() {
 		if d.HasChange("aci_connector_linux") || d.HasChange("azure_policy_enabled") || d.HasChange("http_application_routing_enabled") || d.HasChange("oms_agent") || d.HasChange("ingress_application_gateway") || d.HasChange("open_service_mesh_enabled") || d.HasChange("azure_keyvault_secrets_provider") {
 			updateCluster = true
-			addOns := map[string]interface{}{
-				"aci_connector_linux":              d.Get("aci_connector_linux").([]interface{}),
-				"azure_policy_enabled":             d.Get("azure_policy_enabled").(bool),
-				"http_application_routing_enabled": d.Get("http_application_routing_enabled").(bool),
-				"oms_agent":                        d.Get("oms_agent").([]interface{}),
-				"ingress_application_gateway":      d.Get("ingress_application_gateway").([]interface{}),
-				"open_service_mesh_enabled":        d.Get("open_service_mesh_enabled").(bool),
-				"azure_keyvault_secrets_provider":  d.Get("azure_keyvault_secrets_provider").([]interface{}),
-			}
-			addonProfiles, err := expandKubernetesAddOn(d, addOns, env)
+			addOns := collectKubernetesAddons(d)
+			addonProfiles, err := expandKubernetesAddOns(d, addOns, env)
 			if err != nil {
 				return err
 			}
@@ -1771,7 +1755,7 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		if features.ThreePointOh() {
-			addOns := flattenKubernetesAddOn(props.AddonProfiles)
+			addOns := flattenKubernetesAddOns(props.AddonProfiles)
 			d.Set("aci_connector_linux", addOns["aci_connector_linux"])
 			d.Set("azure_policy_enabled", addOns["azure_policy_enabled"].(bool))
 			d.Set("http_application_routing_enabled", addOns["http_application_routing_enabled"].(bool))

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1384,7 +1384,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	// TODO cleanup
+	// TODO 3.0 - Remove this block
 	if d.HasChange("addon_profile") {
 		updateCluster = true
 		addOnProfilesRaw := d.Get("addon_profile").([]interface{})
@@ -1748,7 +1748,7 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 		}
 
-		// TODO 3.0 - clean up
+		// TODO 3.0 - Remove this
 		addonProfiles := flattenKubernetesAddOnProfiles(props.AddonProfiles)
 		if err := d.Set("addon_profile", addonProfiles); err != nil {
 			return fmt.Errorf("setting `addon_profile`: %+v", err)


### PR DESCRIPTION
For better behavioural consistency across this resource and the provider the schema for AKS add-ons has been updated.
The main changes are the following:
- Removal of the `addon_profile` block and shifting all AKS add-on properties to the top level
- Removal of the enabled field for all add-ons

This change is feature flagged and the new schema will be documented when the release is open for beta.

Test results when ThreePointOh() returns true
```
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled (681.38s)
--- PASS: TestAccKubernetesCluster_addonProfileAzureKeyVaultSecretsProvider (761.63s)
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinux (873.86s)
--- PASS: TestAccKubernetesCluster_addonProfileRoutingToggle (932.59s)
--- PASS: TestAccKubernetesCluster_addonProfileOMS (933.20s)
--- PASS: TestAccKubernetesCluster_addonProfileOpenServiceMesh (1045.48s)
--- PASS: TestAccKubernetesCluster_addonProfileAzurePolicy (1310.55s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId (1322.95s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR (1374.84s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId (1439.35s)
--- PASS: TestAccKubernetesCluster_addonProfileOMSToggle (1443.88s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    1446.495s
```
