### PR TITLE
`azurerm_cdn_endpoint_custom_domain` - `tls_version` add one more possible value: `None`

### DIFF
--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -87,6 +87,7 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								string(cdn.MinimumTLSVersionNone),
 								string(cdn.MinimumTLSVersionTLS10),
 								string(cdn.MinimumTLSVersionTLS12),
 							}, false),
@@ -113,6 +114,7 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								string(cdn.MinimumTLSVersionNone),
 								string(cdn.MinimumTLSVersionTLS10),
 								string(cdn.MinimumTLSVersionTLS12),
 							}, false),

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -87,11 +87,9 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(cdn.MinimumTLSVersionNone),
 								string(cdn.MinimumTLSVersionTLS10),
 								string(cdn.MinimumTLSVersionTLS12),
 							}, false),
-							Default: string(cdn.MinimumTLSVersionTLS12),
 						},
 					},
 				},
@@ -114,11 +112,9 @@ func resourceArmCdnEndpointCustomDomain() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(cdn.MinimumTLSVersionNone),
 								string(cdn.MinimumTLSVersionTLS10),
 								string(cdn.MinimumTLSVersionTLS12),
 							}, false),
-							Default: string(cdn.MinimumTLSVersionTLS12),
 						},
 					},
 				},
@@ -404,7 +400,11 @@ func expandArmCdnEndpointCustomDomainCdnManagedHttpsSettings(input []interface{}
 		},
 		CertificateSource: cdn.CertificateSourceCdn,
 		ProtocolType:      cdn.ProtocolType(raw["protocol_type"].(string)),
-		MinimumTLSVersion: cdn.MinimumTLSVersion(raw["tls_version"].(string)),
+		MinimumTLSVersion: cdn.MinimumTLSVersionNone,
+	}
+
+	if v := raw["tls_version"].(string); v != "" {
+		output.MinimumTLSVersion = cdn.MinimumTLSVersion(v)
 	}
 
 	return output
@@ -447,7 +447,11 @@ func expandArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Contex
 		},
 		CertificateSource: cdn.CertificateSourceAzureKeyVault,
 		ProtocolType:      cdn.ProtocolTypeServerNameIndication,
-		MinimumTLSVersion: cdn.MinimumTLSVersion(raw["tls_version"].(string)),
+		MinimumTLSVersion: cdn.MinimumTLSVersionNone,
+	}
+
+	if v := raw["tls_version"].(string); v != "" {
+		output.MinimumTLSVersion = cdn.MinimumTLSVersion(v)
 	}
 
 	return output, nil
@@ -459,11 +463,16 @@ func flattenArmCdnEndpointCustomDomainCdnManagedHttpsSettings(input cdn.ManagedH
 		certificateType = string(params.CertificateType)
 	}
 
+	tlsVersion := ""
+	if input.MinimumTLSVersion != cdn.MinimumTLSVersionNone {
+		tlsVersion = string(input.MinimumTLSVersion)
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"certificate_type": certificateType,
 			"protocol_type":    string(input.ProtocolType),
-			"tls_version":      string(input.MinimumTLSVersion),
+			"tls_version":      tlsVersion,
 		},
 	}
 }
@@ -521,10 +530,15 @@ func flattenArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Conte
 		certIdLiteral = certId.VersionlessID()
 	}
 
+	tlsVersion := ""
+	if input.MinimumTLSVersion != cdn.MinimumTLSVersionNone {
+		tlsVersion = string(input.MinimumTLSVersion)
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"key_vault_certificate_id": certIdLiteral,
-			"tls_version":              string(input.MinimumTLSVersion),
+			"tls_version":              tlsVersion,
 		},
 	}, nil
 }

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
@@ -236,6 +236,7 @@ resource "azurerm_cdn_endpoint_custom_domain" "test" {
   cdn_managed_https {
     certificate_type = "Dedicated"
     protocol_type    = "ServerNameIndication"
+    tls_version      = "TLS12"
   }
 }
 `, template, data.RandomIntOfLength(8))
@@ -318,6 +319,7 @@ resource "azurerm_cdn_endpoint_custom_domain" "test" {
   host_name       = "${azurerm_dns_cname_record.test.name}.${data.azurerm_dns_zone.test.name}"
   user_managed_https {
     key_vault_certificate_id = azurerm_key_vault_certificate.test.id
+    tls_version              = "TLS12"
   }
 }
 `, template, data.RandomIntOfLength(8), r.CertificateP12)

--- a/website/docs/r/cdn_endpoint_custom_domain.html.markdown
+++ b/website/docs/r/cdn_endpoint_custom_domain.html.markdown
@@ -89,7 +89,7 @@ A `cdn_managed_https` block supports the following:
  
 * `protocol_type` - (Required) The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
 
-* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `None`, `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
+* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2).
 
 ---
 
@@ -97,7 +97,7 @@ A `user_managed_https` block supports the following:
 
 * `key_vault_certificate_id` - (Required) The ID of the Key Vault Certificate that contains the HTTPS certificate.
  
-* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `None`, `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
+* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2).
 
 ## Attributes Reference
 

--- a/website/docs/r/cdn_endpoint_custom_domain.html.markdown
+++ b/website/docs/r/cdn_endpoint_custom_domain.html.markdown
@@ -89,7 +89,7 @@ A `cdn_managed_https` block supports the following:
  
 * `protocol_type` - (Required) The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
 
-* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
+* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `None`, `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
 
 ---
 
@@ -97,7 +97,7 @@ A `user_managed_https` block supports the following:
 
 * `key_vault_certificate_id` - (Required) The ID of the Key Vault Certificate that contains the HTTPS certificate.
  
-* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
+* `tls_version` - (Optional) The TLS protocol version that is used for HTTPS. Possible values are `None`, `TLS10` (representing TLS 1.0/1.1) and `TLS12` (representing TLS 1.2). Defaults to `TLS12`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Some CDN profile doesn't allow users to specify the `tls_version` to values other than `None`, when enabling HTTPS for the endpoint custom domain.

Fix #15704 