### PR TITLE
updating `go-azure-helpers` to `v0.22.0` / updating usages of `identity`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-azure-helpers v0.21.0
+	github.com/hashicorp/go-azure-helpers v0.22.0
 	github.com/hashicorp/go-getter v1.5.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.21.0 h1:wp8IIrpYBln+MaMqySsSVqpoe2te+19sI1xmSIsATxo=
-github.com/hashicorp/go-azure-helpers v0.21.0/go.mod h1:Z2IvHhrwmpdDU5Mdld+vETChcenndWcY1bws4Hsn+Wk=
+github.com/hashicorp/go-azure-helpers v0.22.0 h1:5qoRzEuRme44jEpRDCF4uN7JNpTVmWDFJPokdO0QIoE=
+github.com/hashicorp/go-azure-helpers v0.22.0/go.mod h1:Z2IvHhrwmpdDU5Mdld+vETChcenndWcY1bws4Hsn+Wk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/datalake/data_lake_store_resource.go
+++ b/internal/services/datalake/data_lake_store_resource.go
@@ -119,7 +119,7 @@ func resourceDataLakeStore() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": commonschema.SystemAssignedIdentity(),
+			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"tags": commonschema.Tags(),
 		},

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -592,7 +592,7 @@ func resourceIotHub() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": commonschema.SystemAssignedUserAssignedIdentity(),
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"tags": tags.Schema(),
 		},

--- a/internal/services/logic/logic_app_workflow_data_source.go
+++ b/internal/services/logic/logic_app_workflow_data_source.go
@@ -58,7 +58,7 @@ func dataSourceLogicAppWorkflow() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": commonschema.SystemOrUserAssignedIdentityDataSource(),
+			"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
 
 			"access_endpoint": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -198,7 +198,7 @@ func resourceLogicAppWorkflow() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": commonschema.SystemOrUserAssignedIdentity(),
+			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
 			"logic_app_integration_account_id": {
 				Type:         pluginsdk.TypeString,

--- a/internal/services/streamanalytics/stream_analytics_job_data_source.go
+++ b/internal/services/streamanalytics/stream_analytics_job_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
@@ -61,26 +63,7 @@ func dataSourceStreamAnalyticsJob() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 
 			"output_error_policy": {
 				Type:     pluginsdk.TypeString,
@@ -122,7 +105,7 @@ func dataSourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	if err := d.Set("identity", flattenStreamAnalyticsJobIdentity(resp.Identity)); err != nil {
+	if err := d.Set("identity", flattenJobIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("setting `identity`: %v", err)
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -5,6 +5,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/streamanalytics/mgmt/2020-03-01-preview/streamanalytics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -121,30 +125,7 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"SystemAssigned",
-							}, false),
-						},
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"job_id": {
 				Type:     pluginsdk.TypeString,
@@ -199,6 +180,11 @@ func resourceStreamAnalyticsJobCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		},
 	}
 
+	expandedIdentity, err := expandStreamAnalyticsJobIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
+
 	props := streamanalytics.StreamingJob{
 		Name:     utils.String(id.Name),
 		Location: utils.String(location),
@@ -212,7 +198,8 @@ func resourceStreamAnalyticsJobCreateUpdate(d *pluginsdk.ResourceData, meta inte
 			EventsOutOfOrderPolicy:             streamanalytics.EventsOutOfOrderPolicy(eventsOutOfOrderPolicy),
 			OutputErrorPolicy:                  streamanalytics.OutputErrorPolicy(outputErrorPolicy),
 		},
-		Tags: tags.Expand(t),
+		Identity: expandedIdentity,
+		Tags:     tags.Expand(t),
 	}
 
 	if streamAnalyticsCluster := d.Get("stream_analytics_cluster_id"); streamAnalyticsCluster != "" {
@@ -227,10 +214,6 @@ func resourceStreamAnalyticsJobCreateUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if dataLocale, ok := d.GetOk("data_locale"); ok {
 		props.StreamingJobProperties.DataLocale = utils.String(dataLocale.(string))
-	}
-
-	if identity, ok := d.GetOk("identity"); ok {
-		props.Identity = expandStreamAnalyticsJobIdentity(identity.([]interface{}))
 	}
 
 	if d.IsNewResource() {
@@ -294,7 +277,7 @@ func resourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("location", azure.NormalizeLocation(*resp.Location))
 	}
 
-	if err := d.Set("identity", flattenStreamAnalyticsJobIdentity(resp.Identity)); err != nil {
+	if err := d.Set("identity", flattenJobIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("setting `identity`: %v", err)
 	}
 
@@ -349,14 +332,18 @@ func resourceStreamAnalyticsJobDelete(d *pluginsdk.ResourceData, meta interface{
 	return nil
 }
 
-func expandStreamAnalyticsJobIdentity(identity []interface{}) *streamanalytics.Identity {
-	b := identity[0].(map[string]interface{})
-	return &streamanalytics.Identity{
-		Type: utils.String(b["type"].(string)),
+func expandStreamAnalyticsJobIdentity(input []interface{}) (*streamanalytics.Identity, error) {
+	expanded, err := identity.ExpandSystemAssigned(input)
+	if err != nil {
+		return nil, err
 	}
+
+	return &streamanalytics.Identity{
+		Type: utils.String(string(expanded.Type)),
+	}, nil
 }
 
-func flattenStreamAnalyticsJobIdentity(identity *streamanalytics.Identity) []interface{} {
+func flattenJobIdentity(identity *streamanalytics.Identity) []interface{} {
 	if identity == nil {
 		return nil
 	}

--- a/internal/services/synapse/synapse_workspace_data_source.go
+++ b/internal/services/synapse/synapse_workspace_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
@@ -42,28 +44,7 @@ func dataSourceSynapseWorkspace() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 
 			"tags": tags.SchemaDataSource(),
 		},
@@ -92,7 +73,7 @@ func dataSourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{})
 	if props := resp.WorkspaceProperties; props != nil {
 		d.Set("connectivity_endpoints", utils.FlattenMapStringPtrString(props.ConnectivityEndpoints))
 	}
-	if err := d.Set("identity", flattenArmWorkspaceManagedIdentity(resp.Identity)); err != nil {
+	if err := d.Set("identity", flattenIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -7,12 +7,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/synapse/mgmt/2021-03-01/synapse"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -174,28 +179,14 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+			"identity": func() *schema.Schema {
+				// TODO: update the docs and tests to account for this
+				if features.ThreePointOh() {
+					return commonschema.SystemAssignedIdentityRequired()
+				}
 
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+				return commonschema.SystemAssignedIdentityComputed()
+			}(),
 
 			"managed_resource_group_name": azure.SchemaResourceGroupNameOptionalComputed(),
 
@@ -374,10 +365,19 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 			WorkspaceRepositoryConfiguration: expandWorkspaceRepositoryConfiguration(d),
 			Encryption:                       expandEncryptionDetails(d),
 		},
-		Identity: &synapse.ManagedIdentity{
-			Type: synapse.ResourceIdentityTypeSystemAssigned,
-		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if features.ThreePointOh() {
+		expandedIdentity, err := expandIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+		workspaceInfo.Identity = expandedIdentity
+	} else {
+		workspaceInfo.Identity = &synapse.ManagedIdentity{
+			Type: synapse.ResourceIdentityTypeSystemAssigned,
+		}
 	}
 
 	if purviewId, ok := d.GetOk("purview_id"); ok {
@@ -497,7 +497,8 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	if err := d.Set("identity", flattenArmWorkspaceManagedIdentity(resp.Identity)); err != nil {
+
+	if err := d.Set("identity", flattenIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 	if props := resp.WorkspaceProperties; props != nil {
@@ -773,28 +774,6 @@ func expandEncryptionDetails(d *pluginsdk.ResourceData) *synapse.EncryptionDetai
 	return nil
 }
 
-func flattenArmWorkspaceManagedIdentity(input *synapse.ManagedIdentity) []interface{} {
-	if input == nil {
-		return make([]interface{}, 0)
-	}
-
-	var principalId string
-	if input.PrincipalID != nil {
-		principalId = *input.PrincipalID
-	}
-	var tenantId string
-	if input.TenantID != nil {
-		tenantId = input.TenantID.String()
-	}
-	return []interface{}{
-		map[string]interface{}{
-			"type":         string(input.Type),
-			"principal_id": principalId,
-			"tenant_id":    tenantId,
-		},
-	}
-}
-
 func flattenArmWorkspaceDataLakeStorageAccountDetails(input *synapse.DataLakeStorageAccountDetails) string {
 	if input != nil && input.AccountURL != nil && input.Filesystem != nil {
 		return fmt.Sprintf("%s/%s", *input.AccountURL, *input.Filesystem)
@@ -899,4 +878,35 @@ func flattenEncryptionDetails(encryption *synapse.EncryptionDetails) []interface
 	}
 
 	return make([]interface{}, 0)
+}
+
+func expandIdentity(input []interface{}) (*synapse.ManagedIdentity, error) {
+	expanded, err := identity.ExpandSystemAssigned(input)
+	if err != nil {
+		return nil, err
+	}
+
+	out := synapse.ManagedIdentity{
+		Type: synapse.ResourceIdentityType(string(expanded.Type)),
+	}
+	return &out, nil
+}
+
+func flattenIdentity(input *synapse.ManagedIdentity) []interface{} {
+	var config *identity.SystemAssigned
+
+	if input != nil {
+		config = &identity.SystemAssigned{
+			Type: identity.Type(string(input.Type)),
+		}
+
+		if input.PrincipalID != nil {
+			config.PrincipalId = *input.PrincipalID
+		}
+		if input.TenantID != nil {
+			config.TenantId = input.TenantID.String()
+		}
+	}
+
+	return identity.FlattenSystemAssigned(config)
 }

--- a/internal/services/videoanalyzer/video_analyzer_resource.go
+++ b/internal/services/videoanalyzer/video_analyzer_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/videoanalyzer/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -73,32 +73,9 @@ func resourceVideoAnalyzer() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string("UserAssigned"),
-							}, false),
-						},
-						"identity_ids": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							MinItems: 1,
-							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: msivalidate.UserAssignedIdentityID,
-							},
-						},
-					},
-				},
-			},
-			"tags": tags.Schema(),
+			"identity": commonschema.UserAssignedIdentityRequired(),
+
+			"tags": commonschema.Tags(),
 		},
 	}
 }

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -227,6 +227,7 @@ func schemaAppServiceAuthSettings() *pluginsdk.Schema {
 }
 
 func schemaAppServiceIdentity() *pluginsdk.Schema {
+	// TODO: 3.0 - conditionally switch this out
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -643,30 +643,6 @@ func flattenFunctionAppSiteCredential(input *web.UserProperties) []interface{} {
 	return append(results, result)
 }
 
-func flattenFunctionAppIdentity(input *web.ManagedServiceIdentity) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-
-	principalID := ""
-	if input.PrincipalID != nil {
-		principalID = *input.PrincipalID
-	}
-
-	tenantID := ""
-	if input.TenantID != nil {
-		tenantID = *input.TenantID
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"type":         string(input.Type),
-			"principal_id": principalID,
-			"tenant_id":    tenantID,
-		},
-	}
-}
-
 func appSettingsMapToNameValuePair(input map[string]*string) *[]web.NameValuePair {
 	if len(input) == 0 {
 		return nil

--- a/internal/services/web/function_app_data_source.go
+++ b/internal/services/web/function_app_data_source.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
@@ -126,28 +129,7 @@ func dataSourceFunctionApp() *pluginsdk.Resource {
 
 			"source_control": schemaAppServiceSiteSourceControlDataSource(),
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
 
 			"tags": tags.Schema(),
 		},
@@ -245,7 +227,11 @@ func dataSourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := d.Set("identity", flattenFunctionAppIdentity(resp.Identity)); err != nil {
+	flattenedIdentity, err := flattenFunctionAppDataSourceIdentity(resp.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	if err := d.Set("identity", flattenedIdentity); err != nil {
 		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 
@@ -265,4 +251,28 @@ func dataSourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func flattenFunctionAppDataSourceIdentity(input *web.ManagedServiceIdentity) (*[]interface{}, error) {
+	var config *identity.SystemAndUserAssignedList
+
+	if input != nil {
+		config = &identity.SystemAndUserAssignedList{
+			Type: identity.Type(string(input.Type)),
+		}
+
+		if input.PrincipalID != nil {
+			config.PrincipalId = *input.PrincipalID
+		}
+		if input.TenantID != nil {
+			config.TenantId = *input.TenantID
+		}
+
+		userAssignedIdentityIds := make([]string, 0)
+		for k := range input.UserAssignedIdentities {
+			userAssignedIdentityIds = append(userAssignedIdentityIds, k)
+		}
+	}
+
+	return identity.FlattenSystemAndUserAssignedList(config)
 }

--- a/internal/services/web/function_app_data_source.go
+++ b/internal/services/web/function_app_data_source.go
@@ -272,6 +272,7 @@ func flattenFunctionAppDataSourceIdentity(input *web.ManagedServiceIdentity) (*[
 		for k := range input.UserAssignedIdentities {
 			userAssignedIdentityIds = append(userAssignedIdentityIds, k)
 		}
+		config.IdentityIds = userAssignedIdentityIds
 	}
 
 	return identity.FlattenSystemAndUserAssignedList(config)

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -78,7 +78,7 @@ func resourceStaticSite() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": commonschema.SystemOrUserAssignedIdentity(),
+			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
 			"api_key": {
 				Type:     pluginsdk.TypeString,

--- a/vendor/github.com/hashicorp/go-azure-helpers/lang/response/response.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/lang/response/response.go
@@ -4,6 +4,11 @@ import (
 	"net/http"
 )
 
+// WasBadRequest returns true if the HttpResponse is non-nil and has a status code of BadRequest
+func WasBadRequest(resp *http.Response) bool {
+	return responseWasStatusCode(resp, http.StatusBadRequest)
+}
+
 // WasConflict returns true if the HttpResponse is non-nil and has a status code of Conflict
 func WasConflict(resp *http.Response) bool {
 	return responseWasStatusCode(resp, http.StatusConflict)

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system.go
@@ -7,7 +7,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func SystemAssignedIdentity() *schema.Schema {
+// SystemAssignedIdentityRequired returns the System Assigned Identity schema where this is Required
+func SystemAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemAssignedIdentityOptional returns the System Assigned Identity schema where this is Optional
+func SystemAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -34,7 +63,8 @@ func SystemAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemAssignedIdentityDataSource() *schema.Schema {
+// SystemAssignedIdentityOptional returns the System Assigned Identity schema where this is Computed
+func SystemAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system_or_user.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system_or_user.go
@@ -13,7 +13,45 @@ import (
 // from a users perspective however, these should both be represented using the same schema
 // so we have a single schema and separate Expand/Flatten functions
 
-func SystemOrUserAssignedIdentity() *schema.Schema {
+// SystemOrUserAssignedIdentityRequired returns the System or User Assigned Identity schema where this is Required
+func SystemOrUserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrUserAssignedIdentityOptional returns the System or User Assigned Identity schema where this is Optional
+func SystemOrUserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -49,7 +87,8 @@ func SystemOrUserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemOrUserAssignedIdentityDataSource() *schema.Schema {
+// SystemOrUserAssignedIdentityComputed returns the System or User Assigned Identity schema where this is Computed
+func SystemOrUserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system_user.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_system_user.go
@@ -13,7 +13,46 @@ import (
 // from a users perspective however, these should both be represented using the same schema
 // so we have a single schema and separate Expand/Flatten functions
 
-func SystemAssignedUserAssignedIdentity() *schema.Schema {
+// SystemAssignedUserAssignedIdentityRequired returns the System Assigned User Assigned Identity schema where this is Required
+func SystemAssignedUserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+						string(identity.TypeSystemAssignedUserAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemAssignedUserAssignedIdentityOptional returns the System Assigned User Assigned Identity schema where this is Optional
+func SystemAssignedUserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -50,7 +89,8 @@ func SystemAssignedUserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemAssignedUserAssignedIdentityDataSource() *schema.Schema {
+// SystemAssignedUserAssignedIdentityComputed returns the System Assigned User Assigned Identity schema where this is Computed
+func SystemAssignedUserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_user.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/identity_user.go
@@ -7,7 +7,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func UserAssignedIdentity() *schema.Schema {
+// UserAssignedIdentityRequired returns the User Assigned Identity schema where this is Required
+func UserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+			},
+		},
+	}
+}
+
+// UserAssignedIdentityOptional returns the User Assigned Identity schema where this is Optional
+func UserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -34,7 +63,8 @@ func UserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func UserAssignedIdentityDataSource() *schema.Schema {
+// UserAssignedIdentityComputed returns the User Assigned Identity schema where this is Computed
+func UserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.21.0
+# github.com/hashicorp/go-azure-helpers v0.22.0
 ## explicit
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -168,11 +168,13 @@ A `source_control` block exports the following:
 
 An `identity` block exports the following:
 
-* `principal_id` - The ID of the System Managed Service Principal assigned to the function app.
+* `identity_ids` - A list of User Assigned Identity IDs assigned to the Function App.
 
-* `tenant_id` - The ID of the Tenant of the System Managed Service Principal assigned to the function app.
+* `principal_id` - The ID of the Managed Identity assigned to the Function App.
 
-* `type` - The identity type of the Managed Identity assigned to the function app.
+* `tenant_id` - The ID of the Tenant where the Managed Identity assigned to the Function App is located.
+
+* `type` - The identity type of the Managed Identity assigned to the Function App.
 
 ## Timeouts
 


### PR DESCRIPTION
This PR includes:

1. `dependencies: upgrading github.com/hashicorp/go-azure-helpers to v0.22.0`
2. handling the breaking changes in that upgrade
3. refactors existing `identity` blocks to using the new common schema
4. also refactors `identity` within the storage account - this is currently Optional & Computed but the Computed value isn't used, so can just be Optional.
5. synapse workspace, `identity` becomes required in 3.0 - this is currently defaulted in the create and so computed, but in line with #15187 should be required