### PR TITLE
Doc Fix: azurerm_key_vault_secret - Fix missing argument "sensitive = true" in TF doc

### DIFF
--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -22,7 +22,8 @@ data "azurerm_key_vault_secret" "example" {
 }
 
 output "secret_value" {
-  value = data.azurerm_key_vault_secret.example.value
+  value     = data.azurerm_key_vault_secret.example.value
+  sensitive = true
 }
 ```
 


### PR DESCRIPTION
Fix issue [#15154](https://github.com/hashicorp/terraform-provider-azurerm/issues/15154).  "sensitive = true" is missing in the following block in TF [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret).It would cause `terraform plan` or `terraform apply` to fail. So, submitted this PR to add the "sensitive = true" to the block to improve user experience.
```
output "secret_value" {
  value = data.azurerm_key_vault_secret.example.value
}
```