### PR TITLE
refactor: adding ID Validators across all resources

### DIFF
--- a/internal/services/apimanagement/api_management_api_version_set_resource.go
+++ b/internal/services/apimanagement/api_management_api_version_set_resource.go
@@ -24,8 +24,10 @@ func resourceApiManagementApiVersionSet() *pluginsdk.Resource {
 		Read:   resourceApiManagementApiVersionSetRead,
 		Update: resourceApiManagementApiVersionSetCreateUpdate,
 		Delete: resourceApiManagementApiVersionSetDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ApiVersionSetID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_email_template_resource.go
+++ b/internal/services/apimanagement/api_management_email_template_resource.go
@@ -24,8 +24,10 @@ func resourceApiManagementEmailTemplate() *pluginsdk.Resource {
 		Read:   resourceApiManagementEmailTemplateRead,
 		Update: resourceApiManagementEmailTemplateCreateUpdate,
 		Delete: resourceApiManagementEmailTemplateDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.EmailTemplateID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
@@ -23,8 +23,8 @@ func resourceApiManagementIdentityProviderAAD() *pluginsdk.Resource {
 		Read:   resourceApiManagementIdentityProviderAADRead,
 		Update: resourceApiManagementIdentityProviderAADCreateUpdate,
 		Delete: resourceApiManagementIdentityProviderAADDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeAad),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -23,8 +23,8 @@ func resourceArmApiManagementIdentityProviderAADB2C() *pluginsdk.Resource {
 		Read:   resourceArmApiManagementIdentityProviderAADB2CRead,
 		Update: resourceArmApiManagementIdentityProviderAADB2CCreateUpdate,
 		Delete: resourceArmApiManagementIdentityProviderAADB2CDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeAadB2C),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
@@ -23,8 +23,8 @@ func resourceApiManagementIdentityProviderFacebook() *pluginsdk.Resource {
 		Read:   resourceApiManagementIdentityProviderFacebookRead,
 		Update: resourceApiManagementIdentityProviderFacebookCreateUpdate,
 		Delete: resourceApiManagementIdentityProviderFacebookDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeFacebook),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_google_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_google_resource.go
@@ -24,8 +24,8 @@ func resourceApiManagementIdentityProviderGoogle() *pluginsdk.Resource {
 		Read:   resourceApiManagementIdentityProviderGoogleRead,
 		Update: resourceApiManagementIdentityProviderGoogleCreateUpdate,
 		Delete: resourceApiManagementIdentityProviderGoogleDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeGoogle),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_microsoft_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_microsoft_resource.go
@@ -23,8 +23,8 @@ func resourceApiManagementIdentityProviderMicrosoft() *pluginsdk.Resource {
 		Read:   resourceApiManagementIdentityProviderMicrosoftRead,
 		Update: resourceApiManagementIdentityProviderMicrosoftCreateUpdate,
 		Delete: resourceApiManagementIdentityProviderMicrosoftDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeMicrosoft),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
@@ -23,8 +23,8 @@ func resourceApiManagementIdentityProviderTwitter() *pluginsdk.Resource {
 		Read:   resourceApiManagementIdentityProviderTwitterRead,
 		Update: resourceApiManagementIdentityProviderTwitterCreateUpdate,
 		Delete: resourceApiManagementIdentityProviderTwitterDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: identityProviderImportFunc(apimanagement.IdentityProviderTypeTwitter),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/api_management_policy_resource.go
+++ b/internal/services/apimanagement/api_management_policy_resource.go
@@ -22,8 +22,11 @@ func resourceApiManagementPolicy() *pluginsdk.Resource {
 		Read:   resourceApiManagementPolicyRead,
 		Update: resourceApiManagementPolicyCreateUpdate,
 		Delete: resourceApiManagementPolicyDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.PolicyID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/internal/services/apimanagement/api_management_subscription_resource.go
@@ -28,8 +28,11 @@ func resourceApiManagementSubscription() *pluginsdk.Resource {
 		Read:   resourceApiManagementSubscriptionRead,
 		Update: resourceApiManagementSubscriptionCreateUpdate,
 		Delete: resourceApiManagementSubscriptionDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.SubscriptionID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/apimanagement/identity_provider_import.go
+++ b/internal/services/apimanagement/identity_provider_import.go
@@ -1,0 +1,25 @@
+package apimanagement
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func identityProviderImportFunc(providerType apimanagement.IdentityProviderType) *schema.ResourceImporter {
+	return pluginsdk.ImporterValidatingResourceId(func(id string) error {
+		parsed, err := parse.IdentityProviderID(id)
+		if err != nil {
+			return err
+		}
+
+		if parsed.Name != string(providerType) {
+			return fmt.Errorf("this resource only supports Identity Provider Type %q", string(providerType))
+		}
+
+		return nil
+	})
+}

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -28,8 +28,11 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 		Create: resourceArmRoleAssignmentCreate,
 		Read:   resourceArmRoleAssignmentRead,
 		Delete: resourceArmRoleAssignmentDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.RoleAssignmentID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/blueprints/blueprint_assignment_resource.go
+++ b/internal/services/blueprints/blueprint_assignment_resource.go
@@ -26,8 +26,10 @@ func resourceBlueprintAssignment() *pluginsdk.Resource {
 		Read:   resourceBlueprintAssignmentRead,
 		Delete: resourceBlueprintAssignmentDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.AssignmentID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
@@ -31,7 +31,10 @@ func resourceCognitiveAccountCustomerManagedKey() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := cognitiveservicesaccounts.ParseAccountID(id)
+			return err
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"cognitive_account_id": {

--- a/internal/services/containers/container_registry_scope_map_resource.go
+++ b/internal/services/containers/container_registry_scope_map_resource.go
@@ -19,11 +19,15 @@ import (
 
 func resourceContainerRegistryScopeMap() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create:   resourceContainerRegistryScopeMapCreate,
-		Read:     resourceContainerRegistryScopeMapRead,
-		Update:   resourceContainerRegistryScopeMapUpdate,
-		Delete:   resourceContainerRegistryScopeMapDelete,
-		Importer: pluginsdk.DefaultImporter(),
+		Create: resourceContainerRegistryScopeMapCreate,
+		Read:   resourceContainerRegistryScopeMapRead,
+		Update: resourceContainerRegistryScopeMapUpdate,
+		Delete: resourceContainerRegistryScopeMapDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ContainerRegistryScopeMapID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/containers/container_registry_token_resource.go
+++ b/internal/services/containers/container_registry_token_resource.go
@@ -18,11 +18,15 @@ import (
 
 func resourceContainerRegistryToken() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create:   resourceContainerRegistryTokenCreate,
-		Read:     resourceContainerRegistryTokenRead,
-		Update:   resourceContainerRegistryTokenUpdate,
-		Delete:   resourceContainerRegistryTokenDelete,
-		Importer: pluginsdk.DefaultImporter(),
+		Create: resourceContainerRegistryTokenCreate,
+		Read:   resourceContainerRegistryTokenRead,
+		Update: resourceContainerRegistryTokenUpdate,
+		Delete: resourceContainerRegistryTokenDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ContainerRegistryTokenID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -82,8 +82,10 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 			}),
 		),
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.DatabaseAccountID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(180 * time.Minute),

--- a/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource.go
@@ -26,8 +26,10 @@ func resourceCosmosDbCassandraKeyspace() *pluginsdk.Resource {
 		Update: resourceCosmosDbCassandraKeyspaceUpdate,
 		Delete: resourceCosmosDbCassandraKeyspaceDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.CassandraKeyspaceID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -25,8 +25,10 @@ func resourceCosmosDbCassandraTable() *pluginsdk.Resource {
 		Update: resourceCosmosDbCassandraTableUpdate,
 		Delete: resourceCosmosDbCassandraTableDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.CassandraTableID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
@@ -26,8 +26,10 @@ func resourceCosmosGremlinDatabase() *pluginsdk.Resource {
 		Read:   resourceCosmosGremlinDatabaseRead,
 		Delete: resourceCosmosGremlinDatabaseDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.GremlinDatabaseID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -29,8 +29,10 @@ func resourceCosmosDbGremlinGraph() *pluginsdk.Resource {
 		Update: resourceCosmosDbGremlinGraphUpdate,
 		Delete: resourceCosmosDbGremlinGraphDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.GremlinGraphID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_mongo_database_resource.go
+++ b/internal/services/cosmos/cosmosdb_mongo_database_resource.go
@@ -26,8 +26,10 @@ func resourceCosmosDbMongoDatabase() *pluginsdk.Resource {
 		Read:   resourceCosmosDbMongoDatabaseRead,
 		Delete: resourceCosmosDbMongoDatabaseDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.MongodbDatabaseID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -27,8 +27,10 @@ func resourceCosmosDbSQLContainer() *pluginsdk.Resource {
 		Update: resourceCosmosDbSQLContainerUpdate,
 		Delete: resourceCosmosDbSQLContainerDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.SqlContainerID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -26,8 +26,10 @@ func resourceCosmosDbSQLDatabase() *pluginsdk.Resource {
 		Update: resourceCosmosDbSQLDatabaseUpdate,
 		Delete: resourceCosmosDbSQLDatabaseDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.SqlDatabaseID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
@@ -25,8 +25,10 @@ func resourceCosmosDbSQLStoredProcedure() *pluginsdk.Resource {
 		Update: resourceCosmosDbSQLStoredProcedureUpdate,
 		Delete: resourceCosmosDbSQLStoredProcedureDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.SqlStoredProcedureID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/cosmos/cosmosdb_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_table_resource.go
@@ -26,8 +26,10 @@ func resourceCosmosDbTable() *pluginsdk.Resource {
 		Update: resourceCosmosDbTableUpdate,
 		Delete: resourceCosmosDbTableDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.TableID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -24,8 +24,10 @@ func resourceEventHubAuthorizationRule() *pluginsdk.Resource {
 		Update: resourceEventHubAuthorizationRuleCreateUpdate,
 		Delete: resourceEventHubAuthorizationRuleDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := eventhubs.ParseEventhubAuthorizationRuleID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -24,8 +24,10 @@ func resourceEventHubNamespaceAuthorizationRule() *pluginsdk.Resource {
 		Update: resourceEventHubNamespaceAuthorizationRuleCreateUpdate,
 		Delete: resourceEventHubNamespaceAuthorizationRuleDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := authorizationrulesnamespaces.ParseAuthorizationRuleID(id)
+			return err
+		}),
 
 		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -3,7 +3,10 @@ package eventhub
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -165,48 +168,55 @@ func resourceEventHubNamespaceCustomerManagedKeyRead(d *pluginsdk.ResourceData, 
 }
 
 func resourceEventHubNamespaceCustomerManagedKeyDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.NamespacesClient
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+	if !features.ThreePointOhBeta() {
 
-	id, err := namespaces.ParseNamespaceID(d.Id())
-	if err != nil {
-		return err
-	}
+		client := meta.(*clients.Client).Eventhub.NamespacesClient
+		ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+		defer cancel()
 
-	locks.ByName(id.NamespaceName, "azurerm_eventhub_namespace")
-	defer locks.UnlockByName(id.NamespaceName, "azurerm_eventhub_namespace")
-
-	resp, err := client.Get(ctx, *id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			return nil
+		id, err := namespaces.ParseNamespaceID(d.Id())
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
-	}
 
-	// Since this isn't a real object and it cannot be disabled once Customer Managed Key at rest has been enabled
-	// And it must keep at least one key once Customer Managed Key is enabled
-	// So for the delete operation, it has to recreate the EventHub Namespace with disabled Customer Managed Key
-	future, err := client.Delete(ctx, *id)
-	if err != nil {
-		if response.WasNotFound(future.HttpResponse) {
-			return nil
+		locks.ByName(id.NamespaceName, "azurerm_eventhub_namespace")
+		defer locks.UnlockByName(id.NamespaceName, "azurerm_eventhub_namespace")
+
+		resp, err := client.Get(ctx, *id)
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return nil
+			}
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
 		}
-		return fmt.Errorf("deleting %s: %+v", *id, err)
+
+		// Since this isn't a real object and it cannot be disabled once Customer Managed Key at rest has been enabled
+		// And it must keep at least one key once Customer Managed Key is enabled
+		// So for the delete operation, it has to recreate the EventHub Namespace with disabled Customer Managed Key
+		future, err := client.Delete(ctx, *id)
+		if err != nil {
+			if response.WasNotFound(future.HttpResponse) {
+				return nil
+			}
+			return fmt.Errorf("deleting %s: %+v", *id, err)
+		}
+
+		if err := waitForEventHubNamespaceToBeDeleted(ctx, client, *id); err != nil {
+			return err
+		}
+
+		namespace := resp.Model
+		namespace.Properties.Encryption = nil
+
+		if err = client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
+			return fmt.Errorf("removing %s: %+v", *id, err)
+		}
+
+		return nil
 	}
 
-	if err := waitForEventHubNamespaceToBeDeleted(ctx, client, *id); err != nil {
-		return err
-	}
-
-	namespace := resp.Model
-	namespace.Properties.Encryption = nil
-
-	if err = client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
-		return fmt.Errorf("removing %s: %+v", *id, err)
-	}
-
+	log.Printf(`[INFO] Customer Managed Keys cannot be removed from EventHub Namespaces once added. To remove the Customer Managed Key delete and recreate the parent EventHub Namespace")
+`)
 	return nil
 }
 

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -39,7 +39,9 @@ func resourceEventHubNamespaceCustomerManagedKey() *pluginsdk.Resource {
 			return err
 		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
 			client := meta.(*clients.Client).Eventhub.NamespacesClient
-			ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+
+			var cancel context.CancelFunc
+			ctx, cancel = timeouts.ForRead(ctx, d)
 			defer cancel()
 
 			id, err := namespaces.ParseNamespaceID(d.Id())

--- a/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
@@ -27,8 +27,10 @@ func resourceEventHubNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 		Update: resourceEventHubNamespaceDisasterRecoveryConfigUpdate,
 		Delete: resourceEventHubNamespaceDisasterRecoveryConfigDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := disasterrecoveryconfigs.ParseDisasterRecoveryConfigID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -55,8 +55,12 @@ func resourceHDInsightHadoopCluster() *pluginsdk.Resource {
 		Read:   resourceHDInsightHadoopClusterRead,
 		Update: hdinsightClusterUpdate("Hadoop", resourceHDInsightHadoopClusterRead),
 		Delete: hdinsightClusterDelete("Hadoop"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -47,8 +47,11 @@ func resourceHDInsightHBaseCluster() *pluginsdk.Resource {
 		Read:   resourceHDInsightHBaseClusterRead,
 		Update: hdinsightClusterUpdate("HBase", resourceHDInsightHBaseClusterRead),
 		Delete: hdinsightClusterDelete("HBase"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -48,8 +48,11 @@ func resourceHDInsightInteractiveQueryCluster() *pluginsdk.Resource {
 		Read:   resourceHDInsightInteractiveQueryClusterRead,
 		Update: hdinsightClusterUpdate("Interactive Query", resourceHDInsightInteractiveQueryClusterRead),
 		Delete: hdinsightClusterDelete("Interactive Query"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -56,8 +56,11 @@ func resourceHDInsightKafkaCluster() *pluginsdk.Resource {
 		Read:   resourceHDInsightKafkaClusterRead,
 		Update: hdinsightClusterUpdate("Kafka", resourceHDInsightKafkaClusterRead),
 		Delete: hdinsightClusterDelete("Kafka"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		// TODO: won't be needed in v3.0
 		CustomizeDiff: resourceHDInsightKafkaClusterCustomizeDiff,

--- a/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
@@ -62,8 +62,11 @@ https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#
 		Read:   resourceHDInsightMLServicesClusterRead,
 		Update: hdinsightClusterUpdate("MLServices", resourceHDInsightMLServicesClusterRead),
 		Delete: hdinsightClusterDelete("MLServices"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
@@ -62,8 +62,11 @@ https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#
 		Read:   resourceHDInsightRServerClusterRead,
 		Update: hdinsightClusterUpdate("RServer", resourceHDInsightRServerClusterRead),
 		Delete: hdinsightClusterDelete("RServer"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -48,8 +48,11 @@ func resourceHDInsightSparkCluster() *pluginsdk.Resource {
 		Read:   resourceHDInsightSparkClusterRead,
 		Update: hdinsightClusterUpdate("Spark", resourceHDInsightSparkClusterRead),
 		Delete: hdinsightClusterDelete("Spark"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
@@ -51,8 +51,11 @@ https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#
 		Read:   resourceHDInsightStormClusterRead,
 		Update: hdinsightClusterUpdate("Storm", resourceHDInsightStormClusterRead),
 		Delete: hdinsightClusterDelete("Storm"),
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/keyvault/mgmt/2020-04-01-preview/keyvault"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -27,7 +29,9 @@ func resourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 		Delete: resourceKeyVaultAccessPolicyDelete,
 
 		// TODO: switch below to using an ID Parser and then replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -25,7 +25,8 @@ func resourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 		Read:   resourceKeyVaultAccessPolicyRead,
 		Update: resourceKeyVaultAccessPolicyUpdate,
 		Delete: resourceKeyVaultAccessPolicyDelete,
-		// TODO: replace this with an importer which validates the ID during import
+
+		// TODO: switch below to using an ID Parser and then replace this with an importer which validates the ID during import
 		Importer: pluginsdk.DefaultImporter(),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -31,11 +31,15 @@ import (
 
 func resourceKeyVaultKey() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create:   resourceKeyVaultKeyCreate,
-		Read:     resourceKeyVaultKeyRead,
-		Update:   resourceKeyVaultKeyUpdate,
-		Delete:   resourceKeyVaultKeyDelete,
-		Importer: pluginsdk.DefaultImporter(),
+		Create: resourceKeyVaultKeyCreate,
+		Read:   resourceKeyVaultKeyRead,
+		Update: resourceKeyVaultKeyUpdate,
+		Delete: resourceKeyVaultKeyDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ParseNestedItemID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -46,8 +46,10 @@ func resourceKeyVault() *pluginsdk.Resource {
 		Update: resourceKeyVaultUpdate,
 		Delete: resourceKeyVaultDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.VaultID(id)
+			return err
+		}),
 
 		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -27,9 +27,10 @@ func resourceKustoClusterCustomerManagedKey() *pluginsdk.Resource {
 		Update: resourceKustoClusterCustomerManagedKeyCreateUpdate,
 		Delete: resourceKustoClusterCustomerManagedKeyDelete,
 
-		// TODO: this needs a custom ID validating importer
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
@@ -22,8 +22,10 @@ func resourceKustoClusterPrincipalAssignment() *pluginsdk.Resource {
 		Read:   resourceKustoClusterPrincipalAssignmentRead,
 		Delete: resourceKustoClusterPrincipalAssignmentDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ClusterPrincipalAssignmentID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/kusto/kusto_database_principal_resource.go
+++ b/internal/services/kusto/kusto_database_principal_resource.go
@@ -26,11 +26,12 @@ func resourceKustoDatabasePrincipal() *pluginsdk.Resource {
 
 		DeprecationMessage: "This resource has been superseded by `azurerm_kusto_database_principal_assignment` to reflects changes in the API/SDK and will be removed in version 3.0 of the provider.",
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.DatabasePrincipalID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			// TODO: confirm these
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/kusto/registration.go
+++ b/internal/services/kusto/registration.go
@@ -1,6 +1,7 @@
 package kusto
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -34,12 +35,11 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	out := map[string]*pluginsdk.Resource{
 		"azurerm_kusto_cluster":                         resourceKustoCluster(),
 		"azurerm_kusto_cluster_customer_managed_key":    resourceKustoClusterCustomerManagedKey(),
 		"azurerm_kusto_cluster_principal_assignment":    resourceKustoClusterPrincipalAssignment(),
 		"azurerm_kusto_database":                        resourceKustoDatabase(),
-		"azurerm_kusto_database_principal":              resourceKustoDatabasePrincipal(),
 		"azurerm_kusto_database_principal_assignment":   resourceKustoDatabasePrincipalAssignment(),
 		"azurerm_kusto_eventgrid_data_connection":       resourceKustoEventGridDataConnection(),
 		"azurerm_kusto_eventhub_data_connection":        resourceKustoEventHubDataConnection(),
@@ -47,4 +47,10 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_kusto_attached_database_configuration": resourceKustoAttachedDatabaseConfiguration(),
 		"azurerm_kusto_script":                          resourceKustoDatabaseScript(),
 	}
+
+	if !features.ThreePointOhBeta() {
+		out["azurerm_kusto_database_principal"] = resourceKustoDatabasePrincipal()
+	}
+
+	return out
 }

--- a/internal/services/lighthouse/lighthouse_assignment_resource.go
+++ b/internal/services/lighthouse/lighthouse_assignment_resource.go
@@ -24,8 +24,11 @@ func resourceLighthouseAssignment() *pluginsdk.Resource {
 		Create: resourceLighthouseAssignmentCreate,
 		Read:   resourceLighthouseAssignmentRead,
 		Delete: resourceLighthouseAssignmentDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.LighthouseAssignmentID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/lighthouse/lighthouse_definition_resource.go
+++ b/internal/services/lighthouse/lighthouse_definition_resource.go
@@ -24,8 +24,11 @@ func resourceLighthouseDefinition() *pluginsdk.Resource {
 		Read:   resourceLighthouseDefinitionRead,
 		Update: resourceLighthouseDefinitionCreateUpdate,
 		Delete: resourceLighthouseDefinitionDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.LighthouseDefinitionID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource.go
@@ -32,8 +32,12 @@ func resourceLogAnalyticsClusterCustomerManagedKey() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		// TODO: 3.0 - state migration to remove `/CMK` from the ID?
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.LogAnalyticsClusterID(id)
+			return err
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"log_analytics_cluster_id": {

--- a/internal/services/logic/integration_service_environment.go
+++ b/internal/services/logic/integration_service_environment.go
@@ -31,8 +31,11 @@ func resourceIntegrationServiceEnvironment() *pluginsdk.Resource {
 		Read:   resourceIntegrationServiceEnvironmentRead,
 		Update: resourceIntegrationServiceEnvironmentCreateUpdate,
 		Delete: resourceIntegrationServiceEnvironmentDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.IntegrationServiceEnvironmentID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(5 * time.Hour),

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -31,8 +31,11 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 		Read:   resourceMonitorDiagnosticSettingRead,
 		Update: resourceMonitorDiagnosticSettingCreateUpdate,
 		Delete: resourceMonitorDiagnosticSettingDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := ParseMonitorDiagnosticId(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/mysql/mysql_firewall_rule_resource.go
+++ b/internal/services/mysql/mysql_firewall_rule_resource.go
@@ -24,8 +24,10 @@ func resourceMySqlFirewallRule() *pluginsdk.Resource {
 		Update: resourceMySqlFirewallRuleCreateUpdate,
 		Delete: resourceMySqlFirewallRuleDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.FirewallRuleID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/network/vpn_gateway_data_source.go
+++ b/internal/services/network/vpn_gateway_data_source.go
@@ -19,8 +19,6 @@ import (
 func dataSourceVPNGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Read: dataSourceVPNGatewayRead,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/securitycenter/security_center_auto_provisioning_resource.go
+++ b/internal/services/securitycenter/security_center_auto_provisioning_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -25,7 +27,9 @@ func resourceSecurityCenterAutoProvisioning() *pluginsdk.Resource {
 		Delete: resourceSecurityCenterAutoProvisioningDelete,
 
 		// TODO: introduce an ID Parser and then replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/securitycenter/security_center_auto_provisioning_resource.go
+++ b/internal/services/securitycenter/security_center_auto_provisioning_resource.go
@@ -24,7 +24,7 @@ func resourceSecurityCenterAutoProvisioning() *pluginsdk.Resource {
 		Update: resourceSecurityCenterAutoProvisioningUpdate,
 		Delete: resourceSecurityCenterAutoProvisioningDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
+		// TODO: introduce an ID Parser and then replace this with an importer which validates the ID during import
 		Importer: pluginsdk.DefaultImporter(),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/securitycenter/security_center_server_vulnerability_assessment_resource.go
+++ b/internal/services/securitycenter/security_center_server_vulnerability_assessment_resource.go
@@ -22,6 +22,7 @@ const (
 	hybridMachineProvider  = "Microsoft.HybridCompute"
 )
 
+// TODO: 3.0 - split this into two resources for VM and HybridVM
 func resourceServerVulnerabilityAssessment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceServerVulnerabilityAssessmentCreate,

--- a/internal/services/securitycenter/security_center_server_vulnerability_assessment_resource.go
+++ b/internal/services/securitycenter/security_center_server_vulnerability_assessment_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -30,7 +32,9 @@ func resourceServerVulnerabilityAssessment() *pluginsdk.Resource {
 		Delete: resourceServerVulnerabilityAssessmentDelete,
 
 		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/signalr/signalr_service_network_acl_resource.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource.go
@@ -35,7 +35,10 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 		}),
 		SchemaVersion: 1,
 
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := signalr.ParseSignalRID(id)
+			return err
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"signalr_service_id": {

--- a/internal/services/signalr/web_pubsub_network_acl_resource.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource.go
@@ -40,7 +40,10 @@ func resourceWebpubsubNetworkACL() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.WebPubsubID(id)
+			return err
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"web_pubsub_id": {

--- a/internal/services/sql/sql_server_resource.go
+++ b/internal/services/sql/sql_server_resource.go
@@ -33,8 +33,10 @@ func resourceSqlServer() *pluginsdk.Resource {
 		Update: resourceSqlServerCreateUpdate,
 		Delete: resourceSqlServerDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ServerID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),

--- a/internal/services/sql/sql_virtual_network_rule_resource.go
+++ b/internal/services/sql/sql_virtual_network_rule_resource.go
@@ -24,8 +24,10 @@ func resourceSqlVirtualNetworkRule() *pluginsdk.Resource {
 		Update: resourceSqlVirtualNetworkRuleCreateUpdate,
 		Delete: resourceSqlVirtualNetworkRuleDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.VirtualNetworkRuleID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -27,9 +27,10 @@ func resourceStorageAccountCustomerManagedKey() *pluginsdk.Resource {
 		Update: resourceStorageAccountCustomerManagedKeyCreateUpdate,
 		Delete: resourceStorageAccountCustomerManagedKeyDelete,
 
-		// TODO: this needs a custom ID validating importer
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := storageParse.StorageAccountID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -29,8 +29,10 @@ func resourceStorageBlob() *pluginsdk.Resource {
 			0: migration.BlobV0ToV1{},
 		}),
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := blobs.ParseResourceID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -23,8 +23,10 @@ func resourceStorageContainer() *pluginsdk.Resource {
 		Delete: resourceStorageContainerDelete,
 		Update: resourceStorageContainerUpdate,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.StorageContainerDataPlaneID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -20,8 +20,12 @@ func resourceStorageQueue() *pluginsdk.Resource {
 		Read:   resourceStorageQueueRead,
 		Update: resourceStorageQueueUpdate,
 		Delete: resourceStorageQueueDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer:      pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.StorageQueueDataPlaneID(id)
+			return err
+		}),
+
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.QueueV0ToV1{},

--- a/internal/services/storage/storage_share_directory_resource.go
+++ b/internal/services/storage/storage_share_directory_resource.go
@@ -23,8 +23,11 @@ func resourceStorageShareDirectory() *pluginsdk.Resource {
 		Read:   resourceStorageShareDirectoryRead,
 		Update: resourceStorageShareDirectoryUpdate,
 		Delete: resourceStorageShareDirectoryDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := directories.ParseResourceID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -23,8 +23,11 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 		Read:   resourceStorageShareFileRead,
 		Update: resourceStorageShareFileUpdate,
 		Delete: resourceStorageShareFileDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := files.ParseResourceID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -22,8 +22,12 @@ func resourceStorageShare() *pluginsdk.Resource {
 		Read:   resourceStorageShareRead,
 		Update: resourceStorageShareUpdate,
 		Delete: resourceStorageShareDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer:      pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.StorageShareDataPlaneID(id)
+			return err
+		}),
+
 		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.ShareV0ToV1{},

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -21,8 +21,11 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 		Read:   resourceStorageTableEntityRead,
 		Update: resourceStorageTableEntityCreateUpdate,
 		Delete: resourceStorageTableEntityDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := entities.ParseResourceID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -22,8 +22,12 @@ func resourceStorageTable() *pluginsdk.Resource {
 		Read:   resourceStorageTableRead,
 		Delete: resourceStorageTableDelete,
 		Update: resourceStorageTableUpdate,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer:      pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.StorageTableDataPlaneID(id)
+			return err
+		}),
+
 		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.TableV0ToV1{},

--- a/internal/services/trafficmanager/registration.go
+++ b/internal/services/trafficmanager/registration.go
@@ -42,7 +42,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_traffic_manager_nested_endpoint":   resourceNestedEndpoint(),
 		"azurerm_traffic_manager_profile":           resourceArmTrafficManagerProfile(),
 	}
-	
+
 	if !features.ThreePointOhBeta() {
 		out["azurerm_traffic_manager_endpoint"] = resourceArmTrafficManagerEndpoint()
 	}

--- a/internal/services/trafficmanager/registration.go
+++ b/internal/services/trafficmanager/registration.go
@@ -1,6 +1,7 @@
 package trafficmanager
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -35,11 +36,16 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	out := map[string]*pluginsdk.Resource{
 		"azurerm_traffic_manager_azure_endpoint":    resourceAzureEndpoint(),
 		"azurerm_traffic_manager_external_endpoint": resourceExternalEndpoint(),
 		"azurerm_traffic_manager_nested_endpoint":   resourceNestedEndpoint(),
-		"azurerm_traffic_manager_endpoint":          resourceArmTrafficManagerEndpoint(),
 		"azurerm_traffic_manager_profile":           resourceArmTrafficManagerProfile(),
 	}
+	
+	if !features.ThreePointOhBeta() {
+		out["azurerm_traffic_manager_endpoint"] = resourceArmTrafficManagerEndpoint()
+	}
+
+	return out
 }

--- a/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
@@ -28,7 +28,7 @@ func resourceArmTrafficManagerEndpoint() *pluginsdk.Resource {
 		Read:   resourceArmTrafficManagerEndpointRead,
 		Update: resourceArmTrafficManagerEndpointCreateUpdate,
 		Delete: resourceArmTrafficManagerEndpointDelete,
-		// TODO: replace this with an importer which validates the ID during import
+
 		Importer: pluginsdk.DefaultImporter(),
 
 		DeprecationMessage: "The resource 'azurerm_traffic_manager_endpoint' has been deprecated in favour of 'azurerm_traffic_manager_azure_endpoint', 'azurerm_traffic_manager_external_endpoint', and 'azurerm_traffic_manager_nested_endpoint' and will be removed in version 3.0 of the Azure Provider.",

--- a/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -29,7 +31,9 @@ func resourceArmTrafficManagerEndpoint() *pluginsdk.Resource {
 		Update: resourceArmTrafficManagerEndpointCreateUpdate,
 		Delete: resourceArmTrafficManagerEndpointDelete,
 
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		DeprecationMessage: "The resource 'azurerm_traffic_manager_endpoint' has been deprecated in favour of 'azurerm_traffic_manager_azure_endpoint', 'azurerm_traffic_manager_external_endpoint', and 'azurerm_traffic_manager_nested_endpoint' and will be removed in version 3.0 of the Azure Provider.",
 

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -29,8 +29,11 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 		Read:   resourceArmTrafficManagerProfileRead,
 		Update: resourceArmTrafficManagerProfileUpdate,
 		Delete: resourceArmTrafficManagerProfileDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := profiles.ParseTrafficManagerProfileID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
@@ -25,8 +25,11 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 		Read:   resourceAppServiceSlotVirtualNetworkSwiftConnectionRead,
 		Update: resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate,
 		Delete: resourceAppServiceSlotVirtualNetworkSwiftConnectionDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.SlotVirtualNetworkSwiftConnectionID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource.go
@@ -24,8 +24,11 @@ func resourceAppServiceVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 		Read:   resourceAppServiceVirtualNetworkSwiftConnectionRead,
 		Update: resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate,
 		Delete: resourceAppServiceVirtualNetworkSwiftConnectionDelete,
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.VirtualNetworkSwiftConnectionID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -12,17 +12,6 @@ type IDValidationFunc func(id string) error
 
 type ImporterFunc = func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error)
 
-// DefaultImporter is a wrapper around the default importer within the Plugin SDK
-// at this point resources should be using ImporterValidatingResourceId, but this
-// is providing a compatibility shim for the moment
-func DefaultImporter() *schema.ResourceImporter {
-	// NOTE: we should do a secondary sweep and move things _off_ of this, since all resources
-	// should be validating the Resource ID at import time at this point forwards
-	return &schema.ResourceImporter{
-		StateContext: schema.ImportStatePassthroughContext,
-	}
-}
-
 // ImporterValidatingResourceId validates the ID provided at import time is valid
 // using the validateFunc.
 func ImporterValidatingResourceId(validateFunc IDValidationFunc) *schema.ResourceImporter {

--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -502,6 +502,12 @@ The deprecated block `eventhub_endpoint` will be removed in favour of the `event
 
 The deprecated block `hybrid_connection_endpoint` will be removed in favour of the `hybrid_connection_endpoint_id` property.
 
+### Resource: `azurerm_eventhub_namespace_customer_managed_key`
+
+Deleting this resource will become a non-operation as it's not possible to remove a Customer Managed Key from the Namespace without deleting the Namespace, which involves deleting all items nested within it.
+
+In order to remove the Customer Managed Key - in 3.0 the EventHub Namespace resource will need to be recreated in order to remove the Customer Managed Key.
+
 ### Resource: `azurerm_eventhub_namespace_disaster_recovery_config`
 
 The deprecated field `alternate_name` will be removed since any DRC created with an alternate cannot be deleted.

--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Customer Managed Key for a EventHub Namespace.
 
+!> **Note:** In 2.x versions of the Azure Provider during deletion this resource will **delete and recreate the parent EventHub Namespace which may involve data loss** as it's not possible to remove the Customer Managed Key from the EventHub Namespace once it's been added. Version 3.0 of the Azure Provider will change this so that the Delete operation is a noop, requiring the parent EventHub Namespace is deleted/recreated to remove the Customer Managed Key.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
This PR introduces ID Validators to all (non-deprecated) resources - in addition:

1. `azurerm_eventhub_namespace_customer_managed_key` - this makes the Delete operation a noop in 3.0 to avoid unexpected deletion/recreation of the EventHub Namespace.
2. `azurerm_kusto_database_principal` - conditionally removes this deprecated resource in 3.0
3. `azurerm_traffic_manager_endpoint` - conditionally removes this deprecated resource in 3.0

There's a handful resources which aren't using Custom Importers, which will either be split (`azurerm_security_center_server_vulnerability_assessment`) or require an ID Parser (which is outside the scope of this PR)
