### PR TITLE
azurerm_cosmosdb_mongo_collection: Fix the issue that expireAfterSeconds  property could not be set to -1

### DIFF
--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -79,9 +79,12 @@ func resourceCosmosDbMongoCollection() *pluginsdk.Resource {
 
 			// default TTL is simply an index on _ts with expireAfterOption, given we can't seem to set TTLs on a given index lets expose this to match the portal
 			"default_ttl_seconds": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(-1),
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.IntAtLeast(-1),
+					validation.IntNotInSlice([]int{0}),
+				),
 			},
 
 			"analytical_storage_ttl": {
@@ -163,8 +166,8 @@ func resourceCosmosDbMongoCollectionCreate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	var ttl *int
-	if v := d.Get("default_ttl_seconds").(int); v > 0 {
-		ttl = utils.Int(v)
+	if v, ok := d.GetOk("default_ttl_seconds"); ok {
+		ttl = utils.Int(v.(int))
 	}
 
 	indexes, hasIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)
@@ -232,8 +235,8 @@ func resourceCosmosDbMongoCollectionUpdate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	var ttl *int
-	if v := d.Get("default_ttl_seconds").(int); v > 0 {
-		ttl = utils.Int(v)
+	if v, ok := d.GetOk("default_ttl_seconds"); ok {
+		ttl = utils.Int(v.(int))
 	}
 
 	indexes, hasIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -48,9 +48,9 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Cosmos DB Mongo Collection. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
-* `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` or `0`, items are not automatically expired.
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
 * `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this Mongo Collection. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
+* `default_ttl_seconds` - (Optional) The default Time To Live in seconds. If the value is `-1`, items are not automatically expired.
 * # `index` - (Optional) One or more `index` blocks as defined below.
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.


### PR DESCRIPTION
The purpose of this PR:

> Currently, there is such a [description](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_mongo_collection#default_ttl_seconds) of `default_ttl_seconds` in terraform doc,  when the value of ` default_ttl_seconds` is set to -1 or 0, it means the collection never expires(The `default_ttl_seconds` property in Terraform aka the[ `expireAfterSeconds` ](https://github.com/Azure/azure-rest-api-specs/blob/86c11ab0d4ee403ed7c52621d7fdccfed6e4b7d9/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json#L7696)in API).  After checking tf code, if `default_ttl_seconds` <=0  in tf configuration, then terraform will not add "_ts" index and set value of  `expireAfterSeconds` to the value of `default_ttl_seconds`. Per the [doc](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/time-to-live#time-to-live-for-containers-and-items) (TTL behavior for mongoDB collection(container) is the same as SQL, confirmed by service team), it causes the document(item) to never expire despite the ttl of document level being set to a valid value. 

> In fact, when `default_ttl_seconds`  is set to -1, terraform should set `expireAfterSeconds`  to -1.  Also, it is confirmed that 0 is not supported for `expireAfterSeconds` property. So, the updates are as follows:     

> ```
> • Create a "_ts" index with `expireAfterSeconds` value of -1 when `default_ttl_seconds` is set to -1.
> • Update the tf doc to clarify that -1 means never expired.
> • Update the validation of `default_ttl_seconds` to allow only a nonzero positive integer, or '-1'.
> • Add test case to cover never expires.
> ```


Test Results:

> PASS: TestAccCosmosDbMongoCollection_serverless (1558.45s)
> PASS: TestAccCosmosDbMongoCollection_withIndex (1574.87s)
> PASS: TestAccCosmosDbMongoCollection_neverExpires (1580.70s)
> PASS: TestAccCosmosDbMongoCollection_basic (1581.52s)
> PASS: TestAccCosmosDbMongoCollection_complete (1581.69s)
> PASS: TestAccCosmosDbMongoCollection_autoscaleWithoutShareKey (1582.70s)
> PASS: TestAccCosmosDbMongoCollection_ver36 (1590.43s)
> PASS: TestAccCosmosDbMongoCollection_analyticalStorageTTL (1596.17s)
> PASS: TestAccCosmosDbMongoCollection_throughput (1803.67s)
> PASS: TestAccCosmosDbMongoCollection_update (1844.47s)
> PASS: TestAccCosmosDbMongoCollection_autoscale (1877.26s)