### PR TITLE
Document globally unique constraint on azurerm_key_vault.name

### DIFF
--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -70,7 +70,7 @@ resource "azurerm_key_vault" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Key Vault. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Key Vault. Changing this forces a new resource to be created. The name must be globally unqiue. If the vault is in a recoverable state then the vault will need to be purged before reusing the name.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Added an extra snippet from the error message from Azure as well documenting that you need to purge the old key vault if it's recoverable before reusing the name.