### PR TITLE
`azurerm_kubernetes_cluster` fix unsetting of `outbound_ip_prefix_ids` and `outbound_ip_address_ids`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1463,7 +1463,15 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 			if key := "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"; d.HasChange(key) {
 				outboundIPAddress := d.Get(key)
-				if v := outboundIPAddress.(*pluginsdk.Set).List(); len(v) > 0 {
+				if v := outboundIPAddress.(*pluginsdk.Set).List(); len(v) == 0 {
+					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
+					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is provided
+					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
+						Count: utils.Int32(1),
+					}
+					loadBalancerProfile.OutboundIPs = nil
+					loadBalancerProfile.OutboundIPPrefixes = nil
+				} else {
 					publicIPAddressIDs := idsToResourceReferences(d.Get(key))
 					loadBalancerProfile.OutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
 						PublicIPs: publicIPAddressIDs,
@@ -1472,20 +1480,20 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 					// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
 					loadBalancerProfile.ManagedOutboundIPs = nil
 					loadBalancerProfile.OutboundIPPrefixes = nil
-				} else {
-					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
-					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is provided
-					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
-						Count: utils.Int32(1),
-					}
-					loadBalancerProfile.OutboundIPs = nil
-					loadBalancerProfile.OutboundIPPrefixes = nil
 				}
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids"; d.HasChange(key) {
 				outboundIPPrefixes := d.Get(key)
-				if v := outboundIPPrefixes.(*pluginsdk.Set).List(); len(v) > 0 {
+				if v := outboundIPPrefixes.(*pluginsdk.Set).List(); len(v) == 0 {
+					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
+					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is specified
+					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
+						Count: utils.Int32(1),
+					}
+					loadBalancerProfile.OutboundIPs = nil
+					loadBalancerProfile.OutboundIPPrefixes = nil
+				} else {
 					outboundIPPrefixIDs := idsToResourceReferences(d.Get(key))
 					loadBalancerProfile.OutboundIPPrefixes = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPPrefixes{
 						PublicIPPrefixes: outboundIPPrefixIDs,
@@ -1494,14 +1502,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 					// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
 					loadBalancerProfile.ManagedOutboundIPs = nil
 					loadBalancerProfile.OutboundIPs = nil
-				} else {
-					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
-					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is specified
-					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
-						Count: utils.Int32(1),
-					}
-					loadBalancerProfile.OutboundIPs = nil
-					loadBalancerProfile.OutboundIPPrefixes = nil
 				}
 			}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1462,25 +1462,47 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.outbound_ip_address_ids"; d.HasChange(key) {
-				publicIPAddressIDs := idsToResourceReferences(d.Get(key))
-				loadBalancerProfile.OutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
-					PublicIPs: publicIPAddressIDs,
-				}
+				outboundIPAddress := d.Get(key)
+				if v := outboundIPAddress.(*pluginsdk.Set).List(); len(v) > 0 {
+					publicIPAddressIDs := idsToResourceReferences(d.Get(key))
+					loadBalancerProfile.OutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
+						PublicIPs: publicIPAddressIDs,
+					}
 
-				// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
-				loadBalancerProfile.ManagedOutboundIPs = nil
-				loadBalancerProfile.OutboundIPPrefixes = nil
+					// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
+					loadBalancerProfile.ManagedOutboundIPs = nil
+					loadBalancerProfile.OutboundIPPrefixes = nil
+				} else {
+					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
+					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is provided
+					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
+						Count: utils.Int32(1),
+					}
+					loadBalancerProfile.OutboundIPs = nil
+					loadBalancerProfile.OutboundIPPrefixes = nil
+				}
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.outbound_ip_prefix_ids"; d.HasChange(key) {
-				outboundIPPrefixIDs := idsToResourceReferences(d.Get(key))
-				loadBalancerProfile.OutboundIPPrefixes = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPPrefixes{
-					PublicIPPrefixes: outboundIPPrefixIDs,
-				}
+				outboundIPPrefixes := d.Get(key)
+				if v := outboundIPPrefixes.(*pluginsdk.Set).List(); len(v) > 0 {
+					outboundIPPrefixIDs := idsToResourceReferences(d.Get(key))
+					loadBalancerProfile.OutboundIPPrefixes = &containerservice.ManagedClusterLoadBalancerProfileOutboundIPPrefixes{
+						PublicIPPrefixes: outboundIPPrefixIDs,
+					}
 
-				// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
-				loadBalancerProfile.ManagedOutboundIPs = nil
-				loadBalancerProfile.OutboundIPs = nil
+					// fixes: Load balancer profile must specify one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs.
+					loadBalancerProfile.ManagedOutboundIPs = nil
+					loadBalancerProfile.OutboundIPs = nil
+				} else {
+					// sending [] to unset `outbound_ip_address_ids` results in 400 / Bad Request
+					// instead we default back to AKS managed outbound which is the default of the AKS API when nothing is specified
+					loadBalancerProfile.ManagedOutboundIPs = &containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPs{
+						Count: utils.Int32(1),
+					}
+					loadBalancerProfile.OutboundIPs = nil
+					loadBalancerProfile.OutboundIPPrefixes = nil
+				}
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.outbound_ports_allocated"; d.HasChange(key) {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -539,24 +539,21 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 
 A `load_balancer_profile` block supports the following:
 
-~> **NOTE:** These options are mutually exclusive. Note that when specifying `outbound_ip_address_ids` ([azurerm_public_ip](/docs/providers/azurerm/r/public_ip.html)) the SKU must be `Standard`.
-
-* `outbound_ports_allocated` - (Optional) Number of desired SNAT port for each VM in the clusters load balancer. Must be between `0` and `64000` inclusive. Defaults to `0`.
+~> **NOTE:** The fields `managed_outbound_ip_count`, `outbound_ip_address_ids` and `outbound_ip_prefix_ids` are mutually exclusive. Note that when specifying `outbound_ip_address_ids` ([azurerm_public_ip](/docs/providers/azurerm/r/public_ip.html)) the SKU must be `Standard`.
 
 * `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `120` inclusive. Defaults to `30`.
 
 * `managed_outbound_ip_count` - (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be between `1` and `100` inclusive.
 
--> **NOTE** User has to explicitly set `managed_outbound_ip_count` to empty slice (`[]`) to remove it.
+* `outbound_ip_address_ids` - (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.
+
+-> **NOTE** Set `outbound_ip_address_ids` to an empty slice `[]` in order to unlink it from the cluster. Unlinking a `outbound_ip_address_ids` will revert the load balancing for the cluster back to a managed one.
 
 * `outbound_ip_prefix_ids` - (Optional) The ID of the outbound Public IP Address Prefixes which should be used for the cluster load balancer.
 
--> **NOTE** User has to explicitly set `outbound_ip_prefix_ids` to empty slice (`[]`) to remove it.
+-> **NOTE** Set `outbound_ip_prefix_ids` to an empty slice `[]` in order to unlink it from the cluster. Unlinking a `outbound_ip_prefix_ids` will revert the load balancing for the cluster back to a managed one.
 
-* `outbound_ip_address_ids` - (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.
-
--> **NOTE** User has to explicitly set `outbound_ip_address_ids` to empty slice (`[]`) to remove it.
-
+* `outbound_ports_allocated` - (Optional) Number of desired SNAT port for each VM in the clusters load balancer. Must be between `0` and `64000` inclusive. Defaults to `0`.
 ---
 
 A `nat_gateway_profile` block supports the following:


### PR DESCRIPTION
Closes #7615