### PR TITLE
docs: add required argument to r\active_directory_domain_service example

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -96,7 +96,8 @@ resource azurerm_subnet_network_security_group_association "deploy" {
 }
 
 resource "azuread_group" "dc_admins" {
-  display_name = "AAD DC Administrators"
+  display_name     = "AAD DC Administrators"
+  security_enabled = true
 }
 
 resource "azuread_user" "admin" {

--- a/website/docs/r/active_directory_domain_service_replica_set.html.markdown
+++ b/website/docs/r/active_directory_domain_service_replica_set.html.markdown
@@ -92,7 +92,8 @@ resource azurerm_subnet_network_security_group_association "primary" {
 }
 
 resource "azuread_group" "dc_admins" {
-  name = "AAD DC Administrators"
+  name             = "AAD DC Administrators"
+  security_enabled = true
 }
 
 resource "azuread_user" "admin" {


### PR DESCRIPTION
This PR fixes errors in the examples of the following resources:

- `azurerm_active_directory_domain_service`
- `azurerm_active_directory_domain_service_replica_set`

The `azuread_group.dc_admins` resources requires either `security_enabled` to be set to `true`, otherwise the following error is thrown:

```text
│ Error: Missing required argument
│
│   with azuread_group.dc_admins,
│   on aadds.tf line 12, in resource "azuread_group" "dc_admins":
│   12: resource "azuread_group" "dc_admins" {
│
│ "security_enabled": one of `mail_enabled,security_enabled` must be specified
```