### PR TITLE
`azurerm_api_management_backend` Fix crash around `backend_credentials`

### DIFF
--- a/internal/services/apimanagement/api_management_backend_resource.go
+++ b/internal/services/apimanagement/api_management_backend_resource.go
@@ -389,7 +389,7 @@ func resourceApiManagementBackendDelete(d *pluginsdk.ResourceData, meta interfac
 }
 
 func expandApiManagementBackendCredentials(input []interface{}) *apimanagement.BackendCredentialsContract {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	v := input[0].(map[string]interface{})


### PR DESCRIPTION
Fix #14791 by adding nil check as @tombuildsstuff pointed out.