### PR TITLE
identity: working around the use of legacy identity types

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -12,9 +12,11 @@ import (
 	azautorest "github.com/Azure/go-autorest/autorest"
 	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-getter/helper/url"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -347,7 +349,53 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+			"identity": func() *schema.Schema {
+				if features.ThreePointOhBeta() {
+					return commonschema.SystemAssignedUserAssignedIdentityOptional()
+				}
+
+				return &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"type": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(identity.TypeUserAssigned),
+									string(identity.TypeSystemAssigned),
+									string(identity.TypeSystemAssignedUserAssigned),
+									"SystemAssigned,UserAssigned", // defined in the Swagger but should be normalized as above
+								}, false),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// handle `SystemAssigned, UserAssigned` with and without the spaces being the same
+									oldWithoutSpaces := strings.ReplaceAll(old, " ", "")
+									newWithoutSpaces := strings.ReplaceAll(new, " ", "")
+									return oldWithoutSpaces == newWithoutSpaces
+								},
+							},
+							"identity_ids": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+								},
+							},
+							"principal_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"tenant_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				}
+			}(),
 
 			"blob_properties": {
 				Type:     pluginsdk.TypeList,
@@ -2850,6 +2898,17 @@ func flattenStorageAccountBypass(input storage.Bypass) []interface{} {
 }
 
 func expandAzureRmStorageAccountIdentity(input []interface{}) (*storage.Identity, error) {
+	if !features.ThreePointOhBeta() {
+		// work around the Swagger defining `SystemAssigned,UserAssigned` rather than `SystemAssigned, UserAssigned`
+		if len(input) > 0 {
+			raw := input[0].(map[string]interface{})
+			if identityType := raw["type"].(string); strings.EqualFold("SystemAssigned,UserAssigned", identityType) {
+				raw["type"] = "SystemAssigned, UserAssigned"
+			}
+			input[0] = raw
+		}
+	}
+
 	expanded, err := identity.ExpandSystemAndUserAssignedMap(input)
 	if err != nil {
 		return nil, err
@@ -2857,6 +2916,11 @@ func expandAzureRmStorageAccountIdentity(input []interface{}) (*storage.Identity
 
 	out := storage.Identity{
 		Type: storage.IdentityType(string(expanded.Type)),
+	}
+
+	// work around the Swagger defining `SystemAssigned,UserAssigned` rather than `SystemAssigned, UserAssigned`
+	if expanded.Type == identity.TypeSystemAssignedUserAssigned {
+		out.Type = storage.IdentityTypeSystemAssignedUserAssigned
 	}
 
 	// 'Failed to perform resource identity operation. Status: 'BadRequest'. Response:
@@ -2883,6 +2947,12 @@ func flattenAzureRmStorageAccountIdentity(input *storage.Identity) (*[]interface
 			Type:        identity.Type(string(input.Type)),
 			IdentityIds: nil,
 		}
+
+		// work around the Swagger defining `SystemAssigned,UserAssigned` rather than `SystemAssigned, UserAssigned`
+		if input.Type == storage.IdentityTypeSystemAssignedUserAssigned {
+			config.Type = identity.TypeSystemAssignedUserAssigned
+		}
+
 		if input.PrincipalID != nil {
 			config.PrincipalId = *input.PrincipalID
 		}

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1899,7 +1899,8 @@ resource "azurerm_storage_account" "test" {
 }
 
 func (r StorageAccountResource) systemAssignedUserAssignedIdentity(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_account" "test" {
@@ -1912,6 +1913,27 @@ resource "azurerm_storage_account" "test" {
 
   identity {
     type = "SystemAssigned,UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+}
+`, r.identityTemplate(data), data.RandomString)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
     identity_ids = [
       azurerm_user_assigned_identity.test.id,
     ]

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -338,6 +338,15 @@ func expandStreamAnalyticsJobIdentity(input []interface{}) (*streamanalytics.Ide
 		return nil, err
 	}
 
+	// Otherwise we get:
+	//   Code="BadRequest"
+	//   Message="The JSON provided in the request body is invalid. Cannot convert value 'None' to
+	//   type 'System.Nullable`1[Microsoft.Streaming.Service.Contracts.CSMResourceProvider.IdentityType]"
+	// Upstream issue: https://github.com/Azure/azure-rest-api-specs/issues/17649
+	if expanded.Type == identity.TypeNone {
+		return nil, nil
+	}
+
 	return &streamanalytics.Identity{
 		Type: utils.String(string(expanded.Type)),
 	}, nil

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/Azure/azure-sdk-for-go/services/synapse/mgmt/2021-03-01/synapse"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -112,7 +114,7 @@ func TestAccSynapseWorkspace_azdo(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.azdo(data),
+			Config: r.azureDevOps(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("azure_devops_repo.0.account_name").HasValue("myorg"),
@@ -132,7 +134,7 @@ func TestAccSynapseWorkspace_azdoTenant(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.azdoTenant(data),
+			Config: r.azureDevOpsTenant(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("azure_devops_repo.0.account_name").HasValue("myorg"),
@@ -200,7 +202,9 @@ func (r SynapseWorkspaceResource) Exists(ctx context.Context, client *clients.Cl
 
 func (r SynapseWorkspaceResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_synapse_workspace" "test" {
@@ -212,11 +216,30 @@ resource "azurerm_synapse_workspace" "test" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
 }
 `, template, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_synapse_workspace" "import" {
@@ -228,11 +251,29 @@ resource "azurerm_synapse_workspace" "import" {
   sql_administrator_login_password     = azurerm_synapse_workspace.test.sql_administrator_login_password
 }
 `, config)
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_workspace" "import" {
+  name                                 = azurerm_synapse_workspace.test.name
+  resource_group_name                  = azurerm_synapse_workspace.test.resource_group_name
+  location                             = azurerm_synapse_workspace.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_synapse_workspace.test.storage_data_lake_gen2_filesystem_id
+  sql_administrator_login              = azurerm_synapse_workspace.test.sql_administrator_login
+  sql_administrator_login_password     = azurerm_synapse_workspace.test.sql_administrator_login_password
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, config)
 }
 
 func (r SynapseWorkspaceResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_client_config" "current" {}
@@ -280,10 +321,90 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomString, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+
+resource "azurerm_purview_account" "test" {
+  name                = "acctestacc%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = "%s"
+  sku_name            = "Standard_1"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "%s-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "%s-subnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+  data_exfiltration_protection_enabled = true
+  managed_virtual_network_enabled      = true
+  managed_resource_group_name          = "acctest-ManagedSynapse-%d"
+  sql_identity_control_enabled         = true
+  public_network_access_enabled        = false
+  linking_allowed_for_aad_tenant_ids   = [data.azurerm_client_config.current.tenant_id]
+  purview_id                           = azurerm_purview_account.test.id
+  compute_subnet_id                    = azurerm_subnet.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+}
+`, template, data.RandomString, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) withAadAdmin(data acceptance.TestData) string {
 	template := r.template(data)
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR4!"
+  sql_identity_control_enabled         = true
+  aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  tags = {
+    ENV = "Test2"
+  }
+}
+`, template, data.RandomInteger)
+	}
 	return fmt.Sprintf(`
 %s
 
@@ -302,6 +423,10 @@ resource "azurerm_synapse_workspace" "test" {
     login     = "AzureAD Admin"
     object_id = data.azurerm_client_config.current.object_id
     tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  identity {
+    type = "SystemAssigned"
   }
 
   tags = {
@@ -313,7 +438,8 @@ resource "azurerm_synapse_workspace" "test" {
 
 func (r SynapseWorkspaceResource) withSqlAadAdmin(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_client_config" "current" {
@@ -339,11 +465,43 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR4!"
+  sql_identity_control_enabled         = true
+
+  sql_aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    ENV = "Test2"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) withAadAdmins(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_client_config" "current" {
@@ -374,11 +532,48 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {
 }
 
-func (r SynapseWorkspaceResource) azdo(data acceptance.TestData) string {
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR4!"
+  sql_identity_control_enabled         = true
+  aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  sql_aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    ENV = "Test2"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r SynapseWorkspaceResource) azureDevOps(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_synapse_workspace" "test" {
@@ -399,11 +594,38 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  azure_devops_repo {
+    account_name    = "myorg"
+    project_name    = "myproj"
+    repository_name = "myrepo"
+    branch_name     = "dev"
+    root_folder     = "/"
+    last_commit_id  = "1592393b38543d51feb12714cbd39501d697610c"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
 }
 
-func (r SynapseWorkspaceResource) azdoTenant(data acceptance.TestData) string {
+func (r SynapseWorkspaceResource) azureDevOpsTenant(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_client_config" "current" {}
@@ -426,11 +648,40 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  azure_devops_repo {
+    account_name    = "myorg"
+    project_name    = "myproj"
+    repository_name = "myrepo"
+    branch_name     = "dev"
+    root_folder     = "/"
+    tenant_id       = data.azurerm_client_config.current.tenant_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) github(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_synapse_workspace" "test" {
@@ -451,11 +702,38 @@ resource "azurerm_synapse_workspace" "test" {
   }
 }
 `, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  github_repo {
+    account_name    = "myuser"
+    git_url         = "https://github.mydomain.com"
+    repository_name = "myrepo"
+    branch_name     = "dev"
+    root_folder     = "/"
+    last_commit_id  = "1592393b38543d51feb12714cbd39501d697610c"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) customerManagedKey(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_client_config" "current" {}
@@ -502,6 +780,60 @@ resource "azurerm_synapse_workspace" "test" {
     key_versionless_id = azurerm_key_vault_key.test.versionless_id
   }
 
+}
+`, template, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acckv%d"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "create",
+      "get",
+      "delete",
+      "purge"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts = [
+    "unwrapKey",
+    "wrapKey"
+  ]
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  customer_managed_key {
+    key_versionless_id = azurerm_key_vault_key.test.versionless_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 `, template, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -44,7 +44,6 @@ func TestAccAzureStaticSite_withUserAssignedIdentity(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -142,7 +142,6 @@ The following arguments are supported:
 * `routing` - (Optional) A `routing` block as defined below.
 
 * `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
-* 
 * `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
 
 ~> **NOTE:** For the `queue_encryption_key_type` and `table_encryption_key_type`, the `Account` key type is only allowed when the `account_kind` is set to `StorageV2`

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -142,9 +142,10 @@ The following arguments are supported:
 * `routing` - (Optional) A `routing` block as defined below.
 
 * `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
+* 
 * `table_encryption_key_type` - (Optional) The encryption type of the table service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`. 
 
-~> **NOTE:** For  the `queue_encryption_key_type` and `table_encryption_key_type`, the `Account` key type is only allowed when the `account_kind` is set to `StorageV2`
+~> **NOTE:** For the `queue_encryption_key_type` and `table_encryption_key_type`, the `Account` key type is only allowed when the `account_kind` is set to `StorageV2`
 
 * `infrastructure_encryption_enabled` - (Optional) Is infrastructure encryption enabled? Changing this forces a new resource to be created. Defaults to `false`.
 
@@ -220,7 +221,9 @@ A `hour_metrics` block supports the following:
 
 A `identity` block supports the following:
 
-* `type` - (Required) Specifies the identity type of the Storage Account. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned,UserAssigned` (to enable both).
+* `type` - (Required) Specifies the identity type of the Storage Account. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned` (to enable both).
+
+~> **Note:** The older value `SystemAssigned,UserAssigned` (with no spaces) is deprecated and will be removed in version 3.0 of the Azure Provider.
 
 ~> The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned`  and Storage Account has been created. More details are available below.
 

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) The type of identity used for the Stream Analytics Job. Possible values are `SystemAssigned`.
+* `type` - (Required) The type of identity used for the Stream Analytics Job. The only possible value is `SystemAssigned`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The nightly tests detected a a regression in the Storage Account and Stream Analytics resources from #15207, where the Identity types used in these API's don't match the behaviours from other APIs.

In the case of Storage Account that's because the API is using Common Types v3 rather than v4, meaning that `SystemAssigned, UserAssigned` is `SystemAssigned,UserAssigned` within this API version. To workaround this version 2.x of the Provider has been updated to support both `SystemAssigned,UserAssigned` and `SystemAssigned, UserAssigned` - and in version 3.0 we'll only support `SystemAssigned, UserAssigned` (transforming internally to make these consistent as a part of #15187).
In addition there's an API issue when submitting an empty list of UserAssignedIdentities to the API, which returns and error rather than ignoring them, which this works around and is tracked in the upstream issue: https://github.com/Azure/azure-rest-api-specs/issues/17650

In the case of Stream Analytics the API doesn't support sending `None` as a type, which I've opened an issue to track here: https://github.com/Azure/azure-rest-api-specs/issues/17649