### PR TITLE
fix: ParseEventhubAuthorizationRuleIDInsensitively

### DIFF
--- a/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -129,7 +129,7 @@ func resourceEventHubAuthorizationRuleRead(d *pluginsdk.ResourceData, meta inter
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := eventhubs.ParseEventhubAuthorizationRuleID(d.Id())
+	id, err := eventhubs.ParseEventhubAuthorizationRuleIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/14394.

Tested locally and was able to create `azurerm_eventhub_authorization_rule` resource after change.