### PR TITLE
`azurerm_local_network_gateway` : fix for `address_space` cannot be updated

### DIFF
--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -139,6 +139,15 @@ func resourceLocalNetworkGatewayCreateUpdate(d *pluginsdk.ResourceData, meta int
 	// There is a bug in the provider where the address space ordering doesn't change as expected.
 	// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
 	if !d.IsNewResource() && d.HasChange("address_space") {
+
+		// since the local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, it is by design),
+		// replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
+		if v := d.Get("address_space").([]interface{}); len(v) > 0 {
+			gateway.LocalNetworkGatewayPropertiesFormat.LocalNetworkAddressSpace = &network.AddressSpace{
+				AddressPrefixes: &[]string{v[0].(string)},
+			}
+		}
+
 		future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, gateway)
 		if err != nil {
 			return fmt.Errorf("removing %s: %+v", id, err)

--- a/internal/services/network/local_network_gateway_resource_test.go
+++ b/internal/services/network/local_network_gateway_resource_test.go
@@ -181,7 +181,7 @@ func TestAccLocalNetworkGateway_updateAddressSpace(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.noneAddressSpace(data),
+			Config: r.singleAddressSpace(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -371,7 +371,7 @@ resource "azurerm_local_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (LocalNetworkGatewayResource) noneAddressSpace(data acceptance.TestData) string {
+func (LocalNetworkGatewayResource) singleAddressSpace(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -387,6 +387,7 @@ resource "azurerm_local_network_gateway" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.0.0/24"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
The purpose of this PR:

> Fix issue [#15109](https://github.com/hashicorp/terraform-provider-azurerm/issues/15109). When the `address_space` changes, there is a workaround in the terraform provider. That is clear the `address_space` first, then re-add it. Currently, the backend of API has changed. The local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, this is by design). This would cause the test case in terraform provider to fail. And the use-case for updating `addresws_space` failed. Hence, submitted this PR to fix them. Two updates in this PR.
> 
> -  Add the `address_space` to the test case.
> 
> -  Replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
> 

 
Test results:
 

> PASS: TestAccLocalNetworkGateway_disappears (221.28s)
>  PASS: TestAccLocalNetworkGateway_basic (222.28s)
>  PASS: TestAccLocalNetworkGateway_tags (229.38s)
>  PASS: TestAccLocalNetworkGateway_bgpSettingsComplete (232.32s)
>  PASS: TestAccLocalNetworkGateway_bgpSettings (240.94s)
>  PASS: TestAccLocalNetworkGateway_bgpSettingsEnable (245.99s)
>  PASS: TestAccLocalNetworkGateway_requiresImport (262.95s)
>  PASS: TestAccLocalNetworkGateway_updateAddressSpace (366.86s)
>  PASS: TestAccLocalNetworkGateway_bgpSettingsDisable (311.54s)
>  PASS: TestAccLocalNetworkGateway_fqdn (324.82s)
