### PR TITLE
`dependency` Fix compute vendor mod

### DIFF
--- a/internal/services/compute/shared_image_gallery_data_source.go
+++ b/internal/services/compute/shared_image_gallery_data_source.go
@@ -57,8 +57,7 @@ func dataSourceSharedImageGalleryRead(d *pluginsdk.ResourceData, meta interface{
 
 	id := parse.NewSharedImageGalleryID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "", "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return fmt.Errorf("%s was not found", id)

--- a/internal/services/compute/shared_image_gallery_resource.go
+++ b/internal/services/compute/shared_image_gallery_resource.go
@@ -77,8 +77,7 @@ func resourceSharedImageGalleryCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	t := d.Get("tags").(map[string]interface{})
 
 	if d.IsNewResource() {
-		// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-		existing, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "")
+		existing, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "", "")
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -122,8 +121,7 @@ func resourceSharedImageGalleryRead(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
-	resp, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.GalleryName, "", "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[DEBUG] Shared Image Gallery %q (Resource Group %q) was not found - removing from state", id.GalleryName, id.ResourceGroup)

--- a/internal/services/compute/shared_image_gallery_resource_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_test.go
@@ -75,8 +75,7 @@ func (t SharedImageGalleryResource) Exists(ctx context.Context, clients *clients
 		return nil, err
 	}
 
-	// Upgrading to the 2021-07-01 exposed a new selectParameterin the GET method
-	resp, err := clients.Compute.GalleriesClient.Get(ctx, id.ResourceGroup, id.GalleryName, "")
+	resp, err := clients.Compute.GalleriesClient.Get(ctx, id.ResourceGroup, id.GalleryName, "", "")
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Compute Shared Image Gallery %q", id.String())
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/CHANGELOG.md
@@ -1,2 +1,69 @@
 # Change History
 
+## Breaking Changes
+
+### Signature Changes
+
+#### Funcs
+
+1. GalleriesClient.Get
+	- Params
+		- From: context.Context, string, string, SelectPermissions
+		- To: context.Context, string, string, SelectPermissions, GalleryExpandParams
+1. GalleriesClient.GetPreparer
+	- Params
+		- From: context.Context, string, string, SelectPermissions
+		- To: context.Context, string, string, SelectPermissions, GalleryExpandParams
+
+## Additive Changes
+
+### New Constants
+
+1. Architecture.ArchitectureArm64
+1. Architecture.ArchitectureX64
+1. ArchitectureTypes.ArchitectureTypesArm64
+1. ArchitectureTypes.ArchitectureTypesX64
+1. ConfidentialVMEncryptionType.ConfidentialVMEncryptionTypeEncryptedVMGuestStateOnlyWithPmk
+1. ConfidentialVMEncryptionType.ConfidentialVMEncryptionTypeEncryptedWithCmk
+1. ConfidentialVMEncryptionType.ConfidentialVMEncryptionTypeEncryptedWithPmk
+1. GalleryExpandParams.GalleryExpandParamsSharingProfileGroups
+1. GalleryExtendedLocationType.GalleryExtendedLocationTypeEdgeZone
+1. GalleryExtendedLocationType.GalleryExtendedLocationTypeUnknown
+1. SharingProfileGroupTypes.SharingProfileGroupTypesCommunity
+1. SharingState.SharingStateFailed
+1. SharingState.SharingStateInProgress
+1. SharingState.SharingStateSucceeded
+1. SharingState.SharingStateUnknown
+1. SharingUpdateOperationTypes.SharingUpdateOperationTypesEnableCommunity
+
+### New Funcs
+
+1. CommunityGalleryInfo.MarshalJSON() ([]byte, error)
+1. PossibleArchitectureTypesValues() []ArchitectureTypes
+1. PossibleArchitectureValues() []Architecture
+1. PossibleConfidentialVMEncryptionTypeValues() []ConfidentialVMEncryptionType
+1. PossibleGalleryExpandParamsValues() []GalleryExpandParams
+1. PossibleGalleryExtendedLocationTypeValues() []GalleryExtendedLocationType
+1. PossibleSharingStateValues() []SharingState
+
+### Struct Changes
+
+#### New Structs
+
+1. CommunityGalleryInfo
+1. GalleryExtendedLocation
+1. GalleryTargetExtendedLocation
+1. OSDiskImageSecurityProfile
+1. RegionalSharingStatus
+1. SharingStatus
+
+#### New Struct Fields
+
+1. GalleryApplicationVersionPublishingProfile.TargetExtendedLocations
+1. GalleryArtifactPublishingProfileBase.TargetExtendedLocations
+1. GalleryImageProperties.Architecture
+1. GalleryImageVersionPublishingProfile.TargetExtendedLocations
+1. GalleryProperties.SharingStatus
+1. OSDiskImageEncryption.SecurityProfile
+1. SharingProfile.CommunityGalleryInfo
+1. VirtualMachineImageProperties.Architecture

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/_meta.json
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/_meta.json
@@ -1,11 +1,11 @@
 {
-  "commit": "1118376e6b4c59716f4a2bcf3ddea212aeee5536",
+  "commit": "bb4175d29020cfff55f1d9087c2a5a89765067dc",
   "readme": "/_/azure-rest-api-specs/specification/compute/resource-manager/readme.md",
   "tag": "package-2021-11-01",
   "use": "@microsoft.azure/autorest.go@2.1.187",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
-  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.187 --tag=package-2021-11-01 --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --pass-thru:schema-validator-swagger --enum-prefix /_/azure-rest-api-specs/specification/compute/resource-manager/readme.md",
+  "autorest_command": "autorest --use=@microsoft.azure/autorest.go@2.1.187 --tag=package-2021-11-01 --go-sdk-folder=/_/azure-sdk-for-go --go --verbose --use-onever --version=2.0.4421 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix --pass-thru:schema-validator-swagger /_/azure-rest-api-specs/specification/compute/resource-manager/readme.md",
   "additional_properties": {
-    "additional_options": "--go --verbose --use-onever --version=V2 --go.license-header=MICROSOFT_MIT_NO_VERSION --pass-thru:schema-validator-swagger --enum-prefix"
+    "additional_options": "--go --verbose --use-onever --version=2.0.4421 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix --pass-thru:schema-validator-swagger"
   }
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/enums.go
@@ -42,6 +42,36 @@ func PossibleAggregatedReplicationStateValues() []AggregatedReplicationState {
 	return []AggregatedReplicationState{AggregatedReplicationStateCompleted, AggregatedReplicationStateFailed, AggregatedReplicationStateInProgress, AggregatedReplicationStateUnknown}
 }
 
+// Architecture enumerates the values for architecture.
+type Architecture string
+
+const (
+	// ArchitectureArm64 ...
+	ArchitectureArm64 Architecture = "Arm64"
+	// ArchitectureX64 ...
+	ArchitectureX64 Architecture = "x64"
+)
+
+// PossibleArchitectureValues returns an array of possible values for the Architecture const type.
+func PossibleArchitectureValues() []Architecture {
+	return []Architecture{ArchitectureArm64, ArchitectureX64}
+}
+
+// ArchitectureTypes enumerates the values for architecture types.
+type ArchitectureTypes string
+
+const (
+	// ArchitectureTypesArm64 ...
+	ArchitectureTypesArm64 ArchitectureTypes = "Arm64"
+	// ArchitectureTypesX64 ...
+	ArchitectureTypesX64 ArchitectureTypes = "x64"
+)
+
+// PossibleArchitectureTypesValues returns an array of possible values for the ArchitectureTypes const type.
+func PossibleArchitectureTypesValues() []ArchitectureTypes {
+	return []ArchitectureTypes{ArchitectureTypesArm64, ArchitectureTypesX64}
+}
+
 // AvailabilitySetSkuTypes enumerates the values for availability set sku types.
 type AvailabilitySetSkuTypes string
 
@@ -129,6 +159,23 @@ const (
 // PossibleComponentNamesValues returns an array of possible values for the ComponentNames const type.
 func PossibleComponentNamesValues() []ComponentNames {
 	return []ComponentNames{ComponentNamesMicrosoftWindowsShellSetup}
+}
+
+// ConfidentialVMEncryptionType enumerates the values for confidential vm encryption type.
+type ConfidentialVMEncryptionType string
+
+const (
+	// ConfidentialVMEncryptionTypeEncryptedVMGuestStateOnlyWithPmk ...
+	ConfidentialVMEncryptionTypeEncryptedVMGuestStateOnlyWithPmk ConfidentialVMEncryptionType = "EncryptedVMGuestStateOnlyWithPmk"
+	// ConfidentialVMEncryptionTypeEncryptedWithCmk ...
+	ConfidentialVMEncryptionTypeEncryptedWithCmk ConfidentialVMEncryptionType = "EncryptedWithCmk"
+	// ConfidentialVMEncryptionTypeEncryptedWithPmk ...
+	ConfidentialVMEncryptionTypeEncryptedWithPmk ConfidentialVMEncryptionType = "EncryptedWithPmk"
+)
+
+// PossibleConfidentialVMEncryptionTypeValues returns an array of possible values for the ConfidentialVMEncryptionType const type.
+func PossibleConfidentialVMEncryptionTypeValues() []ConfidentialVMEncryptionType {
+	return []ConfidentialVMEncryptionType{ConfidentialVMEncryptionTypeEncryptedVMGuestStateOnlyWithPmk, ConfidentialVMEncryptionTypeEncryptedWithCmk, ConfidentialVMEncryptionTypeEncryptedWithPmk}
 }
 
 // ConsistencyModeTypes enumerates the values for consistency mode types.
@@ -507,6 +554,34 @@ const (
 // PossibleExtendedLocationTypesValues returns an array of possible values for the ExtendedLocationTypes const type.
 func PossibleExtendedLocationTypesValues() []ExtendedLocationTypes {
 	return []ExtendedLocationTypes{ExtendedLocationTypesEdgeZone}
+}
+
+// GalleryExpandParams enumerates the values for gallery expand params.
+type GalleryExpandParams string
+
+const (
+	// GalleryExpandParamsSharingProfileGroups ...
+	GalleryExpandParamsSharingProfileGroups GalleryExpandParams = "SharingProfile/Groups"
+)
+
+// PossibleGalleryExpandParamsValues returns an array of possible values for the GalleryExpandParams const type.
+func PossibleGalleryExpandParamsValues() []GalleryExpandParams {
+	return []GalleryExpandParams{GalleryExpandParamsSharingProfileGroups}
+}
+
+// GalleryExtendedLocationType enumerates the values for gallery extended location type.
+type GalleryExtendedLocationType string
+
+const (
+	// GalleryExtendedLocationTypeEdgeZone ...
+	GalleryExtendedLocationTypeEdgeZone GalleryExtendedLocationType = "EdgeZone"
+	// GalleryExtendedLocationTypeUnknown ...
+	GalleryExtendedLocationTypeUnknown GalleryExtendedLocationType = "Unknown"
+)
+
+// PossibleGalleryExtendedLocationTypeValues returns an array of possible values for the GalleryExtendedLocationType const type.
+func PossibleGalleryExtendedLocationTypeValues() []GalleryExtendedLocationType {
+	return []GalleryExtendedLocationType{GalleryExtendedLocationTypeEdgeZone, GalleryExtendedLocationTypeUnknown}
 }
 
 // GallerySharingPermissionTypes enumerates the values for gallery sharing permission types.
@@ -1397,13 +1472,34 @@ type SharingProfileGroupTypes string
 const (
 	// SharingProfileGroupTypesAADTenants ...
 	SharingProfileGroupTypesAADTenants SharingProfileGroupTypes = "AADTenants"
+	// SharingProfileGroupTypesCommunity ...
+	SharingProfileGroupTypesCommunity SharingProfileGroupTypes = "Community"
 	// SharingProfileGroupTypesSubscriptions ...
 	SharingProfileGroupTypesSubscriptions SharingProfileGroupTypes = "Subscriptions"
 )
 
 // PossibleSharingProfileGroupTypesValues returns an array of possible values for the SharingProfileGroupTypes const type.
 func PossibleSharingProfileGroupTypesValues() []SharingProfileGroupTypes {
-	return []SharingProfileGroupTypes{SharingProfileGroupTypesAADTenants, SharingProfileGroupTypesSubscriptions}
+	return []SharingProfileGroupTypes{SharingProfileGroupTypesAADTenants, SharingProfileGroupTypesCommunity, SharingProfileGroupTypesSubscriptions}
+}
+
+// SharingState enumerates the values for sharing state.
+type SharingState string
+
+const (
+	// SharingStateFailed ...
+	SharingStateFailed SharingState = "Failed"
+	// SharingStateInProgress ...
+	SharingStateInProgress SharingState = "InProgress"
+	// SharingStateSucceeded ...
+	SharingStateSucceeded SharingState = "Succeeded"
+	// SharingStateUnknown ...
+	SharingStateUnknown SharingState = "Unknown"
+)
+
+// PossibleSharingStateValues returns an array of possible values for the SharingState const type.
+func PossibleSharingStateValues() []SharingState {
+	return []SharingState{SharingStateFailed, SharingStateInProgress, SharingStateSucceeded, SharingStateUnknown}
 }
 
 // SharingUpdateOperationTypes enumerates the values for sharing update operation types.
@@ -1412,6 +1508,8 @@ type SharingUpdateOperationTypes string
 const (
 	// SharingUpdateOperationTypesAdd ...
 	SharingUpdateOperationTypesAdd SharingUpdateOperationTypes = "Add"
+	// SharingUpdateOperationTypesEnableCommunity ...
+	SharingUpdateOperationTypesEnableCommunity SharingUpdateOperationTypes = "EnableCommunity"
 	// SharingUpdateOperationTypesRemove ...
 	SharingUpdateOperationTypesRemove SharingUpdateOperationTypes = "Remove"
 	// SharingUpdateOperationTypesReset ...
@@ -1420,7 +1518,7 @@ const (
 
 // PossibleSharingUpdateOperationTypesValues returns an array of possible values for the SharingUpdateOperationTypes const type.
 func PossibleSharingUpdateOperationTypesValues() []SharingUpdateOperationTypes {
-	return []SharingUpdateOperationTypes{SharingUpdateOperationTypesAdd, SharingUpdateOperationTypesRemove, SharingUpdateOperationTypesReset}
+	return []SharingUpdateOperationTypes{SharingUpdateOperationTypesAdd, SharingUpdateOperationTypesEnableCommunity, SharingUpdateOperationTypesRemove, SharingUpdateOperationTypesReset}
 }
 
 // SnapshotStorageAccountTypes enumerates the values for snapshot storage account types.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleries.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleries.go
@@ -70,7 +70,7 @@ func (client GalleriesClient) CreateOrUpdatePreparer(ctx context.Context, resour
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -151,7 +151,7 @@ func (client GalleriesClient) DeletePreparer(ctx context.Context, resourceGroupN
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -196,7 +196,8 @@ func (client GalleriesClient) DeleteResponder(resp *http.Response) (result autor
 // resourceGroupName - the name of the resource group.
 // galleryName - the name of the Shared Image Gallery.
 // selectParameter - the select expression to apply on the operation.
-func (client GalleriesClient) Get(ctx context.Context, resourceGroupName string, galleryName string, selectParameter SelectPermissions) (result Gallery, err error) {
+// expand - the expand query option to apply on the operation.
+func (client GalleriesClient) Get(ctx context.Context, resourceGroupName string, galleryName string, selectParameter SelectPermissions, expand GalleryExpandParams) (result Gallery, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/GalleriesClient.Get")
 		defer func() {
@@ -207,7 +208,7 @@ func (client GalleriesClient) Get(ctx context.Context, resourceGroupName string,
 			tracing.EndSpan(ctx, sc, err)
 		}()
 	}
-	req, err := client.GetPreparer(ctx, resourceGroupName, galleryName, selectParameter)
+	req, err := client.GetPreparer(ctx, resourceGroupName, galleryName, selectParameter, expand)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "compute.GalleriesClient", "Get", nil, "Failure preparing request")
 		return
@@ -230,19 +231,22 @@ func (client GalleriesClient) Get(ctx context.Context, resourceGroupName string,
 }
 
 // GetPreparer prepares the Get request.
-func (client GalleriesClient) GetPreparer(ctx context.Context, resourceGroupName string, galleryName string, selectParameter SelectPermissions) (*http.Request, error) {
+func (client GalleriesClient) GetPreparer(ctx context.Context, resourceGroupName string, galleryName string, selectParameter SelectPermissions, expand GalleryExpandParams) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"galleryName":       autorest.Encode("path", galleryName),
 		"resourceGroupName": autorest.Encode("path", resourceGroupName),
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
 	if len(string(selectParameter)) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)
+	}
+	if len(string(expand)) > 0 {
+		queryParameters["$expand"] = autorest.Encode("query", expand)
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -316,7 +320,7 @@ func (client GalleriesClient) ListPreparer(ctx context.Context) (*http.Request, 
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -432,7 +436,7 @@ func (client GalleriesClient) ListByResourceGroupPreparer(ctx context.Context, r
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -540,7 +544,7 @@ func (client GalleriesClient) UpdatePreparer(ctx context.Context, resourceGroupN
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryapplications.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryapplications.go
@@ -75,7 +75,7 @@ func (client GalleryApplicationsClient) CreateOrUpdatePreparer(ctx context.Conte
 		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -159,7 +159,7 @@ func (client GalleryApplicationsClient) DeletePreparer(ctx context.Context, reso
 		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -247,7 +247,7 @@ func (client GalleryApplicationsClient) GetPreparer(ctx context.Context, resourc
 		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -329,7 +329,7 @@ func (client GalleryApplicationsClient) ListByGalleryPreparer(ctx context.Contex
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -441,7 +441,7 @@ func (client GalleryApplicationsClient) UpdatePreparer(ctx context.Context, reso
 		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryapplicationversions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryapplicationversions.go
@@ -94,7 +94,7 @@ func (client GalleryApplicationVersionsClient) CreateOrUpdatePreparer(ctx contex
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -180,7 +180,7 @@ func (client GalleryApplicationVersionsClient) DeletePreparer(ctx context.Contex
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -271,7 +271,7 @@ func (client GalleryApplicationVersionsClient) GetPreparer(ctx context.Context, 
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -358,7 +358,7 @@ func (client GalleryApplicationVersionsClient) ListByGalleryApplicationPreparer(
 		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -472,7 +472,7 @@ func (client GalleryApplicationVersionsClient) UpdatePreparer(ctx context.Contex
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryimages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryimages.go
@@ -86,7 +86,7 @@ func (client GalleryImagesClient) CreateOrUpdatePreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -169,7 +169,7 @@ func (client GalleryImagesClient) DeletePreparer(ctx context.Context, resourceGr
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -256,7 +256,7 @@ func (client GalleryImagesClient) GetPreparer(ctx context.Context, resourceGroup
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -337,7 +337,7 @@ func (client GalleryImagesClient) ListByGalleryPreparer(ctx context.Context, res
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -448,7 +448,7 @@ func (client GalleryImagesClient) UpdatePreparer(ctx context.Context, resourceGr
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryimageversions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/galleryimageversions.go
@@ -84,7 +84,7 @@ func (client GalleryImageVersionsClient) CreateOrUpdatePreparer(ctx context.Cont
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -169,7 +169,7 @@ func (client GalleryImageVersionsClient) DeletePreparer(ctx context.Context, res
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -259,7 +259,7 @@ func (client GalleryImageVersionsClient) GetPreparer(ctx context.Context, resour
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -346,7 +346,7 @@ func (client GalleryImageVersionsClient) ListByGalleryImagePreparer(ctx context.
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -459,7 +459,7 @@ func (client GalleryImageVersionsClient) UpdatePreparer(ctx context.Context, res
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/gallerysharingprofile.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/gallerysharingprofile.go
@@ -70,7 +70,7 @@ func (client GallerySharingProfileClient) UpdatePreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2021-07-01"
+	const APIVersion = "2021-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/models.go
@@ -2890,6 +2890,40 @@ type CommunityGalleryImageVersionProperties struct {
 	EndOfLifeDate *date.Time `json:"endOfLifeDate,omitempty"`
 }
 
+// CommunityGalleryInfo information of community gallery if current gallery is shared to community
+type CommunityGalleryInfo struct {
+	// PublisherURI - Community gallery publisher uri
+	PublisherURI *string `json:"publisherUri,omitempty"`
+	// PublisherContact - Community gallery publisher contact email
+	PublisherContact *string `json:"publisherContact,omitempty"`
+	// Eula - Community gallery publisher eula
+	Eula *string `json:"eula,omitempty"`
+	// PublicNamePrefix - Community gallery public name prefix
+	PublicNamePrefix *string `json:"publicNamePrefix,omitempty"`
+	// CommunityGalleryEnabled - READ-ONLY; Contains info about whether community gallery sharing is enabled.
+	CommunityGalleryEnabled *bool `json:"communityGalleryEnabled,omitempty"`
+	// PublicNames - READ-ONLY; Community gallery public name list.
+	PublicNames *[]string `json:"publicNames,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for CommunityGalleryInfo.
+func (cgiVar CommunityGalleryInfo) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if cgiVar.PublisherURI != nil {
+		objectMap["publisherUri"] = cgiVar.PublisherURI
+	}
+	if cgiVar.PublisherContact != nil {
+		objectMap["publisherContact"] = cgiVar.PublisherContact
+	}
+	if cgiVar.Eula != nil {
+		objectMap["eula"] = cgiVar.Eula
+	}
+	if cgiVar.PublicNamePrefix != nil {
+		objectMap["publicNamePrefix"] = cgiVar.PublicNamePrefix
+	}
+	return json.Marshal(objectMap)
+}
+
 // CreationData data used when creating a disk.
 type CreationData struct {
 	// CreateOption - This enumerates the possible sources of a disk's creation. Possible values include: 'DiskCreateOptionEmpty', 'DiskCreateOptionAttach', 'DiskCreateOptionFromImage', 'DiskCreateOptionImport', 'DiskCreateOptionCopy', 'DiskCreateOptionRestore', 'DiskCreateOptionUpload', 'DiskCreateOptionCopyStart', 'DiskCreateOptionImportSecure', 'DiskCreateOptionUploadPreparedSecure'
@@ -7379,6 +7413,8 @@ type GalleryApplicationVersionPublishingProfile struct {
 	StorageAccountType StorageAccountType `json:"storageAccountType,omitempty"`
 	// ReplicationMode - Optional parameter which specifies the mode to be used for replication. This property is not updatable. Possible values include: 'ReplicationModeFull', 'ReplicationModeShallow'
 	ReplicationMode ReplicationMode `json:"replicationMode,omitempty"`
+	// TargetExtendedLocations - The target extended locations where the Image Version is going to be replicated to. This property is updatable.
+	TargetExtendedLocations *[]GalleryTargetExtendedLocation `json:"targetExtendedLocations,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for GalleryApplicationVersionPublishingProfile.
@@ -7410,6 +7446,9 @@ func (gavpp GalleryApplicationVersionPublishingProfile) MarshalJSON() ([]byte, e
 	}
 	if gavpp.ReplicationMode != "" {
 		objectMap["replicationMode"] = gavpp.ReplicationMode
+	}
+	if gavpp.TargetExtendedLocations != nil {
+		objectMap["targetExtendedLocations"] = gavpp.TargetExtendedLocations
 	}
 	return json.Marshal(objectMap)
 }
@@ -7639,6 +7678,8 @@ type GalleryArtifactPublishingProfileBase struct {
 	StorageAccountType StorageAccountType `json:"storageAccountType,omitempty"`
 	// ReplicationMode - Optional parameter which specifies the mode to be used for replication. This property is not updatable. Possible values include: 'ReplicationModeFull', 'ReplicationModeShallow'
 	ReplicationMode ReplicationMode `json:"replicationMode,omitempty"`
+	// TargetExtendedLocations - The target extended locations where the Image Version is going to be replicated to. This property is updatable.
+	TargetExtendedLocations *[]GalleryTargetExtendedLocation `json:"targetExtendedLocations,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for GalleryArtifactPublishingProfileBase.
@@ -7661,6 +7702,9 @@ func (gappb GalleryArtifactPublishingProfileBase) MarshalJSON() ([]byte, error) 
 	}
 	if gappb.ReplicationMode != "" {
 		objectMap["replicationMode"] = gappb.ReplicationMode
+	}
+	if gappb.TargetExtendedLocations != nil {
+		objectMap["targetExtendedLocations"] = gappb.TargetExtendedLocations
 	}
 	return json.Marshal(objectMap)
 }
@@ -7723,6 +7767,13 @@ func (gdi GalleryDiskImage) MarshalJSON() ([]byte, error) {
 		objectMap["source"] = gdi.Source
 	}
 	return json.Marshal(objectMap)
+}
+
+// GalleryExtendedLocation the name of the extended location.
+type GalleryExtendedLocation struct {
+	Name *string `json:"name,omitempty"`
+	// Type - Possible values include: 'GalleryExtendedLocationTypeEdgeZone', 'GalleryExtendedLocationTypeUnknown'
+	Type GalleryExtendedLocationType `json:"type,omitempty"`
 }
 
 // GalleryIdentifier describes the gallery unique name.
@@ -8040,6 +8091,8 @@ type GalleryImageProperties struct {
 	ProvisioningState ProvisioningState2 `json:"provisioningState,omitempty"`
 	// Features - A list of gallery image features.
 	Features *[]GalleryImageFeature `json:"features,omitempty"`
+	// Architecture - The architecture of the image. Applicable to OS disks only. Possible values include: 'ArchitectureX64', 'ArchitectureArm64'
+	Architecture Architecture `json:"architecture,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for GalleryImageProperties.
@@ -8083,6 +8136,9 @@ func (gip GalleryImageProperties) MarshalJSON() ([]byte, error) {
 	}
 	if gip.Features != nil {
 		objectMap["features"] = gip.Features
+	}
+	if gip.Architecture != "" {
+		objectMap["architecture"] = gip.Architecture
 	}
 	return json.Marshal(objectMap)
 }
@@ -8593,6 +8649,8 @@ type GalleryImageVersionPublishingProfile struct {
 	StorageAccountType StorageAccountType `json:"storageAccountType,omitempty"`
 	// ReplicationMode - Optional parameter which specifies the mode to be used for replication. This property is not updatable. Possible values include: 'ReplicationModeFull', 'ReplicationModeShallow'
 	ReplicationMode ReplicationMode `json:"replicationMode,omitempty"`
+	// TargetExtendedLocations - The target extended locations where the Image Version is going to be replicated to. This property is updatable.
+	TargetExtendedLocations *[]GalleryTargetExtendedLocation `json:"targetExtendedLocations,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for GalleryImageVersionPublishingProfile.
@@ -8615,6 +8673,9 @@ func (givpp GalleryImageVersionPublishingProfile) MarshalJSON() ([]byte, error) 
 	}
 	if givpp.ReplicationMode != "" {
 		objectMap["replicationMode"] = givpp.ReplicationMode
+	}
+	if givpp.TargetExtendedLocations != nil {
+		objectMap["targetExtendedLocations"] = givpp.TargetExtendedLocations
 	}
 	return json.Marshal(objectMap)
 }
@@ -9024,6 +9085,8 @@ type GalleryProperties struct {
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 	SharingProfile    *SharingProfile   `json:"sharingProfile,omitempty"`
 	SoftDeletePolicy  *SoftDeletePolicy `json:"softDeletePolicy,omitempty"`
+	// SharingStatus - READ-ONLY
+	SharingStatus *SharingStatus `json:"sharingStatus,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for GalleryProperties.
@@ -9085,6 +9148,18 @@ func (future *GallerySharingProfileUpdateFuture) result(client GallerySharingPro
 		}
 	}
 	return
+}
+
+// GalleryTargetExtendedLocation ...
+type GalleryTargetExtendedLocation struct {
+	// Name - The name of the region.
+	Name             *string                  `json:"name,omitempty"`
+	ExtendedLocation *GalleryExtendedLocation `json:"extendedLocation,omitempty"`
+	// ExtendedLocationReplicaCount - The number of replicas of the Image Version to be created per extended location. This property is updatable.
+	ExtendedLocationReplicaCount *int32 `json:"extendedLocationReplicaCount,omitempty"`
+	// StorageAccountType - Specifies the storage account type to be used to store the image. This property is not updatable. Possible values include: 'StorageAccountTypeStandardLRS', 'StorageAccountTypeStandardZRS', 'StorageAccountTypePremiumLRS'
+	StorageAccountType StorageAccountType `json:"storageAccountType,omitempty"`
+	Encryption         *EncryptionImages  `json:"encryption,omitempty"`
 }
 
 // GalleryUpdate specifies information about the Shared Image Gallery that you want to update.
@@ -9582,7 +9657,7 @@ type ImageReference struct {
 	Offer *string `json:"offer,omitempty"`
 	// Sku - The image SKU.
 	Sku *string `json:"sku,omitempty"`
-	// Version - Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
+	// Version - Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available. Please do not use field 'version' for gallery image deployment, gallery image should always use 'id' field for deployment, to use 'latest' version of gallery image, just set '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{imageName}' in the 'id' field without version input.
 	Version *string `json:"version,omitempty"`
 	// ExactVersion - READ-ONLY; Specifies in decimal numbers, the version of platform image or marketplace image used to create the virtual machine. This readonly field differs from 'version', only if the value specified in 'version' field is 'latest'.
 	ExactVersion *string `json:"exactVersion,omitempty"`
@@ -10553,8 +10628,18 @@ type OSDiskImage struct {
 
 // OSDiskImageEncryption contains encryption settings for an OS disk image.
 type OSDiskImageEncryption struct {
+	// SecurityProfile - This property specifies the security profile of an OS disk image.
+	SecurityProfile *OSDiskImageSecurityProfile `json:"securityProfile,omitempty"`
 	// DiskEncryptionSetID - A relative URI containing the resource ID of the disk encryption set.
 	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
+}
+
+// OSDiskImageSecurityProfile contains security profile for an OS disk image.
+type OSDiskImageSecurityProfile struct {
+	// ConfidentialVMEncryptionType - confidential VM encryption types. Possible values include: 'ConfidentialVMEncryptionTypeEncryptedVMGuestStateOnlyWithPmk', 'ConfidentialVMEncryptionTypeEncryptedWithPmk', 'ConfidentialVMEncryptionTypeEncryptedWithCmk'
+	ConfidentialVMEncryptionType ConfidentialVMEncryptionType `json:"confidentialVMEncryptionType,omitempty"`
+	// SecureVMDiskEncryptionSetID - secure VM disk encryption set id
+	SecureVMDiskEncryptionSetID *string `json:"secureVMDiskEncryptionSetId,omitempty"`
 }
 
 // OSFamily describes a cloud service OS family.
@@ -11971,6 +12056,16 @@ type RegionalReplicationStatus struct {
 func (rrs RegionalReplicationStatus) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	return json.Marshal(objectMap)
+}
+
+// RegionalSharingStatus gallery regional sharing status
+type RegionalSharingStatus struct {
+	// Region - Region name
+	Region *string `json:"region,omitempty"`
+	// State - Gallery sharing state in current region. Possible values include: 'SharingStateSucceeded', 'SharingStateInProgress', 'SharingStateFailed', 'SharingStateUnknown'
+	State SharingState `json:"state,omitempty"`
+	// Details - Details of gallery regional sharing failure.
+	Details *string `json:"details,omitempty"`
 }
 
 // ReplicationStatus this is the replication status of the gallery image version.
@@ -14602,6 +14697,8 @@ type SharingProfile struct {
 	Permissions GallerySharingPermissionTypes `json:"permissions,omitempty"`
 	// Groups - READ-ONLY; A list of sharing profile groups.
 	Groups *[]SharingProfileGroup `json:"groups,omitempty"`
+	// CommunityGalleryInfo - Information of community gallery if current gallery is shared to community.
+	CommunityGalleryInfo interface{} `json:"communityGalleryInfo,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for SharingProfile.
@@ -14610,21 +14707,32 @@ func (sp SharingProfile) MarshalJSON() ([]byte, error) {
 	if sp.Permissions != "" {
 		objectMap["permissions"] = sp.Permissions
 	}
+	if sp.CommunityGalleryInfo != nil {
+		objectMap["communityGalleryInfo"] = sp.CommunityGalleryInfo
+	}
 	return json.Marshal(objectMap)
 }
 
 // SharingProfileGroup group of the gallery sharing profile
 type SharingProfileGroup struct {
-	// Type - This property allows you to specify the type of sharing group. <br><br> Possible values are: <br><br> **Subscriptions** <br><br> **AADTenants**. Possible values include: 'SharingProfileGroupTypesSubscriptions', 'SharingProfileGroupTypesAADTenants'
+	// Type - This property allows you to specify the type of sharing group. <br><br> Possible values are: <br><br> **Subscriptions** <br><br> **AADTenants** <br><br> **Community**. Possible values include: 'SharingProfileGroupTypesSubscriptions', 'SharingProfileGroupTypesAADTenants', 'SharingProfileGroupTypesCommunity'
 	Type SharingProfileGroupTypes `json:"type,omitempty"`
 	// Ids - A list of subscription/tenant ids the gallery is aimed to be shared to.
 	Ids *[]string `json:"ids,omitempty"`
 }
 
+// SharingStatus sharing status of current gallery.
+type SharingStatus struct {
+	// AggregatedState - Aggregated sharing state of current gallery. Possible values include: 'SharingStateSucceeded', 'SharingStateInProgress', 'SharingStateFailed', 'SharingStateUnknown'
+	AggregatedState SharingState `json:"aggregatedState,omitempty"`
+	// Summary - Summary of all regional sharing status.
+	Summary *[]RegionalSharingStatus `json:"summary,omitempty"`
+}
+
 // SharingUpdate specifies information about the gallery sharing profile update.
 type SharingUpdate struct {
 	autorest.Response `json:"-"`
-	// OperationType - This property allows you to specify the operation type of gallery sharing update. <br><br> Possible values are: <br><br> **Add** <br><br> **Remove** <br><br> **Reset**. Possible values include: 'SharingUpdateOperationTypesAdd', 'SharingUpdateOperationTypesRemove', 'SharingUpdateOperationTypesReset'
+	// OperationType - This property allows you to specify the operation type of gallery sharing update. <br><br> Possible values are: <br><br> **Add** <br><br> **Remove** <br><br> **Reset**. Possible values include: 'SharingUpdateOperationTypesAdd', 'SharingUpdateOperationTypesRemove', 'SharingUpdateOperationTypesReset', 'SharingUpdateOperationTypesEnableCommunity'
 	OperationType SharingUpdateOperationTypes `json:"operationType,omitempty"`
 	// Groups - A list of sharing profile groups.
 	Groups *[]SharingProfileGroup `json:"groups,omitempty"`
@@ -17081,6 +17189,8 @@ type VirtualMachineImageProperties struct {
 	// Disallowed - Specifies disallowed configuration for the VirtualMachine created from the image
 	Disallowed *DisallowedConfiguration      `json:"disallowed,omitempty"`
 	Features   *[]VirtualMachineImageFeature `json:"features,omitempty"`
+	// Architecture - Possible values include: 'ArchitectureTypesX64', 'ArchitectureTypesArm64'
+	Architecture ArchitectureTypes `json:"architecture,omitempty"`
 }
 
 // VirtualMachineImageResource virtual machine image resource information.


### PR DESCRIPTION
Dependency check of compute version upgrade #15099 ran before Azure go sdk version upgrade change #15716 is checked in, and there is a [breaking change](https://github.com/Azure/azure-sdk-for-go/blob/main/services/compute/mgmt/2021-11-01/compute/CHANGELOG.md#breaking-changes) in the new go sdk version thus cause a `go mod` mismatch