### PR TITLE
Make quota value in example consistent

### DIFF
--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "example" {
 resource "azurerm_storage_share" "example" {
   name                 = "sharename"
   storage_account_name = azurerm_storage_account.example.name
-  quota                = 50
+  quota                = 100
 
   acl {
     id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"


### PR DESCRIPTION
Argument reference for `quota` says
"this must be greater than 100 GB and less than 102400 GB (100 TB)"
and 50 is clearly less than 100