### PR TITLE
`azurerm_web_application_firewall_policy` - `disabled_rules` is now optional

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -226,7 +226,7 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 												},
 												"disabled_rules": {
 													Type:     pluginsdk.TypeList,
-													Required: true,
+													Optional: true,
 													Elem: &pluginsdk.Schema{
 														Type: pluginsdk.TypeString,
 													},
@@ -523,11 +523,13 @@ func expandWebApplicationFirewallPolicyRuleGroupOverrides(input []interface{}) *
 		v := item.(map[string]interface{})
 
 		ruleGroupName := v["rule_group_name"].(string)
-		disabledRules := v["disabled_rules"].([]interface{})
 
 		result := network.ManagedRuleGroupOverride{
 			RuleGroupName: utils.String(ruleGroupName),
-			Rules:         expandWebApplicationFirewallPolicyRules(disabledRules),
+		}
+
+		if disabledRules := v["disabled_rules"].([]interface{}); len(disabledRules) > 0 {
+			result.Rules = expandWebApplicationFirewallPolicyRules(disabledRules)
 		}
 
 		results = append(results, result)
@@ -710,7 +712,7 @@ func flattenWebApplicationFirewallPolicyRuleGroupOverrides(input *[]network.Mana
 
 func flattenWebApplicationFirewallPolicyManagedRuleOverrides(input *[]network.ManagedRuleOverride) []string {
 	results := make([]string, 0)
-	if input == nil {
+	if input == nil || len(*input) == 0 {
 		return results
 	}
 

--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -717,7 +717,7 @@ func flattenWebApplicationFirewallPolicyManagedRuleOverrides(input *[]network.Ma
 	}
 
 	for _, item := range *input {
-		if item.State == "" || item.State == network.ManagedRuleEnabledStateDisabled {
+		if (item.State == "" || item.State == network.ManagedRuleEnabledStateDisabled) && item.RuleID != nil {
 			v := *item.RuleID
 
 			results = append(results, v)

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -177,13 +177,13 @@ func TestAccWebApplicationFirewallPolicy_updateDisabledRules(t *testing.T) {
 	r := WebApplicationFirewallResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		//{
-		//	Config: r.complete(data),
-		//	Check: acceptance.ComposeTestCheckFunc(
-		//		check.That(data.ResourceName).ExistsInAzure(r),
-		//	),
-		//},
-		//data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.updateDisabledRules(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -191,13 +191,13 @@ func TestAccWebApplicationFirewallPolicy_updateDisabledRules(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		//{
-		//	Config: r.complete(data),
-		//	Check: acceptance.ComposeTestCheckFunc(
-		//		check.That(data.ResourceName).ExistsInAzure(r),
-		//	),
-		//},
-		//data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -172,6 +172,35 @@ func TestAccWebApplicationFirewallPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccWebApplicationFirewallPolicy_updateDisabledRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_application_firewall_policy", "test")
+	r := WebApplicationFirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		//{
+		//	Config: r.complete(data),
+		//	Check: acceptance.ComposeTestCheckFunc(
+		//		check.That(data.ResourceName).ExistsInAzure(r),
+		//	),
+		//},
+		//data.ImportStep(),
+		{
+			Config: r.updateDisabledRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		//{
+		//	Config: r.complete(data),
+		//	Check: acceptance.ComposeTestCheckFunc(
+		//		check.That(data.ResourceName).ExistsInAzure(r),
+		//	),
+		//},
+		//data.ImportStep(),
+	})
+}
+
 func (t WebApplicationFirewallResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ApplicationGatewayWebApplicationFirewallPolicyID(state.ID)
 	if err != nil {
@@ -309,6 +338,105 @@ resource "azurerm_web_application_firewall_policy" "test" {
           "920300",
           "920440",
         ]
+      }
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Prevention"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (WebApplicationFirewallResource) updateDisabledRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctestwafpolicy-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  tags = {
+    env = "test"
+  }
+
+  custom_rules {
+    name      = "Rule1"
+    priority  = 1
+    rule_type = "MatchRule"
+
+    match_conditions {
+      match_variables {
+        variable_name = "RemoteAddr"
+      }
+
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24", "10.0.0.0/24"]
+    }
+
+    action = "Block"
+  }
+
+  custom_rules {
+    name      = "Rule2"
+    priority  = 2
+    rule_type = "MatchRule"
+
+    match_conditions {
+      match_variables {
+        variable_name = "RemoteAddr"
+      }
+
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+
+    match_conditions {
+      match_variables {
+        variable_name = "RequestHeaders"
+        selector      = "UserAgent"
+      }
+
+      operator           = "Contains"
+      negation_condition = false
+      match_values       = ["windows"]
+      transforms         = ["Lowercase"]
+    }
+
+    action = "Block"
+  }
+
+  managed_rules {
+    exclusion {
+      match_variable          = "RequestHeaderNames"
+      selector                = "x-shared-secret"
+      selector_match_operator = "Equals"
+    }
+
+    exclusion {
+      match_variable          = "RequestCookieNames"
+      selector                = "too-much-fun"
+      selector_match_operator = "EndsWith"
+    }
+
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.1"
+
+      rule_group_override {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
       }
     }
   }


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15342

The [document](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy#disabled_rules) of  `azurerm_web_application_firewall_policy` resource indicates `disabled_rules` is optional but this property is set as `required`. After tested, this resource can be created successfully without the property `disabled_rules` and [api spec](https://github.com/Azure/azure-rest-api-specs/blob/7c98de7664d4565c088350015ccd0cfc102eab49/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/webapplicationfirewall.json#L659) indicates this property is not required and it allows empty. So I assume this property is optional.

--- PASS: TestAccWebApplicationFirewallPolicy_updateDisabledRules (416.04s)
--- PASS: TestAccWebApplicationFirewallPolicy_basic (295.97s)
--- PASS: TestAccWebApplicationFirewallPolicy_complete (296.49s)
--- PASS: TestAccWebApplicationFirewallPolicy_update (311.67s)
--- PASS: TestAccDataSourceAzureRMWebApplicationFirewallPolicy_basic (219.10s)