### PR TITLE
`azurerm_cosmosdb_cassandra_table `- add test for autoscale_settings.max_throughput/default_ttl/throughput 

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -157,6 +157,7 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
   cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
   autoscale_settings {
     max_throughput = 4000
+
   }
 
   schema {

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -67,7 +67,7 @@ func TestAccCosmosDbCassandraTable_autoScaleSetting(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.autoScaleSetting(data, 4000),
+			Config: r.autoScaleSetting(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -148,7 +148,7 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
 `, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger)
 }
 
-func (CosmosDBCassandraTableResource) autoScaleSetting(data acceptance.TestData, maxThroughput int) string {
+func (CosmosDBCassandraTableResource) autoScaleSetting(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -156,7 +156,7 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
   name                  = "acctest-CCASST-%[2]d"
   cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
   autoscale_settings {
-    max_throughput = %[3]d
+    max_throughput = 4000
   }
 
   schema {
@@ -175,7 +175,7 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
     }
   }
 }
-`, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger, maxThroughput)
+`, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger)
 }
 
 func (CosmosDBCassandraTableResource) analyticalStorageTTLTemplate(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -46,6 +46,36 @@ func TestAccCosmosDbCassandraTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbCassandraTable_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
+	r := CosmosDBCassandraTableResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCosmosDbCassandraTable_complete_max_throughput(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
+	r := CosmosDBCassandraTableResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeMaxThroughput(data, 4000),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCosmosDbCassandraTable_analyticalStorageTTL(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
 	r := CosmosDBCassandraTableResource{}
@@ -87,6 +117,65 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
   }
 }
 `, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger)
+}
+
+func (CosmosDBCassandraTableResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_cassandra_table" "test" {
+  name                  = "acctest-CCASST-%[2]d"
+  cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
+  default_ttl           = 100
+  throughput            = 400
+
+  schema {
+    column {
+      name = "test1"
+      type = "ascii"
+    }
+
+    column {
+      name = "test2"
+      type = "int"
+    }
+
+    partition_key {
+      name = "test1"
+    }
+  }
+}
+`, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger)
+}
+
+func (CosmosDBCassandraTableResource) completeMaxThroughput(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_cassandra_table" "test" {
+  name                  = "acctest-CCASST-%[2]d"
+  cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+
+  schema {
+    column {
+      name = "test1"
+      type = "ascii"
+    }
+
+    column {
+      name = "test2"
+      type = "int"
+    }
+
+    partition_key {
+      name = "test1"
+    }
+  }
+}
+`, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger, maxThroughput)
 }
 
 func (CosmosDBCassandraTableResource) analyticalStorageTTLTemplate(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -61,13 +61,13 @@ func TestAccCosmosDbCassandraTable_complete(t *testing.T) {
 	})
 }
 
-func TestAccCosmosDbCassandraTable_complete_max_throughput(t *testing.T) {
+func TestAccCosmosDbCassandraTable_autoScaleSetting(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
 	r := CosmosDBCassandraTableResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.completeMaxThroughput(data, 4000),
+			Config: r.autoScaleSetting(data, 4000),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -148,7 +148,7 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
 `, CosmosDbCassandraKeyspaceResource{}.basic(data), data.RandomInteger)
 }
 
-func (CosmosDBCassandraTableResource) completeMaxThroughput(data acceptance.TestData, maxThroughput int) string {
+func (CosmosDBCassandraTableResource) autoScaleSetting(data acceptance.TestData, maxThroughput int) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -157,7 +157,6 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
   cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
   autoscale_settings {
     max_throughput = 4000
-
   }
 
   schema {


### PR DESCRIPTION
### create a public pull request for `azurerm_cosmosdb_cassandra_table` - add test for autoscale_settings.max_throughput/default_ttl/throughput
**test result:**
![image](https://user-images.githubusercontent.com/46072066/153123339-350b562a-df21-4e79-9e9d-508a48e75b73.png)
![image](https://user-images.githubusercontent.com/46072066/153126420-43c6f569-2a7a-441c-9149-431f8f5d44d3.png)
