### PR TITLE
`azurerm_app_service_active_slot` - fix regression in ID set in creation of new resource

### DIFF
--- a/internal/services/web/app_service_active_slot_resource.go
+++ b/internal/services/web/app_service_active_slot_resource.go
@@ -86,7 +86,7 @@ func resourceAppServiceActiveSlotCreateUpdate(d *pluginsdk.ResourceData, meta in
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("swapping %s: %+v", id, err)
 	}
-	d.SetId(id.ID())
+	d.SetId(appServiceId.ID())
 	return resourceAppServiceActiveSlotRead(d, meta)
 }
 


### PR DESCRIPTION
Fixes a regression introduced in `v2.93.0`