### PR TITLE
azurerm_virtual_hub - support for virtual_router_asn and virtual_router_ips properties

### DIFF
--- a/internal/services/managedapplications/managed_application_resource.go
+++ b/internal/services/managedapplications/managed_application_resource.go
@@ -380,6 +380,14 @@ func flattenManagedApplicationParametersOrOutputs(input interface{}) (map[string
 				results[k] = v.(float64)
 			case string:
 				results[k] = v.(string)
+			case map[string]interface{}:
+				// Azure NVA managed applications read call returns empty map[string]interface{} parameter 'tags'
+				// Do not return an error if the parameter is unsupported type, but is empty
+				if len(v.(map[string]interface{})) == 0 {
+					log.Printf("parameter '%s' is unexpected type %T, but we're ignoring it because of the empty value", k, t)
+				} else {
+					return nil, fmt.Errorf("unexpected parameter type %T", t)
+				}
 			default:
 				return nil, fmt.Errorf("unexpected parameter type %T", t)
 			}

--- a/internal/services/network/virtual_hub_data_source.go
+++ b/internal/services/network/virtual_hub_data_source.go
@@ -50,12 +50,11 @@ func dataSourceVirtualHub() *pluginsdk.Resource {
 			},
 
 			"virtual_router_ips": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},
-				Set: pluginsdk.HashString,
 			},
 
 			"tags": tags.SchemaDataSource(),

--- a/internal/services/network/virtual_hub_data_source.go
+++ b/internal/services/network/virtual_hub_data_source.go
@@ -44,6 +44,20 @@ func dataSourceVirtualHub() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"virtual_router_asn": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"virtual_router_ips": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+				Set: pluginsdk.HashString,
+			},
+
 			"tags": tags.SchemaDataSource(),
 
 			"default_route_table_id": {
@@ -85,6 +99,18 @@ func dataSourceVirtualHubRead(d *pluginsdk.ResourceData, meta interface{}) error
 			virtualWanId = props.VirtualWan.ID
 		}
 		d.Set("virtual_wan_id", virtualWanId)
+
+		var virtualRouterAsn *int64
+		if props.VirtualRouterAsn != nil {
+			virtualRouterAsn = props.VirtualRouterAsn
+		}
+		d.Set("virtual_router_asn", virtualRouterAsn)
+
+		var virtualRouterIps *[]string
+		if props.VirtualRouterIps != nil {
+			virtualRouterIps = props.VirtualRouterIps
+		}
+		d.Set("virtual_router_ips", virtualRouterIps)
 	}
 
 	virtualHub, err := parse.VirtualHubID(*resp.ID)

--- a/internal/services/network/virtual_hub_data_source_test.go
+++ b/internal/services/network/virtual_hub_data_source_test.go
@@ -20,6 +20,8 @@ func TestAccDataSourceAzureRMVirtualHub_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("address_prefix").Exists(),
 				check.That(data.ResourceName).Key("virtual_wan_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_router_asn").Exists(),
+				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),
 			),
 		},
 	})

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -78,6 +78,20 @@ func resourceVirtualHub() *pluginsdk.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
+			"virtual_router_asn": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"virtual_router_ips": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+				Set: pluginsdk.HashString,
+			},
+
 			"route": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
@@ -234,6 +248,18 @@ func resourceVirtualHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			virtualWanId = props.VirtualWan.ID
 		}
 		d.Set("virtual_wan_id", virtualWanId)
+
+		var virtualRouterAsn *int64
+		if props.VirtualRouterAsn != nil {
+			virtualRouterAsn = props.VirtualRouterAsn
+		}
+		d.Set("virtual_router_asn", virtualRouterAsn)
+
+		var virtualRouterIps *[]string
+		if props.VirtualRouterIps != nil {
+			virtualRouterIps = props.VirtualRouterIps
+		}
+		d.Set("virtual_router_ips", virtualRouterIps)
 	}
 
 	defaultRouteTable := parse.NewHubRouteTableID(id.SubscriptionId, id.ResourceGroup, id.Name, "defaultRouteTable")

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -84,12 +84,11 @@ func resourceVirtualHub() *pluginsdk.Resource {
 			},
 
 			"virtual_router_ips": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 				},
-				Set: pluginsdk.HashString,
 			},
 
 			"route": {

--- a/internal/services/network/virtual_hub_resource_test.go
+++ b/internal/services/network/virtual_hub_resource_test.go
@@ -25,7 +25,7 @@ func TestAccVirtualHub_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("virtual_router_asn").Exists(),
-				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),				
+				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/network/virtual_hub_resource_test.go
+++ b/internal/services/network/virtual_hub_resource_test.go
@@ -24,6 +24,8 @@ func TestAccVirtualHub_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_router_asn").Exists(),
+				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),				
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/d/virtual_hub.html.markdown
+++ b/website/docs/d/virtual_hub.html.markdown
@@ -45,6 +45,10 @@ The following attributes are exported:
 
 * `default_route_table_id` - The ID of the default Route Table in the Virtual Hub.
 
+* `virtual_router_asn` - The Autonomous System Number of the Virtual Hub BGP router.
+
+* `virtual_router_ips` - The IP addresses of the Virtual Hub BGP router.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -73,6 +73,10 @@ The following attributes are exported:
 
 * `default_route_table_id` - The ID of the default Route Table in the Virtual Hub.
 
+* `virtual_router_asn` - The Autonomous System Number of the Virtual Hub BGP router.
+
+* `virtual_router_ips` - The IP addresses of the Virtual Hub BGP router.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
This PR enables deployments of managed NVA appliances (like VMware SD-WAN, Meraki VMX) to Azure Virtual WAN hub.

PR adds two new computed parameters to virtual_hub resource/datasource, which are required for the network integration:
"virtual_router_asn"
"virtual_router_ips"

PR addresses GH issue #13427, where the managed NVA application's read function returns an empty parameter 'tags' of the type map[string]interface{} which is not supported in the current code. To make this clear, these are not resource-level tags, but tags inside of the "parameters" parameter.
I do not see an easy way how to add support of nested tags to the "parameters" schema without making breaking changes so I've at least hot-fixed the problem when the 'tags' are returned but are empty. If the tags will not be empty, the error will be returned as before.

Tested NVA appliances do not use the tags.