### PR TITLE
azurerm_logic_app_integration_account_map - support content type text/plain

### DIFF
--- a/internal/services/logic/logic_app_integration_account_map_resource.go
+++ b/internal/services/logic/logic_app_integration_account_map_resource.go
@@ -104,10 +104,15 @@ func resourceLogicAppIntegrationAccountMapCreateUpdate(d *pluginsdk.ResourceData
 
 	parameters := logic.IntegrationAccountMap{
 		IntegrationAccountMapProperties: &logic.IntegrationAccountMapProperties{
-			MapType:     logic.MapType(d.Get("map_type").(string)),
-			Content:     utils.String(d.Get("content").(string)),
-			ContentType: utils.String("application/xml"),
+			MapType: logic.MapType(d.Get("map_type").(string)),
+			Content: utils.String(d.Get("content").(string)),
 		},
+	}
+
+	if parameters.IntegrationAccountMapProperties.MapType == logic.MapTypeLiquid {
+		parameters.IntegrationAccountMapProperties.ContentType = utils.String("text/plain")
+	} else {
+		parameters.IntegrationAccountMapProperties.ContentType = utils.String("application/xml")
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {

--- a/internal/services/logic/logic_app_integration_account_map_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_map_resource_test.go
@@ -61,6 +61,21 @@ func TestAccLogicAppIntegrationAccountMap_complete(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppIntegrationAccountMap_liquidContentType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_map", "test")
+	r := LogicAppIntegrationAccountMapResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.liquidContentType(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("content"), // not returned from the API
+	})
+}
+
 func TestAccLogicAppIntegrationAccountMap_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account_map", "test")
 	r := LogicAppIntegrationAccountMapResource{}
@@ -179,6 +194,24 @@ resource "azurerm_logic_app_integration_account_map" "test" {
 
   metadata = {
     foo = "bar2"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogicAppIntegrationAccountMapResource) liquidContentType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_integration_account_map" "test" {
+  name                     = "acctest-iamap-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  integration_account_name = azurerm_logic_app_integration_account.test.name
+  map_type                 = "Liquid"
+  content                  = file("testdata/integration_account_map_content.liquid")
+
+  metadata = {
+    foo = "bar"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/logic/testdata/integration_account_map_content.liquid
+++ b/internal/services/logic/testdata/integration_account_map_content.liquid
@@ -1,0 +1,1 @@
+<h2>Terraform Test</h2>


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15350

--- PASS: TestAccLogicAppIntegrationAccountMap_complete (276.85s)
--- PASS: TestAccLogicAppIntegrationAccountMap_liquidContentType (296.04s)
--- PASS: TestAccLogicAppIntegrationAccountMap_basic (296.90s)
--- PASS: TestAccLogicAppIntegrationAccountMap_requiresImport (319.43s)
--- PASS: TestAccLogicAppIntegrationAccountMap_update (393.26s)