### PR TITLE
New Data Source: `azurerm_portal_dashboard`

### DIFF
--- a/internal/services/portal/portal_dashboard_data_source.go
+++ b/internal/services/portal/portal_dashboard_data_source.go
@@ -1,0 +1,77 @@
+package portal
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/portal/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/portal/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourceDashboard() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceDashboardRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.DashboardName,
+			},
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+			"location":            azure.SchemaLocationForDataSource(),
+			"dashboard_properties": {
+				Type:      pluginsdk.TypeString,
+				Optional:  true,
+				Computed:  true,
+				StateFunc: utils.NormalizeJson,
+			},
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceDashboardRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Portal.DashboardsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewDashboardID(subscriptionId, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("dashboard %q was not found in Resource Group %q", id.Name, id.ResourceGroup)
+		}
+		return fmt.Errorf("retrieving Dashboard %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.SetId(id.ID())
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+
+	props, jsonErr := json.Marshal(resp.DashboardProperties)
+	if jsonErr != nil {
+		return fmt.Errorf("parsing JSON for Dashboard Properties: %+v", jsonErr)
+	}
+	d.Set("dashboard_properties", string(props))
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/internal/services/portal/portal_dashboard_data_source.go
+++ b/internal/services/portal/portal_dashboard_data_source.go
@@ -15,9 +15,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-func dataSourceDashboard() *pluginsdk.Resource {
+func dataSourcePortalDashboard() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Read: dataSourceDashboardRead,
+		Read: dataSourcePortalDashboardRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
@@ -42,7 +42,7 @@ func dataSourceDashboard() *pluginsdk.Resource {
 	}
 }
 
-func dataSourceDashboardRead(d *pluginsdk.ResourceData, meta interface{}) error {
+func dataSourcePortalDashboardRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Portal.DashboardsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	name := d.Get("name").(string)
@@ -54,9 +54,9 @@ func dataSourceDashboardRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("dashboard %q was not found in Resource Group %q", id.Name, id.ResourceGroup)
+			return fmt.Errorf("portal dashboard %q was not found in Resource Group %q", id.Name, id.ResourceGroup)
 		}
-		return fmt.Errorf("retrieving Dashboard %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving Portal Dashboard %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.SetId(id.ID())
@@ -69,7 +69,7 @@ func dataSourceDashboardRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	props, jsonErr := json.Marshal(resp.DashboardProperties)
 	if jsonErr != nil {
-		return fmt.Errorf("parsing JSON for Dashboard Properties: %+v", jsonErr)
+		return fmt.Errorf("parsing JSON for Portal Dashboard Properties: %+v", jsonErr)
 	}
 	d.Set("dashboard_properties", string(props))
 

--- a/internal/services/portal/portal_dashboard_data_source_test.go
+++ b/internal/services/portal/portal_dashboard_data_source_test.go
@@ -11,7 +11,7 @@ import (
 type PortalDashboardDataSource struct{}
 
 func TestAccDataSourcePortalDashboard_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_dashboard", "test")
+	data := acceptance.BuildTestData(t, "data.azurerm_portal_dashboard", "test")
 	r := PortalDashboardDataSource{}
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -25,7 +25,7 @@ func TestAccDataSourcePortalDashboard_basic(t *testing.T) {
 }
 
 func TestAccDataSourcePortalDashboard_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_dashboard", "test")
+	data := acceptance.BuildTestData(t, "data.azurerm_portal_dashboard", "test")
 	r := PortalDashboardDataSource{}
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -46,7 +46,7 @@ func (PortalDashboardDataSource) basic(data acceptance.TestData) string {
 
 %s
 
-data "azurerm_dashboard" "test" {
+data "azurerm_portal_dashboard" "test" {
   name                = azurerm_dashboard.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
@@ -58,7 +58,7 @@ func (PortalDashboardDataSource) complete(data acceptance.TestData) string {
 
 %s
 
-data "azurerm_dashboard" "test" {
+data "azurerm_portal_dashboard" "test" {
   name                = azurerm_dashboard.test.name
   resource_group_name = azurerm_resource_group.test.name
 }

--- a/internal/services/portal/portal_dashboard_data_source_test.go
+++ b/internal/services/portal/portal_dashboard_data_source_test.go
@@ -1,0 +1,66 @@
+package portal_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type PortalDashboardDataSource struct{}
+
+func TestAccDataSourcePortalDashboard_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dashboard", "test")
+	r := PortalDashboardDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("my-test-dashboard"),
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+			),
+		},
+	})
+}
+
+func TestAccDataSourcePortalDashboard_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dashboard", "test")
+	r := PortalDashboardDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("my-test-dashboard"),
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.ENV").HasValue("Test"),
+				check.That(data.ResourceName).Key("dashboard_properties").HasValue("{\"lenses\":{\"0\":{\"order\":0,\"parts\":{\"0\":{\"metadata\":{\"inputs\":[],\"settings\":{\"content\":{\"settings\":{\"content\":\"## This is only a test :)\",\"subtitle\":\"\",\"title\":\"Test MD Tile\"}}},\"type\":\"Extension/HubsExtension/PartType/MarkdownPart\"},\"position\":{\"colSpan\":3,\"rowSpan\":2,\"x\":0,\"y\":0}}}}}}"),
+			),
+		},
+	})
+}
+
+func (PortalDashboardDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+data "azurerm_dashboard" "test" {
+  name                = azurerm_dashboard.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, PortalDashboardResource{}.basic(data))
+}
+
+func (PortalDashboardDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+data "azurerm_dashboard" "test" {
+  name                = azurerm_dashboard.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, PortalDashboardResource{}.complete(data))
+}

--- a/internal/services/portal/registration.go
+++ b/internal/services/portal/registration.go
@@ -27,7 +27,9 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
+	return map[string]*pluginsdk.Resource{
+		"azurerm_dashboard": dataSourceDashboard(), // TODO 3.0 rename to azurerm_portal_dashboard
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/internal/services/portal/registration.go
+++ b/internal/services/portal/registration.go
@@ -28,7 +28,7 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_dashboard": dataSourceDashboard(), // TODO 3.0 rename to azurerm_portal_dashboard
+		"azurerm_portal_dashboard": dataSourcePortalDashboard(),
 	}
 }
 

--- a/website/docs/d/dashboard.html.markdown
+++ b/website/docs/d/dashboard.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Portal"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_dashboard"
+description: |-
+  Gets information about an existing shared dashboard in the Azure Portal.
+---
+
+# Data Source: azurerm_dashboard
+
+Use this data source to access information about an existing shared dashboard in the Azure Portal.
+
+## Example Usage
+
+```hcl
+
+data "azurerm_dashboard" "example" {
+  name                = "existing-dashboard"
+  resource_group_name = "dashboard-rg"
+}
+
+output "id" {
+  value = data.azurerm_dashboard.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the shared Azure Dashboard.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the shared Azure Dashboard is located in.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the shared Azure dashboard.
+
+* `location` - The Azure Region where the shared Azure dashboard exists.
+
+* `dashboard_properties` - JSON data representing dashboard body.
+
+* `tags` - A mapping of tags assigned to the shared Azure dashboard.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the shared Azure Dashboard.
+

--- a/website/docs/d/portal_dashboard.html.markdown
+++ b/website/docs/d/portal_dashboard.html.markdown
@@ -1,20 +1,20 @@
 ---
 subcategory: "Portal"
 layout: "azurerm"
-page_title: "Azure Resource Manager: Data Source: azurerm_dashboard"
+page_title: "Azure Resource Manager: Data Source: azurerm_portal_dashboard"
 description: |-
   Gets information about an existing shared dashboard in the Azure Portal.
 ---
 
-# Data Source: azurerm_dashboard
+# Data Source: azurerm_portal_dashboard
 
-Use this data source to access information about an existing shared dashboard in the Azure Portal.
+Use this data source to access information about an existing shared dashboard in the Azure Portal. This is the data source of the `azurerm_dashboard` resource.
 
 ## Example Usage
 
 ```hcl
 
-data "azurerm_dashboard" "example" {
+data "azurerm_portal_dashboard" "example" {
   name                = "existing-dashboard"
   resource_group_name = "dashboard-rg"
 }
@@ -28,21 +28,21 @@ output "id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the shared Azure Dashboard.
+* `name` - (Required) Specifies the name of the shared Azure Portal Dashboard.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the shared Azure Dashboard is located in.
+* `resource_group_name` - (Required) Specifies the name of the resource group the shared Azure Portal Dashboard is located in.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the shared Azure dashboard.
+* `id` - The ID of the shared Azure Portal dashboard.
 
-* `location` - The Azure Region where the shared Azure dashboard exists.
+* `location` - The Azure Region where the shared Azure Portal dashboard exists.
 
 * `dashboard_properties` - JSON data representing dashboard body.
 
-* `tags` - A mapping of tags assigned to the shared Azure dashboard.
+* `tags` - A mapping of tags assigned to the shared Azure Portal dashboard.
 
 ## Timeouts
 


### PR DESCRIPTION
# New Data Source: `azurerm_portal_dashboard`

## Summary

Adding support for a new data source `azurerm_portal_dashboard`.

## Tests

```
> make acctests SERVICE='portal' TESTARGS='-run=TestAccDataSourcePortalDashboard_basic' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/portal -run=TestAccDataSourcePortalDashboard_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourcePortalDashboard_basic
=== PAUSE TestAccDataSourcePortalDashboard_basic
=== CONT  TestAccDataSourcePortalDashboard_basic
--- PASS: TestAccDataSourcePortalDashboard_basic (89.41s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/portal        89.465s

> make acctests SERVICE='portal' TESTARGS='-run=TestAccDataSourcePortalDashboard_complete' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/portal -run=TestAccDataSourcePortalDashboard_complete -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourcePortalDashboard_complete
=== PAUSE TestAccDataSourcePortalDashboard_complete
=== CONT  TestAccDataSourcePortalDashboard_complete
--- PASS: TestAccDataSourcePortalDashboard_complete (143.56s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/portal        143.594s
```