### PR TITLE
DOC: fix invalid JSON in parameter definition of azurerm_resource_group_policy_assignment

### DIFF
--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -44,12 +44,14 @@ resource "azurerm_resource_group_policy_assignment" "example" {
   policy_definition_id = azurerm_policy_definition.example.id
 
   parameters = <<PARAMS
+    {
       "tagName": {
         "value": "Business Unit"
       },
       "tagValue": {
         "value": "BU"
       }
+    }
 PARAMS
 }
 ```


### PR DESCRIPTION
Error produced by terraform : 

`Error: "parameters" contains an invalid JSON: invalid character ':' after top-level value`