### PR TITLE
Update dns_zone.html.markdown

### DIFF
--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -22,11 +22,6 @@ resource "azurerm_dns_zone" "example-public" {
   name                = "mydomain.com"
   resource_group_name = azurerm_resource_group.example.name
 }
-
-resource "azurerm_private_dns_zone" "example-private" {
-  name                = "mydomain.com"
-  resource_group_name = azurerm_resource_group.example.name
-}
 ```
 ## Argument Reference
 


### PR DESCRIPTION
The documentation for DNS Zone shouldn't contain azurerm_private_dns_zone as that is in it's own document.