### PR TITLE
`azurerm_storage_data_lake_gen2_filesystem` - add supports of `owner` and `group`

### DIFF
--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -75,6 +75,20 @@ func resourceStorageDataLakeGen2FileSystem() *pluginsdk.Resource {
 
 			"properties": MetaDataSchema(),
 
+			"owner": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"group": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
 			"ace": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
@@ -168,15 +182,28 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta
 		return fmt.Errorf("creating File System %q in Storage Account %q: %s", fileSystemName, storageID.Name, err)
 	}
 
-	if acl != nil {
-		log.Printf("[INFO] Creating acl %q in File System %q in Storage Account %q.", acl, fileSystemName, storageID.Name)
+	var owner *string
+	if v, ok := d.GetOk("owner"); ok {
+		sv := v.(string)
+		owner = &sv
+	}
+	var group *string
+	if v, ok := d.GetOk("group"); ok {
+		sv := v.(string)
+		group = &sv
+	}
+
+	if acl != nil || owner != nil || group != nil {
 		var aclString *string
-		v := acl.String()
-		aclString = &v
+		if acl != nil {
+			log.Printf("[INFO] Creating acl %q in File System %q in Storage Account %q.", acl, fileSystemName, storageID.Name)
+			v := acl.String()
+			aclString = &v
+		}
 		accessControlInput := paths.SetAccessControlInput{
 			ACL:   aclString,
-			Owner: nil,
-			Group: nil,
+			Owner: owner,
+			Group: group,
 		}
 		if _, err := pathClient.SetAccessControl(ctx, storageID.Name, fileSystemName, "/", accessControlInput); err != nil {
 			return fmt.Errorf("setting access control for root path in File System %q in Storage Account %q: %s", fileSystemName, storageID.Name, err)
@@ -237,15 +264,28 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta
 		return fmt.Errorf("updating Properties for File System %q in Storage Account %q: %s", id.DirectoryName, id.AccountName, err)
 	}
 
-	if acl != nil {
-		log.Printf("[INFO] Creating acl %q in File System %q in Storage Account %q.", acl, id.DirectoryName, id.AccountName)
+	var owner *string
+	if v, ok := d.GetOk("owner"); ok {
+		sv := v.(string)
+		owner = &sv
+	}
+	var group *string
+	if v, ok := d.GetOk("group"); ok {
+		sv := v.(string)
+		group = &sv
+	}
+
+	if acl != nil || owner != nil || group != nil {
 		var aclString *string
-		v := acl.String()
-		aclString = &v
+		if acl != nil {
+			log.Printf("[INFO] Creating acl %q in File System %q in Storage Account %q.", acl, id.DirectoryName, id.AccountName)
+			v := acl.String()
+			aclString = &v
+		}
 		accessControlInput := paths.SetAccessControlInput{
 			ACL:   aclString,
-			Owner: nil,
-			Group: nil,
+			Owner: owner,
+			Group: group,
 		}
 		if _, err := pathClient.SetAccessControl(ctx, id.AccountName, id.DirectoryName, "/", accessControlInput); err != nil {
 			return fmt.Errorf("setting access control for root path in File System %q in Storage Account %q: %s", id.DirectoryName, id.AccountName, err)
@@ -303,6 +343,7 @@ func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta i
 	}
 
 	var ace []interface{}
+	var owner, group string
 	// acl is only enabled when `IsHnsEnabled` is true otherwise the rest api will report error
 	if storageAccount.AccountProperties != nil && storageAccount.AccountProperties.IsHnsEnabled != nil &&
 		*storageAccount.AccountProperties.IsHnsEnabled {
@@ -315,9 +356,13 @@ func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta i
 				return fmt.Errorf("parsing response ACL %q: %s", pathResponse.ACL, err)
 			}
 			ace = FlattenDataLakeGen2AceList(acl)
+			owner = pathResponse.Owner
+			group = pathResponse.Group
 		}
 	}
 	d.Set("ace", ace)
+	d.Set("owner", owner)
+	d.Set("group", group)
 
 	return nil
 }

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -116,6 +116,18 @@ func TestAccStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion(t *testi
 	})
 }
 
+func TestAccStorageDataLakeGen2FileSystem_withOwnerGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_data_lake_gen2_filesystem", "test")
+	r := StorageDataLakeGen2FileSystemResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.withOwnerGroup,
+			TestResource: r,
+		}),
+	})
+}
+
 func (r StorageDataLakeGen2FileSystemResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := filesystems.ParseResourceID(state.ID)
 	if err != nil {
@@ -293,6 +305,38 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
     azurerm_role_assignment.storageAccountRoleAssignment,
     azuread_service_principal.test
   ]
+}
+`, template, data.RandomInteger)
+}
+
+func (r StorageDataLakeGen2FileSystemResource) withOwnerGroup(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azuread" {}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_role_assignment" "storage_blob_owner" {
+  role_definition_name = "Storage Blob Data Owner"
+  scope                = azurerm_resource_group.test.id
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azuread_application" "test" {
+  display_name = "acctestspa%[2]d"
+}
+
+resource "azuread_service_principal" "test" {
+  application_id = azuread_application.test.application_id
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
+  name               = "acctest-%[2]d"
+  storage_account_id = azurerm_storage_account.test.id
+  owner = azuread_service_principal.test.object_id
+  group = azuread_service_principal.test.object_id
 }
 `, template, data.RandomInteger)
 }

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -335,8 +335,8 @@ resource "azuread_service_principal" "test" {
 resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
   name               = "acctest-%[2]d"
   storage_account_id = azurerm_storage_account.test.id
-  owner = azuread_service_principal.test.object_id
-  group = azuread_service_principal.test.object_id
+  owner              = azuread_service_principal.test.object_id
+  group              = azuread_service_principal.test.object_id
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -52,6 +52,10 @@ The following arguments are supported:
 
 * `ace` - (Optional) One or more `ace` blocks as defined below to specify the entries for the ACL for the path.
 
+* `owner` - (Optional) Specifies the Object ID of the Azure Active Directory User to make the owning user of the root path (i.e. `/`).
+
+* `group` - (Optional) Specifies the Object ID of the Azure Active Directory Group to make the owning group of the root path (i.e. `/`).
+
 ~> **NOTE:** The Storage Account requires `account_kind` to be either `StorageV2` or `BlobStorage`. In addition, `is_hns_enabled` has to be set to `true`.
 
 ---


### PR DESCRIPTION
Fixes #15547

## Test

```bash
💢  TF_ACC=1 go test -parallel 30 -v -timeout=20h ./internal/services/storage -run="TestAccStorageDataLakeGen2FileSystem_withOwnerGroup"
=== RUN   TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
=== PAUSE TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
=== CONT  TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
--- PASS: TestAccStorageDataLakeGen2FileSystem_withOwnerGroup (211.09s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       211.103s
```
