### PR TITLE
[3.0 Beta] TODO changes for hdinsight

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -700,7 +700,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_hadoop_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -791,7 +790,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -842,7 +840,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -911,7 +908,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -982,7 +978,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1048,7 +1043,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1107,7 +1101,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     hadoop = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1168,7 +1161,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     hadoop = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1620,7 +1612,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     hadoop = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1706,7 +1697,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     hadoop = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1794,7 +1784,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     hadoop = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1856,7 +1845,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -659,7 +659,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -672,7 +672,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -802,20 +802,20 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       ssh_keys = [var.ssh_key]
     }
 
     worker_node {
-      vm_size               = "Standard_D4_v2"
+      vm_size               = "Standard_D4_V2"
       username              = "acctestusrvm"
       ssh_keys              = [var.ssh_key]
       target_instance_count = 3
     }
 
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       ssh_keys = [var.ssh_key]
     }
@@ -852,20 +852,20 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
 
     worker_node {
-      vm_size               = "Standard_D4_v2"
+      vm_size               = "Standard_D4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 5
     }
 
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -920,7 +920,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = azurerm_subnet.test.id
@@ -928,7 +928,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_D4_v2"
+      vm_size               = "Standard_D4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -937,7 +937,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = azurerm_subnet.test.id
@@ -995,7 +995,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = azurerm_subnet.test.id
@@ -1003,7 +1003,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_D4_v2"
+      vm_size               = "Standard_D4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -1012,7 +1012,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = azurerm_subnet.test.id
@@ -1055,7 +1055,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1068,7 +1068,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1112,7 +1112,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1123,7 +1123,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1177,7 +1177,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1188,7 +1188,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1622,7 +1622,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1633,7 +1633,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1707,7 +1707,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1718,7 +1718,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1794,7 +1794,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1805,7 +1805,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1857,7 +1857,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1870,7 +1870,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1907,7 +1907,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1918,7 +1918,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1950,7 +1950,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1967,7 +1967,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       }
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1999,7 +1999,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -2025,7 +2025,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       }
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -2079,7 +2079,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "sshuser"
       password           = "TerrAform123!"
       subnet_id          = azurerm_subnet.test.id

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1426,7 +1426,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1437,7 +1437,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1513,7 +1513,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1524,7 +1524,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -493,7 +493,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -544,7 +543,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -652,7 +650,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -718,7 +715,6 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_hbase_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -793,7 +789,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -844,7 +839,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -913,7 +907,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -984,7 +977,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1335,7 +1327,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1425,7 +1416,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
     hbase = "2.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1513,7 +1503,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
     hbase = "2.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1575,7 +1564,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1631,7 +1619,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1697,7 +1684,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "sshuser"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -531,7 +531,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -584,7 +583,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -757,7 +755,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_interactive_query_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -832,7 +829,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -883,7 +879,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -952,7 +947,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1023,7 +1017,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1372,7 +1365,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1426,7 +1418,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1516,7 +1507,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     interactive_hive = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1604,7 +1594,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     interactive_hive = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1666,7 +1655,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1719,7 +1707,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     interactive_hive = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1769,7 +1756,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     interactive_hive = "3.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1831,7 +1817,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "sshuser"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -484,7 +484,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -538,7 +537,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -594,7 +592,6 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_kafka_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -670,7 +667,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -722,7 +718,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -792,7 +787,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -864,7 +858,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -997,7 +990,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1088,7 +1080,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
     kafka = "2.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1177,7 +1168,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
     kafka = "2.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1240,7 +1230,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1304,7 +1293,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1369,7 +1357,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1421,7 +1408,6 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "sshuser"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1090,7 +1090,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1102,7 +1102,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
       number_of_disks_per_node = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1178,7 +1178,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1190,7 +1190,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
       number_of_disks_per_node = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }

--- a/internal/services/hdinsight/hdinsight_ml_services_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_ml_services_cluster_resource_test.go
@@ -231,7 +231,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -285,7 +284,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_ml_services_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -372,7 +370,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -426,7 +423,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -498,7 +494,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -574,7 +569,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -668,7 +662,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "test" {
   tls_min_version     = "1.2"
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_rserver_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_rserver_cluster_resource_test.go
@@ -231,7 +231,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -285,7 +284,6 @@ resource "azurerm_hdinsight_rserver_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_rserver_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -372,7 +370,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -426,7 +423,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -498,7 +494,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -574,7 +569,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -668,7 +662,6 @@ resource "azurerm_hdinsight_rserver_cluster" "test" {
   rstudio             = true
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -531,7 +531,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -584,7 +583,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -757,7 +755,6 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_spark_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -832,7 +829,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -883,7 +879,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -952,7 +947,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1023,7 +1017,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1372,7 +1365,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1426,7 +1418,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1516,7 +1507,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     spark = "2.4"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1604,7 +1594,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     spark = "2.4"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1666,7 +1655,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1719,7 +1707,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     spark = "2.4"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1769,7 +1756,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     spark = "2.4"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1831,7 +1817,6 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "sshuser"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1517,7 +1517,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1528,7 +1528,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1604,7 +1604,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1615,7 +1615,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -1846,7 +1846,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     }
 
     zookeeper_node {
-      vm_size            = "Standard_D3_v2"
+      vm_size            = "Standard_D3_V2"
       username           = "sshuser"
       password           = "TerrAform123!"
       subnet_id          = azurerm_subnet.test.id

--- a/internal/services/hdinsight/hdinsight_storm_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_storm_cluster_resource_test.go
@@ -392,7 +392,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -446,7 +445,6 @@ resource "azurerm_hdinsight_storm_cluster" "import" {
   dynamic "gateway" {
     for_each = azurerm_hdinsight_storm_cluster.test.gateway
     content {
-      enabled  = gateway.value.enabled
       password = gateway.value.password
       username = gateway.value.username
     }
@@ -521,7 +519,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -572,7 +569,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -641,7 +637,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -712,7 +707,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -802,7 +796,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -892,7 +885,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
     storm = "1.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -980,7 +972,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
     storm = "1.1"
   }
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
@@ -1042,7 +1033,6 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }

--- a/internal/services/hdinsight/hdinsight_storm_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_storm_cluster_resource_test.go
@@ -895,7 +895,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -906,7 +906,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -982,7 +982,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
   }
   roles {
     head_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
@@ -993,7 +993,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
       target_instance_count = 2
     }
     zookeeper_node {
-      vm_size  = "Standard_D3_v2"
+      vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -482,13 +482,15 @@ func FlattenHDInsightsConfigurations(input map[string]*string, d *pluginsdk.Reso
 		password = d.Get("gateway.0.password").(string)
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"enabled":  enabled,
-			"username": username,
-			"password": password,
-		},
+	out := map[string]interface{}{
+		"username": username,
+		"password": password,
 	}
+	if !features.ThreePointOhBeta() {
+		out["enabled"] = enabled
+	}
+
+	return []interface{}{out}
 }
 
 func FlattenHDInsightsHiveMetastore(env map[string]*string, site map[string]*string) []interface{} {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -88,43 +88,47 @@ func hdinsightClusterVersionDiffSuppressFunc(_, old, new string, _ *pluginsdk.Re
 }
 
 func SchemaHDInsightsGateway() *pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		// NOTE: these are Required since if these aren't present you get a `500 bad request`
+		"username": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"password": {
+			Type:      pluginsdk.TypeString,
+			Required:  true,
+			Sensitive: true,
+			// Azure returns the key as *****. We'll suppress that here.
+			DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
+				return (new == d.Get(k).(string)) && (old == "*****")
+			},
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		s["enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Default:    true,
+			Deprecated: "HDInsight doesn't support disabling gateway anymore",
+			ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+				enabled := i.(bool)
+
+				if !enabled {
+					errors = append(errors, fmt.Errorf("Only true is supported, because HDInsight doesn't support disabling gateway anymore. Provided value %t", enabled))
+				}
+				return warnings, errors
+			},
+		}
+	}
+
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Required: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				// TODO 3.0: remove this attribute
-				"enabled": {
-					Type:       pluginsdk.TypeBool,
-					Optional:   true,
-					Default:    true,
-					Deprecated: "HDInsight doesn't support disabling gateway anymore",
-					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-						enabled := i.(bool)
-
-						if !enabled {
-							errors = append(errors, fmt.Errorf("Only true is supported, because HDInsight doesn't support disabling gateway anymore. Provided value %t", enabled))
-						}
-						return warnings, errors
-					},
-				},
-				// NOTE: these are Required since if these aren't present you get a `500 bad request`
-				"username": {
-					Type:     pluginsdk.TypeString,
-					Required: true,
-					ForceNew: true,
-				},
-				"password": {
-					Type:      pluginsdk.TypeString,
-					Required:  true,
-					Sensitive: true,
-					// Azure returns the key as *****. We'll suppress that here.
-					DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
-						return (new == d.Get(k).(string)) && (old == "*****")
-					},
-				},
-			},
+			Schema: s,
 		},
 	}
 }
@@ -797,15 +801,17 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 			countValidation = validation.IntBetween(definition.MinInstanceCount, *definition.MaxInstanceCount)
 		}
 
-		// TODO 3.0: remove this property
-		result["min_instance_count"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeInt,
-			Optional:     true,
-			ForceNew:     true,
-			Computed:     true,
-			Deprecated:   "this has been deprecated from the API and will be removed in version 3.0 of the provider",
-			ValidateFunc: countValidation,
+		if !features.ThreePointOhBeta() {
+			result["min_instance_count"] = &pluginsdk.Schema{
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				Deprecated:   "this has been deprecated from the API and will be removed in version 3.0 of the provider",
+				ValidateFunc: countValidation,
+			}
 		}
+
 		result["target_instance_count"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeInt,
 			Required:     true,
@@ -989,9 +995,11 @@ func ExpandHDInsightNodeDefinition(name string, input []interface{}, definition 
 	}
 
 	if definition.CanSpecifyInstanceCount {
-		minInstanceCount := v["min_instance_count"].(int)
-		if minInstanceCount > 0 {
-			role.MinInstanceCount = utils.Int32(int32(minInstanceCount))
+		if !features.ThreePointOhBeta() {
+			minInstanceCount := v["min_instance_count"].(int)
+			if minInstanceCount > 0 {
+				role.MinInstanceCount = utils.Int32(int32(minInstanceCount))
+			}
 		}
 
 		targetInstanceCount := v["target_instance_count"].(int)
@@ -1177,11 +1185,13 @@ func FlattenHDInsightNodeDefinition(input *hdinsight.Role, existing []interface{
 	}
 
 	if definition.CanSpecifyInstanceCount {
-		output["min_instance_count"] = 0
 		output["target_instance_count"] = 0
 
-		if input.MinInstanceCount != nil {
-			output["min_instance_count"] = int(*input.MinInstanceCount)
+		if !features.ThreePointOhBeta() {
+			output["min_instance_count"] = 0
+			if input.MinInstanceCount != nil {
+				output["min_instance_count"] = int(*input.MinInstanceCount)
+			}
 		}
 
 		if input.TargetInstanceCount != nil {


### PR DESCRIPTION
[3.0 Beta] Removed `enabled` from HDInsightsGateway and `min_instance_count` from worker_node,  head_node and worker_node specifications

[3.0 Beta] `security_group_name` is now a required attribute in `azurerm_hdinsight_kafka_cluster`