### PR TITLE
3.0 Test Fix: Firewall

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -924,7 +924,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
       admin_username       = "myadmin"
       admin_password       = "Passwword1234"
 
-      enable_automatic_updates = false
+      enable_automatic_updates = true
       provision_vm_agent       = true
       timezone                 = "W. Europe Standard Time"
 
@@ -996,7 +996,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
       admin_username       = "myadmin"
       admin_password       = "Passwword1234"
 
-      enable_automatic_updates = false
+      enable_automatic_updates = true
       provision_vm_agent       = true
 
       winrm_listener {

--- a/internal/services/firewall/firewall_data_source_test.go
+++ b/internal/services/firewall/firewall_data_source_test.go
@@ -125,6 +125,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -183,8 +183,7 @@ resource "azurerm_firewall_policy" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   dns {
-    network_rule_fqdn_enabled = false
-    proxy_enabled             = true
+    proxy_enabled = true
   }
 }
 resource "azurerm_ip_group" "test_source" {
@@ -330,8 +329,7 @@ resource "azurerm_firewall_policy" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   dns {
-    network_rule_fqdn_enabled = false
-    proxy_enabled             = true
+    proxy_enabled = true
   }
 }
 resource "azurerm_ip_group" "test_source" {
@@ -456,8 +454,7 @@ resource "azurerm_firewall_policy" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "Premium"
   dns {
-    network_rule_fqdn_enabled = false
-    proxy_enabled             = true
+    proxy_enabled = true
   }
 }
 resource "azurerm_ip_group" "test_source" {
@@ -606,8 +603,7 @@ resource "azurerm_firewall_policy" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   dns {
-    network_rule_fqdn_enabled = false
-    proxy_enabled             = true
+    proxy_enabled = true
   }
 }
 resource "azurerm_ip_group" "test_source" {

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -164,12 +164,7 @@ func resourceFirewall() *pluginsdk.Resource {
 					}
 					return string(network.AzureFirewallThreatIntelModeAlert)
 				}(),
-				Computed: func() bool {
-					if features.ThreePointOhBeta() {
-						return true
-					}
-					return false
-				}(),
+				Computed: features.ThreePointOhBeta(),
 				ValidateFunc: func() pluginsdk.SchemaValidateFunc {
 					out := []string{
 						string(network.AzureFirewallThreatIntelModeOff),

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -164,6 +164,12 @@ func resourceFirewall() *pluginsdk.Resource {
 					}
 					return string(network.AzureFirewallThreatIntelModeAlert)
 				}(),
+				Computed: func() bool {
+					if features.ThreePointOhBeta() {
+						return true
+					}
+					return false
+				}(),
 				ValidateFunc: func() pluginsdk.SchemaValidateFunc {
 					out := []string{
 						string(network.AzureFirewallThreatIntelModeOff),

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -382,6 +382,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -430,7 +432,9 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
   sku_tier            = "Standard"
+
   ip_configuration {
     name                 = "configuration"
     subnet_id            = azurerm_subnet.test.id
@@ -483,6 +487,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -547,6 +553,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -610,6 +618,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -634,6 +644,8 @@ resource "azurerm_firewall" "import" {
   name                = azurerm_firewall.test.name
   location            = azurerm_firewall.test.location
   resource_group_name = azurerm_firewall.test.resource_group_name
+  sku_name            = azurerm_firewall.test.sku_name
+  sku_tier            = azurerm_firewall.test.sku_tier
 
   ip_configuration {
     name                 = "configuration"
@@ -682,6 +694,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -734,6 +748,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -786,6 +802,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -835,6 +853,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -890,6 +910,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"
@@ -941,8 +963,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctest-firewall-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "AZFW_Hub"
+  sku_name            = "AZFW_Hub"
+  sku_tier            = "Standard"
 
   virtual_hub {
     virtual_hub_id  = azurerm_virtual_hub.test.id
@@ -992,6 +1014,8 @@ resource "azurerm_firewall" "test" {
   name                = "acctestfirewall%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
 
   ip_configuration {
     name                 = "configuration"

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -796,6 +796,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  zones               = [%s]
 }
 
 resource "azurerm_firewall" "test" {
@@ -813,7 +814,7 @@ resource "azurerm_firewall" "test" {
 
   zones = [%s]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, zoneString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, zoneString, data.RandomInteger, zoneString)
 }
 
 func (FirewallResource) withoutZone(data acceptance.TestData) string {
@@ -972,7 +973,6 @@ resource "azurerm_firewall" "test" {
   }
 
   firewall_policy_id = azurerm_firewall_policy.test.id
-  threat_intel_mode  = ""
 }
 `, data.RandomInteger, data.Locations.Primary, pipCount)
 }


### PR DESCRIPTION
```
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicWindows (817.99s)
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicWindowsNoTimezone (843.38s)
```

Most firewall tests are now passing with a few odd balls that require further investigation 

<img width="343" alt="image" src="https://user-images.githubusercontent.com/6515518/155626727-94e255d9-12a2-4de7-906b-85f1aa55d769.png">

There is also a question of whether `threat_intel_mode` should be computed or required.