### PR TITLE
Doc Fix: `azurerm_sql_managed_instance`  updates `license_type` to correct values

### DIFF
--- a/website/docs/r/sql_managed_instance.html.markdown
+++ b/website/docs/r/sql_managed_instance.html.markdown
@@ -217,7 +217,7 @@ The following arguments are supported:
 
 * `storage_size_in_gb` - (Required) Maximum storage space for your instance. It should be a multiple of 32GB.
 
-* `license_type` - (Required) What type of license the Managed Instance will use. Valid values include can be `PriceIncluded` or `BasePrice`.
+* `license_type` - (Required) What type of license the Managed Instance will use. Valid values include can be `LicenseIncluded` or `BasePrice`.
 
 * `administrator_login` - (Required) The administrator login name for the new server. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Changes the incorrect value `PriceIncluded` to `LicenseIncluded` per [MS documentation](https://docs.microsoft.com/en-us/rest/api/sql/2021-02-01-preview/managed-instances/create-or-update#managedinstancelicensetype).

Fixes #15188

I checked the code and it has the correct value.

https://github.com/hashicorp/terraform-provider-azurerm/blob/a9c675b638d4bd6d1b54dd7e13db0531493e51f0/internal/services/sql/sql_managed_instance_resource.go#L103-L109

I also checked the other documentation pages for managed instances to verify they are using correct values. They are all using `BasePrice` which is a valid value.