### PR TITLE
Set key vault id on key import issue #12357

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -36,10 +36,10 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 		Update: resourceKeyVaultKeyUpdate,
 		Delete: resourceKeyVaultKeyDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := parse.ParseNestedItemID(id)
 			return err
-		}),
+		}, nestedItemResourceImporter),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),


### PR DESCRIPTION
Use the nested importer i the same manner as for certificates and secrets, which sets the key vault id.

Tested import of key created via console and import of key previously created through Terraform. Both imported successfully and Terraform did not attempt to recreate (though it did 'update' the console created key because of the different order of the key_opts but that is another matter common to many resource sets).

I don't believe any further documentation or test files need updating.