### PR TITLE
fix: MergeUserAppSettings does not deduplicate merged app settings (#15733)

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -2099,9 +2099,8 @@ func MergeUserAppSettings(systemSettings *[]web.NameValuePair, userSettings map[
 	for k, v := range userSettings {
 		// Dedupe, explicit user settings take priority over enumerated, e.g. specifying KeyVault for `AzureWebJobsStorage`
 		for i, x := range combined {
-			if strings.EqualFold(*x.Name, v) {
+			if x.Name != nil && strings.EqualFold(*x.Name, k) {
 				copy(combined[i:], combined[i+1:])
-				combined[len(combined)-1] = web.NameValuePair{}
 				combined = combined[:len(combined)-1]
 			}
 		}


### PR DESCRIPTION
Fix for issue #15733 

Verified locally with `azurerm_windows_function_app`: that the user supplied `app_settings.AzureWebJobsStorage` overwrites the value sourced from  `storage_account_access_key`.