### PR TITLE
`azurerm_signalr_service` Fix #15626 by adding nil check.

### DIFF
--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -73,11 +73,26 @@ func resourceArmSignalRServiceCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	sku := d.Get("sku").([]interface{})
-	featureFlags := d.Get("features").(*pluginsdk.Set).List()
-	connectivityLogsEnabled := d.Get("connectivity_logs_enabled").(bool)
-	messagingLogsEnabled := d.Get("messaging_logs_enabled").(bool)
-	liveTraceEnabled := d.Get("live_trace_enabled").(bool)
-	serviceMode := d.Get("service_mode").(string)
+	var featureFlags []interface{}
+	if d.Get("features") != nil {
+		featureFlags = d.Get("features").(*pluginsdk.Set).List()
+	}
+	connectivityLogsEnabled := false
+	if d.Get("connectivity_logs_enabled") != nil {
+		connectivityLogsEnabled = d.Get("connectivity_logs_enabled").(bool)
+	}
+	messagingLogsEnabled := false
+	if d.Get("messaging_logs_enabled") != nil {
+		messagingLogsEnabled = d.Get("messaging_logs_enabled").(bool)
+	}
+	liveTraceEnabled := false
+	if d.Get("live_trace_enabled") != nil {
+		liveTraceEnabled = d.Get("live_trace_enabled").(bool)
+	}
+	serviceMode := "Default"
+	if d.Get("service_mode") != nil {
+		serviceMode = d.Get("service_mode").(string)
+	}
 
 	cors := d.Get("cors").([]interface{})
 	upstreamSettings := d.Get("upstream_endpoint").(*pluginsdk.Set).List()
@@ -234,29 +249,44 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		if d.HasChange("features") {
-			featuresRaw := d.Get("features").(*pluginsdk.Set).List()
+			var featuresRaw []interface{}
+			if d.Get("features") != nil {
+				featuresRaw = d.Get("features").(*pluginsdk.Set).List()
+			}
 			resourceType.Properties.Features = expandSignalRFeatures(featuresRaw)
 		}
 
 		if d.HasChanges("connectivity_logs_enabled", "messaging_logs_enabled", "service_mode", "live_trace_enabled") {
 			features := make([]signalr.SignalRFeature, 0)
 			if d.HasChange("connectivity_logs_enabled") {
-				connectivityLogsEnabled := d.Get("connectivity_logs_enabled").(bool)
+				connectivityLogsEnabled := false
+				if d.Get("connectivity_logs_enabled") != nil {
+					connectivityLogsEnabled = d.Get("connectivity_logs_enabled").(bool)
+				}
 				features = append(features, signalRFeature(signalr.FeatureFlagsEnableConnectivityLogs, strconv.FormatBool(connectivityLogsEnabled)))
 			}
 
 			if d.HasChange("messaging_logs_enabled") {
-				messagingLogsEnabled := d.Get("messaging_logs_enabled").(bool)
+				messagingLogsEnabled := false
+				if d.Get("messaging_logs_enabled") != nil {
+					messagingLogsEnabled = d.Get("messaging_logs_enabled").(bool)
+				}
 				features = append(features, signalRFeature(signalr.FeatureFlagsEnableMessagingLogs, strconv.FormatBool(messagingLogsEnabled)))
 			}
 
 			if d.HasChange("live_trace_enabled") {
-				liveTraceEnabled := d.Get("live_trace_enabled").(bool)
+				liveTraceEnabled := false
+				if d.Get("live_trace_enabled") != nil {
+					liveTraceEnabled = d.Get("live_trace_enabled").(bool)
+				}
 				features = append(features, signalRFeature("EnableLiveTrace", strconv.FormatBool(liveTraceEnabled)))
 			}
 
 			if d.HasChange("service_mode") {
-				serviceMode := d.Get("service_mode").(string)
+				serviceMode := "Default"
+				if d.Get("service_mode") != nil {
+					serviceMode = d.Get("service_mode").(string)
+				}
 				features = append(features, signalRFeature(signalr.FeatureFlagsServiceMode, serviceMode))
 			}
 			resourceType.Properties.Features = &features

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -63,13 +63,13 @@ The following arguments are supported:
 
 ~> **NOTE:** The `features` block is deprecated, use `connectivity_logs_enabled`, `messaging_logs_enabled`, `live_trace_enabled` and `service_mode` instead.
 
-* `connectivity_logs_enabled`- (Optional) Specifies if Connectivity Logs are enabled or not.
+* `connectivity_logs_enabled`- (Optional) Specifies if Connectivity Logs are enabled or not. Defaults to `false`.
 
-* `messaging_logs_enabled`- (Optional) Specifies if Messaging Logs are enabled or not. 
+* `messaging_logs_enabled`- (Optional) Specifies if Messaging Logs are enabled or not. Defaults to `false`.
 
-* `live_trace_enabled`- (Optional) Specifies if Live Trace is enabled or not.
+* `live_trace_enabled`- (Optional) Specifies if Live Trace is enabled or not. Defaults to `false`.
 
-* `service_mode`- (Optional) Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`.
+* `service_mode`- (Optional) Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`. Defaults to `Default`.
 
 * `upstream_endpoint` - (Optional) An `upstream_endpoint` block as documented below. Using this block requires the SignalR service to be Serverless. When creating multiple blocks they will be processed in the order they are defined in.
 


### PR DESCRIPTION
Fix #15626 by adding nil check. According to the origin [read function](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/signalr/signalr_service_resource.go#L169), the `connectivity_logs_enabled`/`messaging_logs_enabled`/`live_trace_enabled` default values should be `false`, and the `service_mode` default value should be `Default`. As they are all `computed` arguments so we cannot declare default value on the schema, this patch implement these default values in crud functions.