### PR TITLE
website: example of python function app

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -128,6 +128,63 @@ resource "azurerm_function_app" "example" {
 }
 ```
 ~> **Note:** Version `~3` is required for Linux Function Apps.
+~> **Note:** Linux Function Apps will be available separately as `azurerm_linux_function_app` **as an opt-in Beta** in [the upcoming version 3.0 of the Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-overview).
+
+## Example Usage (Python in a Consumption Plan)
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "azure-functions-cptest-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "functionsapptestsa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "azure-functions-test-service-plan"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      kind
+    ]
+  }
+}
+
+resource "azurerm_function_app" "example" {
+  name                       = "test-azure-functions"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  os_type                    = "linux"
+  version                    = "~4"
+
+  app_settings {
+    FUNCTIONS_WORKER_RUNTIME = "python"
+  }
+
+  site_config {
+    linux_fx_version = "python|3.9"
+  }
+}
+```
+~> **Note:** While you can develop your Python based Azure Functions locally on Windows, Python is only supported on a Linux based hosting plan when running in Azure.  See [the documentation for additional information](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python).
 
 ## Argument Reference
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -128,18 +128,17 @@ resource "azurerm_function_app" "example" {
 }
 ```
 ~> **Note:** Version `~3` is required for Linux Function Apps.
-~> **Note:** Linux Function Apps will be available separately as `azurerm_linux_function_app` **as an opt-in Beta** in [the upcoming version 3.0 of the Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-overview).
 
 ## Example Usage (Python in a Consumption Plan)
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "azure-functions-cptest-rg"
+  name     = "azure-functions-example-rg"
   location = "West Europe"
 }
 
 resource "azurerm_storage_account" "example" {
-  name                     = "functionsapptestsa"
+  name                     = "functionsappexamlpesa"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
@@ -147,7 +146,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_app_service_plan" "example" {
-  name                = "azure-functions-test-service-plan"
+  name                = "azure-functions-example-sp"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   kind                = "Linux"
@@ -166,7 +165,7 @@ resource "azurerm_app_service_plan" "example" {
 }
 
 resource "azurerm_function_app" "example" {
-  name                       = "test-azure-functions"
+  name                       = "example-azure-function"
   location                   = azurerm_resource_group.example.location
   resource_group_name        = azurerm_resource_group.example.name
   app_service_plan_id        = azurerm_app_service_plan.example.id
@@ -184,7 +183,7 @@ resource "azurerm_function_app" "example" {
   }
 }
 ```
-~> **Note:** While you can develop your Python based Azure Functions locally on Windows, Python is only supported on a Linux based hosting plan when running in Azure.  See [the documentation for additional information](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python).
+~> **Note:** The Python runtime is only supported on a Linux based hosting plan.  See [the documentation for additional information](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python).
 
 ## Argument Reference
 


### PR DESCRIPTION
I apologize in advance.  It might be that this PR does not make sense to include and is otherwise irrelevant.

I was recently exploring `azurerm_function_app`'s and spent time troubleshooting as documented in https://github.com/Azure/azure-functions-python-worker/issues/627 what was a simple miss of including `FUNCTIONS_WORKER_RUNTIME`.  While the term is mentioned in this page, having a more complete example in this page might have saved me some time; maybe it can also help others.