### PR TITLE
update conditional schemas for tflint errors

### DIFF
--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -27,7 +27,7 @@ import (
 var azureFirewallResourceName = "azurerm_firewall"
 
 func resourceFirewall() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := pluginsdk.Resource{
 		Create: resourceFirewallCreateUpdate,
 		Read:   resourceFirewallRead,
 		Update: resourceFirewallCreateUpdate,
@@ -55,30 +55,6 @@ func resourceFirewall() *pluginsdk.Resource {
 			"location": azure.SchemaLocation(),
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: features.ThreePointOhBeta(),
-				Optional: !features.ThreePointOhBeta(),
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(network.AzureFirewallSkuNameAZFWHub),
-					string(network.AzureFirewallSkuNameAZFWVNet),
-				}, false),
-			},
-
-			"sku_tier": {
-				Type:     pluginsdk.TypeString,
-				Required: features.ThreePointOhBeta(),
-				Optional: !features.ThreePointOhBeta(),
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(network.AzureFirewallSkuTierPremium),
-					string(network.AzureFirewallSkuTierStandard),
-				}, false),
-			},
 
 			"firewall_policy_id": {
 				Type:         pluginsdk.TypeString,
@@ -226,6 +202,51 @@ func resourceFirewall() *pluginsdk.Resource {
 			"tags": tags.Schema(),
 		},
 	}
+
+	if features.ThreePointOhBeta() {
+		resource.Schema["sku_tier"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(network.AzureFirewallSkuTierPremium),
+				string(network.AzureFirewallSkuTierStandard),
+			}, false),
+		}
+		resource.Schema["sku_name"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(network.AzureFirewallSkuNameAZFWHub),
+				string(network.AzureFirewallSkuNameAZFWVNet),
+			}, false),
+		}
+	} else {
+		resource.Schema["sku_name"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(network.AzureFirewallSkuNameAZFWHub),
+				string(network.AzureFirewallSkuNameAZFWVNet),
+			}, false),
+		}
+
+		resource.Schema["sku_tier"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(network.AzureFirewallSkuTierPremium),
+				string(network.AzureFirewallSkuTierStandard),
+			}, false),
+		}
+	}
+
+	return &resource
 }
 
 func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -314,21 +314,6 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 	out := map[string]*pluginsdk.Schema{
 		"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
-		"workspace_id": {
-			Type:             pluginsdk.TypeString,
-			Computed:         !features.ThreePointOhBeta(),
-			Optional:         !features.ThreePointOhBeta(),
-			Required:         features.ThreePointOhBeta(),
-			DiffSuppressFunc: suppress.CaseDifference,
-			ValidateFunc:     azure.ValidateResourceID,
-			ExactlyOneOf: func() []string {
-				if !features.ThreePointOhBeta() {
-					return []string{"workspace_id", "workspace_name"}
-				}
-				return []string{}
-			}(),
-		},
-
 		"read_access_id": {
 			Type:         pluginsdk.TypeString,
 			Computed:     true,
@@ -365,6 +350,19 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 	}
 
 	if !features.ThreePointOhBeta() {
+		out["workspace_id"] = &pluginsdk.Schema{
+			Type:             pluginsdk.TypeString,
+			Computed:         true,
+			Optional:         true,
+			DiffSuppressFunc: suppress.CaseDifference,
+			ValidateFunc:     azure.ValidateResourceID,
+			ExactlyOneOf: func() []string {
+				if !features.ThreePointOhBeta() {
+					return []string{"workspace_id", "workspace_name"}
+				}
+				return []string{}
+			}(),
+		}
 
 		out["workspace_name"] = &pluginsdk.Schema{
 			Type:             pluginsdk.TypeString,
@@ -397,6 +395,19 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 			Deprecated: "This field has been deprecated and will be removed in a future version of the provider",
 		}
 
+	} else {
+		out["workspace_id"] = &pluginsdk.Schema{
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			DiffSuppressFunc: suppress.CaseDifference,
+			ValidateFunc:     azure.ValidateResourceID,
+			ExactlyOneOf: func() []string {
+				if !features.ThreePointOhBeta() {
+					return []string{"workspace_id", "workspace_name"}
+				}
+				return []string{}
+			}(),
+		}
 	}
 
 	return out


### PR DESCRIPTION
`tflint` raises schema errors. 
e.g. 
```
internal/services/firewall/firewall_resource.go:59:16: S010: schema should not only enable Computed and configure ValidateFunc
```

Whilst these are non-failing, they are noise that may obscure other problems.

![image](https://user-images.githubusercontent.com/11830746/153624869-47442619-7dcc-4593-922f-b69f240d9d9a.png)

![image](https://user-images.githubusercontent.com/11830746/153624916-284c997b-0902-426c-a11b-1d33b83c4bf9.png)
