### PR TITLE
`azurerm_lb_nat_rule` - `frontend_port` and `backend_port` now support `0`

### DIFF
--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -76,13 +76,13 @@ func resourceArmLoadBalancerNatRule() *pluginsdk.Resource {
 			"frontend_port": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validate.PortNumber,
+				ValidateFunc: validate.PortNumberOrZero,
 			},
 
 			"backend_port": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validate.PortNumber,
+				ValidateFunc: validate.PortNumberOrZero,
 			},
 
 			"frontend_ip_configuration_name": {

--- a/website/docs/r/lb_nat_rule.html.markdown
+++ b/website/docs/r/lb_nat_rule.html.markdown
@@ -60,8 +60,8 @@ The following arguments are supported:
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the NAT Rule.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp`, `Tcp` or `All`.
-* `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 1 and 65534, inclusive.
-* `backend_port` - (Required) The port used for internal connections on the endpoint. Possible values range between 1 and 65535, inclusive.
+* `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 0 and 65534, inclusive.
+* `backend_port` - (Required) The port used for internal connections on the endpoint. Possible values range between 0 and 65535, inclusive.
 * `idle_timeout_in_minutes` - (Optional) Specifies the idle timeout in minutes for TCP connections. Valid values are between `4` and `30` minutes. Defaults to `4` minutes.
 * `enable_floating_ip` - (Optional) Are the Floating IPs enabled for this Load Balancer Rule? A "floating” IP is reassigned to a secondary server in case the primary server fails. Required to configure a SQL AlwaysOn Availability Group. Defaults to `false`.
 * `enable_tcp_reset` - (Optional) Is TCP Reset enabled for this Load Balancer Rule? Defaults to `false`.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15674

--- PASS: TestAccAzureRMLoadBalancerNatRule_complete (267.42s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_basic (272.45s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_zeroPortNumber (289.62s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_disappears (312.02s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_requiresImport (336.27s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_updateMultipleRules (413.76s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_update (474.60s)