### PR TITLE
Update signalr_service.html.markdown

### DIFF
--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -32,8 +32,8 @@ resource "azurerm_signalr_service" "example" {
     allowed_origins = ["http://www.example.com"]
   }
 
-  connectivity_logs_enabled = "True"
-  messaging_logs_enabled    = "True"
+  connectivity_logs_enabled = true
+  messaging_logs_enabled    = true
   service_mode              = "Default"
 
   upstream_endpoint {


### PR DESCRIPTION
This is to fix in documentation where some boolean values were set as strings, causing a plan and apply failure in terraform configuration