### PR TITLE
azurerm_cosmosdb_mongo_collection: support to set autoscale_settings without shard_key when creating a cosmos DB mongo collection

### DIFF
--- a/internal/services/cosmos/common/schema.go
+++ b/internal/services/cosmos/common/schema.go
@@ -93,13 +93,6 @@ func DatabaseAutoscaleSettingsSchema() *pluginsdk.Schema {
 	}
 }
 
-func MongoCollectionAutoscaleSettingsSchema() *pluginsdk.Schema {
-	autoscaleSettingsDatabaseSchema := DatabaseAutoscaleSettingsSchema()
-	autoscaleSettingsDatabaseSchema.RequiredWith = []string{"shard_key"}
-
-	return autoscaleSettingsDatabaseSchema
-}
-
 func CosmosDbIndexingPolicySchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,

--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -97,7 +97,7 @@ func resourceCosmosDbMongoCollection() *pluginsdk.Resource {
 				ValidateFunc: validate.CosmosThroughput,
 			},
 
-			"autoscale_settings": common.MongoCollectionAutoscaleSettingsSchema(),
+			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
 
 			"index": {
 				Type:     pluginsdk.TypeSet,

--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
@@ -205,6 +205,21 @@ func TestAccCosmosDbMongoCollection_serverless(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbMongoCollection_autoscaleWithoutShareKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_mongo_collection", "test")
+	r := CosmosMongoCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleWithoutShareKey(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t CosmosMongoCollectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.MongodbCollectionID(state.ID)
 	if err != nil {
@@ -428,4 +443,23 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
   analytical_storage_ttl = 600
 }
 `, CosmosDBAccountResource{}.mongoAnalyticalStorage(data, documentdb.DefaultConsistencyLevelEventual), data.RandomInteger, data.RandomInteger)
+}
+
+func (CosmosMongoCollectionResource) autoscaleWithoutShareKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "azurerm_cosmosdb_mongo_collection" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_mongo_database.test.resource_group_name
+  account_name        = azurerm_cosmosdb_mongo_database.test.account_name
+  database_name       = azurerm_cosmosdb_mongo_database.test.name
+  index {
+    keys   = ["_id"]
+    unique = true
+  }
+  autoscale_settings {
+    max_throughput = "4000"
+  }
+}
+`, CosmosMongoDatabaseResource{}.basic(data), data.RandomInteger)
 }

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this Mongo Collection. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 * # `index` - (Optional) One or more `index` blocks as defined below.
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
-* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 


### PR DESCRIPTION
The purpose of this PR:

> When creating a cosmos DB mongo collection, specifying `autoscale_settings` requires setting `shard_key` in terraform. After checking, both Azure portal and [API ](https://github.com/Azure/azure-rest-api-specs/blob/2033a837e0703789ce4af7ac25206011772e41b5/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json#L3084)support to set `autoscale_settings` without `shard_key`. So, to remove the validation to fix issue [#15495](https://github.com/hashicorp/terraform-provider-azurerm/issues/15495).

Test Results:

> PASS: TestAccCosmosDbMongoCollection_basic (1496.30s)
> PASS: TestAccCosmosDbMongoCollection_withIndex (1497.38s)
> PASS: TestAccCosmosDbMongoCollection_serverless (1513.60s)
> PASS: TestAccCosmosDbMongoCollection_ver36 (1519.73s)
> PASS: TestAccCosmosDbMongoCollection_analyticalStorageTTL (1533.87s)
> PASS: TestAccCosmosDbMongoCollection_autoscaleWithoutShareKey (1559.38s)
> PASS: TestAccCosmosDbMongoCollection_complete (1562.01s)
> PASS: TestAccCosmosDbMongoCollection_update (1813.61s)
> PASS: TestAccCosmosDbMongoCollection_throughput (1833.26s)
> PASS: TestAccCosmosDbMongoCollection_autoscale (1890.34s)