### PR TITLE
refactor: moving smaller usages of Location/Resource Group to `commonschema`

### DIFF
--- a/helpers/azure/location.go
+++ b/helpers/azure/location.go
@@ -1,19 +1,20 @@
 package azure
 
 import (
-	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func SchemaLocation() *pluginsdk.Schema {
-	return location.Schema()
+	return commonschema.Location()
 }
 
 func SchemaLocationForDataSource() *pluginsdk.Schema {
-	return location.SchemaComputed()
+	return commonschema.LocationComputed()
 }
 
-// azure.NormalizeLocation is a function which normalises human-readable region/location
+// NormalizeLocation is a function which normalises human-readable region/location
 // names (e.g. "West US") to the values used and returned by the Azure API (e.g. "westus").
 // In state we track the API internal version as it is easier to go from the human form
 // to the canonical form than the other way around.

--- a/helpers/azure/location.go
+++ b/helpers/azure/location.go
@@ -9,10 +9,6 @@ func SchemaLocation() *pluginsdk.Schema {
 	return location.Schema()
 }
 
-func SchemaLocationOptional() *pluginsdk.Schema {
-	return location.SchemaOptional()
-}
-
 func SchemaLocationForDataSource() *pluginsdk.Schema {
 	return location.SchemaComputed()
 }

--- a/helpers/azure/resource_group.go
+++ b/helpers/azure/resource_group.go
@@ -36,16 +36,6 @@ func SchemaResourceGroupNameForDataSource() *pluginsdk.Schema {
 	}
 }
 
-func SchemaResourceGroupNameOptionalComputed() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:         pluginsdk.TypeString,
-		ForceNew:     true,
-		Optional:     true,
-		Computed:     true,
-		ValidateFunc: ValidateResourceGroupName,
-	}
-}
-
 func ValidateResourceGroupName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 

--- a/helpers/azure/resource_group.go
+++ b/helpers/azure/resource_group.go
@@ -18,25 +18,6 @@ func SchemaResourceGroupName() *pluginsdk.Schema {
 	}
 }
 
-func SchemaResourceGroupNameDeprecated() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:         pluginsdk.TypeString,
-		Optional:     true,
-		ValidateFunc: ValidateResourceGroupName,
-		Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
-	}
-}
-
-func SchemaResourceGroupNameDeprecatedComputed() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:         pluginsdk.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ValidateFunc: ValidateResourceGroupName,
-		Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
-	}
-}
-
 func SchemaResourceGroupNameDiffSuppress() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:             pluginsdk.TypeString,

--- a/helpers/azure/resource_group.go
+++ b/helpers/azure/resource_group.go
@@ -46,14 +46,6 @@ func SchemaResourceGroupNameOptionalComputed() *pluginsdk.Schema {
 	}
 }
 
-func SchemaResourceGroupNameOptional() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:         pluginsdk.TypeString,
-		Optional:     true,
-		ValidateFunc: ValidateResourceGroupName,
-	}
-}
-
 func SchemaResourceGroupNameSetOptional() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,

--- a/helpers/azure/resource_group.go
+++ b/helpers/azure/resource_group.go
@@ -46,17 +46,6 @@ func SchemaResourceGroupNameOptionalComputed() *pluginsdk.Schema {
 	}
 }
 
-func SchemaResourceGroupNameSetOptional() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeSet,
-		Optional: true,
-		Elem: &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			ValidateFunc: ValidateResourceGroupName,
-		},
-	}
-}
-
 func ValidateResourceGroupName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 

--- a/internal/location/schema.go
+++ b/internal/location/schema.go
@@ -10,10 +10,6 @@ func Schema() *pluginsdk.Schema {
 	return commonschema.Location()
 }
 
-func SchemaOptional() *pluginsdk.Schema {
-	return commonschema.LocationOptional()
-}
-
 func SchemaComputed() *pluginsdk.Schema {
 	return commonschema.LocationComputed()
 }

--- a/internal/location/schema.go
+++ b/internal/location/schema.go
@@ -14,10 +14,6 @@ func SchemaComputed() *pluginsdk.Schema {
 	return commonschema.LocationComputed()
 }
 
-func SchemaWithoutForceNew() *pluginsdk.Schema {
-	return commonschema.LocationWithoutForceNew()
-}
-
 func DiffSuppressFunc(v, old, new string, d *pluginsdk.ResourceData) bool {
 	return location.DiffSuppressFunc(v, old, new, d)
 }

--- a/internal/services/advisor/advisor_recommendations_data_source.go
+++ b/internal/services/advisor/advisor_recommendations_data_source.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/advisor/mgmt/2020-01-01/advisor"
 	"github.com/gofrs/uuid"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -41,7 +41,7 @@ func dataSourceAdvisorRecommendations() *pluginsdk.Resource {
 				},
 			},
 
-			"filter_by_resource_groups": azure.SchemaResourceGroupNameSetOptional(),
+			"filter_by_resource_groups": commonschema.ResourceGroupNameSetOptional(),
 
 			"recommendations": {
 				Type:     pluginsdk.TypeList,

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -170,7 +170,7 @@ func resourceApiManagementSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"location": location.SchemaWithoutForceNew(),
+					"location": commonschema.LocationWithoutForceNew(),
 
 					"virtual_network_configuration": {
 						Type:     pluginsdk.TypeList,

--- a/internal/services/bot/bot_channel_direct_line_speech_resource.go
+++ b/internal/services/bot/bot_channel_direct_line_speech_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/botservice/mgmt/2021-03-01/botservice"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -58,7 +59,7 @@ func resourceBotChannelDirectLineSpeech() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"cognitive_service_location": location.SchemaWithoutForceNew(),
+			"cognitive_service_location": commonschema.LocationWithoutForceNew(),
 
 			"custom_speech_model_id": {
 				Type:         schema.TypeString,

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
-	validate2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
+	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -857,7 +857,7 @@ func resourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validate2.ContainerRegistryName,
+			ValidateFunc: containerValidate.ContainerRegistryName,
 		},
 
 		"resource_group_name": azure.SchemaResourceGroupName(),
@@ -903,7 +903,7 @@ func resourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 			}(),
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"location": location.SchemaWithoutForceNew(),
+					"location": commonschema.LocationWithoutForceNew(),
 
 					"zone_redundancy_enabled": {
 						Type:     pluginsdk.TypeBool,

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -292,7 +292,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 							Computed: true,
 						},
 
-						"location": location.SchemaWithoutForceNew(),
+						"location": commonschema.LocationWithoutForceNew(),
 
 						"failover_priority": {
 							Type:         pluginsdk.TypeInt,

--- a/internal/services/cosmos/cosmosdb_restorable_database_accounts_data_source.go
+++ b/internal/services/cosmos/cosmosdb_restorable_database_accounts_data_source.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -29,7 +29,7 @@ func dataSourceCosmosDbRestorableDatabaseAccounts() *pluginsdk.Resource {
 				ValidateFunc: validate.CosmosAccountName,
 			},
 
-			"location": location.SchemaWithoutForceNew(),
+			"location": commonschema.LocationWithoutForceNew(),
 
 			"accounts": {
 				Type:     pluginsdk.TypeList,

--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -941,7 +941,7 @@ func resourceFirewallPolicySchema() map[string]*pluginsdk.Schema {
 									Required:     true,
 									ValidateFunc: logAnalytiscValidate.LogAnalyticsWorkspaceID,
 								},
-								"firewall_location": location.SchemaWithoutForceNew(),
+								"firewall_location": commonschema.LocationWithoutForceNew(),
 							},
 						},
 					},

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -337,7 +337,7 @@ func resourceIotHub() *pluginsdk.Resource {
 							ValidateFunc:     iothubValidate.FileNameFormat,
 						},
 
-						"resource_group_name": azure.SchemaResourceGroupNameOptional(),
+						"resource_group_name": commonschema.ResourceGroupNameOptional(),
 					},
 				},
 			},

--- a/internal/services/loadbalancer/backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_resource.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -131,7 +131,7 @@ func resourceArmLoadBalancerBackendAddressPool() *pluginsdk.Resource {
 			}
 
 			if !features.ThreePointOhBeta() {
-				s["resource_group_name"] = azure.SchemaResourceGroupNameDeprecatedComputed()
+				s["resource_group_name"] = commonschema.ResourceGroupNameDeprecatedComputed()
 				s["backend_address"] = &pluginsdk.Schema{
 					Type:       pluginsdk.TypeSet,
 					Optional:   true,

--- a/internal/services/policy/assignment_base_resource.go
+++ b/internal/services/policy/assignment_base_resource.go
@@ -315,7 +315,7 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 			Optional: true,
 		},
 
-		"location": azure.SchemaLocationOptional(),
+		"location": commonschema.LocationOptional(),
 
 		"identity": commonschema.SystemAssignedIdentityOptional(),
 

--- a/internal/services/policy/policy_assignment_resource.go
+++ b/internal/services/policy/policy_assignment_resource.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -84,7 +85,7 @@ resources and will be removed in version 3.0 of the Azure Provider.
 				Optional: true,
 			},
 
-			"location": azure.SchemaLocationOptional(),
+			"location": commonschema.LocationOptional(),
 
 			//lintignore:XS003
 			"identity": {

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -187,7 +187,7 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 				return commonschema.SystemAssignedIdentityComputed()
 			}(),
 
-			"managed_resource_group_name": azure.SchemaResourceGroupNameOptionalComputed(),
+			"managed_resource_group_name": commonschema.ResourceGroupNameOptionalComputed(),
 
 			"azure_devops_repo": {
 				Type:          pluginsdk.TypeList,

--- a/internal/services/web/app_service_environment_resource.go
+++ b/internal/services/web/app_service_environment_resource.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -504,9 +506,9 @@ func resourceAppServiceEnvironmentSchema() map[string]*pluginsdk.Schema {
 
 		"resource_group_name": func() *pluginsdk.Schema {
 			if !features.ThreePointOhBeta() {
-				return azure.SchemaResourceGroupNameOptionalComputed()
+				return commonschema.ResourceGroupNameOptionalComputed()
 			}
-			return azure.SchemaResourceGroupName()
+			return commonschema.ResourceGroupName()
 		}(),
 
 		"tags": tags.ForceNewSchema(),


### PR DESCRIPTION
This is a larger job, so I'm intentionally breaking this up to separate the smaller usages out