### PR TITLE
Refactor beta [windows|linux] function app slots for ID

### DIFF
--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -271,7 +271,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			id := parse.NewFunctionAppSlotID(subscriptionId, functionAppId.ResourceGroup, functionAppId.SiteName, functionAppSlot.Name)
 			functionApp, err := client.Get(ctx, functionAppId.ResourceGroup, functionAppId.SiteName)
 			if err != nil {
-				return fmt.Errorf("reading parent Windows Function App for %s: %+v", id, err)
+				return fmt.Errorf("retrieving parent Linux %s: %+v", *functionAppId, err)
 			}
 			if functionApp.Location == nil {
 				return fmt.Errorf("could not determine location for %s: %+v", id, err)
@@ -390,7 +390,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp,linux"),
 				Identity: helpers.ExpandIdentity(functionAppSlot.Identity),
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:         props.ServerFarmID,
+					ServerFarmID:         utils.String(servicePlanId.ID()),
 					Enabled:              utils.Bool(functionAppSlot.Enabled),
 					HTTPSOnly:            utils.Bool(functionAppSlot.HttpsOnly),
 					SiteConfig:           siteConfig,

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -743,30 +743,6 @@ func TestAccLinuxFunctionAppSlot_appStackPowerShellCore(t *testing.T) {
 
 // Others
 
-func TestAccLinuxFunctionAppSlot_updateServicePlan(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
-	r := LinuxFunctionAppSlotResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data, SkuStandardPlan),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.servicePlanUpdate(data, SkuStandardPlan),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccLinuxFunctionAppSlot_updateStorageAccount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
 	r := LinuxFunctionAppSlotResource{}
@@ -822,10 +798,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -844,10 +817,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -868,10 +838,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -893,10 +860,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -920,10 +884,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -944,10 +905,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -971,10 +929,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -999,10 +954,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1023,10 +975,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1071,10 +1020,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1105,10 +1051,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1132,10 +1075,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1158,10 +1098,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1184,10 +1121,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1210,10 +1144,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1236,10 +1167,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1266,10 +1194,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1303,10 +1228,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1329,10 +1251,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1374,10 +1293,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%[2]d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1534,10 +1450,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%[2]d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1708,10 +1621,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%[2]d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1813,30 +1723,6 @@ resource "azurerm_linux_function_app_slot" "test" {
 `, r.storageContainerTemplate(data, SkuElasticPremiumPlan), data.RandomInteger)
 }
 
-func (r LinuxFunctionAppSlotResource) servicePlanUpdate(data acceptance.TestData, planSku string) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_linux_function_app_slot" "test" {
-  name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.update.id
-  storage_account_name       = azurerm_storage_account.test.name
-  storage_account_access_key = azurerm_storage_account.test.primary_access_key
-
-  site_config {}
-
-  depends_on = [azurerm_service_plan.update]
-}
-`, r.templateServicePlanUpdate(data, planSku), data.RandomInteger)
-}
-
 func (r LinuxFunctionAppSlotResource) updateStorageAccount(data acceptance.TestData, planSku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1847,10 +1733,7 @@ provider "azurerm" {
 
 resource "azurerm_linux_function_app_slot" "test" {
   name                       = "acctest-LFAS-%d"
-  function_app_name          = azurerm_linux_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_linux_function_app.test.id
   storage_account_name       = azurerm_storage_account.update.name
   storage_account_access_key = azurerm_storage_account.update.primary_access_key
 
@@ -1944,20 +1827,6 @@ resource "azurerm_linux_function_app" "test" {
   site_config {}
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, planSku)
-}
-
-func (r LinuxFunctionAppSlotResource) templateServicePlanUpdate(data acceptance.TestData, planSku string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_service_plan" "update" {
-  name                = "acctestASP2-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  os_type             = "Linux"
-  sku_name            = "%s"
-}
-`, r.template(data, planSku), data.RandomInteger, planSku)
 }
 
 func (r LinuxFunctionAppSlotResource) storageContainerTemplate(data acceptance.TestData, planSku string) string {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -278,7 +278,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			id := parse.NewFunctionAppSlotID(subscriptionId, functionAppId.ResourceGroup, functionAppId.SiteName, functionAppSlot.Name)
 			functionApp, err := client.Get(ctx, functionAppId.ResourceGroup, functionAppId.SiteName)
 			if err != nil {
-				return fmt.Errorf("reading parent Windows Function App for %s: %+v", id, err)
+				return fmt.Errorf("retrieving parent Windows %s: %+v", *functionAppId, err)
 			}
 			if functionApp.Location == nil {
 				return fmt.Errorf("could not determine location for %s: %+v", id, err)

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
@@ -26,10 +24,7 @@ type WindowsFunctionAppSlotResource struct{}
 
 type WindowsFunctionAppSlotModel struct {
 	Name                          string                                     `tfschema:"name"`
-	ResourceGroup                 string                                     `tfschema:"resource_group_name"`
-	FunctionAppName               string                                     `tfschema:"function_app_name"`
-	Location                      string                                     `tfschema:"location"`
-	ServicePlanId                 string                                     `tfschema:"service_plan_id"`
+	FunctionAppID                 string                                     `tfschema:"function_app_id"`
 	StorageAccountName            string                                     `tfschema:"storage_account_name"`
 	StorageAccountKey             string                                     `tfschema:"storage_account_access_key"`
 	StorageUsesMSI                bool                                       `tfschema:"storage_uses_managed_identity"` // Storage uses MSI not account key
@@ -82,23 +77,12 @@ func (r WindowsFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema
 			Description:  "Specifies the name of the Windows Function App Slot.",
 		},
 
-		"function_app_name": {
+		"function_app_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validate.WebAppName,
-			Description:  "The name of the Windows Function App this Slot is a member of.",
-		},
-
-		"resource_group_name": azure.SchemaResourceGroupName(),
-
-		"location": location.Schema(),
-
-		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.ServicePlanID,
-			Description:  "The ID of the App Service Plan within which to create this Function App Slot.",
+			ValidateFunc: validate.FunctionAppID,
+			Description:  "The ID of the Windows Function App this Slot is a member of.",
 		},
 
 		"storage_account_name": {
@@ -282,13 +266,28 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.AppService.WebAppsClient
+			functionAppId, err := parse.FunctionAppID(functionAppSlot.FunctionAppID)
+			if err != nil {
+				return err
+			}
+
 			aseClient := metadata.Client.AppService.AppServiceEnvironmentClient
 			servicePlanClient := metadata.Client.AppService.ServicePlanClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			id := parse.NewFunctionAppSlotID(subscriptionId, functionAppSlot.ResourceGroup, functionAppSlot.FunctionAppName, functionAppSlot.Name)
-
-			servicePlanId, err := parse.ServicePlanID(functionAppSlot.ServicePlanId)
+			id := parse.NewFunctionAppSlotID(subscriptionId, functionAppId.ResourceGroup, functionAppId.SiteName, functionAppSlot.Name)
+			functionApp, err := client.Get(ctx, functionAppId.ResourceGroup, functionAppId.SiteName)
+			if err != nil {
+				return fmt.Errorf("reading parent Windows Function App for %s: %+v", id, err)
+			}
+			if functionApp.Location == nil {
+				return fmt.Errorf("could not determine location for %s: %+v", id, err)
+			}
+			props := functionApp.SiteProperties
+			if props == nil || props.ServerFarmID == nil {
+				return fmt.Errorf("could not determine Service Plan ID for %s: %+v", id, err)
+			}
+			servicePlanId, err := parse.ServicePlanID(*props.ServerFarmID)
 			if err != nil {
 				return err
 			}
@@ -392,12 +391,12 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			siteConfig.AppSettings = helpers.MergeUserAppSettings(siteConfig.AppSettings, functionAppSlot.AppSettings)
 
 			siteEnvelope := web.Site{
-				Location: utils.String(functionAppSlot.Location),
+				Location: functionApp.Location,
 				Tags:     tags.FromTypedObject(functionAppSlot.Tags),
 				Kind:     utils.String("functionapp"),
 				Identity: helpers.ExpandIdentity(functionAppSlot.Identity),
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:         utils.String(functionAppSlot.ServicePlanId),
+					ServerFarmID:         utils.String(servicePlanId.ID()),
 					Enabled:              utils.Bool(functionAppSlot.Enabled),
 					HTTPSOnly:            utils.Bool(functionAppSlot.HttpsOnly),
 					SiteConfig:           siteConfig,
@@ -522,10 +521,7 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 
 			state := WindowsFunctionAppSlotModel{
 				Name:                 id.SlotName,
-				FunctionAppName:      id.SiteName,
-				ResourceGroup:        id.ResourceGroup,
-				ServicePlanId:        utils.NormalizeNilableString(props.ServerFarmID),
-				Location:             location.NormalizeNilable(functionAppSlot.Location),
+				FunctionAppID:        parse.NewFunctionAppID(id.SubscriptionId, id.ResourceGroup, id.SiteName).ID(),
 				Enabled:              utils.NormaliseNilableBool(functionAppSlot.Enabled),
 				ClientCertMode:       string(functionAppSlot.ClientCertMode),
 				DailyMemoryTimeQuota: int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
@@ -612,10 +608,6 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 			}
 
 			// Some service plan updates are allowed - see customiseDiff for exceptions
-			if metadata.ResourceData.HasChange("service_plan_id") {
-				existing.SiteProperties.ServerFarmID = utils.String(state.ServicePlanId)
-			}
-
 			if metadata.ResourceData.HasChange("enabled") {
 				existing.SiteProperties.Enabled = utils.Bool(state.Enabled)
 			}

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -752,10 +752,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -774,10 +771,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -801,10 +795,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -846,10 +837,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%[2]d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1003,10 +991,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%[2]d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1169,10 +1154,7 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%[2]d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1280,10 +1262,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1328,10 +1307,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1352,10 +1328,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1380,10 +1353,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1407,10 +1377,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1441,10 +1408,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1465,10 +1429,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1489,10 +1450,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1514,10 +1472,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1541,10 +1496,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1567,10 +1519,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1593,10 +1542,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1619,10 +1565,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1645,10 +1588,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
@@ -1669,10 +1609,7 @@ provider "azurerm" {
 
 resource "azurerm_windows_function_app_slot" "test" {
   name                       = "acctest-WFAS-%d"
-  function_app_name          = azurerm_windows_function_app.test.name
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  service_plan_id            = azurerm_service_plan.test.id
+  function_app_id            = azurerm_windows_function_app.test.id
   storage_account_name       = azurerm_storage_account.update.name
   storage_account_access_key = azurerm_storage_account.update.primary_access_key
 

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Function App Slot. Changing this forces a new resource to be created.
 
-* `function_app_name` - (Required) The name of the Linux Function App this Slot is a member of. Changing this forces a new resource to be created.
+* `function_app_id` - (Required) The ID of the Linux Function App this Slot is a member of. Changing this forces a new resource to be created.
 
 * `site_config` - (Required) a `site_config` block as detailed below.
 

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -52,10 +52,7 @@ resource "azurerm_linux_function_app" "example" {
 
 resource "azurerm_linux_function_app_slot" "example" {
   name                 = "example-linux-function-app-slot"
-  function_app_name    = azurerm_linux_function_app.example.name
-  location             = azurerm_resource_group.example.location
-  resource_group_name  = azurerm_resource_group.example.name
-  service_plan_id      = azurerm_service_plan.example.id
+  function_app_id      = azurerm_linux_function_app.example.id
   storage_account_name = azurerm_storage_account.example.name
 
   site_config {}
@@ -70,12 +67,6 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Function App Slot. Changing this forces a new resource to be created.
 
 * `function_app_name` - (Required) The name of the Linux Function App this Slot is a member of. Changing this forces a new resource to be created.
-
-* `location` - (Required) The Azure Region where the Linux Function App should exist. Changing this forces a new Resource to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Linux Function App Slot should exist. Changing this forces a new Resource to be created.
-
-* `service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App Slot.
 
 * `site_config` - (Required) a `site_config` block as detailed below.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -42,11 +42,8 @@ resource "azurerm_linux_web_app" "example" {
 }
 
 resource "azurerm_linux_web_app_slot" "example" {
-  name                = "example"
-  app_service_name    = azurerm_linux_web_app.example.name
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_service_plan.example.location
-  service_plan_id     = azurerm_service_plan.example.id
+  name           = "example-slot"
+  app_service_id = azurerm_linux_web_app.example.id
 
   site_config {}
 }
@@ -61,13 +58,7 @@ The following arguments are supported:
 
 * ~> **NOTE:** Terraform will perform a name availability check as part of the creation progress, if this Web App is part of an App Service Environment terraform will require Read permission on the ASE for this to complete reliably.
 
-* `location` - (Required) The Azure Region where the Linux Web App should exist. Changing this forces a new Linux Web App to be created.
-
-* `app_service_name` - (Required) The name of the Linux Web App this Deployment Slot will be part of.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Linux Web App should exist. Changing this forces a new Linux Web App to be created.
-
-* `service_plan_id` - (Required) The ID of the Service Plan that this Linux App Service will be created in.
+* `app_service_ID` - (Required) The ID of the Linux Web App this Deployment Slot will be part of.
 
 * `site_config` - (Required) A `site_config` block as defined below.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * ~> **NOTE:** Terraform will perform a name availability check as part of the creation progress, if this Web App is part of an App Service Environment terraform will require Read permission on the ASE for this to complete reliably.
 
-* `app_service_ID` - (Required) The ID of the Linux Web App this Deployment Slot will be part of.
+* `app_service_id` - (Required) The ID of the Linux Web App this Deployment Slot will be part of. Changing this forces a new Linux Web App to be created.
 
 * `site_config` - (Required) A `site_config` block as defined below.
 

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -51,12 +51,9 @@ resource "azurerm_windows_function_app" "example" {
 }
 
 resource "azurerm_windows_function_app_slot" "example" {
-  name                 = "example"
-  function_app_name    = "example"
-  location             = "example"
-  resource_group_name  = "example"
-  service_plan_id      = "example"
-  storage_account_name = "example"
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
 
   site_config = {}
 }

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -65,13 +65,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Windows Function App Slot. Changing this forces a new resource to be created.
 
-* `function_app_name` - (Required) The name of the Windows Function App this Slot is a member of. Changing this forces a new resource to be created.
-
-* `location` - (Required) The Azure Region where the Windows Function App should exist. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Windows Function App should exist. Changing this forces a new resource to be created.
-
-* `service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App Slot.
+* `function_app_id` - (Required) The name of the Windows Function App this Slot is a member of. Changing this forces a new resource to be created.
 
 * `site_config` - (Required) a `site_config` block as detailed below.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_service_plan" "example" {
 }
 
 resource "azurerm_windows_web_app" "example" {
-  name                = "example"
+  name                = "example-windows-web-app"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_service_plan.example.location
   service_plan_id     = azurerm_service_plan.example.id
@@ -42,7 +42,7 @@ resource "azurerm_windows_web_app" "example" {
 }
 
 resource "azurerm_windows_web_app_slot" "example" {
-  name           = "example"
+  name           = "example-slot"
   app_service_id = azurerm_windows_web_app.example.id
 
   site_config {}
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * ~> **NOTE:** Terraform will perform a name availability check as part of the creation progress, if this Web App is part of an App Service Environment terraform will require Read permission on the App Service Environment for this to complete reliably.
 
-* `app_service_id` - (Required) The ID of the Windows Web App this Deployment Slot will be part of.
+* `app_service_id` - (Required) The ID of the Windows Web App this Deployment Slot will be part of. Changing this forces a new Windows Web App to be created.
 
 * `site_config` - (Required) A `site_config` block as defined below.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -42,11 +42,8 @@ resource "azurerm_windows_web_app" "example" {
 }
 
 resource "azurerm_windows_web_app_slot" "example" {
-  name                = "example"
-  app_service_name    = azurerm_windows_web_app.example.name
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_service_plan.example.location
-  service_plan_id     = azurerm_service_plan.example.id
+  name           = "example"
+  app_service_id = azurerm_windows_web_app.example.id
 
   site_config {}
 }
@@ -61,13 +58,7 @@ The following arguments are supported:
 
 * ~> **NOTE:** Terraform will perform a name availability check as part of the creation progress, if this Web App is part of an App Service Environment terraform will require Read permission on the App Service Environment for this to complete reliably.
 
-* `location` - (Required) The Azure Region where the Windows Web App Slot should exist. Changing this forces a new Windows Web App Slot to be created.
-
-* `app_service_name` - (Required) The name of the Windows Web App this Deployment Slot will be part of.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Windows Web App Slot should exist. Changing this forces a new Windows Web App Slot to be created.
-
-* `service_plan_id` - (Required) The ID of the Service Plan that this Windows App Service will be created in.
+* `app_service_id` - (Required) The ID of the Windows Web App this Deployment Slot will be part of.
 
 * `site_config` - (Required) A `site_config` block as defined below.
 


### PR DESCRIPTION
`azurerm_linux_function_app_slot` - refactor to take Function App ID in place of separate components
`azurerm_windows_function_app_slot` - refactor to take Function App ID in place of separate components