### PR TITLE
`azurerm_storage_share` - fix re-create error

### DIFF
--- a/internal/services/storage/shim/shares_data_plane.go
+++ b/internal/services/storage/shim/shares_data_plane.go
@@ -43,9 +43,8 @@ func (w DataPlaneStorageShareWrapper) Create(ctx context.Context, _, accountName
 			Timeout:        time.Until(timeout),
 		}
 
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return err
-		}
+		_, err := stateConf.WaitForStateContext(ctx)
+		return err
 	}
 
 	// otherwise it's a legit error, so raise it


### PR DESCRIPTION
Fixes #15166 

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageShare_protocolUpdate'
=== RUN   TestAccStorageShare_protocolUpdate
=== PAUSE TestAccStorageShare_protocolUpdate
=== CONT  TestAccStorageShare_protocolUpdate
--- PASS: TestAccStorageShare_protocolUpdate (147.86s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       147.878s
```