### PR TITLE
[3.0 Beta] TODO changes for netapp

### DIFF
--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -20,11 +21,59 @@ import (
 )
 
 func resourceNetAppSnapshot() *pluginsdk.Resource {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.SnapshotName,
+		},
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"location": azure.SchemaLocation(),
+
+		"account_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.AccountName,
+		},
+
+		"pool_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.PoolName,
+		},
+
+		"volume_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.VolumeName,
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		s["tags"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Deprecated: "This property has been deprecated as the API no longer supports tags and will be removed in version 3.0 of the provider.",
+		}
+	}
 	return &pluginsdk.Resource{
 		Create: resourceNetAppSnapshotCreate,
 		Read:   resourceNetAppSnapshotRead,
-		// todo remove this in version 3.0 of the provider as tags was the only updatable property and they can no longer be updated and will also be removed
-		Update: resourceNetAppSnapshotUpdate,
+		Update: func() pluginsdk.UpdateFunc {
+			if !features.ThreePointOhBeta() {
+				return resourceNetAppSnapshotUpdate
+			}
+			return nil
+		}(),
 		Delete: resourceNetAppSnapshotDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -38,51 +87,7 @@ func resourceNetAppSnapshot() *pluginsdk.Resource {
 			return err
 		}),
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.SnapshotName,
-			},
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"location": azure.SchemaLocation(),
-
-			"account_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.AccountName,
-			},
-
-			"pool_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.PoolName,
-			},
-
-			"volume_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.VolumeName,
-			},
-
-			// TODO: remove this in a next breaking changes release since tags are
-			// not supported anymore on Snapshots (todo 3.0)
-			// todo remove this in version 3.0 of the provider
-			"tags": {
-				Type:     pluginsdk.TypeMap,
-				Optional: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-				Deprecated: "This property as been deprecated as the API no longer supports tags and will be removed in version 3.0 of the provider.",
-			},
-		},
+		Schema: s,
 	}
 }
 
@@ -159,12 +164,14 @@ func resourceNetAppSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) err
 	return nil
 }
 
-// todo remove this in version 3.0 of the provider
+// CLEANUP: remove this in version 3.0 of the provider
 func resourceNetAppSnapshotUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	// Snapshot resource in Azure changed its type to proxied resource, therefore
-	// tags are not supported anymore, ignoring any tags.
-	if tags.Expand(d.Get("tags").(map[string]interface{})) == nil {
-		log.Printf("[WARN] Tags are not supported on snaphots anymore, no update will happen in a snapshot at this time.")
+	if !features.ThreePointOhBeta() {
+		// Snapshot resource in Azure changed its type to proxied resource, therefore
+		// tags are not supported anymore, ignoring any tags.
+		if tags.Expand(d.Get("tags").(map[string]interface{})) == nil {
+			log.Printf("[WARN] Tags are not supported on snaphots anymore, no update will happen in a snapshot at this time.")
+		}
 	}
 
 	return resourceNetAppSnapshotRead(d, meta)

--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -112,7 +112,7 @@ func resourceNetAppSnapshotCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 
-	if tags.Expand(d.Get("tags").(map[string]interface{})) != nil {
+	if !features.ThreePointOhBeta() && tags.Expand(d.Get("tags").(map[string]interface{})) != nil {
 		log.Printf("[WARN] Tags are not supported on snaphots anymore, ignoring values.")
 	}
 

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 
 	"github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2021-06-01/netapp"
@@ -25,6 +27,77 @@ import (
 )
 
 func resourceNetAppVolume() *pluginsdk.Resource {
+	exportPolicyRuleSchema := map[string]*pluginsdk.Schema{
+		"rule_index": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntBetween(1, 5),
+		},
+
+		"allowed_clients": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validate.CIDR,
+			},
+		},
+
+		"protocols_enabled": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			MinItems: 1,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					"NFSv3",
+					"NFSv4.1",
+					"CIFS",
+				}, false),
+			},
+		},
+
+		"unix_read_only": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"unix_read_write": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"root_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		exportPolicyRuleSchema["cifs_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "Deprecated in favour of `protocols_enabled`",
+		}
+
+		exportPolicyRuleSchema["nfsv3_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "Deprecated in favour of `protocols_enabled`",
+		}
+
+		exportPolicyRuleSchema["nfsv4_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "Deprecated in favour of `protocols_enabled`",
+		}
+	}
+
 	return &pluginsdk.Resource{
 		Create: resourceNetAppVolumeCreate,
 		Read:   resourceNetAppVolumeRead,
@@ -145,77 +218,7 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 				Optional: true,
 				MaxItems: 5,
 				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"rule_index": {
-							Type:         pluginsdk.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 5),
-						},
-
-						"allowed_clients": {
-							Type:     pluginsdk.TypeSet,
-							Required: true,
-							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: validate.CIDR,
-							},
-						},
-
-						"protocols_enabled": {
-							Type:     pluginsdk.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							MinItems: 1,
-							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									"NFSv3",
-									"NFSv4.1",
-									"CIFS",
-								}, false),
-							},
-						},
-
-						// todo remove this in version 3.0 of the provider
-						"cifs_enabled": {
-							Type:       pluginsdk.TypeBool,
-							Optional:   true,
-							Computed:   true,
-							Deprecated: "Deprecated in favour of `protocols_enabled`",
-						},
-
-						// todo remove this in version 3.0 of the provider
-						"nfsv3_enabled": {
-							Type:       pluginsdk.TypeBool,
-							Optional:   true,
-							Computed:   true,
-							Deprecated: "Deprecated in favour of `protocols_enabled`",
-						},
-
-						// todo remove this in version 3.0 of the provider
-						"nfsv4_enabled": {
-							Type:       pluginsdk.TypeBool,
-							Optional:   true,
-							Computed:   true,
-							Deprecated: "Deprecated in favour of `protocols_enabled`",
-						},
-
-						"unix_read_only": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
-
-						"unix_read_write": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
-
-						"root_access_enabled": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
-					},
+					Schema: exportPolicyRuleSchema,
 				},
 			},
 
@@ -899,12 +902,9 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 							}
 						}
 					}
-				} else {
-					// todo remove this in version 3.0 of the provider
+				} else if !features.ThreePointOhBeta() {
 					cifsEnabled = v["cifs_enabled"].(bool)
-					// todo remove this in version 3.0 of the provider
 					nfsv3Enabled = v["nfsv3_enabled"].(bool)
-					// todo remove this in version 3.0 of the provider
 					nfsv41Enabled = v["nfsv4_enabled"].(bool)
 				}
 			}
@@ -960,12 +960,9 @@ func expandNetAppVolumeExportPolicyRulePatch(input []interface{}) *netapp.Volume
 							}
 						}
 					}
-				} else {
-					// todo remove this in version 3.0 of the provider
+				} else if features.ThreePointOhBeta() {
 					cifsEnabled = v["cifs_enabled"].(bool)
-					// todo remove this in version 3.0 of the provider
 					nfsv3Enabled = v["nfsv3_enabled"].(bool)
-					// todo remove this in version 3.0 of the provider
 					nfsv41Enabled = v["nfsv4_enabled"].(bool)
 				}
 			}
@@ -1072,32 +1069,32 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 		if v := item.AllowedClients; v != nil {
 			allowedClients = strings.Split(*v, ",")
 		}
-		// todo remove this in version 3.0 of the provider
+
 		cifsEnabled := false
-		// todo remove this in version 3.0 of the provider
 		nfsv3Enabled := false
-		// todo remove this in version 3.0 of the provider
 		nfsv4Enabled := false
+
 		protocolsEnabled := []string{}
 		if v := item.Cifs; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "CIFS")
 			}
-			// todo remove this in version 3.0 of the provider
-			cifsEnabled = *v
+			if !features.ThreePointOhBeta() {
+				cifsEnabled = *v
+			}
 		}
 		if v := item.Nfsv3; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "NFSv3")
 			}
-			// todo remove this in version 3.0 of the provider
-			nfsv3Enabled = *v
+			if !features.ThreePointOhBeta() {
+				nfsv3Enabled = *v
+			}
 		}
 		if v := item.Nfsv41; v != nil {
 			if *v {
 				protocolsEnabled = append(protocolsEnabled, "NFSv4.1")
 			}
-			// todo remove this in version 3.0 of the provider
 			nfsv4Enabled = *v
 		}
 		unixReadOnly := false
@@ -1113,20 +1110,20 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 			rootAccessEnabled = *v
 		}
 
-		results = append(results, map[string]interface{}{
+		result := map[string]interface{}{
 			"rule_index":          ruleIndex,
 			"allowed_clients":     utils.FlattenStringSlice(&allowedClients),
 			"unix_read_only":      unixReadOnly,
 			"unix_read_write":     unixReadWrite,
 			"root_access_enabled": rootAccessEnabled,
 			"protocols_enabled":   utils.FlattenStringSlice(&protocolsEnabled),
-			// todo remove this in version 3.0 of the provider
-			"cifs_enabled": cifsEnabled,
-			// todo remove this in version 3.0 of the provider
-			"nfsv3_enabled": nfsv3Enabled,
-			// todo remove this in version 3.0 of the provider
-			"nfsv4_enabled": nfsv4Enabled,
-		})
+		}
+		if !features.ThreePointOhBeta() {
+			result["cifs_enabled"] = cifsEnabled
+			result["nfsv3_enabled"] = nfsv3Enabled
+			result["nfsv4_enabled"] = nfsv4Enabled
+		}
+		results = append(results, result)
 	}
 
 	return results


### PR DESCRIPTION
[3.0 Beta] Remove `tags` attribute from netapp_snapshot and remove the Update function, since all other attributes have ForceNew set to true.

[3.0 Beta] Remove `replication_schedule` attribute of netapp_volume data source's `data_protection_replication_schema` block

[3.0 Beta] Remove `cifs_enabled`, `nfsv3_enabled`, and `nfsv4_enabled` attributes from `export_policy_rule` block of netapp_volume resource.