### PR TITLE
Wait LRO for automation resources

### DIFF
--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
@@ -110,8 +110,12 @@ func resourceAutomationDscNodeConfigurationCreateUpdate(d *pluginsdk.ResourceDat
 		Name: utils.String(id.Name),
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name, parameters); err != nil {
-		return err
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name, parameters)
+	if err != nil {
+		return fmt.Errorf("creating/updating %q: %+v", id, err)
+	}
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update for %q: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/automation/automation_runbook_resource.go
+++ b/internal/services/automation/automation_runbook_resource.go
@@ -204,12 +204,21 @@ func resourceAutomationRunbookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 		reader := io.NopCloser(bytes.NewBufferString(content))
 		draftClient := meta.(*clients.Client).Automation.RunbookDraftClient
 
-		if _, err := draftClient.ReplaceContent(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name, reader); err != nil {
+		_, err := draftClient.ReplaceContent(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name, reader)
+		if err != nil {
 			return fmt.Errorf("setting the draft for %s: %+v", id, err)
 		}
+		// Uncomment below once https://github.com/Azure/azure-sdk-for-go/issues/17196 is resolved.
+		// if err := f1.WaitForCompletionRef(ctx, draftClient.Client); err != nil {
+		// 	return fmt.Errorf("waiting for set the draft for %s: %+v", id, err)
+		// }
 
-		if _, err := client.Publish(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name); err != nil {
+		f2, err := client.Publish(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
+		if err != nil {
 			return fmt.Errorf("publishing the updated %s: %+v", id, err)
+		}
+		if err := f2.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("waiting for publish the updated %s: %+v", id, err)
 		}
 	}
 


### PR DESCRIPTION
The change in *automation_dsc_nodeconfiguration_resource.go* is not tested due to: https://github.com/Azure/azure-rest-api-specs/issues/17932

Linked to #15641