### PR TITLE
Document `azurerm_hdinsight_spark_cluster` Fix #15451 by correcting document. 

### DIFF
--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -230,7 +230,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
According to the [code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/hdinsight/schema.go#L809) the `target_instance_count` should be `Required` instead of `Optional`.