### PR TITLE
`azurerm_log_analytics_linked_storage_account` - correct casing for `data_source_type` when using `ingestion`

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
@@ -48,7 +48,7 @@ func resourceLogAnalyticsLinkedStorageAccount() *pluginsdk.Resource {
 					strings.ToLower(string(operationalinsights.Query)),
 					strings.ToLower(string(operationalinsights.Alerts)),
 					// Value removed from enum in 2020-08-01, but effectively still works
-					"Ingestion",
+					"ingestion",
 				}, false),
 			},
 

--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource_test.go
@@ -86,6 +86,21 @@ func TestAcclogAnalyticsLinkedStorageAccount_update(t *testing.T) {
 	})
 }
 
+func TestAcclogAnalyticsLinkedStorageAccount_ingestion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_linked_storage_account", "test")
+	r := LogAnalyticsLinkedStorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ingestion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t LogAnalyticsLinkedStorageAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LogAnalyticsLinkedStorageAccountID(state.ID)
 	if err != nil {
@@ -174,4 +189,17 @@ resource "azurerm_log_analytics_linked_storage_account" "test" {
   storage_account_ids   = [azurerm_storage_account.test.id, azurerm_storage_account.test2.id]
 }
 `, r.template(data), data.RandomString)
+}
+
+func (r LogAnalyticsLinkedStorageAccountResource) ingestion(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_linked_storage_account" "test" {
+  data_source_type      = "ingestion"
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  storage_account_ids   = [azurerm_storage_account.test.id]
+}
+`, r.template(data))
 }

--- a/website/docs/r/log_analytics_linked_storage_account.html.markdown
+++ b/website/docs/r/log_analytics_linked_storage_account.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_log_analytics_linked_storage_account" "example" {
 
 The following arguments are supported:
 
-* `data_source_type` - (Required) The data source type which should be used for this Log Analytics Linked Storage Account. Possible values are "customlogs", "azurewatson", "query", "Ingestion" and "alerts". Changing this forces a new Log Analytics Linked Storage Account to be created.
+* `data_source_type` - (Required) The data source type which should be used for this Log Analytics Linked Storage Account. Possible values are "customlogs", "azurewatson", "query", "ingestion" and "alerts". Changing this forces a new Log Analytics Linked Storage Account to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Log Analytics Linked Storage Account should exist. Changing this forces a new Log Analytics Linked Storage Account to be created.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15382

After checked, [all types](https://github.com/hashicorp/terraform-provider-azurerm/blob/587a190eb801aa77a292d3e428f091a58d8afca5/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go#L41) of `data_source_type` defined in TF are lower case except `Ingestion`. So I think the `ingestion` type also should be lower case since api returns lower case for them.

--- PASS: TestAcclogAnalyticsLinkedStorageAccount_ingestion (229.21s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_basic (286.30s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_requiresImport (323.68s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_complete (289.91s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_update (580.79s)