### PR TITLE
`example`: Fix sentinel csv watchlist item example

### DIFF
--- a/examples/sentinel/watchlist-item-from-csv-file/main.tf
+++ b/examples/sentinel/watchlist-item-from-csv-file/main.tf
@@ -2,6 +2,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "random" {}
+
 resource "azurerm_resource_group" "example" {
   name     = "example-rg"
   location = "West Europe"
@@ -45,5 +47,5 @@ resource "azurerm_sentinel_watchlist_item" "example" {
 
   name         = random_uuid.item[count.index].id
   watchlist_id = azurerm_sentinel_watchlist.example.id
-  fields       = local.csv_data[count.index]
+  properties   = local.csv_data[count.index]
 }


### PR DESCRIPTION
Seems to be a property name mismatch in this example `fields` v.s. `properties`  and a missing `random` provider.
https://github.com/hashicorp/terraform-provider-azurerm/blob/7ff39550ede7c88b9ede7851f0978ec85f911616/internal/services/sentinel/sentinel_watchlist_item_resource.go#L43-L45