### PR TITLE
App Service Beta - fix custom values for `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` in Function App resources

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -378,8 +378,12 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 					functionApp.AppSettings = make(map[string]string)
 				}
 				suffix := uuid.New().String()[0:4]
-				functionApp.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionApp.Name), suffix)
-				functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				if _, present := functionApp.AppSettings["WEBSITE_CONTENTSHARE"]; !present {
+					functionApp.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionApp.Name), suffix)
+				}
+				if _, present := functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]; !present {
+					functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				}
 			}
 
 			siteConfig.LinuxFxVersion = helpers.EncodeFunctionAppLinuxFxVersion(functionApp.SiteConfig[0].ApplicationStack)

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -170,9 +170,10 @@ func TestAccLinuxFunctionApp_withCustomContentShareElasticPremiumPlan(t *testing
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
 				check.That(data.ResourceName).Key("app_settings.%").HasValue("3"),
+				check.That(data.ResourceName).Key("app_settings.WEBSITE_CONTENTSHARE").HasValue("test-acc-custom-content-share"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("app_settings.WEBSITE_CONTENTSHARE", "app_settings.%"),
 	})
 }
 

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -159,6 +159,23 @@ func TestAccLinuxFunctionApp_withAppSettingsElasticPremiumPlan(t *testing.T) {
 	})
 }
 
+func TestAccLinuxFunctionApp_withCustomContentShareElasticPremiumPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsCustomContentShare(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxFunctionApp_withAppSettingsPremiumPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
 	r := LinuxFunctionAppResource{}
@@ -1022,6 +1039,34 @@ resource "azurerm_linux_function_app" "test" {
   app_settings = {
     foo    = "bar"
     secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppResource) appSettingsCustomContentShare(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo                  = "bar"
+    secret               = "sauce"
+    WEBSITE_CONTENTSHARE = "test-acc-custom-content-share"
   }
 
   site_config {}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -377,8 +377,12 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 					functionAppSlot.AppSettings = make(map[string]string)
 				}
 				suffix := uuid.New().String()[0:4]
-				functionAppSlot.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionAppSlot.Name), suffix)
-				functionAppSlot.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				if _, present := functionAppSlot.AppSettings["WEBSITE_CONTENTSHARE"]; !present {
+					functionAppSlot.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionAppSlot.Name), suffix)
+				}
+				if _, present := functionAppSlot.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]; !present {
+					functionAppSlot.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				}
 			}
 
 			siteConfig.LinuxFxVersion = helpers.EncodeFunctionAppLinuxFxVersion(functionAppSlot.SiteConfig[0].ApplicationStack)
@@ -742,10 +746,12 @@ func (m *LinuxFunctionAppSlotModel) unpackLinuxFunctionAppSettings(input web.Str
 			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"); ok {
 				appSettings[k] = utils.NormalizeNilableString(v)
 			}
+
 		case "WEBSITE_CONTENTSHARE":
 			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_CONTENTSHARE"); ok {
 				appSettings[k] = utils.NormalizeNilableString(v)
 			}
+
 		case "WEBSITE_HTTPLOGGING_RETENTION_DAYS":
 		case "FUNCTIONS_WORKER_RUNTIME":
 			if m.SiteConfig[0].ApplicationStack != nil {

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -118,6 +118,24 @@ func TestAccLinuxFunctionAppSlot_withAppSettingsElasticPremiumPlan(t *testing.T)
 	})
 }
 
+func TestAccLinuxFunctionAppSlot_withCustomContentShareElasticPremiumPla(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
+	r := LinuxFunctionAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsCustomContentShare(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("3"),
+				check.That(data.ResourceName).Key("app_settings.WEBSITE_CONTENTSHARE").HasValue("test-acc-custom-content-share"),
+			),
+		},
+		data.ImportStep("app_settings.WEBSITE_CONTENTSHARE", "app_settings.%"),
+	})
+}
+
 func TestAccLinuxFunctionAppSlot_withAppSettingsPremiumPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
 	r := LinuxFunctionAppSlotResource{}
@@ -909,6 +927,31 @@ resource "azurerm_linux_function_app_slot" "test" {
   app_settings = {
     foo    = "bar"
     secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppSlotResource) appSettingsCustomContentShare(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app_slot" "test" {
+  name                       = "acctest-LFAS-%d"
+  function_app_id            = azurerm_linux_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo                  = "bar"
+    secret               = "sauce"
+    WEBSITE_CONTENTSHARE = "test-acc-custom-content-share"
   }
 
   site_config {}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -851,17 +851,13 @@ func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input web.Str
 
 		case "WEBSITE_NODE_DEFAULT_VERSION": // Note - This is only set if it's not the default of 12, but we collect it from WindowsFxVersion so can discard it here
 		case "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":
-			if conf, ok := metadata.ResourceData.Get("app_settings").(map[string]interface{}); ok {
-				if connectionString, ok := conf["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]; ok {
-					appSettings[k] = connectionString.(string)
-				}
+			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"); ok {
+				appSettings[k] = utils.NormalizeNilableString(v)
 			}
 
 		case "WEBSITE_CONTENTSHARE":
-			if conf, ok := metadata.ResourceData.Get("app_settings").(map[string]interface{}); ok {
-				if contentShare, ok := conf["WEBSITE_CONTENTSHARE"]; ok {
-					appSettings[k] = contentShare.(string)
-				}
+			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_CONTENTSHARE"); ok {
+				appSettings[k] = utils.NormalizeNilableString(v)
 			}
 
 		case "WEBSITE_HTTPLOGGING_RETENTION_DAYS":

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -204,7 +204,7 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"https_only": {
 			Type:        pluginsdk.TypeBool,
 			Optional:    true,
-			Default:     false,
+			Computed:    true,
 			Description: "Can the Function App only be accessed via HTTPS?",
 		},
 
@@ -377,8 +377,12 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 					functionApp.AppSettings = make(map[string]string)
 				}
 				suffix := uuid.New().String()[0:4]
-				functionApp.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionApp.Name), suffix)
-				functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				if _, present := functionApp.AppSettings["WEBSITE_CONTENTSHARE"]; !present {
+					functionApp.AppSettings["WEBSITE_CONTENTSHARE"] = fmt.Sprintf("%s-%s", strings.ToLower(functionApp.Name), suffix)
+				}
+				if _, present := functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]; !present {
+					functionApp.AppSettings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"] = storageString
+				}
 			}
 
 			siteConfig.WindowsFxVersion = helpers.EncodeFunctionAppWindowsFxVersion(functionApp.SiteConfig[0].ApplicationStack)
@@ -541,7 +545,7 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 			}
 			state.SiteConfig = []helpers.SiteConfigWindowsFunctionApp{*siteConfig}
 
-			state.unpackWindowsFunctionAppSettings(appSettingsResp)
+			state.unpackWindowsFunctionAppSettings(appSettingsResp, metadata)
 
 			state.ConnectionStrings = helpers.FlattenConnectionStrings(connectionStrings)
 
@@ -831,7 +835,7 @@ func (r WindowsFunctionAppResource) CustomizeDiff() sdk.ResourceFunc {
 	}
 }
 
-func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input web.StringDictionary) {
+func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input web.StringDictionary, metadata sdk.ResourceMetaData) {
 	if input.Properties == nil {
 		return
 	}
@@ -847,7 +851,19 @@ func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input web.Str
 
 		case "WEBSITE_NODE_DEFAULT_VERSION": // Note - This is only set if it's not the default of 12, but we collect it from WindowsFxVersion so can discard it here
 		case "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":
+			if conf, ok := metadata.ResourceData.Get("app_settings").(map[string]interface{}); ok {
+				if connectionString, ok := conf["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]; ok {
+					appSettings[k] = connectionString.(string)
+				}
+			}
+
 		case "WEBSITE_CONTENTSHARE":
+			if conf, ok := metadata.ResourceData.Get("app_settings").(map[string]interface{}); ok {
+				if contentShare, ok := conf["WEBSITE_CONTENTSHARE"]; ok {
+					appSettings[k] = contentShare.(string)
+				}
+			}
+
 		case "WEBSITE_HTTPLOGGING_RETENTION_DAYS":
 		case "FUNCTIONS_WORKER_RUNTIME":
 			if len(m.SiteConfig) > 0 && len(m.SiteConfig[0].ApplicationStack) > 0 {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -164,7 +164,7 @@ func TestAccWindowsFunctionApp_withCustomContentShareElasticPremiumPlan(t *testi
 				check.That(data.ResourceName).Key("app_settings.WEBSITE_CONTENTSHARE").HasValue("test-acc-custom-content-share"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("app_settings.WEBSITE_CONTENTSHARE", "app_settings.%"),
 	})
 }
 

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -150,6 +150,24 @@ func TestAccWindowsFunctionApp_withAppSettingsElasticPremiumPlan(t *testing.T) {
 	})
 }
 
+func TestAccWindowsFunctionApp_withCustomContentShareElasticPremiumPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
+	r := WindowsFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsCustomContentShare(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("3"),
+				check.That(data.ResourceName).Key("app_settings.WEBSITE_CONTENTSHARE").HasValue("test-acc-custom-content-share"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccWindowsFunctionApp_withAppSettingsPremiumPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
 	r := WindowsFunctionAppResource{}
@@ -845,6 +863,34 @@ resource "azurerm_windows_function_app" "test" {
   app_settings = {
     foo    = "bar"
     secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r WindowsFunctionAppResource) appSettingsCustomContentShare(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo                  = "bar"
+    secret               = "sauce"
+    WEBSITE_CONTENTSHARE = "test-acc-custom-content-share"
   }
 
   site_config {}

--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -104,7 +104,7 @@ func TestAccLogAnalyticsLinkedService_withWriteAccessResourceId(t *testing.T) {
 	})
 }
 
-func (t LogAnalyticsLinkedServiceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r LogAnalyticsLinkedServiceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LogAnalyticsLinkedServiceID(state.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes a bug where the user specified values for these items in the `app_settings` map would be overwritten by the locally generated values.