### PR TITLE
New resource: azurerm_virtual_network_gateway_nat_rule

### DIFF
--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	VirtualHubBgpConnectionClient          *network.VirtualHubBgpConnectionClient
 	VirtualHubIPClient                     *network.VirtualHubIPConfigurationClient
 	VnetGatewayConnectionsClient           *network.VirtualNetworkGatewayConnectionsClient
+	VnetGatewayNatRuleClient               *network.VirtualNetworkGatewayNatRulesClient
 	VnetGatewayClient                      *network.VirtualNetworkGatewaysClient
 	VnetClient                             *network.VirtualNetworksClient
 	VnetPeeringsClient                     *network.VirtualNetworkPeeringsClient
@@ -198,6 +199,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	VnetGatewayConnectionsClient := network.NewVirtualNetworkGatewayConnectionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&VnetGatewayConnectionsClient.Client, o.ResourceManagerAuthorizer)
 
+	VnetGatewayNatRuleClient := network.NewVirtualNetworkGatewayNatRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&VnetGatewayNatRuleClient.Client, o.ResourceManagerAuthorizer)
+
 	VirtualWanClient := network.NewVirtualWansClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&VirtualWanClient.Client, o.ResourceManagerAuthorizer)
 
@@ -265,6 +269,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		VirtualHubBgpConnectionClient:          &VirtualHubBgpConnectionClient,
 		VirtualHubIPClient:                     &VirtualHubIPClient,
 		VnetGatewayConnectionsClient:           &VnetGatewayConnectionsClient,
+		VnetGatewayNatRuleClient:               &VnetGatewayNatRuleClient,
 		VnetGatewayClient:                      &VnetGatewayClient,
 		VnetClient:                             &VnetClient,
 		VnetPeeringsClient:                     &VnetPeeringsClient,

--- a/internal/services/network/parse/virtual_network_gateway_nat_rule.go
+++ b/internal/services/network/parse/virtual_network_gateway_nat_rule.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type VirtualNetworkGatewayNatRuleId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	VirtualNetworkGatewayName string
+	NatRuleName               string
+}
+
+func NewVirtualNetworkGatewayNatRuleID(subscriptionId, resourceGroup, virtualNetworkGatewayName, natRuleName string) VirtualNetworkGatewayNatRuleId {
+	return VirtualNetworkGatewayNatRuleId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		VirtualNetworkGatewayName: virtualNetworkGatewayName,
+		NatRuleName:               natRuleName,
+	}
+}
+
+func (id VirtualNetworkGatewayNatRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Nat Rule Name %q", id.NatRuleName),
+		fmt.Sprintf("Virtual Network Gateway Name %q", id.VirtualNetworkGatewayName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Gateway Nat Rule", segmentsStr)
+}
+
+func (id VirtualNetworkGatewayNatRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworkGateways/%s/natRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName)
+}
+
+// VirtualNetworkGatewayNatRuleID parses a VirtualNetworkGatewayNatRule ID into an VirtualNetworkGatewayNatRuleId struct
+func VirtualNetworkGatewayNatRuleID(input string) (*VirtualNetworkGatewayNatRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualNetworkGatewayNatRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VirtualNetworkGatewayName, err = id.PopSegment("virtualNetworkGateways"); err != nil {
+		return nil, err
+	}
+	if resourceId.NatRuleName, err = id.PopSegment("natRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/virtual_network_gateway_nat_rule_test.go
+++ b/internal/services/network/parse/virtual_network_gateway_nat_rule_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = VirtualNetworkGatewayNatRuleId{}
+
+func TestVirtualNetworkGatewayNatRuleIDFormatter(t *testing.T) {
+	actual := NewVirtualNetworkGatewayNatRuleID("12345678-1234-9876-4563-123456789012", "resGroup1", "gw1", "rule1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/rule1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualNetworkGatewayNatRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualNetworkGatewayNatRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Error: true,
+		},
+
+		{
+			// missing NatRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/",
+			Error: true,
+		},
+
+		{
+			// missing value for NatRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/rule1",
+			Expected: &VirtualNetworkGatewayNatRuleId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:             "resGroup1",
+				VirtualNetworkGatewayName: "gw1",
+				NatRuleName:               "rule1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1/NATRULES/RULE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualNetworkGatewayNatRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VirtualNetworkGatewayName != v.Expected.VirtualNetworkGatewayName {
+			t.Fatalf("Expected %q but got %q for VirtualNetworkGatewayName", v.Expected.VirtualNetworkGatewayName, actual.VirtualNetworkGatewayName)
+		}
+		if actual.NatRuleName != v.Expected.NatRuleName {
+			t.Fatalf("Expected %q but got %q for NatRuleName", v.Expected.NatRuleName, actual.NatRuleName)
+		}
+	}
+}

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -108,6 +108,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_virtual_hub_route_table_route":             resourceVirtualHubRouteTableRoute(),
 		"azurerm_virtual_network_dns_servers":               resourceVirtualNetworkDnsServers(),
 		"azurerm_virtual_network_gateway_connection":        resourceVirtualNetworkGatewayConnection(),
+		"azurerm_virtual_network_gateway_nat_rule":          resourceVirtualNetworkGatewayNatRule(),
 		"azurerm_virtual_network_gateway":                   resourceVirtualNetworkGateway(),
 		"azurerm_virtual_network_peering":                   resourceVirtualNetworkPeering(),
 		"azurerm_virtual_network":                           resourceVirtualNetwork(),

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -87,6 +87,7 @@ package network
 // Virtual Network Gateway
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkGateway -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkGatewayIpConfiguration -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/cfg1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkGatewayNatRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/rule1
 
 // Express Route Connection
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ExpressRouteCircuit -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/expressRouteCircuits/erCircuit1

--- a/internal/services/network/validate/virtual_network_gateway_nat_rule_id.go
+++ b/internal/services/network/validate/virtual_network_gateway_nat_rule_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func VirtualNetworkGatewayNatRuleID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualNetworkGatewayNatRuleID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/virtual_network_gateway_nat_rule_id_test.go
+++ b/internal/services/network/validate/virtual_network_gateway_nat_rule_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualNetworkGatewayNatRuleID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Valid: false,
+		},
+
+		{
+			// missing NatRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for NatRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/rule1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1/NATRULES/RULE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualNetworkGatewayNatRuleID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/network/virtual_network_gateway_data_source.go
+++ b/internal/services/network/virtual_network_gateway_data_source.go
@@ -76,6 +76,11 @@ func dataSourceVirtualNetworkGateway() *pluginsdk.Resource {
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
 						"name": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
@@ -305,6 +310,10 @@ func flattenVirtualNetworkGatewayDataSourceIPConfigurations(ipConfigs *[]network
 		for _, cfg := range *ipConfigs {
 			props := cfg.VirtualNetworkGatewayIPConfigurationPropertiesFormat
 			v := make(map[string]interface{})
+
+			if id := cfg.ID; id != nil {
+				v["id"] = *id
+			}
 
 			if name := cfg.Name; name != nil {
 				v["name"] = *name

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -54,7 +54,7 @@ func resourceVirtualNetworkGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"external_mapping": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Required: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -74,7 +74,7 @@ func resourceVirtualNetworkGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"internal_mapping": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Required: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -150,8 +150,8 @@ func resourceVirtualNetworkGatewayNatRuleCreate(d *pluginsdk.ResourceData, meta 
 	props := network.VirtualNetworkGatewayNatRule{
 		Name: utils.String(d.Get("name").(string)),
 		VirtualNetworkGatewayNatRuleProperties: &network.VirtualNetworkGatewayNatRuleProperties{
-			ExternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("external_mapping").(*pluginsdk.Set).List()),
-			InternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("internal_mapping").(*pluginsdk.Set).List()),
+			ExternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("external_mapping").([]interface{})),
+			InternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("internal_mapping").([]interface{})),
 			Mode:             network.VpnNatRuleMode(d.Get("mode").(string)),
 			Type:             network.VpnNatRuleType(d.Get("type").(string)),
 		},
@@ -230,8 +230,8 @@ func resourceVirtualNetworkGatewayNatRuleUpdate(d *pluginsdk.ResourceData, meta 
 	props := network.VirtualNetworkGatewayNatRule{
 		Name: utils.String(d.Get("name").(string)),
 		VirtualNetworkGatewayNatRuleProperties: &network.VirtualNetworkGatewayNatRuleProperties{
-			ExternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("external_mapping").(*pluginsdk.Set).List()),
-			InternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("internal_mapping").(*pluginsdk.Set).List()),
+			ExternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("external_mapping").([]interface{})),
+			InternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("internal_mapping").([]interface{})),
 			Mode:             network.VpnNatRuleMode(d.Get("mode").(string)),
 			Type:             network.VpnNatRuleType(d.Get("type").(string)),
 		},

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -1,0 +1,288 @@
+package network
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceVirtualNetworkGatewayNatRule() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceVirtualNetworkGatewayNatRuleCreateUpdate,
+		Read:   resourceVirtualNetworkGatewayNatRuleRead,
+		Update: resourceVirtualNetworkGatewayNatRuleCreateUpdate,
+		Delete: resourceVirtualNetworkGatewayNatRuleDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.VirtualNetworkGatewayNatRuleID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"virtual_network_gateway_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.VirtualNetworkGatewayID,
+			},
+
+			"external_mapping": {
+				Type:     pluginsdk.TypeSet,
+				Required: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"address_space": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsCIDR,
+						},
+
+						"port_range": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"internal_mapping": {
+				Type:     pluginsdk.TypeSet,
+				Required: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"address_space": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsCIDR,
+						},
+
+						"port_range": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(network.VpnNatRuleModeEgressSnat),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.VpnNatRuleModeEgressSnat),
+					string(network.VpnNatRuleModeIngressSnat),
+				}, false),
+			},
+
+			"type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(network.VpnNatRuleTypeStatic),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.VpnNatRuleTypeStatic),
+					string(network.VpnNatRuleTypeDynamic),
+				}, false),
+			},
+
+			"ip_configuration_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.VirtualNetworkGatewayIpConfigurationID,
+			},
+		},
+	}
+}
+
+func resourceVirtualNetworkGatewayNatRuleCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Network.VnetGatewayNatRuleClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	vnetGatewayId, err := parse.VirtualNetworkGatewayID(d.Get("virtual_network_gateway_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewVirtualNetworkGatewayNatRuleID(subscriptionId, d.Get("resource_group_name").(string), vnetGatewayId.Name, d.Get("name").(string))
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_virtual_network_gateway_nat_rule", id.ID())
+		}
+	}
+
+	props := network.VirtualNetworkGatewayNatRule{
+		Name: utils.String(d.Get("name").(string)),
+		VirtualNetworkGatewayNatRuleProperties: &network.VirtualNetworkGatewayNatRuleProperties{
+			ExternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("external_mapping").(*pluginsdk.Set).List()),
+			InternalMappings: expandVirtualNetworkGatewayNatRuleMappings(d.Get("internal_mapping").(*pluginsdk.Set).List()),
+			Mode:             network.VpnNatRuleMode(d.Get("mode").(string)),
+			Type:             network.VpnNatRuleType(d.Get("type").(string)),
+		},
+	}
+
+	if v, ok := d.GetOk("ip_configuration_id"); ok {
+		props.VirtualNetworkGatewayNatRuleProperties.IPConfigurationID = utils.String(v.(string))
+	}
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName, props)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of the %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceVirtualNetworkGatewayNatRuleRead(d, meta)
+}
+
+func resourceVirtualNetworkGatewayNatRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VnetGatewayNatRuleClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualNetworkGatewayNatRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] %s was not found - removing from state", id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", id.NatRuleName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
+	vnetGatewayId := parse.NewVirtualNetworkGatewayID(id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkGatewayName)
+	d.Set("virtual_network_gateway_id", vnetGatewayId.ID())
+
+	if props := resp.VirtualNetworkGatewayNatRuleProperties; props != nil {
+		if err := d.Set("external_mapping", flattenVirtualNetworkGatewayNatRuleMappings(props.ExternalMappings)); err != nil {
+			return fmt.Errorf("setting `external_mapping`: %+v", err)
+		}
+
+		if err := d.Set("internal_mapping", flattenVirtualNetworkGatewayNatRuleMappings(props.InternalMappings)); err != nil {
+			return fmt.Errorf("setting `internal_mapping`: %+v", err)
+		}
+
+		d.Set("ip_configuration_id", props.IPConfigurationID)
+		d.Set("mode", props.Mode)
+		d.Set("type", props.Type)
+	}
+
+	return nil
+}
+
+func resourceVirtualNetworkGatewayNatRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VnetGatewayNatRuleClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualNetworkGatewayNatRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName)
+	if err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of the %s: %+v", id, err)
+	}
+
+	return nil
+}
+
+func expandVirtualNetworkGatewayNatRuleMappings(input []interface{}) *[]network.VpnNatRuleMapping {
+	results := make([]network.VpnNatRuleMapping, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+
+		result := network.VpnNatRuleMapping{
+			AddressSpace: utils.String(v["address_space"].(string)),
+		}
+
+		if portRange := v["port_range"].(string); portRange != "" {
+			result.PortRange = utils.String(portRange)
+		}
+
+		results = append(results, result)
+	}
+
+	return &results
+}
+
+func flattenVirtualNetworkGatewayNatRuleMappings(input *[]network.VpnNatRuleMapping) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		var addressSpace string
+		if item.AddressSpace != nil {
+			addressSpace = *item.AddressSpace
+		}
+
+		var portRange string
+		if item.PortRange != nil {
+			portRange = *item.PortRange
+		}
+
+		results = append(results, map[string]interface{}{
+			"address_space": addressSpace,
+			"port_range":    portRange,
+		})
+	}
+
+	return results
+}

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
@@ -88,14 +88,14 @@ func TestAccVirtualNetworkGatewayNatRule_updatePortRange(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.updatePortRange(data, "100", "200"),
+			Config: r.updatePortRange(data, "10.1.0.0/26", "100", "10.2.0.0/26", "200"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.updatePortRange(data, "300", "400"),
+			Config: r.updatePortRange(data, "10.3.0.0/26", "300", "10.4.0.0/26", "400"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -192,7 +192,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r VirtualNetworkGatewayNatRuleResource) updatePortRange(data acceptance.TestData, externalPortRange, internalPortRange string) string {
+func (r VirtualNetworkGatewayNatRuleResource) updatePortRange(data acceptance.TestData, externalAddressSpace, externalPortRange, internalAddressSpace, internalPortRange string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -204,16 +204,16 @@ resource "azurerm_virtual_network_gateway_nat_rule" "test" {
   type                       = "Static"
 
   external_mapping {
-    address_space = "10.2.0.0/26"
+    address_space = "%s"
     port_range    = "%s"
   }
 
   internal_mapping {
-    address_space = "10.4.0.0/26"
+    address_space = "%s"
     port_range    = "%s"
   }
 }
-`, r.template(data), data.RandomInteger, externalPortRange, internalPortRange)
+`, r.template(data), data.RandomInteger, externalAddressSpace, externalPortRange, internalAddressSpace, internalPortRange)
 }
 
 func (r VirtualNetworkGatewayNatRuleResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
@@ -1,0 +1,246 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type VirtualNetworkGatewayNatRuleResource struct{}
+
+func TestAccVirtualNetworkGatewayNatRule_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_nat_rule", "test")
+	r := VirtualNetworkGatewayNatRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkGatewayNatRule_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_nat_rule", "test")
+	r := VirtualNetworkGatewayNatRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkGatewayNatRule_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_nat_rule", "test")
+	r := VirtualNetworkGatewayNatRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccVirtualNetworkGatewayNatRule_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_nat_rule", "test")
+	r := VirtualNetworkGatewayNatRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r VirtualNetworkGatewayNatRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VirtualNetworkGatewayNatRuleID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Network.VnetGatewayNatRuleClient.Get(ctx, id.ResourceGroup, id.VirtualNetworkGatewayName, id.NatRuleName)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r VirtualNetworkGatewayNatRuleResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test" {
+  name                       = "acctest-vnetgwnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+
+  external_mapping {
+    address_space = "10.1.0.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.3.0.0/26"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VirtualNetworkGatewayNatRuleResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test" {
+  name                       = "acctest-vnetgwnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.1.0.0/26"
+    port_range    = "100"
+  }
+
+  external_mapping {
+    address_space = "10.2.0.0/26"
+    port_range    = "200"
+  }
+
+  internal_mapping {
+    address_space = "10.3.0.0/26"
+    port_range    = "300"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+    port_range    = "400"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VirtualNetworkGatewayNatRuleResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_gateway_nat_rule" "test" {
+  name                       = "acctest-vnetgwnatrule-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.test.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.test.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.2.0.0/26"
+    port_range    = "200"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+    port_range    = "400"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VirtualNetworkGatewayNatRuleResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_gateway_nat_rule" "import" {
+  name                       = azurerm_virtual_network_gateway_nat_rule.test.name
+  resource_group_name        = azurerm_virtual_network_gateway_nat_rule.test.resource_group_name
+  virtual_network_gateway_id = azurerm_virtual_network_gateway_nat_rule.test.virtual_network_gateway_id
+  external_mapping           = azurerm_virtual_network_gateway_nat_rule.test.external_mapping
+  internal_mapping           = azurerm_virtual_network_gateway_nat_rule.test.internal_mapping
+}
+`, r.basic(data))
+}
+
+func (VirtualNetworkGatewayNatRuleResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vnetgwnatrule-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "Basic"
+
+  ip_configuration {
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+
+data "azurerm_virtual_network_gateway" "test" {
+  name                = azurerm_virtual_network_gateway.test.name
+  resource_group_name = azurerm_virtual_network_gateway.test.resource_group_name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -62,6 +62,8 @@ output "virtual_network_gateway_id" {
 
 The `ip_configuration` block supports:
 
+* `id` - The resource ID of the IP configuration.
+
 * `name` - A user-defined name of the IP configuration.
 
 * `private_ip_address_allocation` - Defines how the private IP address

--- a/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
+++ b/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
@@ -1,0 +1,142 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_network_gateway_nat_rule"
+description: |-
+  Manages a Virtual Network Gateway Nat Rule.
+---
+
+# azurerm_virtual_network_gateway_nat_rule
+
+Manages a Virtual Network Gateway Nat Rule.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-vnet"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "example" {
+  name                = "example-pip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "example" {
+  name                = "example-vnetgw"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "Basic"
+
+  ip_configuration {
+    public_ip_address_id          = azurerm_public_ip.example.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
+}
+
+data "azurerm_virtual_network_gateway" "example" {
+  name                = azurerm_virtual_network_gateway.example.name
+  resource_group_name = azurerm_virtual_network_gateway.example.resource_group_name
+}
+
+resource "azurerm_virtual_network_gateway_nat_rule" "example" {
+  name                       = "example-vnetgwnatrule"
+  resource_group_name        = azurerm_resource_group.example.name
+  virtual_network_gateway_id = data.azurerm_virtual_network_gateway.example.id
+  mode                       = "EgressSnat"
+  type                       = "Dynamic"
+  ip_configuration_id        = data.azurerm_virtual_network_gateway.example.ip_configuration.0.id
+
+  external_mapping {
+    address_space = "10.2.0.0/26"
+    port_range    = "200"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+    port_range    = "400"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Virtual Network Gateway Nat Rule. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The Name of the Resource Group in which this Virtual Network Gateway Nat Rule should be created. Changing this forces a new resource to be created.
+
+* `virtual_network_gateway_id` - (Required) The ID of the Virtual Network Gateway that this Virtual Network Gateway Nat Rule belongs to. Changing this forces a new resource to be created.
+
+* `external_mapping` - (Required) One or more `external_mapping` blocks as documented below.
+
+* `internal_mapping` - (Required) One or more `internal_mapping` blocks as documented below.
+
+* `ip_configuration_id` - (Optional) The ID of the IP Configuration this Virtual Network Gateway Nat Rule applies to.
+
+* `mode` - (Optional) The source Nat direction of the Virtual Network Gateway Nat. Possible values are `EgressSnat` and `IngressSnat`. Defaults to `EgressSnat`. Changing this forces a new resource to be created.
+
+* `type` - (Optional) The type of the Virtual Network Gateway Nat Rule. Possible values are `Dynamic` and `Static`. Defaults to `Static`. Changing this forces a new resource to be created.
+
+---
+
+A `external_mapping` block exports the following:
+
+* `address_space` - The string CIDR representing the address space for the Virtual Network Gateway Nat Rule external mapping.
+
+* `port_range` - The single port range for the Virtual Network Gateway Nat Rule external mapping.
+
+---
+
+A `internal_mapping` block exports the following:
+
+* `address_space` - The string CIDR representing the address space for the Virtual Network Gateway Nat Rule internal mapping.
+
+* `port_range` - The single port range for the Virtual Network Gateway Nat Rule internal mapping.
+
+---
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Virtual Network Gateway Nat Rule.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Gateway Nat Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Gateway Nat Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the Virtual Network Gateway Nat Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Network Gateway Nat Rule.
+
+## Import
+
+Virtual Network Gateway Nat Rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_network_gateway_nat_rule.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/natRules/rule1
+```

--- a/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
+++ b/website/docs/r/virtual_network_gateway_nat_rule.html.markdown
@@ -104,17 +104,17 @@ The following arguments are supported:
 
 A `external_mapping` block exports the following:
 
-* `address_space` - The string CIDR representing the address space for the Virtual Network Gateway Nat Rule external mapping.
+* `address_space` - (Required) The string CIDR representing the address space for the Virtual Network Gateway Nat Rule external mapping.
 
-* `port_range` - The single port range for the Virtual Network Gateway Nat Rule external mapping.
+* `port_range` - (Optional) The single port range for the Virtual Network Gateway Nat Rule external mapping.
 
 ---
 
 A `internal_mapping` block exports the following:
 
-* `address_space` - The string CIDR representing the address space for the Virtual Network Gateway Nat Rule internal mapping.
+* `address_space` - (Required) The string CIDR representing the address space for the Virtual Network Gateway Nat Rule internal mapping.
 
-* `port_range` - The single port range for the Virtual Network Gateway Nat Rule internal mapping.
+* `port_range` - (Optional) The single port range for the Virtual Network Gateway Nat Rule internal mapping.
 
 ---
 


### PR DESCRIPTION
To resolve the issue https://github.com/hashicorp/terraform-provider-azurerm/issues/15348, it has to implement Virtual Network Gateway Nat Rule first. Once this PR is merged, I assume it has to submit another PR to implement  [`egressNatRules`](https://github.com/Azure/azure-rest-api-specs/blob/a70086b6711c1058aaf3c5906744a665a492a504/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/virtualNetworkGateway.json#L3386) and [`ingressNatRules`](https://github.com/Azure/azure-rest-api-specs/blob/a70086b6711c1058aaf3c5906744a665a492a504/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/virtualNetworkGateway.json#L3379) of Virtual Network Gateway Connection (azurerm_virtual_network_gateway_connection).

--- PASS: TestAccVirtualNetworkGatewayNatRule_basic (2589.57s)
--- PASS: TestAccVirtualNetworkGatewayNatRule_updatePortRange (2697.90s)
--- PASS: TestAccVirtualNetworkGatewayNatRule_complete (2774.72s)
--- PASS: TestAccVirtualNetworkGatewayNatRule_requiresImport (2803.29s)
--- PASS: TestAccVirtualNetworkGatewayNatRule_update (3078.08s)

API reference:
https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/virtualNetworkGateway.json#L2389