### PR TITLE
azurerm_api_management_api_operation_policy.operation_id validation too restrictive

### DIFF
--- a/internal/services/apimanagement/validate/api_management.go
+++ b/internal/services/apimanagement/validate/api_management.go
@@ -10,7 +10,7 @@ func ApiManagementChildName(v interface{}, k string) (warnings []string, errors 
 	value := v.(string)
 
 	// from the portal: `The field may contain only numbers, letters, and dash (-) sign when preceded and followed by number or a letter.`
-	if matched := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,78}[a-zA-Z0-9])?$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-_]{0,78}[a-zA-Z0-9])?$`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes up to 80 characters in length", k))
 	}
 

--- a/internal/services/apimanagement/validate/api_management.go
+++ b/internal/services/apimanagement/validate/api_management.go
@@ -9,9 +9,9 @@ import (
 func ApiManagementChildName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	// from the portal: `The field may contain only numbers, letters, and dash (-) sign when preceded and followed by number or a letter.`
+	// from the portal: `The field may contain only numbers, letters, underscore (-), and dash (-) sign when preceded and followed by number or a letter.`
 	if matched := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-_]{0,78}[a-zA-Z0-9])?$`).Match([]byte(value)); !matched {
-		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes up to 80 characters in length", k))
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, underscores and dashes up to 80 characters in length", k))
 	}
 
 	return warnings, errors

--- a/internal/services/apimanagement/validate/api_management_test.go
+++ b/internal/services/apimanagement/validate/api_management_test.go
@@ -223,7 +223,7 @@ func TestApiManagementChildName(t *testing.T) {
 		{
 			name:  "v_1",
 			input: "v_1",
-			valid: false,
+			valid: true,
 		},
 		{
 			name:  "v.1",
@@ -238,6 +238,16 @@ func TestApiManagementChildName(t *testing.T) {
 		{
 			name:  "-v1",
 			input: "-v1",
+			valid: false,
+		},
+		{
+			name:  "v1_",
+			input: "v1_",
+			valid: false,
+		},
+		{
+			name:  "_v1",
+			input: "_v1",
 			valid: false,
 		},
 	}


### PR DESCRIPTION
Fixes #15417 and fixes #15620