### PR TITLE
Bug Fix: azurerm_batch_job - Fix failure to create azurerm_batch_job with multiple properties in common_environment_properties

### DIFF
--- a/internal/services/batch/batch_job_resource.go
+++ b/internal/services/batch/batch_job_resource.go
@@ -294,8 +294,8 @@ func (r BatchJobResource) expandEnvironmentSettings(input map[string]string) *[]
 	m := make([]batchDataplane.EnvironmentSetting, 0, len(input))
 	for k, v := range input {
 		m = append(m, batchDataplane.EnvironmentSetting{
-			Name:  &k,
-			Value: &v,
+			Name:  utils.String(k),
+			Value: utils.String(v),
 		})
 	}
 	return &m

--- a/internal/services/batch/batch_job_resource_test.go
+++ b/internal/services/batch/batch_job_resource_test.go
@@ -133,7 +133,8 @@ resource "azurerm_batch_job" "test" {
   batch_pool_id = azurerm_batch_pool.test.id
   display_name  = "testaccbj-display-%[2]d"
   common_environment_properties = {
-    env = "Test"
+    env       = "Test"
+    terraform = "true"
   }
   priority           = 1
   task_retry_maximum = 1


### PR DESCRIPTION
Since a for loop in golang always uses the same memory to receive the value of variable in the loop, the `common_environment_properties` is set to the same value(the value of last loop) when multiple properties are configured in it. Replace with `utils.String` to get a new temporary variable, then set the value to resolve issue [#15647](https://github.com/hashicorp/terraform-provider-azurerm/issues/15647). 


