### PR TITLE
support user assigned identity for policy assignments for azurerm_subscription_policy_assignment, azurerm_management_group_policy_assignment, azurerm_resource_group_policy_assignment and azurerm_resource_policy_assignment resources

### DIFF
--- a/internal/services/policy/assignment_base_resource.go
+++ b/internal/services/policy/assignment_base_resource.go
@@ -158,7 +158,8 @@ func (br assignmentBaseResource) readFunc(scopeFieldName string) sdk.ResourceFun
 			//lintignore:R001
 			metadata.ResourceData.Set(scopeFieldName, id.Scope)
 
-			if err := metadata.ResourceData.Set("identity", br.flattenIdentity(resp.Identity)); err != nil {
+			identity, _ := br.flattenIdentity(resp.Identity)
+			if err := metadata.ResourceData.Set("identity", identity); err != nil {
 				return fmt.Errorf("setting `identity`: %+v", err)
 			}
 
@@ -317,7 +318,7 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 
 		"location": azure.SchemaLocationOptional(),
 
-		"identity": commonschema.SystemAssignedIdentityOptional(),
+		"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
 		"enforce": {
 			Type:     pluginsdk.TypeBool,
@@ -376,34 +377,47 @@ func (br assignmentBaseResource) attributes() map[string]*pluginsdk.Schema {
 }
 
 func (br assignmentBaseResource) expandIdentity(input []interface{}) (*policy.Identity, error) {
-	expanded, err := identity.ExpandSystemAssigned(input)
+	expanded, err := identity.ExpandSystemOrUserAssignedMap(input)
 	if err != nil {
 		return nil, err
 	}
 
-	return &policy.Identity{
-		Type: policy.ResourceIdentityType(expanded.Type),
-	}, nil
-}
-
-func (br assignmentBaseResource) flattenIdentity(input *policy.Identity) []interface{} {
-	var config *identity.SystemAssigned
-	if input != nil {
-		principalId := ""
-		if input.PrincipalID != nil {
-			principalId = *input.PrincipalID
-		}
-		tenantId := ""
-		if input.TenantID != nil {
-			tenantId = *input.TenantID
-		}
-		config = &identity.SystemAssigned{
-			Type:        identity.Type(string(input.Type)),
-			PrincipalId: principalId,
-			TenantId:    tenantId,
+	out := policy.Identity{
+		Type: policy.ResourceIdentityType(string(expanded.Type)),
+	}
+	if expanded.Type == identity.TypeUserAssigned {
+		out.UserAssignedIdentities = make(map[string]*policy.IdentityUserAssignedIdentitiesValue)
+		for k := range expanded.IdentityIds {
+			out.UserAssignedIdentities[k] = &policy.IdentityUserAssignedIdentitiesValue{
+				// intentionally empty
+			}
 		}
 	}
-	return identity.FlattenSystemAssigned(config)
+	return &out, nil
+}
+
+func (br assignmentBaseResource) flattenIdentity(input *policy.Identity) (*[]interface{}, error) {
+	var config *identity.SystemOrUserAssignedMap
+	if input != nil {
+		config = &identity.SystemOrUserAssignedMap{
+			Type:        identity.Type(string(input.Type)),
+			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
+		}
+
+		if input.PrincipalID != nil {
+			config.PrincipalId = *input.PrincipalID
+		}
+		if input.TenantID != nil {
+			config.TenantId = *input.TenantID
+		}
+		for k, v := range input.UserAssignedIdentities {
+			config.IdentityIds[k] = identity.UserAssignedIdentityDetails{
+				ClientId:    v.ClientID,
+				PrincipalId: v.PrincipalID,
+			}
+		}
+	}
+	return identity.FlattenSystemOrUserAssignedMap(config)
 }
 
 func (br assignmentBaseResource) flattenNonComplianceMessages(input *[]policy.NonComplianceMessage) []interface{} {

--- a/internal/services/policy/assignment_management_group_resource_test.go
+++ b/internal/services/policy/assignment_management_group_resource_test.go
@@ -107,6 +107,28 @@ func TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet(t *testing
 	})
 }
 
+func TestAccManagementGroupPolicyAssignment_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_assignment", "test")
+	r := ManagementGroupAssignmentTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_assignment", "test")
 	r := ManagementGroupAssignmentTestResource{}
@@ -720,4 +742,68 @@ resource "azurerm_management_group" "test" {
   display_name = "Acceptance Test MgmtGroup %[1]d"
 }
 `, data.RandomInteger)
+}
+
+func (r ManagementGroupAssignmentTestResource) systemAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_policy_set_definition" "test" {
+  display_name = "Audit machines with insecure password security settings"
+}
+
+resource "azurerm_management_group_policy_assignment" "test" {
+  name                 = "acctestpol-%[2]s"
+  management_group_id  = azurerm_management_group.test.id
+  policy_definition_id = data.azurerm_policy_set_definition.test.id
+  location             = %[3]q
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomString, data.Locations.Primary)
+}
+
+func (r ManagementGroupAssignmentTestResource) userAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_policy_set_definition" "test" {
+  display_name = "Audit machines with insecure password security settings"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-pa-%[2]s"
+  location = %[3]q
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestua%[2]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_management_group_policy_assignment" "test" {
+  name                 = "acctestpol-%[2]s"
+  management_group_id  = azurerm_management_group.test.id
+  policy_definition_id = data.azurerm_policy_set_definition.test.id
+  location             = %[3]q
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, template, data.RandomString, data.Locations.Primary)
 }

--- a/internal/services/policy/assignment_resource_group_resource_test.go
+++ b/internal/services/policy/assignment_resource_group_resource_test.go
@@ -107,6 +107,28 @@ func TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet(t *testing.T
 	})
 }
 
+func TestAccResourceGroupPolicyAssignment_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_group_policy_assignment", "test")
+	r := ResourceGroupAssignmentTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_resource_group_policy_assignment", "test")
 	r := ResourceGroupAssignmentTestResource{}
@@ -582,4 +604,63 @@ resource "azurerm_resource_group" "test" {
   location = %[2]q
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ResourceGroupAssignmentTestResource) systemAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_policy_set_definition" "test" {
+  display_name = "Audit machines with insecure password security settings"
+}
+
+resource "azurerm_resource_group_policy_assignment" "test" {
+  name                 = "acctestpa-%[2]d"
+  resource_group_id    = azurerm_resource_group.test.id
+  policy_definition_id = data.azurerm_policy_set_definition.test.id
+  location             = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ResourceGroupAssignmentTestResource) userAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_policy_set_definition" "test" {
+  display_name = "Audit machines with insecure password security settings"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestua%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_resource_group_policy_assignment" "test" {
+  name                 = "acctestpa-%[2]d"
+  resource_group_id    = azurerm_resource_group.test.id
+  policy_definition_id = data.azurerm_policy_set_definition.test.id
+  location             = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -81,7 +81,11 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. The only possible value is `SystemAssigned`.
+* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Policy Definition.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
 ---
 

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -92,7 +92,11 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. The only possible value is `SystemAssigned`.
+* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Policy Definition.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
 ---
 

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -83,7 +83,11 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. The only possible value is `SystemAssigned`.
+* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Policy Definition.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
 ---
 

--- a/website/docs/r/subscription_policy_assignment.html.markdown
+++ b/website/docs/r/subscription_policy_assignment.html.markdown
@@ -78,7 +78,11 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. The only possible value is `SystemAssigned`.
+* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Policy Definition.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
 ---
 


### PR DESCRIPTION

The purpose of this PR:

> Currently, the resources for azurerm_subscription_policy_assignment, azurerm_management_group_policy_assignment, azurerm_resource_group_policy_assignment and azurerm_resource_policy_assignment only support `SystemAssigned` identity in terraform. To support "UserAssigned" identity in terraform as a ad hot request to PG team.

Test Results:

> PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet (548.38s)
> PASS: TestAccSubscriptionPolicyAssignment_identity (582.87s)
> PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy (624.55s)
> PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (660.37s)
> PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete (736.98s)
> PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (854.23s)
> PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy (856.30s)
> PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicyRequiresImport (515.01s)
> PASS: TestAccResourcePolicyAssignment_identity (665.29s)
> PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicySet (702.62s)
> PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicy (754.82s)
> PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (828.97s)
> PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicyComplete (841.58s)
> PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (958.69s)
> PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicy (958.96s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyRequiresImport (503.99s)
> PASS: TestAccResourceGroupPolicyAssignment_identity (594.68s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet (649.31s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (693.25s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicy (716.77s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyComplete (814.09s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (945.63s)
> PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicy (945.65s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicy (899.77s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyRequiresImport (471.84s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet (610.89s)
> PASS: TestAccManagementGroupPolicyAssignment_identity (622.25s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyComplete (1283.53s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (699.33s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (702.01s)
> PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicy (662.29s)
> PASS: TestAccManagementGroupPolicyAssignment_basicComplexWithCustomPolicy (772.52s)
> 
