### PR TITLE
internal: splitting the 3.0 Beta and 3.0 GA feature-flags

### DIFF
--- a/internal/features/three_point_oh.go
+++ b/internal/features/three_point_oh.go
@@ -21,13 +21,23 @@ func DeprecatedInThreePointOh(deprecationMessage string) string {
 }
 
 // ThreePointOh returns whether this provider is running in 3.0 mode
-// that is to say - that functionality which requires/changes in 3.0
-// should be conditionally toggled on
+// that is to say - the final 3.0 release
 //
-// At this point in time this exists just to be able to place this
-// infrastructure as required - but in time we'll flip this through
-// a Beta and then GA at 3.0 release.
+// This exists to allow breaking changes to be piped through the provider
+// during the development of 2.x until 3.0 is ready.
 func ThreePointOh() bool {
+	return false
+}
+
+// ThreePointOhBeta returns whether this provider is running in 3.0 mode
+// which is an opt-in Beta of the (non-breaking changes) coming in 3.0.
+//
+// Any features behind this flag should be backwards-compatible to allow
+// users to try out 3.0 functionality.
+//
+// Whilst this currently isn't exposed, this will be via an Environment
+// Variable in the future.
+func ThreePointOhBeta() bool {
 	return false
 }
 

--- a/internal/features/three_point_oh.go
+++ b/internal/features/three_point_oh.go
@@ -44,7 +44,7 @@ func ThreePointOhBeta() bool {
 // ThreePointOhBetaResources returns whether this provider is opted into
 // the Beta Resources coming in v3.0 - or explicitly opted into v3.0.
 func ThreePointOhBetaResources() bool {
-	if ThreePointOh() {
+	if ThreePointOh() || ThreePointOhBeta() {
 		return true
 	}
 

--- a/internal/features/three_point_oh.go
+++ b/internal/features/three_point_oh.go
@@ -38,7 +38,7 @@ func ThreePointOh() bool {
 // Whilst this currently isn't exposed, this will be via an Environment
 // Variable in the future.
 func ThreePointOhBeta() bool {
-	return false
+	return ThreePointOh() || false
 }
 
 // ThreePointOhBetaResources returns whether this provider is opted into

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -160,7 +160,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 		},
 	}
 
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		f := featuresMap["key_vault"].Elem.(*pluginsdk.Resource)
 		// TODO: Add this to 3.0 Upgrade guide
 		// `recover_soft_deleted_keys` - (Default: true) when enabled soft-deleted `azurerm_key_vault_key` resources will be restored, instead of creating new ones.
@@ -284,7 +284,7 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			featuresMap.KeyVault.PurgeSoftDeletedCertsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
 			featuresMap.KeyVault.PurgeSoftDeletedSecretsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
 
-			if features.ThreePointOh() {
+			if features.ThreePointOhBeta() {
 				if v, ok := keyVaultRaw["recover_soft_deleted_certificates"]; ok {
 					featuresMap.KeyVault.RecoverSoftDeletedCerts = v.(bool)
 				}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -242,7 +242,7 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 		ResourcesMap:   resources,
 	}
 
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		p.Schema["skip_credentials_validation"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -279,7 +279,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		}
 
 		useMsal := d.Get("use_msal").(bool)
-		if features.ThreePointOh() {
+		if features.ThreePointOhBeta() {
 			useMsal = true
 		}
 

--- a/internal/services/costmanagement/registration.go
+++ b/internal/services/costmanagement/registration.go
@@ -43,7 +43,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	resources := make(map[string]*pluginsdk.Resource)
 
-	if features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		resources["azurerm_cost_management_export_resource_group"] = resourceCostManagementExportResourceGroup()
 	}
 

--- a/internal/services/devspace/registration.go
+++ b/internal/services/devspace/registration.go
@@ -28,7 +28,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		return map[string]*pluginsdk.Resource{}
 	}
 

--- a/internal/services/disks/registration.go
+++ b/internal/services/disks/registration.go
@@ -23,7 +23,7 @@ func (r Registration) Resources() []sdk.Resource {
 		DiskPoolManagedDiskAttachmentResource{},
 	}
 
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		resources = append(resources, StorageDisksPoolResource{})
 	}
 

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -106,14 +106,14 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 						"apply_allocation_policy": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default:  features.ThreePointOh(),
+							Default:  features.ThreePointOhBeta(),
 						},
 						// TODO update docs with new default for 3.0
 						"allocation_weight": {
 							Type:     pluginsdk.TypeInt,
 							Optional: true,
 							Default: func() interface{} {
-								if features.ThreePointOh() {
+								if features.ThreePointOhBeta() {
 									return 1
 								}
 								return 0

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -648,7 +648,7 @@ func resourceIotHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if _, ok := d.GetOk("fallback_route"); ok {
 		routingProperties.FallbackRoute = expandIoTHubFallbackRoute(d)
-	} else if features.ThreePointOh() {
+	} else if features.ThreePointOhBeta() {
 		// TODO update docs for 3.0
 		routingProperties.FallbackRoute = &devices.FallbackRouteProperties{
 			Source:        utils.String(string(devices.RoutingSourceDeviceMessages)),

--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -157,7 +157,7 @@ func dataSourceKeyVault() *pluginsdk.Resource {
 
 				"tags": tags.SchemaDataSource(),
 			}
-			if !features.ThreePointOh() {
+			if !features.ThreePointOhBeta() {
 				dsSchema["soft_delete_enabled"] = &pluginsdk.Schema{
 					Type:       pluginsdk.TypeBool,
 					Computed:   true,
@@ -203,7 +203,7 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("vault_uri", props.VaultURI)
 
 		// TODO: remove in 3.0
-		if !features.ThreePointOh() {
+		if !features.ThreePointOhBeta() {
 			d.Set("soft_delete_enabled", true)
 		}
 

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -228,7 +228,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 				},
 			}
 
-			if !features.ThreePointOh() {
+			if !features.ThreePointOhBeta() {
 				rSchema["soft_delete_enabled"] = &pluginsdk.Schema{
 					Type:       pluginsdk.TypeBool,
 					Optional:   true,
@@ -651,7 +651,7 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("soft_delete_retention_days", softDeleteRetentionDays)
 
 	// TODO: remove in 3.0
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		d.Set("soft_delete_enabled", true)
 	}
 

--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -143,7 +143,7 @@ func flattenTrustedExternalTenants(input *[]kusto.TrustedExternalTenant) []inter
 
 	output := make([]interface{}, 0)
 
-	if !features.ThreePointOh() && len(*input) == 0 {
+	if !features.ThreePointOhBeta() && len(*input) == 0 {
 		return append(output, "MyTenantOnly")
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -110,7 +110,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice(func() []string {
-						if features.ThreePointOh() {
+						if features.ThreePointOhBeta() {
 							return []string{"*"}
 						}
 						return []string{"MyTenantOnly", "*"}
@@ -291,11 +291,11 @@ func resourceKustoClusterCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 		clusterProperties.VirtualNetworkConfiguration = vnet
 	}
 
-	if v, ok := d.GetOk("trusted_external_tenants"); ok && !features.ThreePointOh() {
+	if v, ok := d.GetOk("trusted_external_tenants"); ok && !features.ThreePointOhBeta() {
 		trustedExternalTenants := expandTrustedExternalTenants(v.([]interface{}))
 		clusterProperties.TrustedExternalTenants = trustedExternalTenants
 	}
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		trustedExternalTenants := expandTrustedExternalTenants(d.Get("trusted_external_tenants").([]interface{}))
 		clusterProperties.TrustedExternalTenants = trustedExternalTenants
 	}

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -300,7 +300,7 @@ func TestAccKustoCluster_engineV3(t *testing.T) {
 }
 
 func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		t.Skip("Skipping since 3.0 mode is enabled")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
@@ -339,7 +339,7 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 }
 
 func TestAccKustoCluster_trustedExternalTenantsThreePointOh(t *testing.T) {
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		t.Skip("Skipping since 3.0 mode is disabled")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")

--- a/internal/services/loadbalancer/backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_resource.go
@@ -133,7 +133,7 @@ func resourceArmLoadBalancerBackendAddressPool() *pluginsdk.Resource {
 				},
 			}
 
-			if !features.ThreePointOh() {
+			if !features.ThreePointOhBeta() {
 				s["backend_address"] = &pluginsdk.Schema{
 					Type:       pluginsdk.TypeSet,
 					Optional:   true,
@@ -318,7 +318,7 @@ func resourceArmLoadBalancerBackendAddressPoolRead(d *pluginsdk.ResourceData, me
 
 	if props := resp.BackendAddressPoolPropertiesFormat; props != nil {
 		// TODO: remove in 3.0
-		if !features.ThreePointOh() {
+		if !features.ThreePointOhBeta() {
 			// @tombuildsstuff: this is a Set so won't be referenced, let's just nil this out for now
 			if err := d.Set("backend_address", []interface{}{}); err != nil {
 				return fmt.Errorf("setting `backend_address`: %v", err)

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -315,7 +315,7 @@ func resourceMsSqlDatabase() *pluginsdk.Resource {
 				return strings.HasPrefix(old.(string), "HS") && !strings.HasPrefix(new.(string), "HS")
 			}),
 			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-				if !features.ThreePointOh() {
+				if !features.ThreePointOhBeta() {
 					return nil
 				}
 				sku := d.Get("sku_name").(string)
@@ -325,7 +325,7 @@ func resourceMsSqlDatabase() *pluginsdk.Resource {
 				return nil
 			}),
 	}
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		// TODO: Update docs with the following text:
 		//
 		// * `transparent_data_encryption_enabled` - If set to true, Transparent Data Encryption will be enabled on the database.
@@ -582,7 +582,7 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("waiting for create/update of %s: %+v", id, err)
 	}
 
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		statusProperty := sql.TransparentDataEncryptionStatusDisabled
 		encryptionStatus := d.Get("transparent_data_encryption_enabled").(bool)
 		if encryptionStatus {
@@ -816,7 +816,7 @@ func resourceMsSqlDatabaseRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("setting `geo_backup_enabled`: %+v", err)
 	}
 
-	if features.ThreePointOh() {
+	if features.ThreePointOhBeta() {
 		tde, err := transparentEncryptionClient.Get(ctx, id.ResourceGroup, id.ServerName, id.Name)
 		if err != nil {
 			return fmt.Errorf("while retrieving Transparent Data Encryption status of %q: %+v", id.String(), err)

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -698,7 +698,7 @@ func TestAccMsSqlDatabase_geoBackupPolicy(t *testing.T) {
 }
 
 func TestAccMsSqlDatabase_transitDataEncryption(t *testing.T) {
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		t.Skipf("This test runs only on 3.0")
 	}
 
@@ -726,7 +726,7 @@ func TestAccMsSqlDatabase_transitDataEncryption(t *testing.T) {
 }
 
 func TestAccMsSqlDatabase_errorOnDisabledEncryption(t *testing.T) {
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		t.Skipf("This test runs only on 3.0")
 	}
 

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -177,7 +177,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default: func() interface{} {
-					if features.ThreePointOh() {
+					if features.ThreePointOhBeta() {
 						return "1.2"
 					}
 					return nil

--- a/internal/services/mysql/mysql_server_resource.go
+++ b/internal/services/mysql/mysql_server_resource.go
@@ -220,7 +220,7 @@ func resourceMySqlServer() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default: func() interface{} {
-					if features.ThreePointOh() {
+					if features.ThreePointOhBeta() {
 						return string(mysql.TLS12)
 					}
 					return string(mysql.TLSEnforcementDisabled)

--- a/internal/services/policy/registration.go
+++ b/internal/services/policy/registration.go
@@ -56,7 +56,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_virtual_machine_configuration_policy_assignment": resourceVirtualMachineConfigurationPolicyAssignment(),
 	}
 
-	if !features.ThreePointOh() {
+	if !features.ThreePointOhBeta() {
 		resources["azurerm_policy_assignment"] = resourceArmPolicyAssignment()
 	}
 

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -302,7 +302,7 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default: func() interface{} {
-					if features.ThreePointOh() {
+					if features.ThreePointOhBeta() {
 						return string(postgresql.TLS12)
 					}
 					return string(postgresql.TLSEnforcementDisabled)

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -93,7 +93,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default: func() interface{} {
-					if features.ThreePointOh() {
+					if features.ThreePointOhBeta() {
 						return string(redis.TLSVersionOneFullStopTwo)
 					}
 					return string(redis.TLSVersionOneFullStopZero)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -233,7 +233,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default: func() interface{} {
-					if features.ThreePointOh() {
+					if features.ThreePointOhBeta() {
 						return string(storage.MinimumTLSVersionTLS12)
 					}
 					return string(storage.MinimumTLSVersionTLS10)


### PR DESCRIPTION
This PR splits the 3.0 Beta and 3.0 GA feature-flags to allow the Beta functionality to be tested in the future - any one-way upgrades (such as in Storage) are left for the GA release.