### PR TITLE
`azurerm_backup_protected_vm`: Make `source_vm_id` case-insensitive

### DIFF
--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -55,6 +56,8 @@ func resourceRecoveryServicesBackupProtectedVM() *pluginsdk.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
+				// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/10357
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"backup_policy_id": {


### PR DESCRIPTION
Fix #15635
While waiting for a fix on API side, making this case-insensitive to avoid the diff