### PR TITLE
`document`: Fix `r\site_recovery_replicated_vm` doc example

### DIFF
--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -109,6 +109,16 @@ resource "azurerm_site_recovery_protection_container_mapping" "container-mapping
   recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.policy.id
 }
 
+resource "azurerm_site_recovery_network_mapping" "network-mapping" {
+  name                        = "network-mapping"
+  resource_group_name         = azurerm_resource_group.secondary.name
+  recovery_vault_name         = azurerm_recovery_services_vault.vault.name
+  source_recovery_fabric_name = azurerm_site_recovery_fabric.primary.name
+  target_recovery_fabric_name = azurerm_site_recovery_fabric.secondary.name
+  source_network_id           = azurerm_virtual_network.primary.id
+  target_network_id           = azurerm_virtual_network.secondary.id
+}
+
 resource "azurerm_storage_account" "primary" {
   name                     = "primaryrecoverycache"
   location                 = azurerm_resource_group.primary.location
@@ -197,9 +207,14 @@ resource "azurerm_site_recovery_replicated_vm" "vm-replication" {
 
   network_interface {
     source_network_interface_id   = azurerm_network_interface.vm.id
-    target_subnet_name            = "network2-subnet"
+    target_subnet_name            = azurerm_subnet.secondary.name
     recovery_public_ip_address_id = azurerm_public_ip.secondary.id
   }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.container-mapping,
+    azurerm_site_recovery_network_mapping.network-mapping,
+  ]
 }
 ```
 


### PR DESCRIPTION
- Below error is thrown for the example in doc. Looks like a target network needs to be configured.
Fix according to the [acc test](https://github.com/hashicorp/terraform-provider-azurerm/blob/b383b552ae9b05ca861df67892aea701306ea957/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go#L155) to add a `azurerm_site_recovery_network_mapping` and `depends_on`
```
Error: target_network_id must be set when a network_interface is configured
│
│   with azurerm_site_recovery_replicated_vm.vm-replication,
│   on main.tf line 90, in resource "azurerm_site_recovery_replicated_vm" "vm-replication":
│   90: resource "azurerm_site_recovery_replicated_vm" "vm-replication" {
```
- Use variable reference instead of const for `target_subnet_name`