### PR TITLE
Address panic in azurerm_virtual_network_gateway

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -646,7 +646,10 @@ func expandVirtualNetworkGatewayBgpSettings(id parse.VirtualNetworkGatewayId, d 
 	bgp := bgpSets[0].(map[string]interface{})
 
 	asn := int64(bgp["asn"].(int))
-	peeringAddress := bgp["peering_address"].(string)
+	var peeringAddress string
+	if !features.ThreePointOhBeta() {
+		peeringAddress = bgp["peering_address"].(string)
+	}
 	peerWeight := int32(bgp["peer_weight"].(int))
 
 	ipConfiguration := d.Get("ip_configuration").([]interface{})
@@ -849,7 +852,7 @@ func flattenVirtualNetworkGatewayBgpSettings(settings *network.BgpSettings) ([]i
 		if asn := settings.Asn; asn != nil {
 			flat["asn"] = int(*asn)
 		}
-		if address := settings.BgpPeeringAddress; address != nil {
+		if address := settings.BgpPeeringAddress; !features.ThreePointOhBeta() && address != nil {
 			flat["peering_address"] = *address
 		}
 		if weight := settings.PeerWeight; weight != nil {


### PR DESCRIPTION
Fixes the following:

```
------- Stderr: -------
panic: interface conversion: interface {} is nil, not string
goroutine 447 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/network.expandVirtualNetworkGatewayBgpSettings({{0xc000052254, 0x24}, {0xc0022b7240, 0x20}, {0xc0022b7120, 0x1d}}, 0x61aba0f)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/internal/services/network/virtual_network_gateway_resource.go:649 +0x3da
github.com/hashicorp/terraform-provider-azurerm/internal/services/network.getVirtualNetworkGatewayProperties({{0xc000052254, 0x24}, {0xc0022b7240, 0x20}, {0xc0022b7120, 0x1d}}, 0x6fc23ac00)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/internal/services/network/virtual_network_gateway_resource.go:602 +0x534
....
```
