### PR TITLE
`r\site_recovery_replicated_vm`: Fix issue of `create` depending on `update` timeout

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -304,16 +304,19 @@ func resourceSiteRecoveryReplicatedItemCreate(d *pluginsdk.ResourceData, meta in
 
 	// We are not allowed to configure the NIC on the initial setup, and the VM has to be replicated before
 	// we can reconfigure. Hence this call to update when we create.
-	return resourceSiteRecoveryReplicatedItemUpdate(d, meta)
+	return resourceSiteRecoveryReplicatedItemUpdateInternal(ctx, d, meta)
 }
 
 func resourceSiteRecoveryReplicatedItemUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+	return resourceSiteRecoveryReplicatedItemUpdateInternal(ctx, d, meta)
+}
+
+func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) error {
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	client := meta.(*clients.Client).RecoveryServices.ReplicationMigrationItemsClient(resGroup, vaultName)
-
-	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
 
 	// We are only allowed to update the configuration once the VM is fully protected
 	state, err := waitForReplicationToBeHealthy(ctx, d, meta)
@@ -569,7 +572,11 @@ func waitForReplicationToBeHealthy(ctx context.Context, d *pluginsdk.ResourceDat
 		PollInterval: time.Minute,
 	}
 
-	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil, fmt.Errorf("context had no deadline")
+	}
+	stateConf.Timeout = time.Until(deadline)
 
 	result, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {


### PR DESCRIPTION
Fix #13725
- `create` internally calls `update` due to API limitation, and there is a long-running job in `update` waiting for `VMProtectionState` to become `Protected` (Fully replicated) during the first creation. Thus `timeouts.create` and `timeouts.update` both need a longer value when VM is large, which could cause confusion when a user does the first creation with only `timeouts.create` set to a longer value.
- This change tries removing the `timeouts.update` limitation in the `create`