### PR TITLE
`s\recoveryservices` `s\loganalytics`: Deprecate unsupported tags

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -144,7 +144,6 @@ func resourceLogAnalyticsLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, me
 	resourceGroup := d.Get("resource_group_name").(string)
 	readAccess := d.Get("read_access_id").(string)
 	writeAccess := d.Get("write_access_id").(string)
-	t := d.Get("tags").(map[string]interface{})
 
 	if !features.ThreePointOhBeta() {
 		if resourceId := d.Get("resource_id").(string); resourceId != "" {
@@ -199,7 +198,6 @@ func resourceLogAnalyticsLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, me
 
 	parameters := operationalinsights.LinkedService{
 		LinkedServiceProperties: &operationalinsights.LinkedServiceProperties{},
-		Tags:                    tags.Expand(t),
 	}
 
 	if id.LinkedServiceName == "Automation" {
@@ -267,7 +265,7 @@ func resourceLogAnalyticsLinkedServiceRead(d *pluginsdk.ResourceData, meta inter
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceLogAnalyticsLinkedServiceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -345,8 +343,6 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
-
-		"tags": tags.Schema(),
 	}
 
 	if !features.ThreePointOhBeta() {
@@ -395,6 +391,7 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 			Deprecated: "This field has been deprecated and will be removed in a future version of the provider",
 		}
 
+		out["tags"] = tags.SchemaDeprecatedUnsupported()
 	} else {
 		out["workspace_id"] = &pluginsdk.Schema{
 			Type:             pluginsdk.TypeString,

--- a/internal/services/recoveryservices/backup_policy_file_share_data_source.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_data_source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -23,22 +24,7 @@ func dataSourceBackupPolicyFileShare() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"recovery_vault_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: validate.RecoveryServicesVaultName,
-			},
-
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"tags": tags.SchemaDataSource(),
-		},
+		Schema: dataSourceBackupPolicyFileShareSchema(),
 	}
 }
 
@@ -65,5 +51,28 @@ func dataSourceBackupPolicyFileShareRead(d *pluginsdk.ResourceData, meta interfa
 	id := strings.Replace(*protectionPolicy.ID, "Subscriptions", "subscriptions", 1)
 	d.SetId(id)
 
-	return tags.FlattenAndSet(d, protectionPolicy.Tags)
+	return nil
+}
+
+func dataSourceBackupPolicyFileShareSchema() map[string]*pluginsdk.Schema {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"recovery_vault_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.RecoveryServicesVaultName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+
+	if !features.ThreePointOhBeta() {
+		schema["tags"] = tags.SchemaDataSourceDeprecatedUnsupported()
+	}
+
+	return schema
 }

--- a/internal/services/recoveryservices/backup_policy_file_share_data_source_test.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_data_source_test.go
@@ -21,7 +21,6 @@ func TestAccDataSourceBackupPolicyFileShare_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("recovery_vault_name").Exists(),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
 			),
 		},
 	})

--- a/internal/services/recoveryservices/backup_policy_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_resource.go
@@ -44,199 +44,7 @@ func resourceBackupProtectionPolicyFileShare() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[a-zA-Z][-_!a-zA-Z0-9]{2,149}$"),
-					"Backup Policy name must be 3 - 150 characters long, start with a letter, contain only letters and numbers.",
-				),
-			},
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"recovery_vault_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.RecoveryServicesVaultName,
-			},
-
-			"timezone": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "UTC",
-			},
-
-			"backup": {
-				Type:     pluginsdk.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"frequency": {
-							Type:             pluginsdk.TypeString,
-							Required:         true,
-							DiffSuppressFunc: suppress.CaseDifference,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(backup.ScheduleRunTypeDaily),
-							}, false),
-						},
-
-						"time": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringMatch(
-								regexp.MustCompile("^([01][0-9]|[2][0-3]):([03][0])$"), // time must be on the hour or half past
-								"Time of day must match the format HH:mm where HH is 00-23 and mm is 00 or 30",
-							),
-						},
-					},
-				},
-			},
-
-			"retention_daily": {
-				Type:     pluginsdk.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"count": {
-							Type:         pluginsdk.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 200),
-						},
-					},
-				},
-			},
-
-			"retention_weekly": {
-				Type:     pluginsdk.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"count": {
-							Type:         pluginsdk.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 200),
-						},
-
-						"weekdays": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifference,
-								ValidateFunc:     validation.IsDayOfTheWeek(true),
-							},
-						},
-					},
-				},
-			},
-
-			"retention_monthly": {
-				Type:     pluginsdk.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"count": {
-							Type:         pluginsdk.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 120),
-						},
-
-						"weeks": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifferenceV2Only,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(backup.WeekOfMonthFirst),
-									string(backup.WeekOfMonthSecond),
-									string(backup.WeekOfMonthThird),
-									string(backup.WeekOfMonthFourth),
-									string(backup.WeekOfMonthLast),
-								}, !features.ThreePointOhBeta()),
-							},
-						},
-
-						"weekdays": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifference,
-								ValidateFunc:     validation.IsDayOfTheWeek(true),
-							},
-						},
-					},
-				},
-			},
-
-			"retention_yearly": {
-				Type:     pluginsdk.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"count": {
-							Type:         pluginsdk.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 10),
-						},
-
-						"months": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifference,
-								ValidateFunc:     validation.IsMonth(true),
-							},
-						},
-
-						"weeks": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifferenceV2Only,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(backup.WeekOfMonthFirst),
-									string(backup.WeekOfMonthSecond),
-									string(backup.WeekOfMonthThird),
-									string(backup.WeekOfMonthFourth),
-									string(backup.WeekOfMonthLast),
-								}, !features.ThreePointOhBeta()),
-							},
-						},
-
-						"weekdays": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Set:      set.HashStringIgnoreCase,
-							Elem: &pluginsdk.Schema{
-								Type:             pluginsdk.TypeString,
-								DiffSuppressFunc: suppress.CaseDifference,
-								ValidateFunc:     validation.IsDayOfTheWeek(true),
-							},
-						},
-					},
-				},
-			},
-
-			"tags": tags.Schema(),
-		},
+		Schema: resourceBackupProtectionPolicyFileShareSchema(),
 
 		// if daily, we need daily retention
 		// if weekly daily cannot be set, and we need weekly
@@ -277,7 +85,6 @@ func resourceBackupProtectionPolicyFileShareCreateUpdate(d *pluginsdk.ResourceDa
 	policyName := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
-	t := d.Get("tags").(map[string]interface{})
 
 	log.Printf("[DEBUG] Creating/updating Recovery Service Protection Policy %s (resource group %q)", policyName, resourceGroup)
 
@@ -317,7 +124,6 @@ func resourceBackupProtectionPolicyFileShareCreateUpdate(d *pluginsdk.ResourceDa
 	}
 
 	policy := backup.ProtectionPolicyResource{
-		Tags:       tags.Expand(t),
 		Properties: AzureFileShareProtectionPolicyProperties,
 	}
 
@@ -406,7 +212,7 @@ func resourceBackupProtectionPolicyFileShareRead(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceBackupProtectionPolicyFileShareDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -735,4 +541,204 @@ func resourceBackupProtectionPolicyFileShareRefreshFunc(ctx context.Context, cli
 
 		return resp, "Found", nil
 	}
+}
+
+func resourceBackupProtectionPolicyFileShareSchema() map[string]*pluginsdk.Schema {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile("^[a-zA-Z][-_!a-zA-Z0-9]{2,149}$"),
+				"Backup Policy name must be 3 - 150 characters long, start with a letter, contain only letters and numbers.",
+			),
+		},
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"recovery_vault_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.RecoveryServicesVaultName,
+		},
+
+		"timezone": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "UTC",
+		},
+
+		"backup": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"frequency": {
+						Type:             pluginsdk.TypeString,
+						Required:         true,
+						DiffSuppressFunc: suppress.CaseDifference,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(backup.ScheduleRunTypeDaily),
+						}, false),
+					},
+
+					"time": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringMatch(
+							regexp.MustCompile("^([01][0-9]|[2][0-3]):([03][0])$"), // time must be on the hour or half past
+							"Time of day must match the format HH:mm where HH is 00-23 and mm is 00 or 30",
+						),
+					},
+				},
+			},
+		},
+
+		"retention_daily": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"count": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(1, 200),
+					},
+				},
+			},
+		},
+
+		"retention_weekly": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"count": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(1, 200),
+					},
+
+					"weekdays": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifference,
+							ValidateFunc:     validation.IsDayOfTheWeek(true),
+						},
+					},
+				},
+			},
+		},
+
+		"retention_monthly": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"count": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(1, 120),
+					},
+
+					"weeks": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifferenceV2Only,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(backup.WeekOfMonthFirst),
+								string(backup.WeekOfMonthSecond),
+								string(backup.WeekOfMonthThird),
+								string(backup.WeekOfMonthFourth),
+								string(backup.WeekOfMonthLast),
+							}, !features.ThreePointOhBeta()),
+						},
+					},
+
+					"weekdays": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifference,
+							ValidateFunc:     validation.IsDayOfTheWeek(true),
+						},
+					},
+				},
+			},
+		},
+
+		"retention_yearly": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"count": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(1, 10),
+					},
+
+					"months": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifference,
+							ValidateFunc:     validation.IsMonth(true),
+						},
+					},
+
+					"weeks": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifferenceV2Only,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(backup.WeekOfMonthFirst),
+								string(backup.WeekOfMonthSecond),
+								string(backup.WeekOfMonthThird),
+								string(backup.WeekOfMonthFourth),
+								string(backup.WeekOfMonthLast),
+							}, !features.ThreePointOhBeta()),
+						},
+					},
+
+					"weekdays": {
+						Type:     pluginsdk.TypeSet,
+						Required: true,
+						Set:      set.HashStringIgnoreCase,
+						Elem: &pluginsdk.Schema{
+							Type:             pluginsdk.TypeString,
+							DiffSuppressFunc: suppress.CaseDifference,
+							ValidateFunc:     validation.IsDayOfTheWeek(true),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		schema["tags"] = tags.SchemaDeprecatedUnsupported()
+	}
+
+	return schema
 }

--- a/internal/services/recoveryservices/backup_policy_vm_data_source.go
+++ b/internal/services/recoveryservices/backup_policy_vm_data_source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -23,22 +24,7 @@ func dataSourceBackupPolicyVm() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"recovery_vault_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: validate.RecoveryServicesVaultName,
-			},
-
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"tags": tags.SchemaDataSource(),
-		},
+		Schema: dataSourceBackupPolicyVmSchema(),
 	}
 }
 
@@ -65,5 +51,28 @@ func dataSourceBackupPolicyVmRead(d *pluginsdk.ResourceData, meta interface{}) e
 	id := strings.Replace(*protectionPolicy.ID, "Subscriptions", "subscriptions", 1)
 	d.SetId(id)
 
-	return tags.FlattenAndSet(d, protectionPolicy.Tags)
+	return nil
+}
+
+func dataSourceBackupPolicyVmSchema() map[string]*pluginsdk.Schema {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"recovery_vault_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.RecoveryServicesVaultName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+
+	if !features.ThreePointOhBeta() {
+		schema["tags"] = tags.SchemaDataSourceDeprecatedUnsupported()
+	}
+
+	return schema
 }

--- a/internal/services/recoveryservices/backup_policy_vm_data_source_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_data_source_test.go
@@ -21,7 +21,6 @@ func TestAccDataSourceBackupPolicyVm_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("recovery_vault_name").Exists(),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
 			),
 		},
 	})

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	vmParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
@@ -41,53 +42,7 @@ func resourceRecoveryServicesBackupProtectedVM() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(80 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"recovery_vault_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.RecoveryServicesVaultName,
-			},
-
-			"source_vm_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
-				// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/10357
-				DiffSuppressFunc: suppress.CaseDifference,
-			},
-
-			"backup_policy_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: azure.ValidateResourceID,
-			},
-
-			"exclude_disk_luns": {
-				Type:          pluginsdk.TypeSet,
-				ConflictsWith: []string{"include_disk_luns"},
-				Optional:      true,
-				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeInt,
-					ValidateFunc: validation.IntAtLeast(0),
-				},
-			},
-
-			"include_disk_luns": {
-				Type:          pluginsdk.TypeSet,
-				ConflictsWith: []string{"exclude_disk_luns"},
-				Optional:      true,
-				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeInt,
-					ValidateFunc: validation.IntAtLeast(0),
-				},
-			},
-
-			"tags": tags.Schema(),
-		},
+		Schema: resourceRecoveryServicesBackupProtectedVMSchema(),
 	}
 }
 
@@ -97,7 +52,6 @@ func resourceRecoveryServicesBackupProtectedVMCreateUpdate(d *pluginsdk.Resource
 	defer cancel()
 
 	resourceGroup := d.Get("resource_group_name").(string)
-	t := d.Get("tags").(map[string]interface{})
 
 	vaultName := d.Get("recovery_vault_name").(string)
 	vmId := d.Get("source_vm_id").(string)
@@ -128,7 +82,6 @@ func resourceRecoveryServicesBackupProtectedVMCreateUpdate(d *pluginsdk.Resource
 	}
 
 	item := backup.ProtectedItemResource{
-		Tags: tags.Expand(t),
 		Properties: &backup.AzureIaaSComputeVMProtectedItem{
 			PolicyID:           &policyId,
 			ProtectedItemType:  backup.ProtectedItemTypeMicrosoftClassicComputevirtualMachines,
@@ -202,7 +155,7 @@ func resourceRecoveryServicesBackupProtectedVMRead(d *pluginsdk.ResourceData, me
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -336,4 +289,58 @@ func expandDiskLunList(input []interface{}) []interface{} {
 		result = append(result, v.(int))
 	}
 	return result
+}
+
+func resourceRecoveryServicesBackupProtectedVMSchema() map[string]*pluginsdk.Schema {
+	schema := map[string]*pluginsdk.Schema{
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"recovery_vault_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.RecoveryServicesVaultName,
+		},
+
+		"source_vm_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/10357
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		"backup_policy_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+
+		"exclude_disk_luns": {
+			Type:          pluginsdk.TypeSet,
+			ConflictsWith: []string{"include_disk_luns"},
+			Optional:      true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeInt,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+		},
+
+		"include_disk_luns": {
+			Type:          pluginsdk.TypeSet,
+			ConflictsWith: []string{"exclude_disk_luns"},
+			Optional:      true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeInt,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		schema["tags"] = tags.SchemaDeprecatedUnsupported()
+	}
+
+	return schema
 }

--- a/internal/tags/schema.go
+++ b/internal/tags/schema.go
@@ -13,6 +13,19 @@ func SchemaDataSource() *pluginsdk.Schema {
 	}
 }
 
+// SchemaDataSourceDeprecatedUnsupported returns the Schema which should be used for Tags on a Data Source
+// TODO remove in 3.0
+func SchemaDataSourceDeprecatedUnsupported() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:       pluginsdk.TypeMap,
+		Computed:   true,
+		Deprecated: "This field is now non-functional and thus will be removed in version 3.0 of the Azure Provider",
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}
+
 // ForceNewSchema returns the Schema which should be used for Tags when changes
 // require recreation of the resource
 func ForceNewSchema() *pluginsdk.Schema {
@@ -33,6 +46,20 @@ func Schema() *pluginsdk.Schema {
 		Type:         pluginsdk.TypeMap,
 		Optional:     true,
 		ValidateFunc: Validate,
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}
+
+// SchemaDeprecatedUnsupported returns the Schema used for deprecated Tags which is not supported by the resource
+// TODO remove in 3.0
+func SchemaDeprecatedUnsupported() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:         pluginsdk.TypeMap,
+		Optional:     true,
+		ValidateFunc: Validate,
+		Deprecated:   "This field is now non-functional and thus will be removed in version 3.0 of the Azure Provider",
 		Elem: &pluginsdk.Schema{
 			Type: pluginsdk.TypeString,
 		},

--- a/website/docs/d/backup_policy_file_share.html.markdown
+++ b/website/docs/d/backup_policy_file_share.html.markdown
@@ -36,8 +36,6 @@ The following attributes are exported:
 
 - `id` - The ID of the File Share Backup Policy.
 
-- `tags` - A mapping of tags assigned to the resource.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/d/backup_policy_vm.html.markdown
+++ b/website/docs/d/backup_policy_vm.html.markdown
@@ -36,9 +36,6 @@ The following attributes are exported:
 
 * `id` - The ID of the Backup VM Protection Policy.
 
-* `tags` - A mapping of tags assigned to the resource.
-
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/backup_policy_vm.html.markdown
+++ b/website/docs/r/backup_policy_vm.html.markdown
@@ -85,8 +85,6 @@ The following arguments are supported:
 
 * `retention_yearly` - (Optional) Configures the policy yearly retention as documented in the `retention_yearly` block below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
-
 ---
 
 The `backup` block supports:

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -60,8 +60,6 @@ The following arguments are supported:
 
 * `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be included for VM Protection.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/log_analytics_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_linked_service.html.markdown
@@ -64,8 +64,6 @@ The following arguments are supported:
 
 ~> **NOTE:** You must define at least one of the above access resource id attributes (e.g. `read_access_resource_id`/`resouce_id` or `write_access_resource_id`).
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/log_analytics_storage_insights.html.markdown
+++ b/website/docs/r/log_analytics_storage_insights.html.markdown
@@ -62,8 +62,6 @@ The following arguments are supported:
 
 * `table_names` - (Optional) The names of the Azure tables that the workspace should read.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Storage Insights.
-
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 


### PR DESCRIPTION
Fix #15357 #15369 #15283 #15284 in batch.
Tags are not supported for below resources/data_sources according to [Tag Support Doc](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-support)

- resources:
`log_analytics_linked_service_resource`: code+doc (no test with tags)
`log_analytics_storage_insights_resource`: code+doc (no test with tags)
`backup_policy_file_share_resource`: code (doc does not have tags, no test with tags)
`backup_policy_vm_resource`: code+doc (no test with tags)
`backup_protected_vm_resource`: code+doc (no test with tags)

- data sources:
`backup_policy_file_share_data_source`: code+test+doc
`backup_policy_vm_data_source`: code+test+doc