### PR TITLE
tooling: generating Github Labels for Services based on the interface being implemented

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,3 +1,4 @@
+# NOTE: this file is generated via 'make generate'
 dependencies:
   - go.mod
   - go.sum

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -4,3 +4,5 @@ dependencies:
   - vendor/**/*
 documentation:
   - website/**/*
+service/aadb2c:
+  - internal/services/aadb2c/**/*

--- a/internal/sdk/service_registration.go
+++ b/internal/sdk/service_registration.go
@@ -37,3 +37,27 @@ type UntypedServiceRegistration interface {
 	// SupportedResources returns the supported Resources supported by this Service
 	SupportedResources() map[string]*pluginsdk.Resource
 }
+
+// TypedServiceRegistrationWithAGitHubLabel is a superset of TypedServiceRegistration allowing
+// a single GitHub Label to be specified that will be automatically applied to any Pull Requests
+// making changes to this package.
+//
+// NOTE: this is intentionally an optional interface as the Service Package : GitHub Labels aren't
+// always 1:1
+type TypedServiceRegistrationWithAGitHubLabel interface {
+	TypedServiceRegistration
+
+	AssociatedGitHubLabel() string
+}
+
+// UntypedServiceRegistrationWithAGitHubLabel is a superset of UntypedServiceRegistration allowing
+// a single GitHub Label to be specified that will be automatically applied to any Pull Requests
+// making changes to this package.
+//
+// NOTE: this is intentionally an optional interface as the Service Package : GitHub Labels aren't
+// always 1:1
+type UntypedServiceRegistrationWithAGitHubLabel interface {
+	UntypedServiceRegistration
+
+	AssociatedGitHubLabel() string
+}

--- a/internal/services/aadb2c/registration.go
+++ b/internal/services/aadb2c/registration.go
@@ -7,8 +7,12 @@ import (
 
 type Registration struct{}
 
-var _ sdk.TypedServiceRegistration = Registration{}
-var _ sdk.UntypedServiceRegistration = Registration{}
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/aadb2c"
+}
 
 // Name is the name of this Service
 func (r Registration) Name() string {

--- a/internal/tools/generator-services/README.md
+++ b/internal/tools/generator-services/README.md
@@ -6,6 +6,7 @@ This generator takes that metadata and uses it to generate two things:
 
 1. Website Categories - which validates the categories used in the website exist, required for website deployments to happen.
 2. Service Definitions - generates the list of services used to run the Acceptance Tests
+3. GitHub Labels - generates the list of tags which should be assigned to a pull request when files within this path are changed. 
 
 This is run via go:generate whenever the "SupportedServices" array is changed so that this is kept up-to-date.
 

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -53,7 +53,7 @@ type generator interface {
 	run(outputFileName string, packagesToSkip map[string]struct{}) error
 }
 
-const githubLabelsTemplate = `
+const githubLabelsTemplate = `# NOTE: this file is generated via 'make generate'
 dependencies:
   - go.mod
   - go.sum

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -73,7 +73,7 @@ func (githubLabelsGenerator) outputPath(rootDirectory string) string {
 }
 
 func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) error {
-	packagesToLabel := make(map[string]string, 0)
+	packagesToLabel := make(map[string]string)
 	// combine and unique these
 	for _, service := range provider.SupportedTypedServices() {
 		v, ok := service.(sdk.TypedServiceRegistrationWithAGitHubLabel)

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -9,9 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 )
 
 // Packages in this list are deprecated and cannot be run due to breaking API changes

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
 )
 
@@ -34,6 +36,7 @@ func main() {
 	}
 
 	generators := []generator{
+		githubLabelsGenerator{},
 		teamCityServicesListGenerator{},
 		websiteCategoriesGenerator{},
 	}
@@ -48,6 +51,70 @@ func main() {
 type generator interface {
 	outputPath(rootDirectory string) string
 	run(outputFileName string, packagesToSkip map[string]struct{}) error
+}
+
+const githubLabelsTemplate = `
+dependencies:
+  - go.mod
+  - go.sum
+  - vendor/**/*
+documentation:
+  - website/**/*
+`
+
+const githubLabelServiceTemplate = `
+%[1]s:
+  - internal/services/%[2]s/**/*
+`
+
+type githubLabelsGenerator struct{}
+
+func (githubLabelsGenerator) outputPath(rootDirectory string) string {
+	return fmt.Sprintf("%s/.github/labeler-pull-request-triage.yml", rootDirectory)
+}
+
+func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) error {
+	packagesToLabel := make(map[string]string, 0)
+	// combine and unique these
+	for _, service := range provider.SupportedTypedServices() {
+		v, ok := service.(sdk.TypedServiceRegistrationWithAGitHubLabel)
+		if !ok {
+			// skipping since this doesn't implement the label interface
+			continue
+		}
+
+		info := reflect.TypeOf(service)
+		packageSegments := strings.Split(info.PkgPath(), "/")
+		packageName := packageSegments[len(packageSegments)-1]
+		packagesToLabel[packageName] = v.AssociatedGitHubLabel()
+	}
+	for _, service := range provider.SupportedUntypedServices() {
+		v, ok := service.(sdk.UntypedServiceRegistrationWithAGitHubLabel)
+		if !ok {
+			// skipping since this doesn't implement the label interface
+			continue
+		}
+
+		info := reflect.TypeOf(service)
+		packageSegments := strings.Split(info.PkgPath(), "/")
+		packageName := packageSegments[len(packageSegments)-1]
+		packagesToLabel[packageName] = v.AssociatedGitHubLabel()
+	}
+
+	sortedPackages := make([]string, 0)
+	for k := range packagesToLabel {
+		sortedPackages = append(sortedPackages, k)
+	}
+	sort.Strings(sortedPackages)
+
+	output := strings.TrimSpace(githubLabelsTemplate)
+	for _, packageName := range sortedPackages {
+		label := packagesToLabel[packageName]
+		templated := fmt.Sprintf(githubLabelServiceTemplate, label, packageName)
+		output += templated
+	}
+
+	return writeToFile(outputFileName, output)
 }
 
 type teamCityServicesListGenerator struct{}


### PR DESCRIPTION
This commit allows specifying a single GitHub Label which should be applied to a Pull Request when anything under that path is changed. As this is an opt-in interface (some packages span multiple GitHub Labels, this can be conditionally implemented if necessary).