### PR TITLE
Fix: Get valid API version from error code for `resource group template deployment` resource when original API version is mismatched

### DIFF
--- a/internal/services/resource/template_deployment_common.go
+++ b/internal/services/resource/template_deployment_common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 
 	providers "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
@@ -139,6 +140,25 @@ func filterOutTemplateDeploymentParameters(input interface{}) interface{} {
 	return output
 }
 
+func deleteResourceById(ctx context.Context, resourcesClient *resources.Client, resourceID string, resourceProviderApiVersion string) (result resources.DeleteByIDFuture, err error) {
+	future, err := resourcesClient.DeleteByID(ctx, resourceID, resourceProviderApiVersion)
+	// NOTE: resourceProviderApiVersion is gotten from one of resource types of the provider.
+	// When the provider has multiple resource types, it may cause API version mismatched.
+	// For such error, try to get available API version from error code. Ugly but this seems sufficient for now
+	if err != nil && strings.Contains(err.Error(), `Code="NoRegisteredProviderFound"`) {
+		apiPat := regexp.MustCompile(`\d{4}-\d{2}-\d{2}(-preview)*`)
+		matches := apiPat.FindAllStringSubmatch(err.Error(), -1)
+		for _, match := range matches {
+			if resourceProviderApiVersion != match[0] {
+				future, err = resourcesClient.DeleteByID(ctx, resourceID, match[0])
+				return future, err
+			}
+		}
+	}
+
+	return future, err
+}
+
 func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client, properties resources.DeploymentPropertiesExtended) error {
 	if properties.Providers == nil {
 		return fmt.Errorf("`properties.Providers` was nil - insufficient data to clean up this Template Deployment")
@@ -181,7 +201,7 @@ func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client
 		}
 
 		log.Printf("[DEBUG] Deleting Nested Resource %q..", *nestedResource.ID)
-		future, err := resourcesClient.DeleteByID(ctx, *nestedResource.ID, resourceProviderApiVersion)
+		future, err := deleteResourceById(ctx, resourcesClient, *nestedResource.ID, resourceProviderApiVersion)
 		if err != nil {
 			if resp := future.Response(); resp != nil && resp.StatusCode == http.StatusNotFound {
 				log.Printf("[DEBUG] Nested Resource %q has been deleted.. continuing..", *nestedResource.ID)

--- a/internal/services/resource/template_deployment_common.go
+++ b/internal/services/resource/template_deployment_common.go
@@ -140,25 +140,6 @@ func filterOutTemplateDeploymentParameters(input interface{}) interface{} {
 	return output
 }
 
-func deleteResourceById(ctx context.Context, resourcesClient *resources.Client, resourceID string, resourceProviderApiVersion string) (result resources.DeleteByIDFuture, err error) {
-	future, err := resourcesClient.DeleteByID(ctx, resourceID, resourceProviderApiVersion)
-	// NOTE: resourceProviderApiVersion is gotten from one of resource types of the provider.
-	// When the provider has multiple resource types, it may cause API version mismatched.
-	// For such error, try to get available API version from error code. Ugly but this seems sufficient for now
-	if err != nil && strings.Contains(err.Error(), `Code="NoRegisteredProviderFound"`) {
-		apiPat := regexp.MustCompile(`\d{4}-\d{2}-\d{2}(-preview)*`)
-		matches := apiPat.FindAllStringSubmatch(err.Error(), -1)
-		for _, match := range matches {
-			if resourceProviderApiVersion != match[0] {
-				future, err = resourcesClient.DeleteByID(ctx, resourceID, match[0])
-				return future, err
-			}
-		}
-	}
-
-	return future, err
-}
-
 func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client, properties resources.DeploymentPropertiesExtended) error {
 	if properties.Providers == nil {
 		return fmt.Errorf("`properties.Providers` was nil - insufficient data to clean up this Template Deployment")
@@ -201,7 +182,22 @@ func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client
 		}
 
 		log.Printf("[DEBUG] Deleting Nested Resource %q..", *nestedResource.ID)
-		future, err := deleteResourceById(ctx, resourcesClient, *nestedResource.ID, resourceProviderApiVersion)
+		future, err := resourcesClient.DeleteByID(ctx, *nestedResource.ID, resourceProviderApiVersion)
+
+		// NOTE: resourceProviderApiVersion is gotten from one of resource types of the provider.
+		// When the provider has multiple resource types, it may cause API version mismatched.
+		// For such error, try to get available API version from error code. Ugly but this seems sufficient for now
+		if err != nil && strings.Contains(err.Error(), `Code="NoRegisteredProviderFound"`) {
+			apiPat := regexp.MustCompile(`\d{4}-\d{2}-\d{2}(-preview)*`)
+			matches := apiPat.FindAllStringSubmatch(err.Error(), -1)
+			for _, match := range matches {
+				if resourceProviderApiVersion != match[0] {
+					future, err = resourcesClient.DeleteByID(ctx, *nestedResource.ID, match[0])
+					break
+				}
+			}
+		}
+
 		if err != nil {
 			if resp := future.Response(); resp != nil && resp.StatusCode == http.StatusNotFound {
 				log.Printf("[DEBUG] Nested Resource %q has been deleted.. continuing..", *nestedResource.ID)


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/issues/14810
![image](https://user-images.githubusercontent.com/76987228/157561941-1ee1ff83-b97b-469b-b8ed-71d17612d339.png)
