### PR TITLE
Windows VMSS: allow prefix end with dashes 

### DIFF
--- a/internal/services/compute/validate/windows_computer_name.go
+++ b/internal/services/compute/validate/windows_computer_name.go
@@ -8,15 +8,15 @@ import (
 
 func WindowsComputerNameFull(i interface{}, k string) (warnings []string, errors []error) {
 	// Windows computer name cannot be more than 15 characters long
-	return windowsComputerName(i, k, 15)
+	return windowsComputerName(i, k, 15, false)
 }
 
 func WindowsComputerNamePrefix(i interface{}, k string) (warnings []string, errors []error) {
 	// Windows computer name prefix cannot be more than 9 characters long
-	return windowsComputerName(i, k, 9)
+	return windowsComputerName(i, k, 9, true)
 }
 
-func windowsComputerName(i interface{}, k string, maxLength int) (warnings []string, errors []error) {
+func windowsComputerName(i interface{}, k string, maxLength int, allowDashSuffix bool) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't!", k))
@@ -33,7 +33,7 @@ func windowsComputerName(i interface{}, k string, maxLength int) (warnings []str
 		errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength, len(v)))
 	}
 
-	if strings.HasSuffix(v, "-") {
+	if !allowDashSuffix && strings.HasSuffix(v, "-") {
 		errors = append(errors, fmt.Errorf("%q cannot end with dash", k))
 	}
 

--- a/internal/services/compute/validate/windows_computer_name_test.go
+++ b/internal/services/compute/validate/windows_computer_name_test.go
@@ -67,7 +67,7 @@ func TestWindowsComputerName(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q..", v.input)
 
-		_, errors := windowsComputerName(v.input, "computer_name", 100)
+		_, errors := windowsComputerName(v.input, "computer_name", 100, false)
 		actual := len(errors) == 0
 		if v.expected != actual {
 			t.Fatalf("Expected %t but got %t", v.expected, actual)
@@ -127,6 +127,11 @@ func TestWindowsComputerNamePrefix(t *testing.T) {
 			// 10 chars
 			input:    "abcdefghij",
 			expected: false,
+		},
+		{
+			// dash suffix
+			input:    "abc-",
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION

Allow azurerm_windows_virtual_machine_scale_set computer_name_prefix to end with dashes

Same as https://github.com/hashicorp/terraform-provider-azurerm/pull/9182 but for windows