### PR TITLE
doc: storage_account_id clarification

### DIFF
--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -52,8 +52,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_storage_account_network_rules" "test" {
-  resource_group_name  = azurerm_resource_group.test.name
-  storage_account_name = azurerm_storage_account.test.name
+  storage_account_id = azurerm_storage_account.test.id
 
   default_action             = "Allow"
   ip_rules                   = ["127.0.0.1"]
@@ -74,7 +73,7 @@ The following arguments are supported:
 
 -> **NOTE:** This property has been deprecated in favour of the `storage_account_id` property and will be removed in version 3.0 of the provider.
 
-* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created. Do not combine with `storage_account_name` and `resource_group_name`.
+* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created. 
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 -> **NOTE:** This property has been deprecated in favour of the `storage_account_id` property and will be removed in version 3.0 of the provider.
 
-* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created. 
+* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created.
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 -> **NOTE:** This property has been deprecated in favour of the `storage_account_id` property and will be removed in version 3.0 of the provider.
 
-* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created.
+* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created. Do not combine with `storage_account_name` and `resource_group_name`.
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 


### PR DESCRIPTION
Document that storage_account_id is mutually exclusive with storage_account_name and resource_group_name.
See #15225