### PR TITLE
`azurerm_firewall` - workaround the destroy failure

### DIFF
--- a/internal/services/firewall/azuresdkhacks/firewall.go
+++ b/internal/services/firewall/azuresdkhacks/firewall.go
@@ -1,0 +1,48 @@
+package azuresdkhacks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func DeleteFirewall(ctx context.Context, client *network.AzureFirewallsClient, resourceGroupName string, azureFirewallName string) (result network.AzureFirewallsDeleteFuture, err error) {
+	req, err := firewallDeletePreparer(ctx, client, resourceGroupName, azureFirewallName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "network.AzureFirewallsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.DeleteSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "network.AzureFirewallsClient", "Delete", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+func firewallDeletePreparer(ctx context.Context, client *network.AzureFirewallsClient, resourceGroupName string, azureFirewallName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"azureFirewallName": autorest.Encode("path", azureFirewallName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2021-05-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		// The patch! See https://github.com/Azure/azure-sdk-for-go/issues/17013 for details
+		autorest.AsContentType("application/json"),
+
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/validate"
 	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
@@ -507,7 +508,8 @@ func resourceFirewallDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	locks.MultipleByName(&subnetNamesToLock, SubnetResourceName)
 	defer locks.UnlockMultipleByName(&subnetNamesToLock, SubnetResourceName)
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.AzureFirewallName)
+	// Change this back to using the SDK method once https://github.com/Azure/azure-sdk-for-go/issues/17013 is addressed.
+	future, err := azuresdkhacks.DeleteFirewall(ctx, client, id.ResourceGroup, id.AzureFirewallName)
 	if err != nil {
 		return fmt.Errorf("deleting Azure Firewall %s : %+v", *id, err)
 	}


### PR DESCRIPTION
This PR added a patch on the Azure track1 SDK to adding the required request header (either `Accept: application/json` or `Content-Type: application/json` works), which is recently introduced by the NRP.

Fixes #14966 

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/firewall  -run='TestAccFirewall_basic'
=== RUN   TestAccFirewall_basic
=== PAUSE TestAccFirewall_basic
=== CONT  TestAccFirewall_basic
--- PASS: TestAccFirewall_basic (649.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      649.030s
```