### PR TITLE
Fix potential deadlocks among provider level

### DIFF
--- a/internal/services/network/network_interface_locking.go
+++ b/internal/services/network/network_interface_locking.go
@@ -13,8 +13,8 @@ type networkInterfaceIPConfigurationLockingDetails struct {
 }
 
 func (details networkInterfaceIPConfigurationLockingDetails) lock() {
-	locks.MultipleByName(&details.subnetNamesToLock, SubnetResourceName)
 	locks.MultipleByName(&details.virtualNetworkNamesToLock, VirtualNetworkResourceName)
+	locks.MultipleByName(&details.subnetNamesToLock, SubnetResourceName)
 }
 
 func (details networkInterfaceIPConfigurationLockingDetails) unlock() {


### PR DESCRIPTION
Fixes #15355 

Implemented a small tool https://github.com/magodo/terraform-provider-azurerm-deadlock to ensure this change here won't affect the other places. The only output of above tool is as below:

```shell
Potential deadlock:
  azurerm_subnet->azurerm_virtual_network:
        - internal/services/network/network_interface_locking.go:15:1
  azurerm_virtual_network->azurerm_subnet:
        - internal/services/firewall/firewall_resource.go:222:1
        - internal/services/firewall/firewall_resource.go:439:1
        - internal/services/network/network_profile_resource.go:198:1
        - internal/services/network/network_profile_resource.go:99:1
        - internal/services/network/subnet_nat_gateway_association_resource.go:55:1
        - internal/services/network/subnet_network_security_group_association_resource.go:184:1
        - internal/services/network/subnet_network_security_group_association_resource.go:55:1
        - internal/services/network/subnet_resource.go:285:1
        - internal/services/network/subnet_resource.go:460:1
        - internal/services/redis/redis_cache_resource.go:339:1
        - internal/services/redis/redis_cache_resource.go:685:1
        - internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go:210:1
        - internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go:60:1
        - internal/services/web/app_service_virtual_network_swift_connection_resource.go:186:1
        - internal/services/web/app_service_virtual_network_swift_connection_resource.go:53:1
```

This reveals that among the provider, it always lock the `azurerm_virtual_network` resource type prior to the `azurerm_subnet`, except *internal/services/network/network_interface_locking.go*.