### PR TITLE
[BUG] `azurerm_linux_virtual_machine_scale_set` - fix for issue 15516

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -761,7 +761,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWithLocation(data, "eastus2"), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS(data acceptance.TestData) string {
@@ -815,7 +815,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWithLocation(data, "eastus2"), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS(data acceptance.TestData) string {
@@ -924,7 +924,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWithLocation(data, "eastus2"), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) disksDataDiskWriteAcceleratorEnabled(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -794,11 +794,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 
   data_disk {
-    storage_account_type = "UltraSSD_LRS"
-    caching              = "None"
-    disk_size_gb         = 10
-    lun                  = 10
-    disk_iops_read_write = 101
+    storage_account_type           = "UltraSSD_LRS"
+    caching                        = "None"
+    disk_size_gb                   = 10
+    lun                            = 10
+    ultra_ssd_disk_iops_read_write = 101
   }
 
   additional_capabilities {
@@ -848,11 +848,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 
   data_disk {
-    storage_account_type = "UltraSSD_LRS"
-    caching              = "None"
-    disk_size_gb         = 10
-    lun                  = 10
-    disk_mbps_read_write = 11
+    storage_account_type           = "UltraSSD_LRS"
+    caching                        = "None"
+    disk_size_gb                   = 10
+    lun                            = 10
+    ultra_ssd_disk_mbps_read_write = 11
   }
 
   additional_capabilities {
@@ -902,12 +902,12 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 
   data_disk {
-    storage_account_type = "UltraSSD_LRS"
-    caching              = "None"
-    disk_size_gb         = 10
-    lun                  = 10
-    disk_iops_read_write = 101
-    disk_mbps_read_write = 11
+    storage_account_type           = "UltraSSD_LRS"
+    caching                        = "None"
+    disk_size_gb                   = 10
+    lun                            = 10
+    ultra_ssd_disk_iops_read_write = 101
+    ultra_ssd_disk_mbps_read_write = 11
   }
 
   additional_capabilities {

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -412,7 +412,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "standard"
-  soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -265,7 +265,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "standard"
-  soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -275,17 +275,17 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
-    "create",
-    "delete",
-    "get",
-    "purge",
-    "update",
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Update",
   ]
 
   secret_permissions = [
-    "get",
-    "delete",
-    "set",
+    "Get",
+    "Delete",
+    "Set",
   ]
 }
 
@@ -342,9 +342,9 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   key_vault_id = azurerm_key_vault.test.id
 
   key_permissions = [
-    "get",
-    "wrapkey",
-    "unwrapkey",
+    "Get",
+    "WrapKey",
+    "UnwrapKey",
   ]
 
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id

--- a/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
@@ -195,8 +195,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
@@ -602,8 +602,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {

--- a/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
@@ -196,7 +196,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -604,7 +603,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -26,7 +26,7 @@ func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking(t *testing.
 
 // This is not a valid test case, so I am removing it. In order to make this work you need to
 // stop and deallocated all VMs in the VMSS in order to enable/disable accelerated networking
-//  https://docs.microsoft.com/azure/virtual-network/create-vm-accelerated-networking-cli#enable-accelerated-networking-on-existing-vms
+// https://docs.microsoft.com/azure/virtual-network/create-vm-accelerated-networking-cli#enable-accelerated-networking-on-existing-vms
 
 // func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated(t *testing.T) {
 // 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -187,7 +187,7 @@ func TestAccLinuxVirtualMachineScaleSet_networkIPv6(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
-			ExpectError: regexp.MustCompile("expanding `network_interface`: An IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary"),
+			ExpectError: regexp.MustCompile("instead add a IPv4 IP Configuration as the Primary"),
 		},
 	})
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -920,8 +920,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -24,34 +24,38 @@ func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking(t *testing.
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+// This is not a valid test case, so I am removing it. In order to make this work you need to
+// stop and deallocated all VMs in the VMSS in order to enable/disable accelerated networking
+//  https://docs.microsoft.com/azure/virtual-network/create-vm-accelerated-networking-cli#enable-accelerated-networking-on-existing-vms
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.networkAcceleratedNetworking(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.networkAcceleratedNetworking(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.networkAcceleratedNetworking(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-	})
-}
+// func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated(t *testing.T) {
+// 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+// 	r := LinuxVirtualMachineScaleSetResource{}
+
+// 	data.ResourceTest(t, r, []acceptance.TestStep{
+// 		{
+// 			Config: r.networkAcceleratedNetworking(data, false),
+// 			Check: acceptance.ComposeTestCheckFunc(
+// 				check.That(data.ResourceName).ExistsInAzure(r),
+// 			),
+// 		},
+// 		data.ImportStep("admin_password"),
+// 		{
+// 			Config: r.networkAcceleratedNetworking(data, true),
+// 			Check: acceptance.ComposeTestCheckFunc(
+// 				check.That(data.ResourceName).ExistsInAzure(r),
+// 			),
+// 		},
+// 		data.ImportStep("admin_password"),
+// 		{
+// 			Config: r.networkAcceleratedNetworking(data, false),
+// 			Check: acceptance.ComposeTestCheckFunc(
+// 				check.That(data.ResourceName).ExistsInAzure(r),
+// 			),
+// 		},
+// 		data.ImportStep("admin_password"),
+// 	})
+// }
 
 func TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -187,7 +187,7 @@ func TestAccLinuxVirtualMachineScaleSet_networkIPv6(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
-			ExpectError: regexp.MustCompile("Error: expanding `network_interface`: An IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary"),
+			ExpectError: regexp.MustCompile("expanding `network_interface`: An IPv6 Primary IP Configuration is unsupported - instead add a IPv4 IP Configuration as the Primary and make the IPv6 IP Configuration the secondary"),
 		},
 	})
 }
@@ -921,7 +921,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -1609,8 +1609,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
@@ -1719,8 +1719,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
@@ -1918,8 +1918,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
@@ -2218,8 +2218,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "backend"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "backend"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_probe" "test" {
@@ -2319,8 +2319,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "backend"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "backend"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_probe" "test" {
@@ -2421,8 +2421,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "backend"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "backend"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_probe" "test" {

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -111,18 +111,14 @@ func TestAccLinuxVirtualMachineScaleSet_otherCustomData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(
-			"admin_password",
-		),
+		data.ImportStep("admin_password", "custom_data"),
 		{
 			Config: r.otherCustomData(data, "/bin/zsh"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(
-			"admin_password",
-		),
+		data.ImportStep("admin_password", "custom_data"),
 		{
 			// removed
 			Config: r.authPassword(data),
@@ -130,9 +126,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherCustomData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(
-			"admin_password",
-		),
+		data.ImportStep("admin_password", "custom_data"),
 	})
 }
 
@@ -1616,7 +1610,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -1727,7 +1720,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -1927,7 +1919,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -2228,7 +2219,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "backend"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -2330,7 +2320,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "backend"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 
@@ -2433,7 +2422,6 @@ resource "azurerm_lb" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   name                = "backend"
-  resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -39,10 +39,10 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 		}, importVirtualMachineScaleSet(compute.OperatingSystemTypesLinux, "azurerm_linux_virtual_machine_scale_set")),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(time.Minute * 30),
+			Create: pluginsdk.DefaultTimeout(time.Minute * 60),
 			Update: pluginsdk.DefaultTimeout(time.Minute * 60),
 			Read:   pluginsdk.DefaultTimeout(time.Minute * 5),
-			Delete: pluginsdk.DefaultTimeout(time.Minute * 30),
+			Delete: pluginsdk.DefaultTimeout(time.Minute * 60),
 		},
 
 		// TODO: exposing requireGuestProvisionSignal once it's available

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -40,8 +40,8 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(time.Minute * 60),
-			Update: pluginsdk.DefaultTimeout(time.Minute * 60),
 			Read:   pluginsdk.DefaultTimeout(time.Minute * 5),
+			Update: pluginsdk.DefaultTimeout(time.Minute * 60),
 			Delete: pluginsdk.DefaultTimeout(time.Minute * 60),
 		},
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -55,3 +55,32 @@ resource "azurerm_subnet" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
+
+func (LinuxVirtualMachineScaleSetResource) templateWithLocation(data acceptance.TestData, location string) string {
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, data.RandomInteger, location, data.RandomInteger)
+}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1346,15 +1346,15 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 	return extensionProfile, hasHealthExtension, nil
 }
 
-func expandOrchestratedSourceImageReference(referenceInput []interface{}, imageId string) (*compute.ImageReference, error) {
+func expandOrchestratedSourceImageReference(referenceInput []interface{}, imageId string) *compute.ImageReference {
 	if len(referenceInput) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	if imageId != "" {
 		return &compute.ImageReference{
 			ID: utils.String(imageId),
-		}, nil
+		}
 	}
 
 	raw := referenceInput[0].(map[string]interface{})
@@ -1363,7 +1363,7 @@ func expandOrchestratedSourceImageReference(referenceInput []interface{}, imageI
 		Offer:     utils.String(raw["offer"].(string)),
 		Sku:       utils.String(raw["sku"].(string)),
 		Version:   utils.String(raw["version"].(string)),
-	}, nil
+	}
 }
 
 func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleSetExtensionProfile, d *pluginsdk.ResourceData) ([]map[string]interface{}, error) {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1346,6 +1346,26 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 	return extensionProfile, hasHealthExtension, nil
 }
 
+func expandOrchestratedSourceImageReference(referenceInput []interface{}, imageId string) (*compute.ImageReference, error) {
+	if len(referenceInput) == 0 {
+		return nil, nil
+	}
+
+	if imageId != "" {
+		return &compute.ImageReference{
+			ID: utils.String(imageId),
+		}, nil
+	}
+
+	raw := referenceInput[0].(map[string]interface{})
+	return &compute.ImageReference{
+		Publisher: utils.String(raw["publisher"].(string)),
+		Offer:     utils.String(raw["offer"].(string)),
+		Sku:       utils.String(raw["sku"].(string)),
+		Version:   utils.String(raw["version"].(string)),
+	}, nil
+}
+
 func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleSetExtensionProfile, d *pluginsdk.ResourceData) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0)
 	if input == nil || input.Extensions == nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -313,11 +313,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference, err := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
-	if err != nil {
-		return err
-	}
-
+	sourceImageReference := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 	virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
 
 	osType := compute.OperatingSystemTypesWindows
@@ -793,10 +789,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			if d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
 				sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 				sourceImageId := d.Get("source_image_id").(string)
-				sourceImageReference, err := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
-				if err != nil {
-					return err
-				}
+				sourceImageReference := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 
 				// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurerm/issues/8273
 				updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -313,7 +313,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	sourceImageReference, err := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 	if err != nil {
 		return err
 	}
@@ -793,7 +793,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			if d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
 				sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 				sourceImageId := d.Get("source_image_id").(string)
-				sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+				sourceImageReference, err := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 				if err != nil {
 					return err
 				}

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -406,7 +406,7 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) (*
 	}
 
 	if len(referenceInput) == 0 {
-		return nil, fmt.Errorf("Either a `source_image_id` or a `source_image_reference` block must be specified!")
+		return nil, fmt.Errorf("either a `source_image_id` or a `source_image_reference` block must be specified")
 	}
 
 	raw := referenceInput[0].(map[string]interface{})

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1063,14 +1063,20 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if iops > 0 {
-			dataDisk["ultra_ssd_disk_iops_read_write"] = iops
-			dataDisk["disk_iops_read_write"] = iops
+			if !features.ThreePointOhBeta() {
+				dataDisk["disk_iops_read_write"] = iops
+			} else {
+				dataDisk["ultra_ssd_disk_iops_read_write"] = iops
+			}
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if mbps > 0 {
-			dataDisk["ultra_ssd_mbps_read_write"] = mbps
-			dataDisk["disk_mbps_read_write"] = mbps
+			if !features.ThreePointOhBeta() {
+				dataDisk["disk_mbps_read_write"] = mbps
+			} else {
+				dataDisk["ultra_ssd_mbps_read_write"] = mbps
+			}
 		}
 
 		output = append(output, dataDisk)

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1075,7 +1075,7 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 			if !features.ThreePointOhBeta() {
 				dataDisk["disk_mbps_read_write"] = mbps
 			} else {
-				dataDisk["ultra_ssd_mbps_read_write"] = mbps
+				dataDisk["ultra_ssd_disk_mbps_read_write"] = mbps
 			}
 		}
 

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -911,6 +911,7 @@ func VirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
 					Optional: true,
 					Default:  false,
 				},
+
 				"ultra_ssd_disk_iops_read_write": {
 					Type:     pluginsdk.TypeInt,
 					Optional: true,
@@ -976,10 +977,15 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 		} else if ssdIops, ok := raw["ultra_ssd_disk_iops_read_write"]; ok && ssdIops.(int) > 0 {
 			iops = ssdIops.(int)
 		}
+
 		if iops > 0 && !ultraSSDEnabled {
 			return nil, fmt.Errorf("disk_iops_read_write and ultra_ssd_disk_iops_read_write are only available for UltraSSD disks")
 		}
-		disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
+
+		// Do not set value unless value is greater than 0 - issue 15516
+		if iops > 0 {
+			disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
+		}
 
 		var mbps int
 		if diskMbps, ok := raw["disk_mbps_read_write"]; ok && diskMbps.(int) > 0 {
@@ -987,10 +993,15 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 		} else if ssdMbps, ok := raw["ultra_ssd_disk_mbps_read_write"]; ok && ssdMbps.(int) > 0 {
 			mbps = ssdMbps.(int)
 		}
+
 		if mbps > 0 && !ultraSSDEnabled {
 			return nil, fmt.Errorf("disk_mbps_read_write and ultra_ssd_disk_mbps_read_write are only available for UltraSSD disks")
 		}
-		disk.DiskMBpsReadWrite = utils.Int64(int64(mbps))
+
+		// Do not set value unless value is greater than 0 - issue 15516
+		if mbps > 0 {
+			disk.DiskMBpsReadWrite = utils.Int64(int64(mbps))
+		}
 
 		disks = append(disks, disk)
 	}
@@ -1040,19 +1051,29 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 			mbps = int(*v.DiskMBpsReadWrite)
 		}
 
-		output = append(output, map[string]interface{}{
-			"caching":                        string(v.Caching),
-			"create_option":                  string(v.CreateOption),
-			"lun":                            lun,
-			"disk_encryption_set_id":         diskEncryptionSetId,
-			"disk_size_gb":                   diskSizeGb,
-			"storage_account_type":           storageAccountType,
-			"write_accelerator_enabled":      writeAcceleratorEnabled,
-			"ultra_ssd_disk_iops_read_write": iops,
-			"ultra_ssd_mbps_read_write":      mbps,
-			"disk_iops_read_write":           iops,
-			"disk_mbps_read_write":           mbps,
-		})
+		dataDisk := map[string]interface{}{
+			"caching":                   string(v.Caching),
+			"create_option":             string(v.CreateOption),
+			"lun":                       lun,
+			"disk_encryption_set_id":    diskEncryptionSetId,
+			"disk_size_gb":              diskSizeGb,
+			"storage_account_type":      storageAccountType,
+			"write_accelerator_enabled": writeAcceleratorEnabled,
+			"disk_iops_read_write":      iops,
+			"disk_mbps_read_write":      mbps,
+		}
+
+		// Do not set value unless value is greater than 0 - issue 15516
+		if iops > 0 {
+			dataDisk["ultra_ssd_disk_iops_read_write"] = iops
+		}
+
+		// Do not set value unless value is greater than 0 - issue 15516
+		if mbps > 0 {
+			dataDisk["ultra_ssd_mbps_read_write"] = mbps
+		}
+
+		output = append(output, dataDisk)
 	}
 
 	return output

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -982,11 +982,6 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 			return nil, fmt.Errorf("disk_iops_read_write and ultra_ssd_disk_iops_read_write are only available for UltraSSD disks")
 		}
 
-		// Do not set value unless value is greater than 0 - issue 15516
-		if iops > 0 {
-			disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
-		}
-
 		var mbps int
 		if diskMbps, ok := raw["disk_mbps_read_write"]; ok && diskMbps.(int) > 0 {
 			mbps = diskMbps.(int)
@@ -996,6 +991,11 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled b
 
 		if mbps > 0 && !ultraSSDEnabled {
 			return nil, fmt.Errorf("disk_mbps_read_write and ultra_ssd_disk_mbps_read_write are only available for UltraSSD disks")
+		}
+
+		// Do not set value unless value is greater than 0 - issue 15516
+		if iops > 0 {
+			disk.DiskIOPSReadWrite = utils.Int64(int64(iops))
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
@@ -1059,18 +1059,18 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 			"disk_size_gb":              diskSizeGb,
 			"storage_account_type":      storageAccountType,
 			"write_accelerator_enabled": writeAcceleratorEnabled,
-			"disk_iops_read_write":      iops,
-			"disk_mbps_read_write":      mbps,
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if iops > 0 {
 			dataDisk["ultra_ssd_disk_iops_read_write"] = iops
+			dataDisk["disk_iops_read_write"] = iops
 		}
 
 		// Do not set value unless value is greater than 0 - issue 15516
 		if mbps > 0 {
 			dataDisk["ultra_ssd_mbps_read_write"] = mbps
+			dataDisk["disk_mbps_read_write"] = mbps
 		}
 
 		output = append(output, dataDisk)

--- a/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
@@ -264,7 +264,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "standard"
-  soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 }

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -512,9 +512,10 @@ An `identity` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Linux Virtual Machine Scale Set.
+* `create` - (Defaults to 60 minutes) Used when creating the Linux Virtual Machine Scale Set.
+* `read` - (Defaults to 5 minutes) Used when reading the Linux Virtual Machine Scale Set.
 * `update` - (Defaults to 60 minutes) Used when updating (and rolling the instances of) the Linux Virtual Machine Scale Set (e.g. when changing SKU).
-* `delete` - (Defaults to 30 minutes) Used when deleting the Linux Virtual Machine Scale Set.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Linux Virtual Machine Scale Set.
 
 ## Import
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -514,9 +514,10 @@ An `identity` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Windows Virtual Machine Scale Set.
+* `create` - (Defaults to 60 minutes) Used when creating the Windows Virtual Machine Scale Set.
+* `read` - (Defaults to 5 minutes) Used when reading the Windows Virtual Machine Scale Set.
 * `update` - (Defaults to 60 minutes) Used when updating (and rolling the instances of) the Windows Virtual Machine Scale Set (e.g. when changing SKU).
-* `delete` - (Defaults to 30 minutes) Used when deleting the Windows Virtual Machine Scale Set.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Windows Virtual Machine Scale Set.
 
 ## Import
 


### PR DESCRIPTION
# Additional Fixes
* `azurerm_orchestrated_virtual_machine_scale_set` - fixed the issue where the orchestrated VMSS would return an error if a `source_image_id` or a `source_image_reference` was not defined in the configuration file. For the Orchestrated VMSS resource that is a valid scenario and the way the "legacy" Orchestrated VMSS works.

* `azurerm_linux_virtual_machine_scale_set` - Various test case fixes... many of the test cases have not been maintained and were failing due to the configurations in the test cases were no longer valid as dependent resource schemas have changed over time. Updated timeouts to be consistent with all VMSS resources. 

* `azurerm_windows_virtual_machine_scale_set` - Fix test case, removed `soft_delete_enabled` from test configuration as it is no longer supported.

{fixes #15516 )