### PR TITLE
refactor: consistent identity blocks - application_gateway - `type` is now required

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -10,12 +10,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -134,39 +132,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
-			"identity": func() *schema.Schema {
-				if !features.ThreePointOhBeta() {
-					return &schema.Schema{
-						Type:     pluginsdk.TypeList,
-						Optional: true,
-						MaxItems: 1,
-						Elem: &pluginsdk.Resource{
-							Schema: map[string]*pluginsdk.Schema{
-								"type": {
-									Type:     pluginsdk.TypeString,
-									Optional: true,
-									Default:  string(network.ResourceIdentityTypeUserAssigned),
-									ValidateFunc: validation.StringInSlice([]string{
-										string(network.ResourceIdentityTypeUserAssigned),
-									}, false),
-								},
-								"identity_ids": {
-									Type:     pluginsdk.TypeList,
-									Required: true,
-									MinItems: 1,
-									MaxItems: 1,
-									Elem: &pluginsdk.Schema{
-										Type:         pluginsdk.TypeString,
-										ValidateFunc: validation.NoZeroValues,
-									},
-								},
-							},
-						},
-					}
-				}
-
-				return commonschema.UserAssignedIdentityOptional()
-			}(),
+			"identity": commonschema.UserAssignedIdentityOptional(),
 
 			// Required
 			"backend_address_pool": {

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -1377,6 +1377,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   identity {
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 
@@ -2049,6 +2050,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   identity {
+    type         = "UserAssigned"
     identity_ids = ["${azurerm_user_assigned_identity.test.id}"]
   }
 
@@ -2222,6 +2224,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   identity {
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 
@@ -4061,6 +4064,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   identity {
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 
@@ -4211,6 +4215,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   identity {
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -326,7 +326,7 @@ A `http_listener` block supports the following:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Managed Service Identity Type of this Application Gateway. The only possible value is `UserAssigned`. Defaults to `UserAssigned`.
+* `type` - (Required) The Managed Service Identity Type of this Application Gateway. The only possible value is `UserAssigned`.
 
 * `identity_ids` - (Required) Specifies a list with a single user managed identity id to be assigned to the Application Gateway.
 


### PR DESCRIPTION
This fixes a panic in both `TestAccApplicationGateway_UserAssignedIdentity` and `TestAccDataSourceAppGateway_userAssignedIdentity` where the older schema used a List and the new uses a Set - whilst we could workaround this they're compatible enough this should be fine.

Part of #15187