### PR TITLE
azurerm_monitor_action_group: fix the format issue of the workspace_id property for itsm_receiver

### DIFF
--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -14,6 +14,7 @@ import (
 	eventHubValidation "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -103,7 +104,7 @@ func resourceMonitorActionGroup() *pluginsdk.Resource {
 						"workspace_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ValidateFunc: validation.IsUUID,
+							ValidateFunc: validate.WorkspaceID,
 						},
 						"connection_id": {
 							Type:         pluginsdk.TypeString,

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -480,6 +480,16 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
 resource "azurerm_monitor_action_group" "test" {
   name                = "acctestActionGroup-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -487,13 +497,13 @@ resource "azurerm_monitor_action_group" "test" {
 
   itsm_receiver {
     name                 = "createorupdateticket"
-    workspace_id         = "6eee3a18-aac3-40e4-b98e-1f309f329816"
+    workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
     ticket_configuration = "{}"
     region               = "eastus"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (MonitorActionGroupResource) azureAppPushReceiver(data acceptance.TestData) string {
@@ -872,6 +882,16 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
 resource "azurerm_monitor_action_group" "test" {
   name                = "acctestActionGroup-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -890,7 +910,7 @@ resource "azurerm_monitor_action_group" "test" {
 
   itsm_receiver {
     name                 = "createorupdateticket"
-    workspace_id         = "6eee3a18-aac3-40e4-b98e-1f309f329816"
+    workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
     ticket_configuration = "{}"
     region               = "eastus"
@@ -1057,7 +1077,7 @@ resource "azurerm_eventhub" "test" {
   message_retention   = 1
 }
 
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MonitorActionGroupResource) disabledBasic(data acceptance.TestData) string {

--- a/internal/services/monitor/validate/workspace_id.go
+++ b/internal/services/monitor/validate/workspace_id.go
@@ -1,0 +1,33 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func WorkspaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	segments := strings.Split(v, "|")
+	if len(segments) == 2 {
+		if _, err := validation.IsUUID(segments[0], key); err != nil {
+			errors = append(errors, fmt.Errorf("expected the <subscription id> in %q to be a valid UUID, but got %q", key, segments[0]))
+			return
+		}
+		if _, err := validation.IsUUID(segments[1], key); err != nil {
+			errors = append(errors, fmt.Errorf("expected the <workSpace id> in %q to be a valid UUID, but got %q", key, segments[1]))
+			return
+		}
+
+	} else {
+		errors = append(errors, fmt.Errorf("expected %q in the format {<subscription id}|{workSpace id} but got %q", key, v))
+	}
+
+	return
+}

--- a/internal/services/monitor/validate/workspace_id_test.go
+++ b/internal/services/monitor/validate/workspace_id_test.go
@@ -1,0 +1,57 @@
+package validate
+
+import "testing"
+
+func TestWorkspaceID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "12345678-1234-9876-4563-123456789012|123456789012",
+			Valid: false,
+		},
+		{
+			Input: "123456789012|12345678-1234-9876-4563-123456789012",
+			Valid: false,
+		},
+		{
+			Input: "|12345678-1234-9876-4563-123456789012",
+			Valid: false,
+		},
+		{
+			Input: "12345678-1234-9876-4563-123456789012|",
+			Valid: false,
+		},
+		{
+			Input: "abcds",
+			Valid: false,
+		},
+		{
+			Input: "123456789012",
+			Valid: false,
+		},
+		{
+			Input: "12345678-1234-9876-4563-123456789012",
+			Valid: false,
+		},
+		{
+			Input: "12345678-1234-9876-4563-123456789012|12345678-dcba-dcba-dcba-098765432109",
+			Valid: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := WorkspaceID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -185,7 +185,7 @@ The following arguments are supported:
 `itsm_receiver` supports the following:
 
 * `name` - (Required) The name of the ITSM receiver.
-* `workspace_id` - (Required) The Azure Log Analytics workspace ID where this connection is defined.
+* `workspace_id` - (Required) The Azure Log Analytics workspace ID where this connection is defined. Format is `<subscription id>|<workspace id>`, for example `00000000-0000-0000-0000-000000000000|00000000-0000-0000-0000-000000000000`.
 * `connection_id` - (Required) The unique connection identifier of the ITSM connection.
 * `ticket_configuration` - (Required) A JSON blob for the configurations of the ITSM action. CreateMultipleWorkItems option will be part of this blob as well.
 * `region` - (Required) The region of the workspace.


### PR DESCRIPTION
The purpose of this PR:


> Fix issue https://github.com/hashicorp/terraform-provider-azurerm/issues/9405. Currently, the [workspace_id](https://github.com/hashicorp/terraform-provider-azurerm/blob/b16280356490695957be1092114bce80b832df33/internal/services/monitor/monitor_action_group_resource.go#L106) property in the terraform provider is required to be a UUID. In fact, the format required by the API is "{subscriptionid}|{workspaceid}", which has been confirmed by the service team. [This](https://github.com/Azure/azure-rest-api-specs/blob/b7ceedcb657cac760383b17627cd2c1f47dd1521/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-09-01/examples/createOrUpdateActionGroup.json#L56) is an example of  `workspace_id` . Since the monitor action group API returns success even though the `workspace_id` is set to a single UUID, I filed an API [issue ](https://github.com/Azure/azure-rest-api-specs/issues/17861)to track it. And update the "ValidateFunc" of `workspace_id` to allow the user to set the correct `workspace_id` value in terraform provider. 

Test Results:

> PASS: TestAccMonitorActionGroup_basic (189.20s)
> PASS: TestAccMonitorActionGroup_webhookReceiver (202.98s)
> PASS: TestAccMonitorActionGroup_armRoleReceiver (208.72s)
> PASS: TestAccMonitorActionGroup_logicAppReceiver (228.37s)
> PASS: TestAccMonitorActionGroup_automationRunbookReceiver (241.21s)
> PASS: TestAccMonitorActionGroup_azureFunctionReceiver (270.93s)
> PASS: TestAccMonitorActionGroup_eventHubReceiver (322.42s)
> PASS: TestAccMonitorActionGroup_complete (350.67s)
> PASS: TestAccMonitorActionGroup_disabledUpdate (359.78s)
> PASS: TestAccMonitorActionGroup_emailReceiver (186.00s)
> PASS: TestAccMonitorActionGroup_voiceReceiver (191.75s)
> PASS: TestAccMonitorActionGroup_itsmReceiver (213.14s)
> PASS: TestAccMonitorActionGroup_requiresImport (211.55s)
> PASS: TestAccMonitorActionGroup_multipleReceiversUpdate (486.53s)
> PASS: TestAccMonitorActionGroup_singleReceiverUpdate (1306.50s)