### PR TITLE
Remove potentially destructive setting in example

### DIFF
--- a/website/docs/r/resource_group_template_deployment.html.markdown
+++ b/website/docs/r/resource_group_template_deployment.html.markdown
@@ -22,7 +22,7 @@ locals {
 resource "azurerm_resource_group_template_deployment" "example" {
   name                = "example-deploy"
   resource_group_name = "example-group"
-  deployment_mode     = "Complete"
+  deployment_mode     = "Incremental"
   parameters_content = jsonencode({
     "vnetName" = {
       value = local.vnet_name


### PR DESCRIPTION
While the implications of setting `deployment_mode = "Complete"` is documented below, it unexpected behavior in terraform that the deployment of a resource deletes unrelated resources.

Therefore, I changed the example given for this resource to remove the potentially destructive setting.