### PR TITLE
sql_retention_policies: Accept also 0 for week_of_year

### DIFF
--- a/internal/services/mssql/helper/sql_retention_policies.go
+++ b/internal/services/mssql/helper/sql_retention_policies.go
@@ -49,7 +49,7 @@ func LongTermRetentionPolicySchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(1, 52),
+					ValidateFunc: validation.IntBetween(0, 52),
 					AtLeastOneOf: atLeastOneOf,
 				},
 			},


### PR DESCRIPTION
Until there is a proper fix for #13035, allow passing 0, to avoid
attempts to modify the resource every time when yearly_retention is 0
or not set.