### PR TITLE
`azurerm_static_site` - fix Free tier creation error

### DIFF
--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -124,7 +124,7 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	// See: https://github.com/Azure/azure-rest-api-specs/issues/17525
 	if skuName == string(web.SkuNameFree) && identity != nil {
-		return fmt.Errorf("a Managed Identity cannot be used when tier is set to `Free`")`
+		return fmt.Errorf("a Managed Identity cannot be used when tier is set to `Free`")
 	}
 
 	siteEnvelope := web.StaticSiteARMResource{

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -124,7 +124,7 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	// See: https://github.com/Azure/azure-rest-api-specs/issues/17525
 	if skuName == string(web.SkuNameFree) && identity != nil {
-		return fmt.Errorf("Free tier Static Site doens't support specifying `identity`")
+		return fmt.Errorf("a Managed Identity cannot be used when tier is set to `Free`")`
 	}
 
 	siteEnvelope := web.StaticSiteARMResource{

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -115,14 +115,21 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	loc := location.Normalize(d.Get("location").(string))
 
+	skuName := d.Get("sku_size").(string)
+
 	identity, err := expandStaticSiteIdentity(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
 
+	// See: https://github.com/Azure/azure-rest-api-specs/issues/17525
+	if skuName == string(web.SkuNameFree) && identity != nil {
+		return fmt.Errorf("Free tier Static Site doens't support specifying `identity`")
+	}
+
 	siteEnvelope := web.StaticSiteARMResource{
 		Sku: &web.SkuDescription{
-			Name: utils.String(d.Get("sku_size").(string)),
+			Name: &skuName,
 			Tier: utils.String(d.Get("sku_tier").(string)),
 		},
 		StaticSite: &web.StaticSite{},
@@ -232,6 +239,10 @@ func expandStaticSiteIdentity(input []interface{}) (*web.ManagedServiceIdentity,
 	config, err := identity.ExpandSystemOrUserAssignedMap(input)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.Type == identity.TypeNone {
+		return nil, nil
 	}
 
 	var identityIds map[string]*web.UserAssignedIdentity

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -167,6 +167,8 @@ resource "azurerm_static_site" "test" {
   name                = "acctestSS-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_size            = "Standard"
+  sku_tier            = "Standard"
 
   identity {
     type = "SystemAssigned"
@@ -197,6 +199,8 @@ resource "azurerm_static_site" "test" {
   name                = "acctestSS-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_size            = "Standard"
+  sku_tier            = "Standard"
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
The free tier seems not support identity anymore, so ensure there is no
`identity` block specified in the request payload in this case.

Besides, even for `Standard` sku, the user assigned identity won't
return an overall principalId. Instead, it returns the principalId for
each user assigned identity. This causes the test case
TestAccAzureStaticSite_withUserAssignedIdentity continue failing.

Fixes #15125