### PR TITLE
identity: making the identity behaviour consistent (W -> N)

### DIFF
--- a/internal/services/network/application_gateway_data_source.go
+++ b/internal/services/network/application_gateway_data_source.go
@@ -4,20 +4,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
-	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
-
-type applicationGatewayDataSourceIdentity = identity.UserAssigned
 
 func dataSourceApplicationGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -33,13 +29,13 @@ func dataSourceApplicationGateway() *pluginsdk.Resource {
 				Required: true,
 			},
 
-			"location": azure.SchemaLocationForDataSource(),
+			"location": commonschema.LocationComputed(),
 
-			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
-			"identity": applicationGatewayDataSourceIdentity{}.SchemaDataSource(),
+			"identity": commonschema.UserAssignedIdentityComputed(),
 
-			"tags": tags.SchemaDataSource(),
+			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
@@ -64,33 +60,13 @@ func dataSourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	identity, err := flattenApplicationGatewayDataSourceIdentity(resp.Identity)
+	identity, err := flattenApplicationGatewayIdentity(resp.Identity)
 	if err != nil {
-		return err
+		return fmt.Errorf("flattening `identity`: %+v", err)
 	}
-	flattenedIdentity := applicationGatewayDataSourceIdentity{}.Flatten(identity)
-	if err = d.Set("identity", flattenedIdentity); err != nil {
-		return err
+	if err = d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
-}
-
-func flattenApplicationGatewayDataSourceIdentity(input *network.ManagedServiceIdentity) (*identity.ExpandedConfig, error) {
-	var config *identity.ExpandedConfig
-	if input != nil {
-		identityIds := make([]string, 0, len(input.UserAssignedIdentities))
-		for id := range input.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(id)
-			if err != nil {
-				return nil, err
-			}
-			identityIds = append(identityIds, parsedId.ID())
-		}
-		config = &identity.ExpandedConfig{
-			Type:                    identity.Type(string(input.Type)),
-			UserAssignedIdentityIds: identityIds,
-		}
-	}
-	return config, nil
 }

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -8,12 +8,15 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
-	msiParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -125,42 +128,45 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			"location": azure.SchemaLocation(),
+			"location": commonschema.Location(),
 
 			"zones": azure.SchemaZones(),
 
-			"resource_group_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(network.ResourceIdentityTypeUserAssigned),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(network.ResourceIdentityTypeUserAssigned),
-							}, false),
-						},
-						"identity_ids": {
-							Type:     pluginsdk.TypeList,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 1,
-							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.NoZeroValues,
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"identity": func() *schema.Schema {
+				if !features.ThreePointOhBeta() {
+					return &schema.Schema{
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"type": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Default:  string(network.ResourceIdentityTypeUserAssigned),
+									ValidateFunc: validation.StringInSlice([]string{
+										string(network.ResourceIdentityTypeUserAssigned),
+									}, false),
+								},
+								"identity_ids": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									MinItems: 1,
+									MaxItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.NoZeroValues,
+									},
+								},
 							},
 						},
-					},
-				},
-			},
+					}
+				}
+
+				return commonschema.UserAssignedIdentityOptional()
+			}(),
 
 			// Required
 			"backend_address_pool": {
@@ -1639,7 +1645,12 @@ func resourceApplicationGatewayCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
-		gateway.Identity = expandAzureRmApplicationGatewayIdentity(d)
+		expandedIdentity, err := expandApplicationGatewayIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		gateway.Identity = expandedIdentity
 	}
 
 	// validation (todo these should probably be moved into their respective expand functions, which would then return an error?)
@@ -1752,7 +1763,7 @@ func resourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 	d.Set("zones", applicationGateway.Zones)
 
-	identity, err := flattenRmApplicationGatewayIdentity(applicationGateway.Identity)
+	identity, err := flattenApplicationGatewayIdentity(applicationGateway.Identity)
 	if err != nil {
 		return err
 	}
@@ -1916,52 +1927,45 @@ func resourceApplicationGatewayDelete(d *pluginsdk.ResourceData, meta interface{
 	return nil
 }
 
-func expandAzureRmApplicationGatewayIdentity(d *pluginsdk.ResourceData) *network.ManagedServiceIdentity {
-	v := d.Get("identity")
-	identities := v.([]interface{})
-	identity := identities[0].(map[string]interface{})
-	identityType := network.ResourceIdentityType(identity["type"].(string))
-
-	identityIds := make(map[string]*network.ManagedServiceIdentityUserAssignedIdentitiesValue)
-	for _, id := range identity["identity_ids"].([]interface{}) {
-		identityIds[id.(string)] = &network.ManagedServiceIdentityUserAssignedIdentitiesValue{}
+func expandApplicationGatewayIdentity(input []interface{}) (*network.ManagedServiceIdentity, error) {
+	expanded, err := identity.ExpandUserAssignedMap(input)
+	if err != nil {
+		return nil, err
 	}
 
-	appGatewayIdentity := network.ManagedServiceIdentity{
-		Type: identityType,
+	out := network.ManagedServiceIdentity{
+		Type: network.ResourceIdentityType(string(expanded.Type)),
 	}
 
-	if identityType == network.ResourceIdentityTypeUserAssigned {
-		appGatewayIdentity.UserAssignedIdentities = identityIds
-	}
-
-	return &appGatewayIdentity
-}
-
-func flattenRmApplicationGatewayIdentity(identity *network.ManagedServiceIdentity) ([]interface{}, error) {
-	if identity == nil {
-		return make([]interface{}, 0), nil
-	}
-
-	result := make(map[string]interface{})
-	result["type"] = string(identity.Type)
-	if result["type"] == "userAssigned" {
-		result["type"] = "UserAssigned"
-	}
-
-	identityIds := make([]string, 0)
-	if identity.UserAssignedIdentities != nil {
-		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiParse.UserAssignedIdentityIDInsensitively(key)
-			if err != nil {
-				return nil, err
-			}
-			identityIds = append(identityIds, parsedId.ID())
+	if expanded.Type == identity.TypeUserAssigned {
+		out.UserAssignedIdentities = make(map[string]*network.ManagedServiceIdentityUserAssignedIdentitiesValue)
+		for k := range expanded.IdentityIds {
+			out.UserAssignedIdentities[k] = &network.ManagedServiceIdentityUserAssignedIdentitiesValue{}
 		}
 	}
-	result["identity_ids"] = identityIds
 
-	return []interface{}{result}, nil
+	return &out, nil
+}
+
+func flattenApplicationGatewayIdentity(input *network.ManagedServiceIdentity) (*[]interface{}, error) {
+	var transform *identity.UserAssignedMap
+
+	if transform != nil {
+		transform = &identity.UserAssignedMap{
+			Type:        identity.Type(string(input.Type)),
+			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
+		}
+		if input.UserAssignedIdentities != nil {
+			for k, v := range input.UserAssignedIdentities {
+				transform.IdentityIds[k] = identity.UserAssignedIdentityDetails{
+					ClientId:    v.ClientID,
+					PrincipalId: v.PrincipalID,
+				}
+			}
+		}
+	}
+
+	return identity.FlattenUserAssignedMap(transform)
 }
 
 func expandApplicationGatewayAuthenticationCertificates(certs []interface{}) *[]network.ApplicationGatewayAuthenticationCertificate {

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -2,12 +2,12 @@ package network
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"log"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -2,8 +2,9 @@ package network
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -147,37 +147,7 @@ func resourceArmExpressRoutePort() *pluginsdk.Resource {
 				}, false),
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"identity_ids": {
-							Type:     pluginsdk.TypeList,
-							Optional: true,
-							MinItems: 1,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								ValidateFunc:     validation.NoZeroValues,
-								DiffSuppressFunc: suppress.CaseDifference,
-							},
-						},
-
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							// TODO: The "ignoreCase" and diff suppression function can be removed once
-							// following issue get resolved:
-							// https://github.com/Azure/azure-rest-api-specs/issues/12330
-							ValidateFunc: validation.StringInSlice([]string{
-								string(network.ResourceIdentityTypeUserAssigned),
-							}, true),
-							DiffSuppressFunc: suppress.CaseDifference,
-						},
-					},
-				},
-			},
+			"identity": commonschema.UserAssignedIdentityOptional(),
 
 			"link1": expressRoutePortSchema,
 
@@ -228,6 +198,10 @@ func resourceArmExpressRoutePortCreateUpdate(d *pluginsdk.ResourceData, meta int
 		}
 	}
 
+	expandedIdentity, err := expandExpressRoutePortIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
 	param := network.ExpressRoutePort{
 		Name:     &name,
 		Location: &location,
@@ -236,7 +210,7 @@ func resourceArmExpressRoutePortCreateUpdate(d *pluginsdk.ResourceData, meta int
 			BandwidthInGbps: utils.Int32(int32(d.Get("bandwidth_in_gbps").(int))),
 			Encapsulation:   network.ExpressRoutePortsEncapsulation(d.Get("encapsulation").(string)),
 		},
-		Identity: expandExpressRoutePortIdentity(d.Get("identity").([]interface{})),
+		Identity: expandedIdentity,
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
@@ -293,7 +267,11 @@ func resourceArmExpressRoutePortRead(d *pluginsdk.ResourceData, meta interface{}
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
-	if err := d.Set("identity", flattenExpressRoutePortIdentity(resp.Identity)); err != nil {
+	flattenedIdentity, err := flattenExpressRoutePortIdentity(resp.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	if err := d.Set("identity", flattenedIdentity); err != nil {
 		return fmt.Errorf("setting `identity`: %v", err)
 	}
 	if prop := resp.ExpressRoutePortPropertiesFormat; prop != nil {
@@ -341,50 +319,46 @@ func resourceArmExpressRoutePortDelete(d *pluginsdk.ResourceData, meta interface
 	return nil
 }
 
-func expandExpressRoutePortIdentity(input []interface{}) *network.ManagedServiceIdentity {
-	if len(input) == 0 {
-		return nil
-	}
-	identity := input[0].(map[string]interface{})
-	identityType := network.ResourceIdentityType(identity["type"].(string))
-
-	managedServiceIdentity := network.ManagedServiceIdentity{
-		Type: identityType,
+func expandExpressRoutePortIdentity(input []interface{}) (*network.ManagedServiceIdentity, error) {
+	expanded, err := identity.ExpandUserAssignedMap(input)
+	if err != nil {
+		return nil, err
 	}
 
-	identityIds := make(map[string]*network.ManagedServiceIdentityUserAssignedIdentitiesValue)
-	for _, id := range identity["identity_ids"].([]interface{}) {
-		identityIds[id.(string)] = &network.ManagedServiceIdentityUserAssignedIdentitiesValue{}
+	out := network.ManagedServiceIdentity{
+		Type: network.ResourceIdentityType(string(expanded.Type)),
 	}
-
-	// TODO: once following issue get resolved, can directly equal test:
-	// https://github.com/Azure/azure-rest-api-specs/issues/12330
-	if strings.EqualFold(string(managedServiceIdentity.Type), string(network.ResourceIdentityTypeUserAssigned)) ||
-		strings.EqualFold(string(managedServiceIdentity.Type), string(network.ResourceIdentityTypeSystemAssignedUserAssigned)) {
-		managedServiceIdentity.UserAssignedIdentities = identityIds
+	if expanded.Type == identity.TypeUserAssigned {
+		out.UserAssignedIdentities = make(map[string]*network.ManagedServiceIdentityUserAssignedIdentitiesValue)
+		for k := range expanded.IdentityIds {
+			out.UserAssignedIdentities[k] = &network.ManagedServiceIdentityUserAssignedIdentitiesValue{
+				// intentionally empty
+			}
+		}
 	}
-
-	return &managedServiceIdentity
+	return &out, nil
 }
 
-func flattenExpressRoutePortIdentity(identity *network.ManagedServiceIdentity) []interface{} {
-	if identity == nil {
-		return make([]interface{}, 0)
-	}
+func flattenExpressRoutePortIdentity(input *network.ManagedServiceIdentity) (*[]interface{}, error) {
+	var transform *identity.UserAssignedMap
 
-	identityIds := make([]string, 0)
-	if identity.UserAssignedIdentities != nil {
-		for key := range identity.UserAssignedIdentities {
-			identityIds = append(identityIds, key)
+	if input != nil {
+		transform = &identity.UserAssignedMap{
+			Type:        identity.Type(string(input.Type)),
+			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
+		}
+
+		if input.UserAssignedIdentities != nil {
+			for key, value := range input.UserAssignedIdentities {
+				transform.IdentityIds[key] = identity.UserAssignedIdentityDetails{
+					ClientId:    value.ClientID,
+					PrincipalId: value.PrincipalID,
+				}
+			}
 		}
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"identity_ids": identityIds,
-			"type":         string(identity.Type),
-		},
-	}
+	return identity.FlattenUserAssignedMap(transform)
 }
 
 func expandExpressRoutePortLinks(link1, link2 []interface{}) *[]network.ExpressRouteLink {

--- a/internal/services/postgres/postgresql_server_data_source.go
+++ b/internal/services/postgres/postgresql_server_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/parse"
@@ -54,28 +55,7 @@ func dataSourcePostgreSqlServer() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 
 			"tags": tags.SchemaDataSource(),
 		},

--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/purview/mgmt/2021-07-01/purview"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -67,11 +70,21 @@ func resourcePurviewAccountCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 
 	account := purview.Account{
 		AccountProperties: &purview.AccountProperties{},
-		Identity: &purview.Identity{
+		Location:          &location,
+		Tags:              tags.Expand(t),
+	}
+
+	if features.ThreePointOhBeta() {
+		expandedIdentity, err := expandIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		account.Identity = expandedIdentity
+	} else {
+		account.Identity = &purview.Identity{
 			Type: purview.TypeSystemAssigned,
-		},
-		Location: &location,
-		Tags:     tags.Expand(t),
+		}
 	}
 
 	if d.Get("public_network_enabled").(bool) {
@@ -121,7 +134,7 @@ func resourcePurviewAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	if err := d.Set("identity", flattenPurviewAccountIdentity(resp.Identity)); err != nil {
+	if err := d.Set("identity", flattenIdentity(resp.Identity)); err != nil {
 		return fmt.Errorf("flattening `identity`: %+v", err)
 	}
 
@@ -177,26 +190,33 @@ func resourcePurviewAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	return nil
 }
 
-func flattenPurviewAccountIdentity(identity *purview.Identity) interface{} {
-	if identity == nil || identity.Type == "None" {
-		return make([]interface{}, 0)
+func expandIdentity(input []interface{}) (*purview.Identity, error) {
+	expanded, err := identity.ExpandSystemAssigned(input)
+	if err != nil {
+		return nil, err
 	}
 
-	principalId := ""
-	if identity.PrincipalID != nil {
-		principalId = *identity.PrincipalID
+	return &purview.Identity{
+		Type: purview.Type(string(expanded.Type)),
+	}, nil
+}
+
+func flattenIdentity(input *purview.Identity) interface{} {
+	var transition *identity.SystemAssigned
+
+	if input != nil {
+		transition = &identity.SystemAssigned{
+			Type: identity.Type(string(input.Type)),
+		}
+		if input.PrincipalID != nil {
+			transition.PrincipalId = *input.PrincipalID
+		}
+		if input.TenantID != nil {
+			transition.TenantId = *input.TenantID
+		}
 	}
-	tenantId := ""
-	if identity.TenantID != nil {
-		tenantId = *identity.TenantID
-	}
-	return []interface{}{
-		map[string]interface{}{
-			"type":         string(identity.Type),
-			"principal_id": principalId,
-			"tenant_id":    tenantId,
-		},
-	}
+
+	return identity.FlattenSystemAssigned(transition)
 }
 
 func flattenPurviewAccountManagedResources(managedResources *purview.AccountPropertiesManagedResources) interface{} {
@@ -254,26 +274,14 @@ func resourcePurviewSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: azure.ValidateResourceGroupName,
 		},
 
-		"identity": {
-			Type:     pluginsdk.TypeList,
-			Computed: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"type": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-					"principal_id": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-					"tenant_id": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
+		"identity": func() *schema.Schema {
+			// TODO: document that this will become required in 3.0
+			if features.ThreePointOhBeta() {
+				return commonschema.SystemAssignedIdentityRequired()
+			}
+
+			return commonschema.SystemAssignedIdentityComputed()
+		}(),
 
 		"managed_resources": {
 			Type:     pluginsdk.TypeList,

--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -256,9 +256,9 @@ func resourcePurviewSchema() map[string]*pluginsdk.Schema {
 				"The Purview account name must be between 3 and 63 characters long, it can contain only letters, numbers and hyphens, and the first and last characters must be a letter or number."),
 		},
 
-		"resource_group_name": azure.SchemaResourceGroupName(),
+		"resource_group_name": commonschema.ResourceGroupName(),
 
-		"location": azure.SchemaLocation(),
+		"location": commonschema.Location(),
 
 		"public_network_enabled": {
 			Type:     pluginsdk.TypeBool,

--- a/internal/services/purview/purview_account_resource_test.go
+++ b/internal/services/purview/purview_account_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -96,7 +98,12 @@ func (r PurviewAccountResource) Exists(ctx context.Context, client *clients.Clie
 
 func (r PurviewAccountResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_purview_account" "test" {
@@ -105,11 +112,35 @@ resource "azurerm_purview_account" "test" {
   location            = azurerm_resource_group.test.location
 }
 `, template, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_purview_account" "test" {
+  name                = "acctestsw%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r PurviewAccountResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_purview_account" "test" {
@@ -117,6 +148,30 @@ resource "azurerm_purview_account" "test" {
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   public_network_enabled = false
+
+  tags = {
+    ENV = "Test"
+  }
+}
+`, template, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_purview_account" "test" {
+  name                   = "acctestsw%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  public_network_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+
   tags = {
     ENV = "Test"
   }
@@ -126,7 +181,12 @@ resource "azurerm_purview_account" "test" {
 
 func (r PurviewAccountResource) requiresImport(data acceptance.TestData) string {
 	template := r.basic(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_purview_account" "import" {
@@ -135,31 +195,69 @@ resource "azurerm_purview_account" "import" {
   location            = azurerm_purview_account.test.location
 }
 `, template)
-}
-
-func (r PurviewAccountResource) template(data acceptance.TestData) string {
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-purview-%d"
-  location = "%s"
+%s
+
+resource "azurerm_purview_account" "import" {
+  name                = azurerm_purview_account.test.name
+  resource_group_name = azurerm_purview_account.test.resource_group_name
+  location            = azurerm_purview_account.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, template)
 }
 
 func (r PurviewAccountResource) withManagedResourceGroupName(data acceptance.TestData, managedResourceGroupName string) string {
 	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.ThreePointOhBeta() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_purview_account" "test" {
   name                        = "acctestsw%d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
-  managed_resource_group_name = "%s"
+  managed_resource_group_name = %q
 }
 `, template, data.RandomInteger, managedResourceGroupName)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_purview_account" "test" {
+  name                        = "acctestsw%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  managed_resource_group_name = %q
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger, managedResourceGroupName)
+}
+
+func (r PurviewAccountResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-purview-%d"
+  location = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/search/search_service_data_source.go
+++ b/internal/services/search/search_service_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/search/parse"
@@ -73,28 +74,7 @@ func dataSourceSearchService() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 		},
 	}
 }

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -349,7 +349,7 @@ func flattenSearchServiceIdentity(input *search.Identity) []interface{} {
 
 	if input != nil {
 		transition = &identity.SystemAssigned{
-			Type: string(input.Type),
+			Type: identity.Type(string(input.Type)),
 		}
 		if input.PrincipalID != nil {
 			transition.PrincipalId = *input.PrincipalID

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/search/mgmt/2020-03-13/search"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -123,32 +125,7 @@ func resourceSearchService() *pluginsdk.Resource {
 				},
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(search.SystemAssigned),
-							}, false),
-						},
-
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"tags": tags.Schema(),
 		},
@@ -183,7 +160,10 @@ func resourceSearchServiceCreateUpdate(d *pluginsdk.ResourceData, meta interface
 		publicNetworkAccess = search.Disabled
 	}
 
-	t := d.Get("tags").(map[string]interface{})
+	expandedIdentity, err := expandSearchServiceIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
 
 	properties := search.Service{
 		Location: utils.String(location),
@@ -196,8 +176,8 @@ func resourceSearchServiceCreateUpdate(d *pluginsdk.ResourceData, meta interface
 				IPRules: expandSearchServiceIPRules(d.Get("allowed_ips").([]interface{})),
 			},
 		},
-		Identity: expandSearchServiceIdentity(d.Get("identity").([]interface{})),
-		Tags:     tags.Expand(t),
+		Identity: expandedIdentity,
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("replica_count"); ok {
@@ -353,38 +333,31 @@ func flattenSearchServiceIPRules(input *search.NetworkRuleSet) []interface{} {
 	return result
 }
 
-func expandSearchServiceIdentity(input []interface{}) *search.Identity {
-	if len(input) == 0 || input[0] == nil {
-		return &search.Identity{
-			Type: search.None,
-		}
+func expandSearchServiceIdentity(input []interface{}) (*search.Identity, error) {
+	expanded, err := identity.ExpandSystemAssigned(input)
+	if err != nil {
+		return nil, err
 	}
-	identity := input[0].(map[string]interface{})
+
 	return &search.Identity{
-		Type: search.IdentityType(identity["type"].(string)),
-	}
+		Type: search.IdentityType(string(expanded.Type)),
+	}, nil
 }
 
-func flattenSearchServiceIdentity(identity *search.Identity) []interface{} {
-	if identity == nil || identity.Type == search.None {
-		return make([]interface{}, 0)
+func flattenSearchServiceIdentity(input *search.Identity) []interface{} {
+	var transition *identity.SystemAssigned
+
+	if input != nil {
+		transition = &identity.SystemAssigned{
+			Type: string(input.Type),
+		}
+		if input.PrincipalID != nil {
+			transition.PrincipalId = *input.PrincipalID
+		}
+		if input.TenantID != nil {
+			transition.TenantId = *input.TenantID
+		}
 	}
 
-	principalId := ""
-	if identity.PrincipalID != nil {
-		principalId = *identity.PrincipalID
-	}
-
-	tenantId := ""
-	if identity.TenantID != nil {
-		tenantId = *identity.TenantID
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"principal_id": principalId,
-			"tenant_id":    tenantId,
-			"type":         string(identity.Type),
-		},
-	}
+	return identity.FlattenSystemAssigned(transition)
 }

--- a/internal/services/sql/sql_managed_instance_data_source.go
+++ b/internal/services/sql/sql_managed_instance_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -99,30 +100,7 @@ func dataSourceArmSqlMiServer() *schema.Resource {
 				Computed: true,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"user_assigned_identity_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 
 			"storage_account_type": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/sql/sql_managed_instance_resource.go
+++ b/internal/services/sql/sql_managed_instance_resource.go
@@ -171,6 +171,7 @@ func resourceArmSqlMiServer() *schema.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
+			// TODO: support User Assigned https://github.com/hashicorp/terraform-provider-azurerm/issues/15277
 			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"storage_account_type": {

--- a/internal/services/sql/sql_server_data_source.go
+++ b/internal/services/sql/sql_server_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
@@ -50,26 +52,7 @@ func dataSourceSqlServer() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityComputed(),
 
 			"tags": tags.SchemaDataSource(),
 		},

--- a/internal/services/sql/sql_server_resource.go
+++ b/internal/services/sql/sql_server_resource.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2017-03-01-preview/sql"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -85,30 +87,7 @@ func resourceSqlServer() *pluginsdk.Resource {
 				}, false),
 			},
 
-			"identity": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"SystemAssigned",
-							}, false),
-						},
-						"principal_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": commonschema.SystemAssignedIdentityOptional(),
 
 			"extended_auditing_policy": helper.ExtendedAuditingSchema(),
 
@@ -251,7 +230,11 @@ func resourceSqlServerCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
-		sqlServerIdentity := expandAzureRmSqlServerIdentity(d)
+		sqlServerIdentity, err := expandAzureRmSqlServerIdentity(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
 		parameters.Identity = sqlServerIdentity
 	}
 
@@ -397,32 +380,38 @@ func resourceSqlServerDelete(d *pluginsdk.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func expandAzureRmSqlServerIdentity(d *pluginsdk.ResourceData) *sql.ResourceIdentity {
-	identities := d.Get("identity").([]interface{})
-	if len(identities) == 0 {
-		return &sql.ResourceIdentity{}
+func expandAzureRmSqlServerIdentity(input []interface{}) (*sql.ResourceIdentity, error) {
+	expanded, err := identity.ExpandSystemAssigned(input)
+	if err != nil {
+		return nil, err
 	}
-	identity := identities[0].(map[string]interface{})
-	identityType := sql.IdentityType(identity["type"].(string))
+
+	if expanded.Type == identity.TypeNone {
+		return &sql.ResourceIdentity{}, nil
+	}
+
 	return &sql.ResourceIdentity{
-		Type: identityType,
-	}
+		Type: sql.IdentityType(string(expanded.Type)),
+	}, nil
 }
 
-func flattenAzureRmSqlServerIdentity(identity *sql.ResourceIdentity) []interface{} {
-	if identity == nil {
-		return []interface{}{}
-	}
-	result := make(map[string]interface{})
-	result["type"] = identity.Type
-	if identity.PrincipalID != nil {
-		result["principal_id"] = identity.PrincipalID.String()
-	}
-	if identity.TenantID != nil {
-		result["tenant_id"] = identity.TenantID.String()
+func flattenAzureRmSqlServerIdentity(input *sql.ResourceIdentity) []interface{} {
+	var transform *identity.SystemAssigned
+
+	if input != nil {
+		transform = &identity.SystemAssigned{
+			Type: identity.Type(string(input.Type)),
+		}
+
+		if input.PrincipalID != nil {
+			transform.PrincipalId = input.PrincipalID.String()
+		}
+		if input.TenantID != nil {
+			transform.TenantId = input.TenantID.String()
+		}
 	}
 
-	return []interface{}{result}
+	return identity.FlattenSystemAssigned(transform)
 }
 
 func flattenSqlServerThreatDetectionPolicy(d *pluginsdk.ResourceData, policy sql.ServerSecurityAlertPolicy) []interface{} {


### PR DESCRIPTION
This PR works through making the identity blocks consistent as a part of #15187 - this has a dependency on https://github.com/hashicorp/go-azure-helpers/pull/101 since the Network API returns the Type for the Identity block insensitively in certain APIs.