### PR TITLE
`azurerm_application_insights` - Add support for `force_customer_storage_for_profiler`

### DIFF
--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -156,6 +156,11 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"force_customer_storage_for_profiler": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -203,6 +208,8 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 		internetQueryEnabled = insights.PublicNetworkAccessTypeEnabled
 	}
 
+	forceCustomerStorageForProfiler := d.Get("force_customer_storage_for_profiler").(bool)
+
 	applicationInsightsComponentProperties := insights.ApplicationInsightsComponentProperties{
 		ApplicationID:                   &name,
 		ApplicationType:                 insights.ApplicationType(applicationType),
@@ -211,6 +218,7 @@ func resourceApplicationInsightsCreateUpdate(d *pluginsdk.ResourceData, meta int
 		DisableLocalAuth:                utils.Bool(localAuthenticationDisabled),
 		PublicNetworkAccessForIngestion: internetIngestionEnabled,
 		PublicNetworkAccessForQuery:     internetQueryEnabled,
+		ForceCustomerStorageForProfiler: utils.Bool(forceCustomerStorageForProfiler),
 	}
 
 	if workspaceRaw, hasWorkspaceId := d.GetOk("workspace_id"); hasWorkspaceId {
@@ -322,6 +330,7 @@ func resourceApplicationInsightsRead(d *pluginsdk.ResourceData, meta interface{}
 
 		d.Set("internet_ingestion_enabled", resp.PublicNetworkAccessForIngestion == insights.PublicNetworkAccessTypeEnabled)
 		d.Set("internet_query_enabled", resp.PublicNetworkAccessForQuery == insights.PublicNetworkAccessTypeEnabled)
+		d.Set("force_customer_storage_for_profiler", props.ForceCustomerStorageForProfiler)
 
 		if v := props.WorkspaceResourceID; v != nil {
 			d.Set("workspace_id", v)

--- a/internal/services/applicationinsights/application_insights_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_resource_test.go
@@ -328,6 +328,7 @@ resource "azurerm_application_insights" "test" {
   daily_data_cap_in_gb                  = 50
   daily_data_cap_notifications_disabled = true
   disable_ip_masking                    = true
+  force_customer_storage_for_profiler	= true
   local_authentication_disabled         = true
 
   tags = {

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -102,6 +102,8 @@ The following arguments are supported:
 
 * `internet_query_enabled` - (Optional) Should the Application Insights component support querying over the Public Internet? Defaults to `true`.
 
+* `force_customer_storage_for_profiler` - (Optional) Should the Application Insights component force users to create their own storage account for profiling? Defaults to `false`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Adding support for configuring the ForceCustomerStorageForProfiler property on Application Insights