### PR TITLE
Fix forces replacement on empty array

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -1660,14 +1660,14 @@ func flattenContainerGroupDnsConfig(input *containerinstance.DNSConfiguration) [
 	// We're converting to TypeSet here from an API response that looks like "a b c" (assumes space delimited)
 	var searchDomains []string
 	if input.SearchDomains != nil {
-		searchDomains = strings.Split(*input.SearchDomains, " ")
+		searchDomains = strings.Fields(*input.SearchDomains)
 	}
 	output["search_domains"] = searchDomains
 
 	// We're converting to TypeSet here from an API response that looks like "a b c" (assumes space delimited)
 	var options []string
 	if input.Options != nil {
-		options = strings.Split(*input.Options, " ")
+		options = strings.Fields(*input.Options)
 	}
 	output["options"] = options
 

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -1370,7 +1370,7 @@ resource "azurerm_container_group" "test" {
   }
 
   dns_config {
-    nameservers    = ["reddog.microsoft.com", "somecompany.somedomain"]
+    nameservers = ["reddog.microsoft.com", "somecompany.somedomain"]
   }
 
   identity {

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -1220,7 +1220,7 @@ resource "azurerm_container_group" "test" {
   }
   dns_config {
     nameservers    = ["reddog.microsoft.com", "somecompany.somedomain"]
-    options        = ["one:option", "two:option", "red:option", "blue:option"]
+    options        = null
     search_domains = ["default.svc.cluster.local."]
   }
 
@@ -1371,7 +1371,7 @@ resource "azurerm_container_group" "test" {
 
   dns_config {
     nameservers    = ["reddog.microsoft.com", "somecompany.somedomain"]
-    options        = ["one:option", "two:option", "red:option", "blue:option"]
+    options        = null
     search_domains = ["default.svc.cluster.local."]
   }
 

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -1220,7 +1220,7 @@ resource "azurerm_container_group" "test" {
   }
   dns_config {
     nameservers    = ["reddog.microsoft.com", "somecompany.somedomain"]
-    options        = null
+    options        = ["one:option", "two:option", "red:option", "blue:option"]
     search_domains = ["default.svc.cluster.local."]
   }
 
@@ -1371,8 +1371,6 @@ resource "azurerm_container_group" "test" {
 
   dns_config {
     nameservers    = ["reddog.microsoft.com", "somecompany.somedomain"]
-    options        = null
-    search_domains = ["default.svc.cluster.local."]
   }
 
   identity {


### PR DESCRIPTION
Trying to fix the issue #11544 
This is my first commit in go language, feel free to discuss and explain any newbie errors.

We have an inconsistent plan (force replacement) on the "azurerm_container_group" resource when options or search_domains is not set (null or []).
Azure api return list as "a b c" format, when options or search_domains is empty, with the Split function the array is not empty, using the Fields function i have a true empty array and an consistent plan (tested through local build and dev_overrides).

Sébastien