### PR TITLE
Support enabled property for azurerm_mssql_database_extended_auditing_policy and azurerm_mssql_server_extended_auditing_policy resources

### DIFF
--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -74,6 +74,16 @@ func resourceMsSqlDatabaseExtendedAuditingPolicy() *pluginsdk.Resource {
 				Optional: true,
 				Default:  true,
 			},
+
+			"state": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(sql.BlobAuditingPolicyStateEnabled),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(sql.BlobAuditingPolicyStateEnabled),
+					string(sql.BlobAuditingPolicyStateDisabled),
+				}, false),
+			},
 		},
 	}
 }
@@ -106,7 +116,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resour
 
 	params := sql.ExtendedDatabaseBlobAuditingPolicy{
 		ExtendedDatabaseBlobAuditingPolicyProperties: &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
-			State:                       sql.BlobAuditingPolicyStateEnabled,
+			State:                       sql.BlobAuditingPolicyState(d.Get("state").(string)),
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
@@ -168,6 +178,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyRead(d *pluginsdk.ResourceData, 
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
 		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
+		d.Set("state", props.State)
 	}
 
 	return nil

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -43,6 +43,12 @@ func resourceMsSqlDatabaseExtendedAuditingPolicy() *pluginsdk.Resource {
 				ValidateFunc: validate.DatabaseID,
 			},
 
+			"enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"storage_endpoint": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -73,16 +79,6 @@ func resourceMsSqlDatabaseExtendedAuditingPolicy() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
-			},
-
-			"state": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(sql.BlobAuditingPolicyStateEnabled),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(sql.BlobAuditingPolicyStateEnabled),
-					string(sql.BlobAuditingPolicyStateDisabled),
-				}, false),
 			},
 		},
 	}
@@ -116,12 +112,17 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resour
 
 	params := sql.ExtendedDatabaseBlobAuditingPolicy{
 		ExtendedDatabaseBlobAuditingPolicyProperties: &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
-			State:                       sql.BlobAuditingPolicyState(d.Get("state").(string)),
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
 			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
 		},
+	}
+
+	if d.Get("enabled").(bool) {
+		params.ExtendedDatabaseBlobAuditingPolicyProperties.State = sql.BlobAuditingPolicyStateEnabled
+	} else {
+		params.ExtendedDatabaseBlobAuditingPolicyProperties.State = sql.BlobAuditingPolicyStateDisabled
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
@@ -178,7 +179,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyRead(d *pluginsdk.ResourceData, 
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
 		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
-		d.Set("state", props.State)
+		d.Set("enabled", props.State == sql.BlobAuditingPolicyStateEnabled)
 	}
 
 	return nil

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -102,6 +102,13 @@ func TestAccMsSqlDatabaseExtendedAuditingPolicy_update(t *testing.T) {
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
+			Config: r.disabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -310,8 +317,44 @@ resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   storage_account_access_key              = azurerm_storage_account.test.primary_access_key
   storage_account_access_key_is_secondary = false
   retention_in_days                       = 6
+  log_monitoring_enabled                  = false
+  state                                   = "Enabled"
 }
 `, r.template(data))
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) disabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[1]d"
+  server_id = azurerm_mssql_server.test.id
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id = azurerm_mssql_database.test.id
+  state       = "Disabled"
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
 func (r MsSqlDatabaseExtendedAuditingPolicyResource) update(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -318,7 +318,7 @@ resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   storage_account_access_key_is_secondary = false
   retention_in_days                       = 6
   log_monitoring_enabled                  = false
-  state                                   = "Enabled"
+  enabled                                 = true
 }
 `, r.template(data))
 }
@@ -351,7 +351,7 @@ resource "azurerm_mssql_database" "test" {
 
 resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   database_id = azurerm_mssql_database.test.id
-  state       = "Disabled"
+  enabled     = false
 }
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -44,6 +44,12 @@ func resourceMsSqlServerExtendedAuditingPolicy() *pluginsdk.Resource {
 				ValidateFunc: validate.ServerID,
 			},
 
+			"enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"storage_endpoint": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -80,15 +86,6 @@ func resourceMsSqlServerExtendedAuditingPolicy() *pluginsdk.Resource {
 				Sensitive:    true,
 				ValidateFunc: validation.IsUUID,
 			},
-			"state": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(sql.BlobAuditingPolicyStateEnabled),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(sql.BlobAuditingPolicyStateEnabled),
-					string(sql.BlobAuditingPolicyStateDisabled),
-				}, false),
-			},
 		},
 	}
 }
@@ -122,12 +119,17 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 
 	params := sql.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
-			State:                       sql.BlobAuditingPolicyState(d.Get("state").(string)),
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
 			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
 		},
+	}
+
+	if d.Get("enabled").(bool) {
+		params.ExtendedServerBlobAuditingPolicyProperties.State = sql.BlobAuditingPolicyStateEnabled
+	} else {
+		params.ExtendedServerBlobAuditingPolicyProperties.State = sql.BlobAuditingPolicyStateDisabled
 	}
 
 	if v, ok := d.GetOk("storage_account_subscription_id"); ok {
@@ -198,7 +200,7 @@ func resourceMsSqlServerExtendedAuditingPolicyRead(d *pluginsdk.ResourceData, me
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
 		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
-		d.Set("state", props.State)
+		d.Set("enabled", props.State == sql.BlobAuditingPolicyStateEnabled)
 
 		if props.StorageAccountSubscriptionID.String() != "00000000-0000-0000-0000-000000000000" {
 			d.Set("storage_account_subscription_id", props.StorageAccountSubscriptionID.String())

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -80,6 +80,15 @@ func resourceMsSqlServerExtendedAuditingPolicy() *pluginsdk.Resource {
 				Sensitive:    true,
 				ValidateFunc: validation.IsUUID,
 			},
+			"state": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(sql.BlobAuditingPolicyStateEnabled),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(sql.BlobAuditingPolicyStateEnabled),
+					string(sql.BlobAuditingPolicyStateDisabled),
+				}, false),
+			},
 		},
 	}
 }
@@ -113,7 +122,7 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 
 	params := sql.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
-			State:                       sql.BlobAuditingPolicyStateEnabled,
+			State:                       sql.BlobAuditingPolicyState(d.Get("state").(string)),
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
@@ -189,6 +198,7 @@ func resourceMsSqlServerExtendedAuditingPolicyRead(d *pluginsdk.ResourceData, me
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
 		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
+		d.Set("state", props.State)
 
 		if props.StorageAccountSubscriptionID.String() != "00000000-0000-0000-0000-000000000000" {
 			d.Set("storage_account_subscription_id", props.StorageAccountSubscriptionID.String())

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
@@ -80,6 +80,13 @@ func TestAccMsSqlServerExtendedAuditingPolicy_update(t *testing.T) {
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
+			Config: r.disabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -186,8 +193,39 @@ resource "azurerm_mssql_server_extended_auditing_policy" "test" {
   storage_account_access_key              = azurerm_storage_account.test.primary_access_key
   storage_account_access_key_is_secondary = false
   retention_in_days                       = 6
+  log_monitoring_enabled                  = false
+  state                                   = "Enabled"
 }
 `, r.template(data))
+}
+
+func (r MsSqlServerExtendedAuditingPolicyResource) disabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id = azurerm_mssql_server.test.id
+  state     = "Disabled"
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (r MsSqlServerExtendedAuditingPolicyResource) update(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
@@ -194,7 +194,7 @@ resource "azurerm_mssql_server_extended_auditing_policy" "test" {
   storage_account_access_key_is_secondary = false
   retention_in_days                       = 6
   log_monitoring_enabled                  = false
-  state                                   = "Enabled"
+  enabled                                 = true
 }
 `, r.template(data))
 }
@@ -222,7 +222,7 @@ resource "azurerm_mssql_server" "test" {
 
 resource "azurerm_mssql_server_extended_auditing_policy" "test" {
   server_id = azurerm_mssql_server.test.id
-  state     = "Disabled"
+  enabled   = false
 }
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -61,6 +61,10 @@ The following arguments are supported:
 
 * `database_id` - (Required) The ID of the sql database to set the extended auditing policy. Changing this forces a new resource to be created.
 
+* `state` - (Required) The state of the extended auditing policy. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+
+->**NOTE:**  If `state` is Enabled, `storage_endpoint` or `log_monitoring_enabled` are required.
+
 * `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 
 * `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -61,9 +61,9 @@ The following arguments are supported:
 
 * `database_id` - (Required) The ID of the sql database to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `state` - (Required) The state of the extended auditing policy. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+* `enabled` - (Required) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
 
-->**NOTE:**  If `state` is Enabled, `storage_endpoint` or `log_monitoring_enabled` are required.
+->**NOTE:**  If `enabled` is `true`, `storage_endpoint` or `log_monitoring_enabled` are required.
 
 * `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -162,6 +162,10 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the sql server to set the extended auditing policy. Changing this forces a new resource to be created.
 
+* `state` - (Required) The state of the extended auditing policy. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+
+->**NOTE:**  If `state` is Enabled, `storage_endpoint` or `log_monitoring_enabled` are required.
+
 * `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 
 * `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -162,9 +162,9 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the sql server to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `state` - (Required) The state of the extended auditing policy. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+* `enabled` - (Required) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
 
-->**NOTE:**  If `state` is Enabled, `storage_endpoint` or `log_monitoring_enabled` are required.
+->**NOTE:**  If `enabled` is `true`, `storage_endpoint` or `log_monitoring_enabled` are required.
 
 * `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 


### PR DESCRIPTION
The purpose of this PR:

> Currently, the [`state` ](https://github.com/Azure/azure-rest-api-specs/blob/4442d8de32ba14a9126cdadd8538da9d4539ff5e/specification/sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/BlobAuditing.json#L646) that actually controls whether auditing is in effect  is not exposed in terraform. Although we can disable the auditing by destroying the extended auditing policy resource. However, when the auditing is disabled outside of terraform (e.g. through the Azure portal), terraform could not detect a change in `state` because the state changed from `Enabled` to `Disabled`, but the `isAzureMonitorTargetEnabled` ( map `log_monitoring_enabled` in terraform )does not change. Also, cx could not re-enabled it via terraform.  So, to expose the `enabled` to resolve the Issue [#14859](https://github.com/hashicorp/terraform-provider-azurerm/issues/14859).


Test Results(the error of the failed test case is the same as before modification):

>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_complete (474.01s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_requiresImport (501.75s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall (509.90s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_basic (708.83s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall (509.90s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_basic (708.83s)
>  PASS: TestAccMsSqlServerExtendedAuditingPolicy_update (910.25s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall (582.49s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_update (818.62s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_complete (462.83s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_basic (467.07s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_requiresImport (474.98s)
>  PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_logAnalytics (776.28s
>  
>  Fail: TestAccMsSqlDatabaseExtendedAuditingPolicy_primaryWithOnlineSecondary

