### PR TITLE
Update azurerm_network_interface to correctly reflect what dynamic means in azure context

### DIFF
--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -100,7 +100,7 @@ The `ip_configuration` block supports the following:
 
 When `private_ip_address_allocation` is set to `Static` the following fields can be configured:
 
-* `private_ip_address` - The Static IP Address which should be used.
+* `private_ip_address` - (Optional) The Static IP Address which should be used.
 
 When `private_ip_address_version` is set to `IPv4` the following fields can be configured:
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -92,7 +92,7 @@ The `ip_configuration` block supports the following:
 
 * `private_ip_address_allocation` - (Required) The allocation method used for the Private IP Address. Possible values are `Dynamic` and `Static`.
 
-~> **Note:** Azure does not assign a Dynamic IP Address until the Network Interface is attached to a running Virtual Machine (or other resource)
+~> **Note:** `Dynamic` means "An IP is automatically assigned during creation of this Network Interface"; `Static` means "User supplied IP address will be used"
 
 * `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this NIC
 
@@ -100,7 +100,7 @@ The `ip_configuration` block supports the following:
 
 When `private_ip_address_allocation` is set to `Static` the following fields can be configured:
 
-* `private_ip_address` - (Optional) The Static IP Address which should be used.
+* `private_ip_address` - The Static IP Address which should be used.
 
 When `private_ip_address_version` is set to `IPv4` the following fields can be configured:
 
@@ -120,11 +120,11 @@ The following attributes are exported:
 
 * `private_ip_address` - The first private IP address of the network interface.
 
-~> **Note:** If a `Dynamic` allocation method is used Azure will not allocate an IP Address until the Network Interface is attached to a running resource (such as a Virtual Machine).
+~> **Note:** If a `Dynamic` allocation method is used Azure will allocate an IP Address on Network Interface creation.
 
 * `private_ip_addresses` - The private IP addresses of the network interface.
 
-~> **Note:** If a `Dynamic` allocation method is used Azure will not allocate an IP Address until the Network Interface is attached to a running resource (such as a Virtual Machine).
+~> **Note:** If a `Dynamic` allocation method is used Azure will allocate an IP Address on Network Interface creation.
 
 * `virtual_machine_id` - The ID of the Virtual Machine which this Network Interface is connected to.
 


### PR DESCRIPTION
Dynamic no longer (since a couple of years it seems) means actual dynamic IPs.

See azure docs:
https://github.com/MicrosoftDocs/azure-docs/blob/4bc20bec0b678d282233f6a67eed633034ad24fa/articles/virtual-network/ip-services/private-ip-addresses.md?plain=1#L38-L54
https://github.com/MicrosoftDocs/azure-docs/blob/798be06dee9d57c838412a459d03e5f0b2afaf10/articles/virtual-network/virtual-network-network-interface.md?plain=1#L49
https://github.com/MicrosoftDocs/azure-docs/commit/f71352ed4682049ba223b6e80f2e43307b884008