### PR TITLE
Bug Fix: azurerm_recovery_services_vault - fix the subscription could not be found in the Azure.Gov environment

### DIFF
--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -30,7 +30,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	vaultConfigsClient := backup.NewResourceVaultConfigsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultConfigsClient.Client, o.ResourceManagerAuthorizer)
 
-	storageConfigsClient := backup.NewResourceStorageConfigsClient(o.SubscriptionId)
+	storageConfigsClient := backup.NewResourceStorageConfigsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&storageConfigsClient.Client, o.ResourceManagerAuthorizer)
 
 	vaultsClient := recoveryservices.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
@@ -54,7 +54,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	backupOperationStatusesClient := backup.NewOperationStatusesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&backupOperationStatusesClient.Client, o.ResourceManagerAuthorizer)
 
-	backupProtectionContainerOperationResultsClient := backup.NewProtectionContainerOperationResultsClient(o.SubscriptionId)
+	backupProtectionContainerOperationResultsClient := backup.NewProtectionContainerOperationResultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&backupProtectionContainerOperationResultsClient.Client, o.ResourceManagerAuthorizer)
 
 	fabricClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient {


### PR DESCRIPTION
The purpose of this PR:

> Fix issue [#15066](https://github.com/hashicorp/terraform-provider-azurerm/issues/15066). Currently, when creating an instance of the storageConfigsClient in [client.go](https://github.com/hashicorp/terraform-provider-azurerm/blob/aa89ab7dc37f41dd272a9e3e023d6f92ca655853/internal/services/recoveryservices/client/client.go#L33) uses `defaultBaseURI` ("https://management.azure.com/") . It causes the subscription could not be found in the Azure.Gov environment, which is mentioned in the issue. Replace `defaultBaseURI` with `ResourceManagerEndpoint` to resolve this issue. Also, fix a similar issue for the [backupProtectionContainerOperationResultsClient](https://github.com/hashicorp/terraform-provider-azurerm/blob/aa89ab7dc37f41dd272a9e3e023d6f92ca655853/internal/services/recoveryservices/client/client.go#L57).



Test Results:

> PASS: TestAccBackupProtectedFileShare_basic (1661.19s)
> PASS: TestAccRecoveryServicesVault_basic (240.51s)