### PR TITLE
Fix #14845 by listing hybrid connection's access keys if listing access keys of relay failed.

### DIFF
--- a/internal/services/web/app_service_hybrid_connection_resource.go
+++ b/internal/services/web/app_service_hybrid_connection_resource.go
@@ -13,6 +13,7 @@ import (
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	relayParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/relay/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/relay/sdk/2017-04-01/hybridconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/relay/sdk/2017-04-01/namespaces"
 	relayValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/relay/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
@@ -157,6 +158,7 @@ func resourceAppServiceHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, m
 
 func resourceAppServiceHybridConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Web.AppServicesClient
+	relayClient := meta.(*clients.Client).Relay.HybridConnectionsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -197,11 +199,17 @@ func resourceAppServiceHybridConnectionRead(d *pluginsdk.ResourceData, meta inte
 		}
 		authRuleId := namespaces.NewAuthorizationRuleID(id.SubscriptionId, *relayNamespaceRG, *resp.ServiceBusNamespace, *resp.SendKeyName)
 		accessKeys, err := relayNamespacesClient.ListKeys(ctx, authRuleId)
-		if err != nil {
-			return fmt.Errorf("unable to List Access Keys for Namespace %q (Resource Group %q): %+v", *resp.ServiceBusNamespace, id.ResourceGroup, err)
+
+		if err == nil && accessKeys.Model != nil {
+			d.Set("send_key_value", accessKeys.Model.PrimaryKey)
+			return nil
 		}
 
-		if model := accessKeys.Model; model != nil {
+		connAccessKeys, err := relayClient.ListKeys(ctx, hybridconnections.NewHybridConnectionAuthorizationRuleID(id.SubscriptionId, *relayNamespaceRG, *resp.ServiceBusNamespace, *resp.Name, *resp.SendKeyName))
+		if err != nil {
+			return fmt.Errorf("unable to List Access Keys for %q (Resource Group %q): %+v", id, id.ResourceGroup, err)
+		}
+		if model := connAccessKeys.Model; model != nil {
 			d.Set("send_key_value", model.PrimaryKey)
 		}
 	}


### PR DESCRIPTION
Fix #14845 by listing hybrid connection's access keys if listing access keys of relay failed.

According to [https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas#shared-access-authorization-policies document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas#shared-access-authorization-policies):

>Each Service Bus namespace and each Service Bus entity has a Shared Access Authorization policy made up of rules. The policy at the namespace level applies to all entities inside the namespace, irrespective of their individual policy configuration.

As the `send_key_name`'s description in [Terraform doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_hybrid_connection#argument-reference) is as below:

> (Optional) The name of the Service Bus key which has Send permissions.

The key could be declared on either "Service Bus namespace" or "Service Bus entity", I think we can support both of them.

Acc Tests:

=== RUN   TestAccAppServiceHybridConnection_basic
=== PAUSE TestAccAppServiceHybridConnection_basic
=== CONT  TestAccAppServiceHybridConnection_basic
--- PASS: TestAccAppServiceHybridConnection_basic (322.99s)
=== RUN   TestAccAppServiceHybridConnection_update
=== PAUSE TestAccAppServiceHybridConnection_update
=== CONT  TestAccAppServiceHybridConnection_update
--- PASS: TestAccAppServiceHybridConnection_update (472.21s)
=== RUN   TestAccAppServiceHybridConnection_requiresImport
=== PAUSE TestAccAppServiceHybridConnection_requiresImport
=== CONT  TestAccAppServiceHybridConnection_requiresImport
--- PASS: TestAccAppServiceHybridConnection_requiresImport (363.03s)
=== RUN   TestAccAppServiceHybridConnection_differentResourceGroup
=== PAUSE TestAccAppServiceHybridConnection_differentResourceGroup
=== CONT  TestAccAppServiceHybridConnection_differentResourceGroup
--- PASS: TestAccAppServiceHybridConnection_differentResourceGroup (331.38s)
PASS

Process finished with the exit code 0
