### PR TITLE
`r\virtual_machine_data_disk_attachment`: Fix panic with disk id is wrong

### DIFF
--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
@@ -301,7 +301,7 @@ func retrieveDataDiskAttachmentManagedDisk(d *pluginsdk.ResourceData, meta inter
 
 	parsedId, err := parse.ManagedDiskID(id)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Managed Disk ID %q: %+v", parsedId.String(), err)
+		return nil, fmt.Errorf("parsing Managed Disk ID %q: %+v", id, err)
 	}
 
 	resp, err := client.Get(ctx, parsedId.ResourceGroup, parsedId.DiskName)


### PR DESCRIPTION
Fix #15436

`parsedId` is nil when error occurs, which would cause a panic when dereferencing it. Use `id` from the parameter instead
