### PR TITLE
Correct argument reference

### DIFF
--- a/website/docs/r/proximity_placement_group.html.markdown
+++ b/website/docs/r/proximity_placement_group.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_proximity_placement_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the availability set. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the proximity placement group. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the availability set. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR corrects a typo in the docs:

Availability set -> proximity placement group