### PR TITLE
Fix refresh failure of removed `azurerm_logic_app_trigger_http_request`

### DIFF
--- a/internal/services/logic/logic_apps.go
+++ b/internal/services/logic/logic_apps.go
@@ -184,7 +184,7 @@ func retrieveLogicAppAction(d *pluginsdk.ResourceData, meta interface{}, resourc
 
 func retrieveLogicAppHttpTrigger(d *pluginsdk.ResourceData, meta interface{}, resourceGroup, logicAppName, name string) (*map[string]interface{}, *logic.Workflow, *string, error) {
 	t, app, err := retrieveLogicAppTrigger(d, meta, resourceGroup, logicAppName, name)
-	if err != nil {
+	if err != nil || t == nil {
 		return nil, nil, nil, err
 	}
 	url, err := retreiveLogicAppTriggerCallbackUrl(d, meta, resourceGroup, logicAppName, name)


### PR DESCRIPTION
<!---
Please note the following potential times when an issue might be in Terraform core:

* [Configuration Language](https://www.terraform.io/docs/configuration/index.html) or resource ordering issues
* [State](https://www.terraform.io/docs/state/index.html) and [State Backend](https://www.terraform.io/docs/backends/index.html) issues
* [Provisioner](https://www.terraform.io/docs/provisioners/index.html) issues
* [Registry](https://registry.terraform.io/) issues
* Spans resources across multiple providers

If you are running into one of these scenarios, we recommend opening an issue in the [Terraform core repository](https://github.com/hashicorp/terraform/) instead.
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->

### Terraform (and AzureRM Provider) Version

```
$ terraform -v
Terraform v1.1.6
on linux_amd64
```
Azurerm provider built from main branch.

### Affected Resource(s)

<!--- Please list the affected resources and data sources. --->

* `azurerm_logic_app_trigger_http_request`

### Terraform Configuration Files

<!--- Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code --->

```hcl
terraform {
	required_providers {
		azurerm = {
			source = "hashicorp/azurerm"
		}
	}
}

provider "azurerm" {
 features {}
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-auto-d"
  location = "westeurope"
}

resource "azurerm_logic_app_workflow" "test" {
	name                = "tstflow"
	location            = azurerm_resource_group.test.location
	resource_group_name = azurerm_resource_group.test.name
}

resource "azurerm_logic_app_trigger_http_request" "test" {
	name         = "some-http-trigger"
	logic_app_id = azurerm_logic_app_workflow.test.id
	schema       = "{}"
}
```

### Expected Behaviour

`terraform refresh` should work even if I remove logic app using Azure Portal

### Actual Behaviour

`terraform refresh` fails with message
```
Error: [ERROR] Error getting trigger callback URL (logic.WorkflowTriggersClient#ListCallbackURL: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Logic/workflows/tstflow' under resource group 'acctestRG-auto-d' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix")
```

### Steps to Reproduce

1. `terraform apply`
2. Remove `tstflow` workflow in `acctestRG-auto-d` resource group using Azure Portal
3. `terraform refresh`
