### PR TITLE
`azurerm_network_security_group` `azurerm_network_security_rule` - Fix case-sensitive resource_group_name to case-insensitive

### DIFF
--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -50,7 +50,7 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 
 			"location": azure.SchemaLocation(),
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"security_rule": {
 				Type:       pluginsdk.TypeSet,

--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -42,7 +42,7 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"network_security_group_name": {
 				Type:     pluginsdk.TypeString,


### PR DESCRIPTION
ResourceGroup name is case-insensitive, but AzureRM Provider deal with case-sensitive value. 
(Reference Doc: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

Also `networkSecurityGroups` and `networkSecurityGroups / securityRules` resource return lowercase `resource group` name. Thus, AzureRM Provider plan to recreate `azurerm_network_security_group` `azurerm_network_security_rule` resources.

## Conclusion
This PR fix `azurerm_network_security_group` `azurerm_network_security_rule`'s `resource_group_name` diff function