### PR TITLE
Enchancement-Make policy assignment `parameters` updatable

### DIFF
--- a/internal/services/policy/assignment_base_resource.go
+++ b/internal/services/policy/assignment_base_resource.go
@@ -358,7 +358,6 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 		"parameters": {
 			Type:             pluginsdk.TypeString,
 			Optional:         true,
-			ForceNew:         true,
 			ValidateFunc:     validation.StringIsJSON,
 			DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
 		},

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) Specifies a list of Resource Scopes (for example a Subscription, or a Resource Group) within this Management Group which are excluded from this Policy.
 
-* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy. Changing this forces a new Management Group Policy Assignment to be created.
+* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
 ---
 

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) Specifies a list of Resource Scopes (for example a Subscription, or a Resource Group) within this Management Group which are excluded from this Policy.
 
-* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy. Changing this forces a new Management Group Policy Assignment to be created.
+* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
 ---
 

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) Specifies a list of Resource Scopes (for example a Subscription, or a Resource Group) within this Management Group which are excluded from this Policy.
 
-* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy. Changing this forces a new Management Group Policy Assignment to be created.
+* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
 ---
 

--- a/website/docs/r/subscription_policy_assignment.html.markdown
+++ b/website/docs/r/subscription_policy_assignment.html.markdown
@@ -38,7 +38,7 @@ POLICY_RULE
 resource "azurerm_subscription_policy_assignment" "example" {
   name                 = "example"
   policy_definition_id = azurerm_policy_definition.example.id
-  subscription_id      = azurerm_subscription.current.id
+  subscription_id      = data.azurerm_subscription.current.id
 }
 ```
 
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) Specifies a list of Resource Scopes (for example a Subscription, or a Resource Group) within this Management Group which are excluded from this Policy.
 
-* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy. Changing this forces a new Management Group Policy Assignment to be created.
+* `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
 ---
 


### PR DESCRIPTION
As #15444 described, the `parameters` is updatable according to the `updateFunc` function in [`assignment_base_resource.go`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/policy/assignment_base_resource.go#L266).

Affected resources: 
* `azurerm_management_group_policy_assignment`
* `azurerm_resource_policy_assignment`
* `azurerm_resource_group_policy_assignment`
* `azurerm_subscription_policy_assignment`

This patch will make `parameters` in those four resources updatable. As for `location` and `policy_definition_id`, though we can see the relevant update code in `updateFunc` function in `assignment_base_resource.go`, but after the test I found that if we update these two fields the API would return 400 errors so I just leave them untouched.

And I think there is an error in [website/docs/r/subscription_policy_assignment.html.markdown](https://github.com/hashicorp/terraform-provider-azurerm/compare/main...lonegunmanb:f-15444?expand=1#diff-23c65b534a18448562e298e38c20945599e3d9fc82eacfbef5964ce7a2f475d4) and I correct it.

The affected resources' ACC tests:

=== RUN   TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicy
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicy
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicy
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicy (769.60s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (774.46s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySet (662.92s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (769.97s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithCustomPolicy
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithCustomPolicy
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithCustomPolicy
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicy (732.00s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyRequiresImport (494.49s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyComplete
=== PAUSE TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyComplete
=== CONT  TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyComplete
--- PASS: TestAccManagementGroupPolicyAssignment_basicWithCustomPolicyComplete (838.84s)
=== RUN   TestAccManagementGroupPolicyAssignment_basicComplexWithCustomPolicy
=== PAUSE TestAccManagementGroupPolicyAssignment_basicComplexWithCustomPolicy
=== CONT  TestAccManagementGroupPolicyAssignment_basicComplexWithCustomPolicy
--- PASS: TestAccManagementGroupPolicyAssignment_basicComplexWithCustomPolicy (830.61s)
PASS

=== RUN   TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicy
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicy
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicy
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicy (821.94s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (817.76s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySet (711.87s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (817.62s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithCustomPolicy
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithCustomPolicy
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithCustomPolicy
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicy (799.07s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyRequiresImport
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyRequiresImport (528.54s)
=== RUN   TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyComplete
=== PAUSE TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyComplete
=== CONT  TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyComplete
--- PASS: TestAccResourceGroupPolicyAssignment_basicWithCustomPolicyComplete (880.36s)
PASS

=== RUN   TestAccResourcePolicyAssignment_basicWithBuiltInPolicy
=== PAUSE TestAccResourcePolicyAssignment_basicWithBuiltInPolicy
=== CONT  TestAccResourcePolicyAssignment_basicWithBuiltInPolicy
--- PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicy (915.82s)
=== RUN   TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== PAUSE TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== CONT  TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
--- PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (921.93s)
=== RUN   TestAccResourcePolicyAssignment_basicWithBuiltInPolicySet
=== PAUSE TestAccResourcePolicyAssignment_basicWithBuiltInPolicySet
=== CONT  TestAccResourcePolicyAssignment_basicWithBuiltInPolicySet
--- PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicySet (749.21s)
=== RUN   TestAccResourcePolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== PAUSE TestAccResourcePolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== CONT  TestAccResourcePolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
--- PASS: TestAccResourcePolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (908.50s)
=== RUN   TestAccResourcePolicyAssignment_basicWithCustomPolicy
=== PAUSE TestAccResourcePolicyAssignment_basicWithCustomPolicy
=== CONT  TestAccResourcePolicyAssignment_basicWithCustomPolicy
--- PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicy (857.52s)
=== RUN   TestAccResourcePolicyAssignment_basicWithCustomPolicyRequiresImport
=== PAUSE TestAccResourcePolicyAssignment_basicWithCustomPolicyRequiresImport
=== CONT  TestAccResourcePolicyAssignment_basicWithCustomPolicyRequiresImport
--- PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicyRequiresImport (549.64s)
=== RUN   TestAccResourcePolicyAssignment_basicWithCustomPolicyComplete
=== PAUSE TestAccResourcePolicyAssignment_basicWithCustomPolicyComplete
=== CONT  TestAccResourcePolicyAssignment_basicWithCustomPolicyComplete
--- PASS: TestAccResourcePolicyAssignment_basicWithCustomPolicyComplete (960.19s)
PASS

=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy (746.57s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (736.78s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet (623.08s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (746.93s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy (690.68s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete (801.01s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport (460.64s)
PASS
