### PR TITLE
Doc Fix: azurerm_mssql_server_vulnerability_assessment - Add comments for the storage_account_access_key and storage_container_sas_key properties

### DIFF
--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -76,7 +76,11 @@ The following arguments are supported:
 
 * `storage_account_access_key` - (Optional) Specifies the identifier key of the storage account for vulnerability assessment scan results. If `storage_container_sas_key` isn't specified, `storage_account_access_key` is required.
 
+-> **NOTE** The `storage_account_access_key` only applies if the storage account is not behind a virtual network or a firewall.
+
 * `storage_container_sas_key` - (Optional) A shared access signature (SAS Key) that has write access to the blob container specified in `storage_container_path` parameter. If `storage_account_access_key` isn't specified, `storage_container_sas_key` is required.
+
+-> **NOTE** The `storage_container_sas_key` only applies if the storage account is not behind a virtual network or a firewall.
 
 * `recurring_scans` - (Optional) The recurring scans settings. The `recurring_scans` block supports fields documented below.
 


### PR DESCRIPTION
Since there are such descriptions for [storageAccountAccessKey](https://github.com/Azure/azure-rest-api-specs/blob/a0edb2b9a2518ffb0c6fe21c94091d42dbf870c0/specification/sql/resource-manager/Microsoft.Sql/preview/2021-05-01-preview/DatabaseVulnerabilityAssessments.json#L285) and [storageContainerSasKey](https://github.com/Azure/azure-rest-api-specs/blob/a0edb2b9a2518ffb0c6fe21c94091d42dbf870c0/specification/sql/resource-manager/Microsoft.Sql/preview/2021-05-01-preview/DatabaseVulnerabilityAssessments.json#L277)  in API, add comments for the `storage_account_access_key` and `storage_container_sas_key` in terraform doc to improve user experience as mentioned in issue [#15425](https://github.com/hashicorp/terraform-provider-azurerm/issues/15425) .