### PR TITLE
`azurerm_bastion_host` - validate subnet name

### DIFF
--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -79,7 +79,7 @@ func resourceBastionHost() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							ValidateFunc: validate.BastionSubnetName,
 						},
 						"public_ip_address_id": {
 							Type:         pluginsdk.TypeString,

--- a/internal/services/network/validate/bastion_subnet_name.go
+++ b/internal/services/network/validate/bastion_subnet_name.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+
+	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func BastionSubnetName(v interface{}, k string) (warnings []string, errors []error) {
+	parsed, err := networkParse.SubnetID(v.(string))
+	if err != nil {
+		errors = append(errors, fmt.Errorf("parsing %q: %+v", v.(string), err))
+		return warnings, errors
+	}
+
+	if parsed.Name != "AzureBastionSubnet" {
+		errors = append(errors, fmt.Errorf("The name of the Subnet for %q must be exactly 'AzureBastionSubnet' to be used for the Azure Bastion Host resource", k))
+	}
+
+	return warnings, errors
+}

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -102,6 +102,8 @@ A `ip_configuration` block supports the following:
 
 * `subnet_id` - (Required) Reference to a subnet in which this Bastion Host has been created.
 
+~> **Note:** The Subnet used for the Bastion Host must have the name `AzureBastionSubnet` and the subnet mask must be at least a `/26`.
+
 * `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host.
 
 ## Attributes Reference


### PR DESCRIPTION
Azure Bastion Host service requires the subnet to be named `AzureBastionSubnet`, this restriction is also present in the Firewall resource where this provider performs the very same validation this PR adds for the Bastion Host.

![image](https://user-images.githubusercontent.com/186349/153432346-d496379a-42bf-4df3-b47d-ba9947b40ab1.png)

```
Error: creating/updating Bastion Host "bastion-test" (Resource Group "Test"): network.BastionHostsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="SubnetNameMustBeAzureBastionSubnet" Message="Subnet name /subscriptions/xxxxxxxxxxxxxxxx/resourceGroups/Test/providers/Microsoft.Network/virtualNetworks/net-test/subnets/snet-bastion is invalid for Azure Bastion. Azure Bastion can only be created in subnet with name 'AzureBastionSubnet'." Details=[]
```