### PR TITLE
[Enhance] azurerm_api_management support public IP address

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -2,6 +2,7 @@ package apimanagement
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -467,6 +468,11 @@ func resourceApiManagementService() *pluginsdk.Resource {
 				},
 			},
 
+			"public_ip_address_id": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+
 			"sign_in": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -730,6 +736,12 @@ func resourceApiManagementServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 		properties.Zones = azure.ExpandZones(v)
 	}
 
+	if v, ok := d.GetOk("public_ip_address_id"); ok {
+		properties.ServiceProperties.PublicIPAddressID = utils.String(v.(string))
+	}
+
+	js, _ := json.Marshal(properties)
+	log.Printf("DDDD %s", js)
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, properties)
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
@@ -867,6 +879,7 @@ func resourceApiManagementServiceRead(d *pluginsdk.ResourceData, meta interface{
 		d.Set("virtual_network_type", props.VirtualNetworkType)
 		d.Set("client_certificate_enabled", props.EnableClientCertificate)
 		d.Set("gateway_disabled", props.DisableGateway)
+		d.Set("public_ip_address_id", props.PublicIPAddressID)
 
 		d.Set("certificate", flattenAPIManagementCertificates(d, props.Certificates))
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `protocols` - (Optional) A `protocols` block as defined below.
 
+* `public_ip_address_id` - (Optional) Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in the region. Supported only for Developer and Premium SKU.
+
 * `security` - (Optional) A `security` block as defined below.
 
 * `sign_in` - (Optional) A `sign_in` block as defined below.


### PR DESCRIPTION
Support configure public IP address  for `azurerm_api_management`
```log
=== RUN   TestAccApiManagement_publicIpAddress
=== PAUSE TestAccApiManagement_publicIpAddress
=== CONT  TestAccApiManagement_publicIpAddress
--- PASS: TestAccApiManagement_publicIpAddress (3341.62s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 3380.245s
```

Issue: #12021 