### PR TITLE
docs: improve local account disabled section

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -114,6 +114,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `local_account_disabled` - (Optional) - If `true` local accounts will be disabled. Defaults to `false`. See [the documentation](https://docs.microsoft.com/en-us/azure/aks/managed-aad#disable-local-accounts) for more information.
 
+-> **NOTE:** If `local_account_disabled` is set to `true`, it is required to enable Kubernetes RBAC and AKS-managed Azure AD integration. See [the documentation](https://docs.microsoft.com/en-us/azure/aks/managed-aad#azure-ad-authentication-overview) for more information.
+
 * `maintenance_window` - (Optional) A `maintenance_window` block as defined below.
 
 * `network_profile` - (Optional) A `network_profile` block as defined below.


### PR DESCRIPTION
When you create an AKS Cluster with `local_account_disabled = true` without enabling Kubernetes RBAC and AKS-managed Azure AD integration you will get this error:

`│ Error: retrieving Access Profile for Cluster: (Managed Cluster Name "aks-1" / Resource Group "aks-rg"): containerservice.ManagedClustersClient#GetAccessProfile: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Getting static credential is not allowed because this cluster is set to disable local accounts."`

This PR is adding a note that users are required to enable Kubernetes RBAC and AKS-managed Azure AD integration.