### PR TITLE
Logic app access control disappear when modifing workflow steps

### DIFF
--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -166,6 +166,12 @@ func TestAccLogicAppWorkflow_accessControl(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.updateAccessControlWithStep(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 	})
 }
 
@@ -514,6 +520,35 @@ resource "azurerm_logic_app_workflow" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r LogicAppWorkflowResource) updateAccessControlWithStep(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_action_custom" "test" {
+  name         = "test"
+  logic_app_id = azurerm_logic_app_workflow.test.id
+
+  body = <<BODY
+{
+    "description": "A variable to configure the auto expiration age in days. Configured in negative number. Default is -30 (30 days old).",
+    "inputs": {
+        "variables": [
+            {
+                "name": "ExpirationAgeInDays",
+                "type": "Integer",
+                "value": -30
+            }
+        ]
+    },
+    "runAfter": {},
+    "type": "InitializeVariable"
+}
+BODY
+}
+
+`, r.updateAccessControl(data))
 }
 
 func (LogicAppWorkflowResource) systemAssignedIdentity(data acceptance.TestData) string {

--- a/internal/services/logic/logic_apps.go
+++ b/internal/services/logic/logic_apps.go
@@ -102,13 +102,14 @@ func resourceLogicAppComponentUpdate(d *pluginsdk.ResourceData, meta interface{}
 	properties := logic.Workflow{
 		Location: read.Location,
 		WorkflowProperties: &logic.WorkflowProperties{
-			Definition: definition,
-			Parameters: read.WorkflowProperties.Parameters,
+			Definition:         definition,
+			Parameters:         read.WorkflowProperties.Parameters,
+			AccessControl:      read.WorkflowProperties.AccessControl,
+			IntegrationAccount: read.WorkflowProperties.IntegrationAccount,
 		},
 		Identity: read.Identity,
 		Tags:     read.Tags,
 	}
-
 	if _, err = client.CreateOrUpdate(ctx, workflowId.ResourceGroup, workflowId.Name, properties); err != nil {
 		return fmt.Errorf("updating Logic App Workflow %s for %s %q: %+v", workflowId, kind, name, err)
 	}


### PR DESCRIPTION
While using `azurerm_logic_app_workflow` I've noticed that the `access_control` settings are not preserved when updating workflow steps.

I've updated the test case and the result from running the test was:
```
   testcase.go:110: Step 5/5 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # azurerm_logic_app_workflow.test will be updated in-place
          ~ resource "azurerm_logic_app_workflow" "test" {
                id                              = "/subscriptions/497cbfee-eccb-4286-8b7a-99c5449bc25a/resourceGroups/acctestRG-logic-220219204857828285/providers/Microsoft.Logic/workflows/acctestlaw-220219204857828285"
                name                            = "acctestlaw-220219204857828285"
                tags                            = {}
                # (10 unchanged attributes hidden)
        
              + access_control {
                  + action {
                      + allowed_caller_ip_address_range = [
                          + "10.10.4.0/24",
                        ]
                    }
        
                  + content {
                      + allowed_caller_ip_address_range = [
                          + "10.10.3.0/24",
                        ]
                    }
        
                  + trigger {
                      + allowed_caller_ip_address_range = [
                          + "10.10.5.0/24",
                        ]
        
                      + open_authentication_policy {
                          + name = "testpolicy4"
        
                          + claim {
                              + name  = "iss"
                              + value = "https://sts.windows.net/"
                            }
                          + claim {
                              + name  = "testclaimname"
                              + value = "testclaimvalue"
                            }
                        }
                    }
        
                  + workflow_management {
                      + allowed_caller_ip_address_range = [
                          + "10.10.6.0/24",
                        ]
                    }
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```

Then I've added the fix and now the test finishes without issues:
```
TF_ACC=1 go test -v ./internal/services/logic -run=TestAccLogicAppWorkflow_accessControl -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLogicAppWorkflow_accessControl
=== PAUSE TestAccLogicAppWorkflow_accessControl
=== CONT  TestAccLogicAppWorkflow_accessControl
--- PASS: TestAccLogicAppWorkflow_accessControl (172.01s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 172.027s
```

There is potential here to refactor `logic_app_workflow_resource.go` and `logic_apps.go` to use one common set of functions to call Azure API to prevent such bugs in the future.