### PR TITLE
`azurerm_storage_object_replication` - supports replicating containers across subscriptions

### DIFF
--- a/internal/services/storage/client/client.go
+++ b/internal/services/storage/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	az "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/shim"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/accounts"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/blobs"
@@ -35,7 +36,7 @@ type Client struct {
 	EncryptionScopesClient      *storage.EncryptionScopesClient
 	Environment                 az.Environment
 	FileServicesClient          *storage.FileServicesClient
-	ObjectReplicationClient     *storage.ObjectReplicationPoliciesClient
+	ObjectReplicationClient     *objectreplicationpolicies.ObjectReplicationPoliciesClient
 	SyncServiceClient           *storagesync.ServicesClient
 	SyncGroupsClient            *storagesync.SyncGroupsClient
 	SubscriptionId              string
@@ -72,7 +73,7 @@ func NewClient(options *common.ClientOptions) *Client {
 	fileServicesClient := storage.NewFileServicesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
 	options.ConfigureClient(&fileServicesClient.Client, options.ResourceManagerAuthorizer)
 
-	objectReplicationPolicyClient := storage.NewObjectReplicationPoliciesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
+	objectReplicationPolicyClient := objectreplicationpolicies.NewObjectReplicationPoliciesClientWithBaseURI(options.ResourceManagerEndpoint)
 	options.ConfigureClient(&objectReplicationPolicyClient.Client, options.ResourceManagerAuthorizer)
 
 	syncServiceClient := storagesync.NewServicesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)

--- a/internal/services/storage/parse/object_replication.go
+++ b/internal/services/storage/parse/object_replication.go
@@ -4,63 +4,40 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies"
 )
 
 // This is manual for concat two ids are not supported in auto-generation
 
 type ObjectReplicationId struct {
-	SrcSubscriptionId     string
-	SrcResourceGroup      string
-	SrcStorageAccountName string
-	SrcName               string
-	DstSubscriptionId     string
-	DstResourceGroup      string
-	DstStorageAccountName string
-	DstName               string
+	Src objectreplicationpolicies.ObjectReplicationPoliciesId
+	Dst objectreplicationpolicies.ObjectReplicationPoliciesId
 }
 
-func NewObjectReplicationID(srcSubscriptionId, srcResourceGroup, strStorageAccountName, srcName, dstSubscriptionId, dstResourceGroup, dstStorageAccountName, dstName string) ObjectReplicationId {
+func NewObjectReplicationID(srcId, dstId objectreplicationpolicies.ObjectReplicationPoliciesId) ObjectReplicationId {
 	return ObjectReplicationId{
-		SrcSubscriptionId:     srcSubscriptionId,
-		SrcResourceGroup:      srcResourceGroup,
-		SrcStorageAccountName: strStorageAccountName,
-		SrcName:               srcName,
-		DstSubscriptionId:     dstSubscriptionId,
-		DstResourceGroup:      dstResourceGroup,
-		DstStorageAccountName: dstStorageAccountName,
-		DstName:               dstName,
+		Src: srcId,
+		Dst: dstId,
 	}
 }
 
 func (id ObjectReplicationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Source Name %q", id.SrcName),
-		fmt.Sprintf("Source Storage Account Name %q", id.SrcStorageAccountName),
-		fmt.Sprintf("Source Resource Group %q", id.SrcResourceGroup),
-		fmt.Sprintf("Source Subscription Id %q", id.SrcSubscriptionId),
-		fmt.Sprintf("Destination Name %q", id.DstName),
-		fmt.Sprintf("Destination Storage Account Name %q", id.DstStorageAccountName),
-		fmt.Sprintf("Destination Resource Group %q", id.DstResourceGroup),
-		fmt.Sprintf("Destination Subscription Id %q", id.DstSubscriptionId),
+		fmt.Sprintf("Source Name %q", id.Src.ObjectReplicationPolicyId),
+		fmt.Sprintf("Source Storage Account Name %q", id.Src.AccountName),
+		fmt.Sprintf("Source Resource Group %q", id.Src.ResourceGroupName),
+		fmt.Sprintf("Source Subscription Id %q", id.Src.SubscriptionId),
+		fmt.Sprintf("Destination Name %q", id.Dst.ObjectReplicationPolicyId),
+		fmt.Sprintf("Destination Storage Account Name %q", id.Dst.AccountName),
+		fmt.Sprintf("Destination Resource Group %q", id.Dst.ResourceGroupName),
+		fmt.Sprintf("Destination Subscription Id %q", id.Dst.SubscriptionId),
 	}
 	segmentsStr := strings.Join(segments, " / ")
 	return fmt.Sprintf("%s: (%s)", "Object Replication", segmentsStr)
 }
 
 func (id ObjectReplicationId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/objectReplicationPolicies/%s;/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/objectReplicationPolicies/%s"
-	return fmt.Sprintf(fmtString, id.SrcSubscriptionId, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName, id.DstSubscriptionId, id.DstResourceGroup, id.DstStorageAccountName, id.DstName)
-}
-
-func (id ObjectReplicationId) SourceObjectReplicationID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/objectReplicationPolicies/%s"
-	return fmt.Sprintf(fmtString, id.SrcSubscriptionId, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName)
-}
-
-func (id ObjectReplicationId) DestinationObjectReplicationID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/objectReplicationPolicies/%s"
-	return fmt.Sprintf(fmtString, id.DstSubscriptionId, id.DstResourceGroup, id.DstStorageAccountName, id.DstName)
+	return fmt.Sprintf("%s;%s", id.Src.ID(), id.Dst.ID())
 }
 
 // ObjectReplicationID parses a ObjectReplication ID into an ObjectReplicationId struct
@@ -69,52 +46,18 @@ func ObjectReplicationID(input string) (*ObjectReplicationId, error) {
 	if len(ids) != 2 {
 		return nil, fmt.Errorf("storage Object Replication Id is composed as format `sourceId;destinationId`")
 	}
-	srcId, err := azure.ParseAzureResourceID(ids[0])
+	srcId, err := objectreplicationpolicies.ParseObjectReplicationPoliciesID(ids[0])
 	if err != nil {
 		return nil, err
 	}
 
-	dstId, err := azure.ParseAzureResourceID(strings.TrimSuffix(ids[1], ";"))
+	dstId, err := objectreplicationpolicies.ParseObjectReplicationPoliciesID(strings.TrimSuffix(ids[1], ";"))
 	if err != nil {
 		return nil, err
 	}
 
-	resourceId := ObjectReplicationId{
-		SrcSubscriptionId: srcId.SubscriptionID,
-		SrcResourceGroup:  srcId.ResourceGroup,
-		DstSubscriptionId: dstId.SubscriptionID,
-		DstResourceGroup:  dstId.ResourceGroup,
-	}
-
-	if resourceId.SrcSubscriptionId == "" || resourceId.DstSubscriptionId == "" {
-		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
-	}
-
-	if resourceId.SrcResourceGroup == "" || resourceId.DstResourceGroup == "" {
-		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
-	}
-
-	if resourceId.SrcStorageAccountName, err = srcId.PopSegment("storageAccounts"); err != nil {
-		return nil, err
-	}
-	if resourceId.SrcName, err = srcId.PopSegment("objectReplicationPolicies"); err != nil {
-		return nil, err
-	}
-
-	if err := srcId.ValidateNoEmptySegments(input); err != nil {
-		return nil, err
-	}
-
-	if resourceId.DstStorageAccountName, err = dstId.PopSegment("storageAccounts"); err != nil {
-		return nil, err
-	}
-	if resourceId.DstName, err = dstId.PopSegment("objectReplicationPolicies"); err != nil {
-		return nil, err
-	}
-
-	if err := dstId.ValidateNoEmptySegments(input); err != nil {
-		return nil, err
-	}
-
-	return &resourceId, nil
+	return &ObjectReplicationId{
+		Src: *srcId,
+		Dst: *dstId,
+	}, nil
 }

--- a/internal/services/storage/parse/object_replication_test.go
+++ b/internal/services/storage/parse/object_replication_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies"
 )
 
 var _ resourceid.Formatter = ObjectReplicationId{}
 
 func TestObjectReplicationIDFormatter(t *testing.T) {
-	actual := NewObjectReplicationID("12345678-1234-9876-4563-123456789012", "resGroup1", "storageAccount1", "objectReplicationPolicy1", "12345678-1234-9876-4563-123456789012", "resGroup2", "storageAccount2", "objectReplicationPolicy2").ID()
+	actual := NewObjectReplicationID(
+		objectreplicationpolicies.NewObjectReplicationPoliciesID("12345678-1234-9876-4563-123456789012", "resGroup1", "storageAccount1", "objectReplicationPolicy1"),
+		objectreplicationpolicies.NewObjectReplicationPoliciesID("12345678-1234-9876-4563-123456789012", "resGroup2", "storageAccount2", "objectReplicationPolicy2"),
+	).ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1/objectReplicationPolicies/objectReplicationPolicy1;/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2/objectReplicationPolicies/objectReplicationPolicy2"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -130,14 +134,18 @@ func TestObjectReplicationID(t *testing.T) {
 			// valid
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1/objectReplicationPolicies/objectReplicationPolicy1;/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup2/providers/Microsoft.Storage/storageAccounts/storageAccount2/objectReplicationPolicies/objectReplicationPolicy2",
 			Expected: &ObjectReplicationId{
-				SrcSubscriptionId:     "12345678-1234-9876-4563-123456789012",
-				SrcResourceGroup:      "resGroup1",
-				SrcStorageAccountName: "storageAccount1",
-				SrcName:               "objectReplicationPolicy1",
-				DstSubscriptionId:     "12345678-1234-9876-4563-123456789012",
-				DstResourceGroup:      "resGroup2",
-				DstStorageAccountName: "storageAccount2",
-				DstName:               "objectReplicationPolicy2",
+				Src: objectreplicationpolicies.ObjectReplicationPoliciesId{
+					SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+					ResourceGroupName:         "resGroup1",
+					AccountName:               "storageAccount1",
+					ObjectReplicationPolicyId: "objectReplicationPolicy1",
+				},
+				Dst: objectreplicationpolicies.ObjectReplicationPoliciesId{
+					SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+					ResourceGroupName:         "resGroup2",
+					AccountName:               "storageAccount2",
+					ObjectReplicationPolicyId: "objectReplicationPolicy2",
+				},
 			},
 		},
 
@@ -163,29 +171,29 @@ func TestObjectReplicationID(t *testing.T) {
 			t.Fatal("Expect an error but didn't get one")
 		}
 
-		if actual.SrcSubscriptionId != v.Expected.SrcSubscriptionId {
-			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SrcSubscriptionId, actual.SrcSubscriptionId)
+		if actual.Src.SubscriptionId != v.Expected.Src.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.Src.SubscriptionId, actual.Src.SubscriptionId)
 		}
-		if actual.SrcResourceGroup != v.Expected.SrcResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.SrcResourceGroup, actual.SrcResourceGroup)
+		if actual.Src.ResourceGroupName != v.Expected.Src.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Src.ResourceGroupName, actual.Src.ResourceGroupName)
 		}
-		if actual.SrcStorageAccountName != v.Expected.SrcStorageAccountName {
-			t.Fatalf("Expected %q but got %q for StorageAccountName", v.Expected.SrcStorageAccountName, actual.SrcStorageAccountName)
+		if actual.Src.AccountName != v.Expected.Src.AccountName {
+			t.Fatalf("Expected %q but got %q for StorageAccountName", v.Expected.Src.AccountName, actual.Src.AccountName)
 		}
-		if actual.SrcName != v.Expected.SrcName {
-			t.Fatalf("Expected %q but got %q for Name", v.Expected.SrcName, actual.SrcName)
+		if actual.Src.ObjectReplicationPolicyId != v.Expected.Src.ObjectReplicationPolicyId {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Src.ObjectReplicationPolicyId, actual.Src.ObjectReplicationPolicyId)
 		}
-		if actual.DstSubscriptionId != v.Expected.DstSubscriptionId {
-			t.Fatalf("Expected %q but got %q for SubscriptionName", v.Expected.DstSubscriptionId, actual.DstSubscriptionId)
+		if actual.Dst.SubscriptionId != v.Expected.Dst.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.Dst.SubscriptionId, actual.Dst.SubscriptionId)
 		}
-		if actual.DstResourceGroup != v.Expected.DstResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.DstResourceGroup, actual.DstResourceGroup)
+		if actual.Dst.ResourceGroupName != v.Expected.Dst.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Dst.ResourceGroupName, actual.Dst.ResourceGroupName)
 		}
-		if actual.DstStorageAccountName != v.Expected.DstStorageAccountName {
-			t.Fatalf("Expected %q but got %q for StorageAccountName", v.Expected.DstStorageAccountName, actual.DstStorageAccountName)
+		if actual.Dst.AccountName != v.Expected.Dst.AccountName {
+			t.Fatalf("Expected %q but got %q for StorageAccountName", v.Expected.Dst.AccountName, actual.Dst.AccountName)
 		}
-		if actual.DstName != v.Expected.DstName {
-			t.Fatalf("Expected %q but got %q for Name", v.Expected.DstName, actual.DstName)
+		if actual.Dst.ObjectReplicationPolicyId != v.Expected.Dst.ObjectReplicationPolicyId {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Dst.ObjectReplicationPolicyId, actual.Dst.ObjectReplicationPolicyId)
 		}
 	}
 }

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/client.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/client.go
@@ -1,0 +1,15 @@
+package objectreplicationpolicies
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ObjectReplicationPoliciesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewObjectReplicationPoliciesClientWithBaseURI(endpoint string) ObjectReplicationPoliciesClient {
+	return ObjectReplicationPoliciesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_objectreplicationpolicies.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_objectreplicationpolicies.go
@@ -1,0 +1,137 @@
+package objectreplicationpolicies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ObjectReplicationPoliciesId{}
+
+// ObjectReplicationPoliciesId is a struct representing the Resource ID for a Object Replication Policies
+type ObjectReplicationPoliciesId struct {
+	SubscriptionId            string
+	ResourceGroupName         string
+	AccountName               string
+	ObjectReplicationPolicyId string
+}
+
+// NewObjectReplicationPoliciesID returns a new ObjectReplicationPoliciesId struct
+func NewObjectReplicationPoliciesID(subscriptionId string, resourceGroupName string, accountName string, objectReplicationPolicyId string) ObjectReplicationPoliciesId {
+	return ObjectReplicationPoliciesId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroupName:         resourceGroupName,
+		AccountName:               accountName,
+		ObjectReplicationPolicyId: objectReplicationPolicyId,
+	}
+}
+
+// ParseObjectReplicationPoliciesID parses 'input' into a ObjectReplicationPoliciesId
+func ParseObjectReplicationPoliciesID(input string) (*ObjectReplicationPoliciesId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ObjectReplicationPoliciesId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ObjectReplicationPoliciesId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.ObjectReplicationPolicyId, ok = parsed.Parsed["objectReplicationPolicyId"]; !ok {
+		return nil, fmt.Errorf("the segment 'objectReplicationPolicyId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseObjectReplicationPoliciesIDInsensitively parses 'input' case-insensitively into a ObjectReplicationPoliciesId
+// note: this method should only be used for API response data and not user input
+func ParseObjectReplicationPoliciesIDInsensitively(input string) (*ObjectReplicationPoliciesId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ObjectReplicationPoliciesId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ObjectReplicationPoliciesId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.ObjectReplicationPolicyId, ok = parsed.Parsed["objectReplicationPolicyId"]; !ok {
+		return nil, fmt.Errorf("the segment 'objectReplicationPolicyId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateObjectReplicationPoliciesID checks that 'input' can be parsed as a Object Replication Policies ID
+func ValidateObjectReplicationPoliciesID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseObjectReplicationPoliciesID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Object Replication Policies ID
+func (id ObjectReplicationPoliciesId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/objectReplicationPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName, id.ObjectReplicationPolicyId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Object Replication Policies ID
+func (id ObjectReplicationPoliciesId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStorage", "Microsoft.Storage", "Microsoft.Storage"),
+		resourceids.StaticSegment("staticStorageAccounts", "storageAccounts", "storageAccounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+		resourceids.StaticSegment("staticObjectReplicationPolicies", "objectReplicationPolicies", "objectReplicationPolicies"),
+		resourceids.UserSpecifiedSegment("objectReplicationPolicyId", "objectReplicationPolicyIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Object Replication Policies ID
+func (id ObjectReplicationPoliciesId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+		fmt.Sprintf("Object Replication Policy: %q", id.ObjectReplicationPolicyId),
+	}
+	return fmt.Sprintf("Object Replication Policies (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_objectreplicationpolicies_test.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_objectreplicationpolicies_test.go
@@ -1,0 +1,324 @@
+package objectreplicationpolicies
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ObjectReplicationPoliciesId{}
+
+func TestNewObjectReplicationPoliciesID(t *testing.T) {
+	id := NewObjectReplicationPoliciesID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "objectReplicationPolicyIdValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.AccountName != "accountValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'AccountName'", id.AccountName, "accountValue")
+	}
+
+	if id.ObjectReplicationPolicyId != "objectReplicationPolicyIdValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ObjectReplicationPolicyId'", id.ObjectReplicationPolicyId, "objectReplicationPolicyIdValue")
+	}
+}
+
+func TestFormatObjectReplicationPoliciesID(t *testing.T) {
+	actual := NewObjectReplicationPoliciesID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "objectReplicationPolicyIdValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies/objectReplicationPolicyIdValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseObjectReplicationPoliciesID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ObjectReplicationPoliciesId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies/objectReplicationPolicyIdValue",
+			Expected: &ObjectReplicationPoliciesId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:         "example-resource-group",
+				AccountName:               "accountValue",
+				ObjectReplicationPolicyId: "objectReplicationPolicyIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies/objectReplicationPolicyIdValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseObjectReplicationPoliciesID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.AccountName != v.Expected.AccountName {
+			t.Fatalf("Expected %q but got %q for AccountName", v.Expected.AccountName, actual.AccountName)
+		}
+
+		if actual.ObjectReplicationPolicyId != v.Expected.ObjectReplicationPolicyId {
+			t.Fatalf("Expected %q but got %q for ObjectReplicationPolicyId", v.Expected.ObjectReplicationPolicyId, actual.ObjectReplicationPolicyId)
+		}
+
+	}
+}
+
+func TestParseObjectReplicationPoliciesIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ObjectReplicationPoliciesId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE/oBjEcTrEpLiCaTiOnPoLiCiEs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies/objectReplicationPolicyIdValue",
+			Expected: &ObjectReplicationPoliciesId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:         "example-resource-group",
+				AccountName:               "accountValue",
+				ObjectReplicationPolicyId: "objectReplicationPolicyIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/objectReplicationPolicies/objectReplicationPolicyIdValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE/oBjEcTrEpLiCaTiOnPoLiCiEs/oBjEcTrEpLiCaTiOnPoLiCyIdVaLuE",
+			Expected: &ObjectReplicationPoliciesId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:         "eXaMpLe-rEsOuRcE-GrOuP",
+				AccountName:               "aCcOuNtVaLuE",
+				ObjectReplicationPolicyId: "oBjEcTrEpLiCaTiOnPoLiCyIdVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE/oBjEcTrEpLiCaTiOnPoLiCiEs/oBjEcTrEpLiCaTiOnPoLiCyIdVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseObjectReplicationPoliciesIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.AccountName != v.Expected.AccountName {
+			t.Fatalf("Expected %q but got %q for AccountName", v.Expected.AccountName, actual.AccountName)
+		}
+
+		if actual.ObjectReplicationPolicyId != v.Expected.ObjectReplicationPolicyId {
+			t.Fatalf("Expected %q but got %q for ObjectReplicationPolicyId", v.Expected.ObjectReplicationPolicyId, actual.ObjectReplicationPolicyId)
+		}
+
+	}
+}
+
+func TestSegmentsForObjectReplicationPoliciesId(t *testing.T) {
+	segments := ObjectReplicationPoliciesId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ObjectReplicationPoliciesId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_storageaccount.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_storageaccount.go
@@ -1,0 +1,124 @@
+package objectreplicationpolicies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = StorageAccountId{}
+
+// StorageAccountId is a struct representing the Resource ID for a Storage Account
+type StorageAccountId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AccountName       string
+}
+
+// NewStorageAccountID returns a new StorageAccountId struct
+func NewStorageAccountID(subscriptionId string, resourceGroupName string, accountName string) StorageAccountId {
+	return StorageAccountId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AccountName:       accountName,
+	}
+}
+
+// ParseStorageAccountID parses 'input' into a StorageAccountId
+func ParseStorageAccountID(input string) (*StorageAccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(StorageAccountId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := StorageAccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseStorageAccountIDInsensitively parses 'input' case-insensitively into a StorageAccountId
+// note: this method should only be used for API response data and not user input
+func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(StorageAccountId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := StorageAccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateStorageAccountID checks that 'input' can be parsed as a Storage Account ID
+func ValidateStorageAccountID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseStorageAccountID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Storage Account ID
+func (id StorageAccountId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Storage Account ID
+func (id StorageAccountId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStorage", "Microsoft.Storage", "Microsoft.Storage"),
+		resourceids.StaticSegment("staticStorageAccounts", "storageAccounts", "storageAccounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+	}
+}
+
+// String returns a human-readable description of this Storage Account ID
+func (id StorageAccountId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+	}
+	return fmt.Sprintf("Storage Account (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_storageaccount_test.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/id_storageaccount_test.go
@@ -1,0 +1,279 @@
+package objectreplicationpolicies
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = StorageAccountId{}
+
+func TestNewStorageAccountID(t *testing.T) {
+	id := NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.AccountName != "accountValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'AccountName'", id.AccountName, "accountValue")
+	}
+}
+
+func TestFormatStorageAccountID(t *testing.T) {
+	actual := NewStorageAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseStorageAccountID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *StorageAccountId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue",
+			Expected: &StorageAccountId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				AccountName:       "accountValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseStorageAccountID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.AccountName != v.Expected.AccountName {
+			t.Fatalf("Expected %q but got %q for AccountName", v.Expected.AccountName, actual.AccountName)
+		}
+
+	}
+}
+
+func TestParseStorageAccountIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *StorageAccountId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue",
+			Expected: &StorageAccountId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				AccountName:       "accountValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/accountValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE",
+			Expected: &StorageAccountId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				AccountName:       "aCcOuNtVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.sToRaGe/sToRaGeAcCoUnTs/aCcOuNtVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseStorageAccountIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.AccountName != v.Expected.AccountName {
+			t.Fatalf("Expected %q but got %q for AccountName", v.Expected.AccountName, actual.AccountName)
+		}
+
+	}
+}
+
+func TestSegmentsForStorageAccountId(t *testing.T) {
+	segments := StorageAccountId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("StorageAccountId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_createorupdate_autorest.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_createorupdate_autorest.go
@@ -1,0 +1,65 @@
+package objectreplicationpolicies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CreateOrUpdateResponse struct {
+	HttpResponse *http.Response
+	Model        *ObjectReplicationPolicy
+}
+
+// CreateOrUpdate ...
+func (c ObjectReplicationPoliciesClient) CreateOrUpdate(ctx context.Context, id ObjectReplicationPoliciesId, input ObjectReplicationPolicy) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c ObjectReplicationPoliciesClient) preparerForCreateOrUpdate(ctx context.Context, id ObjectReplicationPoliciesId, input ObjectReplicationPolicy) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c ObjectReplicationPoliciesClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_delete_autorest.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_delete_autorest.go
@@ -1,0 +1,62 @@
+package objectreplicationpolicies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ObjectReplicationPoliciesClient) Delete(ctx context.Context, id ObjectReplicationPoliciesId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ObjectReplicationPoliciesClient) preparerForDelete(ctx context.Context, id ObjectReplicationPoliciesId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c ObjectReplicationPoliciesClient) responderForDelete(resp *http.Response) (result DeleteResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_get_autorest.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_get_autorest.go
@@ -1,0 +1,64 @@
+package objectreplicationpolicies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *ObjectReplicationPolicy
+}
+
+// Get ...
+func (c ObjectReplicationPoliciesClient) Get(ctx context.Context, id ObjectReplicationPoliciesId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ObjectReplicationPoliciesClient) preparerForGet(ctx context.Context, id ObjectReplicationPoliciesId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ObjectReplicationPoliciesClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_list_autorest.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/method_list_autorest.go
@@ -1,0 +1,65 @@
+package objectreplicationpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListResponse struct {
+	HttpResponse *http.Response
+	Model        *ObjectReplicationPolicies
+}
+
+// List ...
+func (c ObjectReplicationPoliciesClient) List(ctx context.Context, id StorageAccountId) (result ListResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "List", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "objectreplicationpolicies.ObjectReplicationPoliciesClient", "List", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ObjectReplicationPoliciesClient) preparerForList(ctx context.Context, id StorageAccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/objectReplicationPolicies", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ObjectReplicationPoliciesClient) responderForList(resp *http.Response) (result ListResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicies.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicies.go
@@ -1,0 +1,5 @@
+package objectreplicationpolicies
+
+type ObjectReplicationPolicies struct {
+	Value *[]ObjectReplicationPolicy `json:"value,omitempty"`
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicy.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicy.go
@@ -1,0 +1,8 @@
+package objectreplicationpolicies
+
+type ObjectReplicationPolicy struct {
+	Id         *string                            `json:"id,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *ObjectReplicationPolicyProperties `json:"properties,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyfilter.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyfilter.go
@@ -1,0 +1,6 @@
+package objectreplicationpolicies
+
+type ObjectReplicationPolicyFilter struct {
+	MinCreationTime *string   `json:"minCreationTime,omitempty"`
+	PrefixMatch     *[]string `json:"prefixMatch,omitempty"`
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyproperties.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyproperties.go
@@ -1,0 +1,27 @@
+package objectreplicationpolicies
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+type ObjectReplicationPolicyProperties struct {
+	DestinationAccount string                         `json:"destinationAccount"`
+	EnabledTime        *string                        `json:"enabledTime,omitempty"`
+	PolicyId           *string                        `json:"policyId,omitempty"`
+	Rules              *[]ObjectReplicationPolicyRule `json:"rules,omitempty"`
+	SourceAccount      string                         `json:"sourceAccount"`
+}
+
+func (o ObjectReplicationPolicyProperties) GetEnabledTimeAsTime() (*time.Time, error) {
+	if o.EnabledTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EnabledTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o ObjectReplicationPolicyProperties) SetEnabledTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EnabledTime = &formatted
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyrule.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/model_objectreplicationpolicyrule.go
@@ -1,0 +1,8 @@
+package objectreplicationpolicies
+
+type ObjectReplicationPolicyRule struct {
+	DestinationContainer string                         `json:"destinationContainer"`
+	Filters              *ObjectReplicationPolicyFilter `json:"filters,omitempty"`
+	RuleId               *string                        `json:"ruleId,omitempty"`
+	SourceContainer      string                         `json:"sourceContainer"`
+}

--- a/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/version.go
+++ b/internal/services/storage/sdk/2021-04-01/objectreplicationpolicies/version.go
@@ -1,0 +1,9 @@
+package objectreplicationpolicies
+
+import "fmt"
+
+const defaultApiVersion = "2021-04-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/objectreplicationpolicies/%s", defaultApiVersion)
+}

--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -33,7 +32,7 @@ func resourceStorageObjectReplication() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := objectreplicationpolicies.ParseObjectReplicationPoliciesID(id)
+			_, err := parse.ObjectReplicationID(id)
 			return err
 		}),
 
@@ -123,6 +122,9 @@ func resourceStorageObjectReplicationCreate(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
+	srcId := objectreplicationpolicies.NewObjectReplicationPoliciesID(srcAccount.SubscriptionId, srcAccount.ResourceGroupName, srcAccount.AccountName, "default")
+	dstId := objectreplicationpolicies.NewObjectReplicationPoliciesID(dstAccount.SubscriptionId, dstAccount.ResourceGroupName, dstAccount.AccountName, "default")
+
 	resp, err := client.List(ctx, *dstAccount)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -139,41 +141,52 @@ func resourceStorageObjectReplicationCreate(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	props := storage.ObjectReplicationPolicy{
-		ObjectReplicationPolicyProperties: &storage.ObjectReplicationPolicyProperties{
-			SourceAccount:      utils.String(srcAccount.Name),
-			DestinationAccount: utils.String(dstAccount.Name),
+	props := objectreplicationpolicies.ObjectReplicationPolicy{
+		Properties: &objectreplicationpolicies.ObjectReplicationPolicyProperties{
+			SourceAccount:      srcId.AccountName,
+			DestinationAccount: dstId.AccountName,
 			Rules:              expandArmObjectReplicationRuleArray(d.Get("rules").(*pluginsdk.Set).List()),
 		},
 	}
 
 	// create in dest storage account
-	dstResp, err := client.CreateOrUpdate(ctx, dstAccount.ResourceGroup, dstAccount.Name, "default", props)
+	dstResp, err := client.CreateOrUpdate(ctx, dstId, props)
 	if err != nil {
-		return fmt.Errorf("creating Storage Object Replication for destination storage account name %q: %+v", dstAccount.Name, err)
+		return fmt.Errorf("creating Storage Object Replication for destination storage account name %q: %+v", dstId.AccountName, err)
 	}
 
-	if dstResp.ID == nil || *dstResp.ID == "" {
-		return fmt.Errorf("empty or nil ID returned for Storage Object Replication for destination storage account name %q ID", dstAccount.Name)
+	if dstResp.Model == nil {
+		return fmt.Errorf("nil model returned for Storage Object Replication for destination storage account name %q ID", dstId.AccountName)
+	}
+	if dstResp.Model.Id == nil || *dstResp.Model.Id == "" {
+		return fmt.Errorf("empty or nil ID returned for Storage Object Replication for destination storage account name %q ID", dstId.AccountName)
+	}
+	if dstResp.Model.Name == nil || *dstResp.Model.Name == "" {
+		return fmt.Errorf("empty or nil Name returned for Storage Object Replication for destination storage account name %q ID", dstAccount.AccountName)
+	}
+	if dstResp.Model.Properties == nil {
+		return fmt.Errorf("nil properties returned for Storage Object Replication for destination storage account name %q ID", dstAccount.AccountName)
 	}
 
-	if dstResp.Name == nil || *dstResp.Name == "" {
-		return fmt.Errorf("empty or nil Name returned for Storage Object Replication for destination storage account name %q ID", dstAccount.Name)
-	}
+	// Update the srcId and dstId using the returned computed object replication policy ID.
+	srcId.ObjectReplicationPolicyId = *dstResp.Model.Name
+	dstId.ObjectReplicationPolicyId = *dstResp.Model.Name
 
 	// create in source storage account, update policy Id and ruleId which are computed from destination ORP
-	props.Rules = dstResp.Rules
-	srcResp, err := client.CreateOrUpdate(ctx, srcAccount.ResourceGroup, srcAccount.Name, *dstResp.Name, props)
+	props.Properties.Rules = dstResp.Model.Properties.Rules
+	srcResp, err := client.CreateOrUpdate(ctx, srcId, props)
 	if err != nil {
-		return fmt.Errorf("creating Storage Object Replication %q for source storage account name %q: %+v", *dstResp.Name, srcAccount.Name, err)
+		return fmt.Errorf("creating Storage Object Replication %q for source storage account name %q: %+v", srcId.ObjectReplicationPolicyId, srcId.AccountName, err)
 	}
 
-	if srcResp.ID == nil || *srcResp.ID == "" {
-		return fmt.Errorf("empty or nil ID returned for Storage Object Replication for destination storage account name %q ID", dstAccount.Name)
+	if srcResp.Model == nil {
+		return fmt.Errorf("nil model returned for Storage Object Replication for destination storage account name %q ID", srcId.AccountName)
+	}
+	if srcResp.Model.Id == nil || *srcResp.Model.Id == "" {
+		return fmt.Errorf("empty or nil ID returned for Storage Object Replication for destination storage account name %q ID", srcId.AccountName)
 	}
 
-	// here we concat the `srcId;dstId` as the resource id
-	d.SetId(fmt.Sprintf("%s;%s", *srcResp.ID, *dstResp.ID))
+	d.SetId(parse.NewObjectReplicationID(srcId, dstId).ID())
 
 	return resourceStorageObjectReplicationRead(d, meta)
 }
@@ -188,24 +201,30 @@ func resourceStorageObjectReplicationUpdate(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
-	props := storage.ObjectReplicationPolicy{
-		ObjectReplicationPolicyProperties: &storage.ObjectReplicationPolicyProperties{
-			SourceAccount:      utils.String(id.SrcStorageAccountName),
-			DestinationAccount: utils.String(id.DstStorageAccountName),
+	props := objectreplicationpolicies.ObjectReplicationPolicy{
+		Properties: &objectreplicationpolicies.ObjectReplicationPolicyProperties{
+			SourceAccount:      id.Src.AccountName,
+			DestinationAccount: id.Dst.AccountName,
 			Rules:              expandArmObjectReplicationRuleArray(d.Get("rules").(*pluginsdk.Set).List()),
 		},
 	}
 
 	// update in dest storage account
-	resp, err := client.CreateOrUpdate(ctx, id.DstResourceGroup, id.DstStorageAccountName, id.DstName, props)
+	resp, err := client.CreateOrUpdate(ctx, id.Dst, props)
 	if err != nil {
-		return fmt.Errorf("updating %q for destination storage account name %q: %+v", id, id.DstStorageAccountName, err)
+		return fmt.Errorf("updating %q for destination storage account name %q: %+v", id, id.Dst.AccountName, err)
+	}
+	if resp.Model == nil {
+		return fmt.Errorf("nil model returned for Storage Object Replication for destination storage account name %q ID", id.Dst.AccountName)
+	}
+	if resp.Model.Properties == nil {
+		return fmt.Errorf("nil properties returned for Storage Object Replication for destination storage account name %q ID", id.Dst.AccountName)
 	}
 
 	// update in source storage account, update policy Id and ruleId
-	props.Rules = resp.Rules
-	if _, err := client.CreateOrUpdate(ctx, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName, props); err != nil {
-		return fmt.Errorf("updating %q for source storage account name %q: %+v", id, id.SrcStorageAccountName, err)
+	props.Properties.Rules = resp.Model.Properties.Rules
+	if _, err := client.CreateOrUpdate(ctx, id.Src, props); err != nil {
+		return fmt.Errorf("updating %q for source storage account name %q: %+v", id, id.Src.AccountName, err)
 	}
 
 	return resourceStorageObjectReplicationRead(d, meta)
@@ -221,34 +240,36 @@ func resourceStorageObjectReplicationRead(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	dstResp, err := client.Get(ctx, id.DstResourceGroup, id.DstStorageAccountName, id.DstName)
+	dstResp, err := client.Get(ctx, id.Dst)
 	if err != nil {
-		if utils.ResponseWasNotFound(dstResp.Response) {
-			log.Printf("[INFO] storage object replication %q does not exist - removing from state", d.Id())
+		if response.WasNotFound(dstResp.HttpResponse) {
+			log.Printf("[INFO] storage object replication %q (dst) does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	srcResp, err := client.Get(ctx, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName)
+	srcResp, err := client.Get(ctx, id.Src)
 	if err != nil {
-		if utils.ResponseWasNotFound(srcResp.Response) {
-			log.Printf("[INFO] storage object replication %q does not exist - removing from state", d.Id())
+		if response.WasNotFound(srcResp.HttpResponse) {
+			log.Printf("[INFO] storage object replication %q (src) does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	if props := dstResp.ObjectReplicationPolicyProperties; props != nil {
-		d.Set("source_storage_account_id", parse.NewStorageAccountID(id.SrcSubscriptionId, id.SrcResourceGroup, id.SrcStorageAccountName).ID())
-		d.Set("destination_storage_account_id", parse.NewStorageAccountID(id.DstSubscriptionId, id.DstResourceGroup, id.DstStorageAccountName).ID())
-		if err := d.Set("rules", flattenObjectReplicationRules(props.Rules)); err != nil {
-			return fmt.Errorf("setting `rules`: %+v", err)
+	if model := dstResp.Model; model != nil {
+		if props := dstResp.Model.Properties; props != nil {
+			d.Set("source_storage_account_id", parse.NewStorageAccountID(id.Src.SubscriptionId, id.Src.ResourceGroupName, id.Src.AccountName).ID())
+			d.Set("destination_storage_account_id", parse.NewStorageAccountID(id.Dst.SubscriptionId, id.Dst.ResourceGroupName, id.Dst.AccountName).ID())
+			if err := d.Set("rules", flattenObjectReplicationRules(props.Rules)); err != nil {
+				return fmt.Errorf("setting `rules`: %+v", err)
+			}
+			d.Set("source_object_replication_id", id.Src.ID())
+			d.Set("destination_object_replication_id", id.Dst.ID())
 		}
-		d.Set("source_object_replication_id", id.SourceObjectReplicationID())
-		d.Set("destination_object_replication_id", id.DestinationObjectReplicationID())
 	}
 	return nil
 }
@@ -263,30 +284,30 @@ func resourceStorageObjectReplicationDelete(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
-	if _, err := client.Delete(ctx, id.DstResourceGroup, id.DstStorageAccountName, id.DstName); err != nil {
-		return fmt.Errorf("deleting %q: %+v", id, err)
+	if _, err := client.Delete(ctx, id.Dst); err != nil {
+		return fmt.Errorf("deleting %q: %+v", id.Dst, err)
 	}
 
-	if _, err := client.Delete(ctx, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName); err != nil {
-		return fmt.Errorf("deleting %q : %+v", id, err)
+	if _, err := client.Delete(ctx, id.Src); err != nil {
+		return fmt.Errorf("deleting %q : %+v", id.Dst, err)
 	}
 	return nil
 }
 
-func expandArmObjectReplicationRuleArray(input []interface{}) *[]storage.ObjectReplicationPolicyRule {
-	results := make([]storage.ObjectReplicationPolicyRule, 0)
+func expandArmObjectReplicationRuleArray(input []interface{}) *[]objectreplicationpolicies.ObjectReplicationPolicyRule {
+	results := make([]objectreplicationpolicies.ObjectReplicationPolicyRule, 0)
 	for _, item := range input {
 		v := item.(map[string]interface{})
-		result := storage.ObjectReplicationPolicyRule{
-			SourceContainer:      utils.String(v["source_container_name"].(string)),
-			DestinationContainer: utils.String(v["destination_container_name"].(string)),
-			Filters: &storage.ObjectReplicationPolicyFilter{
+		result := objectreplicationpolicies.ObjectReplicationPolicyRule{
+			SourceContainer:      v["source_container_name"].(string),
+			DestinationContainer: v["destination_container_name"].(string),
+			Filters: &objectreplicationpolicies.ObjectReplicationPolicyFilter{
 				MinCreationTime: utils.String(expandArmObjectReplicationMinCreationTime(v["copy_blobs_created_after"].(string))),
 			},
 		}
 
 		if r, ok := v["name"].(string); ok && r != "" {
-			result.RuleID = utils.String(r)
+			result.RuleId = utils.String(r)
 		}
 
 		if f, ok := v["filter_out_blobs_with_prefix"]; ok {
@@ -309,26 +330,19 @@ func expandArmObjectReplicationMinCreationTime(input string) string {
 	}
 }
 
-func flattenObjectReplicationRules(input *[]storage.ObjectReplicationPolicyRule) []interface{} {
+func flattenObjectReplicationRules(input *[]objectreplicationpolicies.ObjectReplicationPolicyRule) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results
 	}
 
 	for _, item := range *input {
-		var destinationContainer string
-		if item.DestinationContainer != nil {
-			destinationContainer = *item.DestinationContainer
-		}
-
-		var sourceContainer string
-		if item.SourceContainer != nil {
-			sourceContainer = *item.SourceContainer
-		}
+		destinationContainer := item.DestinationContainer
+		sourceContainer := item.SourceContainer
 
 		var ruleId string
-		if item.RuleID != nil {
-			ruleId = *item.RuleID
+		if item.RuleId != nil {
+			ruleId = *item.RuleId
 		}
 
 		var minCreationTime string

--- a/internal/services/storage/storage_object_replication_resource_test.go
+++ b/internal/services/storage/storage_object_replication_resource_test.go
@@ -3,9 +3,11 @@ package storage_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -14,7 +16,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type StorageObjectReplicationResource struct{}
+type StorageObjectReplicationResource struct {
+	SecondarySubscriptionId string
+}
 
 func TestAccStorageObjectReplication_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_object_replication", "test")
@@ -116,22 +120,42 @@ func TestAccStorageObjectReplication_update(t *testing.T) {
 	})
 }
 
+func TestAccStorageObjectReplication_crossSubscription(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_object_replication", "test")
+	secondarySubscriptionId := os.Getenv("ARM_TEST_SUBSCRIPTION_ID_ALT")
+	if secondarySubscriptionId == "" {
+		t.Skipf("`ARM_TEST_SUBSCRIPTION_ID_ALT` is not specified")
+	}
+	r := StorageObjectReplicationResource{SecondarySubscriptionId: secondarySubscriptionId}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossSubscription(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("source_object_replication_id").Exists(),
+				check.That(data.ResourceName).Key("destination_object_replication_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageObjectReplicationResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ObjectReplicationID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	dstResp, err := client.Storage.ObjectReplicationClient.Get(ctx, id.DstResourceGroup, id.DstStorageAccountName, id.DstName)
+	dstResp, err := client.Storage.ObjectReplicationClient.Get(ctx, id.Dst)
 	if err != nil {
-		if utils.ResponseWasNotFound(dstResp.Response) {
+		if response.WasNotFound(dstResp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	srcResp, err := client.Storage.ObjectReplicationClient.Get(ctx, id.SrcResourceGroup, id.SrcStorageAccountName, id.SrcName)
+	srcResp, err := client.Storage.ObjectReplicationClient.Get(ctx, id.Src)
 	if err != nil {
-		if utils.ResponseWasNotFound(srcResp.Response) {
+		if response.WasNotFound(srcResp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
@@ -176,7 +200,7 @@ resource "azurerm_storage_container" "src_second" {
 }
 
 resource "azurerm_resource_group" "dst" {
-  name     = "acctest-storage-dst-%[1]d"
+  name     = "acctest-storage-alt-%[1]d"
   location = "%[4]s"
 }
 
@@ -290,4 +314,88 @@ resource "azurerm_storage_object_replication" "test" {
   }
 }
 `, r.template(data), copyTime)
+}
+
+func (r StorageObjectReplicationResource) crossSubscription(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azurerm-alt" {
+  subscription_id = "%[1]s"
+  features {}
+}
+
+resource "azurerm_resource_group" "src" {
+  name     = "acctest-storage-src-%[2]d"
+  location = "%[3]s"
+}
+
+resource "azurerm_storage_account" "src" {
+  name                     = "stracctsrc%[4]s"
+  resource_group_name      = azurerm_resource_group.src.name
+  location                 = azurerm_resource_group.src.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  blob_properties {
+    versioning_enabled  = true
+    change_feed_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "src" {
+  name                  = "strcsrc%[4]s"
+  storage_account_name  = azurerm_storage_account.src.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "src_second" {
+  name                  = "strcsrcsecond%[4]s"
+  storage_account_name  = azurerm_storage_account.src.name
+  container_access_type = "private"
+}
+
+resource "azurerm_resource_group" "dst" {
+  provider = azurerm-alt
+  name     = "acctest-storage-dst-%[2]d"
+  location = "%[5]s"
+}
+
+resource "azurerm_storage_account" "dst" {
+  provider = azurerm-alt
+  name                     = "stracctdst%[4]s"
+  resource_group_name      = azurerm_resource_group.dst.name
+  location                 = azurerm_resource_group.dst.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  blob_properties {
+    versioning_enabled  = true
+    change_feed_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "dst" {
+  provider = azurerm-alt
+  name                  = "strcdst%[4]s"
+  storage_account_name  = azurerm_storage_account.dst.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "dst_second" {
+  provider = azurerm-alt
+  name                  = "strcdstsecond%[4]s"
+  storage_account_name  = azurerm_storage_account.dst.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_object_replication" "test" {
+  source_storage_account_id      = azurerm_storage_account.src.id
+  destination_storage_account_id = azurerm_storage_account.dst.id
+  rules {
+    source_container_name      = azurerm_storage_container.src.name
+    destination_container_name = azurerm_storage_container.dst.name
+  }
+}
+`, r.SecondarySubscriptionId, data.RandomInteger, data.Locations.Primary, data.RandomString, data.Locations.Secondary)
 }


### PR DESCRIPTION
This PR replaces the Azure SDK client by the Pandora SDK client, for the storage object replication policy. The latter has supports for the cross sub use case.

Fixes #15533

## Test

```bash
💢  TF_ACC=1 go test -parallel 30 -v -timeout=20h ./internal/services/storage -run="TestAccStorageObjectReplication_crossSubscription"
=== RUN   TestAccStorageObjectReplication_crossSubscription
=== PAUSE TestAccStorageObjectReplication_crossSubscription
=== CONT  TestAccStorageObjectReplication_crossSubscription
--- PASS: TestAccStorageObjectReplication_crossSubscription (362.73s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       362.742s
```