### PR TITLE
Final sweep of straightforward TODO changes for 3.0

### DIFF
--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -274,17 +274,17 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			if v, ok := keyVaultRaw["recover_soft_deleted_key_vaults"]; ok {
 				featuresMap.KeyVault.RecoverSoftDeletedKeyVaults = v.(bool)
 			}
-			// Inherit Key Vault recovery setting by default. If we're on 3.0 then the code below will overwrite
-			// these values as needed.
-			// TODO: Remove in 3.0
-			featuresMap.KeyVault.RecoverSoftDeletedCerts = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
-			featuresMap.KeyVault.RecoverSoftDeletedSecrets = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
-			featuresMap.KeyVault.RecoverSoftDeletedKeys = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
-			featuresMap.KeyVault.PurgeSoftDeletedKeysOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
-			featuresMap.KeyVault.PurgeSoftDeletedCertsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
-			featuresMap.KeyVault.PurgeSoftDeletedSecretsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
 
-			if features.ThreePointOhBeta() {
+			if !features.ThreePointOhBeta() {
+				// Inherit Key Vault recovery setting by default. If we're on 3.0 then the code below will overwrite
+				// these values as needed.
+				featuresMap.KeyVault.RecoverSoftDeletedCerts = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
+				featuresMap.KeyVault.RecoverSoftDeletedSecrets = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
+				featuresMap.KeyVault.RecoverSoftDeletedKeys = featuresMap.KeyVault.RecoverSoftDeletedKeyVaults
+				featuresMap.KeyVault.PurgeSoftDeletedKeysOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
+				featuresMap.KeyVault.PurgeSoftDeletedCertsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
+				featuresMap.KeyVault.PurgeSoftDeletedSecretsOnDestroy = featuresMap.KeyVault.PurgeSoftDeleteOnDestroy
+			} else {
 				if v, ok := keyVaultRaw["recover_soft_deleted_certificates"]; ok {
 					featuresMap.KeyVault.RecoverSoftDeletedCerts = v.(bool)
 				}

--- a/internal/services/containers/kubernetes_cluster_auth_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_auth_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
-// TODO this can be removed post 3.0 as only `azure_active_directory_role_based_access_control.0.server_app_secret` needs to be ignored in the ImportStep
+// CLEANUP this can be removed post 3.0 as only `azure_active_directory_role_based_access_control.0.server_app_secret` needs to be ignored in the ImportStep
 func rbacServerAppSecret() []string {
 	serverAppSecret := []string{"azure_active_directory_role_based_access_control.0.server_app_secret"}
 	if !features.ThreePointOhBeta() {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1006,7 +1006,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 		},
 	}
 
-	// TODO: post-3.0 we should inline these?
+	// CLEANUP: post-3.0 we should inline these?
 	for k, v := range schemaKubernetesAddOns() {
 		resource.Schema[k] = v
 	}

--- a/internal/services/cosmos/common/indexing_policy.go
+++ b/internal/services/cosmos/common/indexing_policy.go
@@ -151,7 +151,7 @@ func flattenCosmosDBIndexingPolicyCompositeIndex(input []documentdb.CompositePat
 
 		block := make(map[string]interface{})
 		block["path"] = path
-		block["order"] = strings.Title(string(v.Order))
+		block["order"] = string(v.Order)
 		indexPairs = append(indexPairs, block)
 	}
 
@@ -232,7 +232,7 @@ func FlattenAzureRmCosmosDbIndexingPolicy(indexingPolicy *documentdb.IndexingPol
 	}
 
 	result := make(map[string]interface{})
-	result["indexing_mode"] = strings.Title(string(indexingPolicy.IndexingMode))
+	result["indexing_mode"] = string(indexingPolicy.IndexingMode)
 	result["included_path"] = flattenCosmosDBIndexingPolicyIncludedPaths(indexingPolicy.IncludedPaths)
 	result["excluded_path"] = flattenCosmosDBIndexingPolicyExcludedPaths(indexingPolicy.ExcludedPaths)
 	result["composite_index"] = FlattenCosmosDBIndexingPolicyCompositeIndexes(indexingPolicy.CompositeIndexes)

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
@@ -113,16 +114,25 @@ func resourceCosmosDbGremlinGraph() *pluginsdk.Resource {
 						},
 
 						// case change in 2021-01-15, issue https://github.com/Azure/azure-rest-api-specs/issues/14051
-						// todo: change to SDK constants and remove translation code in 3.0
 						"indexing_mode": {
 							Type:             pluginsdk.TypeString,
 							Required:         true,
-							DiffSuppressFunc: suppress.CaseDifference, // Open issue https://github.com/Azure/azure-sdk-for-go/issues/6603
-							ValidateFunc: validation.StringInSlice([]string{
-								"Consistent",
-								"Lazy",
-								"None",
-							}, false),
+							DiffSuppressFunc: suppress.CaseDifferenceV2Only, // Open issue https://github.com/Azure/azure-sdk-for-go/issues/6603
+							ValidateFunc: func() pluginsdk.SchemaValidateFunc {
+								keys := []string{
+									string(documentdb.IndexingModeConsistent),
+									string(documentdb.IndexingModeNone),
+									string(documentdb.IndexingModeLazy),
+								}
+								if !features.ThreePointOhBeta() {
+									keys = []string{
+										"Consistent",
+										"Lazy",
+										"None",
+									}
+								}
+								return validation.StringInSlice(keys, features.ThreePointOhBeta())
+							}(),
 						},
 
 						"included_paths": {
@@ -523,7 +533,7 @@ func flattenAzureRmCosmosDBGremlinGraphIndexingPolicy(input *documentdb.Indexing
 	indexPolicy := make(map[string]interface{})
 
 	indexPolicy["automatic"] = input.Automatic
-	indexPolicy["indexing_mode"] = strings.Title(string(input.IndexingMode))
+	indexPolicy["indexing_mode"] = string(input.IndexingMode)
 	indexPolicy["included_paths"] = pluginsdk.NewSet(pluginsdk.HashString, flattenAzureRmCosmosDBGremlinGraphIncludedPaths(input.IncludedPaths))
 	indexPolicy["excluded_paths"] = pluginsdk.NewSet(pluginsdk.HashString, flattenAzureRmCosmosDBGremlinGraphExcludedPaths(input.ExcludedPaths))
 	indexPolicy["composite_index"] = common.FlattenCosmosDBIndexingPolicyCompositeIndexes(input.CompositeIndexes)

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
@@ -230,7 +230,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic      = true
-    indexing_mode  = "Consistent"
+    indexing_mode  = "consistent"
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
   }
@@ -257,7 +257,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic     = false
-    indexing_mode = "None"
+    indexing_mode = "none"
   }
 
   conflict_resolution_policy {
@@ -282,27 +282,27 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic     = true
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     composite_index {
       index {
         path  = "/path1"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path2"
-        order = "Descending"
+        order = "descending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
 
@@ -337,27 +337,27 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic     = true
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     composite_index {
       index {
         path  = "/path1"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path2"
-        order = "Descending"
+        order = "descending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
   }
@@ -385,7 +385,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic      = true
-    indexing_mode  = "Consistent"
+    indexing_mode  = "consistent"
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
   }
@@ -414,7 +414,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 
   index_policy {
     automatic      = true
-    indexing_mode  = "Consistent"
+    indexing_mode  = "consistent"
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
   }

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -265,7 +265,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   default_ttl = 500
   throughput  = 600
   indexing_policy {
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     included_path {
       path = "/*"
@@ -281,22 +281,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
     composite_index {
       index {
         path  = "/path1"
-        order = "Descending"
+        order = "descending"
       }
       index {
         path  = "/path2"
-        order = "Ascending"
+        order = "ascending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
   }
@@ -341,7 +341,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   default_ttl = 1000
   throughput  = 400
   indexing_policy {
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     included_path {
       path = "/*"
@@ -358,22 +358,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
     composite_index {
       index {
         path  = "/path1"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path2"
-        order = "Descending"
+        order = "descending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
   }
@@ -409,7 +409,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   partition_key_path  = "/definition/id"
 
   indexing_policy {
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     included_path {
       path = "/*"
@@ -426,22 +426,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
     composite_index {
       index {
         path  = "/path1"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path2"
-        order = "Descending"
+        order = "descending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
   }
@@ -461,7 +461,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   partition_key_path  = "/definition/id"
 
   indexing_policy {
-    indexing_mode = "Consistent"
+    indexing_mode = "consistent"
 
     included_path {
       path = "/*"
@@ -478,22 +478,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
     composite_index {
       index {
         path  = "/path1"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path2"
-        order = "Descending"
+        order = "descending"
       }
     }
 
     composite_index {
       index {
         path  = "/path3"
-        order = "Ascending"
+        order = "ascending"
       }
       index {
         path  = "/path4"
-        order = "Descending"
+        order = "descending"
       }
     }
 

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -312,8 +312,6 @@ func resourceIotHub() *pluginsdk.Resource {
 								DiffSuppressFunc: suppressIfTypeIsNot("AzureIotHub.StorageContainer"),
 							},
 
-							// encoding should be case-sensitive but kept case-insensitive for backward compatibility.
-							// todo remove suppress.CaseDifference, make encoding case-sensitive and normalize it with pandora in 3.0 or 4.0
 							"encoding": {
 								Type:     pluginsdk.TypeString,
 								Optional: true,

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -523,17 +523,21 @@ func resourceKeyVaultKeyDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
+	kv, err := keyVaultsClient.VaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
 	if err != nil {
-		return fmt.Errorf("checking if key vault %q for Key %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
+		if utils.ResponseWasNotFound(kv.Response) {
+			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving key vault %q properties: %+v", *keyVaultId, err)
 	}
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedKeysOnDestroy
+	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
+		return fmt.Errorf("cannot purge %q because vault %q has purge protection enabled", keyVaultId)
+	}
+
 	description := fmt.Sprintf("Key %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)
 	deleter := deleteAndPurgeKey{
 		client:      client,

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -535,7 +535,7 @@ func resourceKeyVaultKeyDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedKeysOnDestroy
 	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
-		return fmt.Errorf("cannot purge %q because vault %q has purge protection enabled", keyVaultId)
+		return fmt.Errorf("cannot purge key %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
 	}
 
 	description := fmt.Sprintf("Key %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)

--- a/internal/services/network/migration/network_watcher_flow_log.go
+++ b/internal/services/network/migration/network_watcher_flow_log.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -110,10 +111,9 @@ func (NetworkWatcherFlowLogV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"location": {
-			// TODO: `computed` should be removed in 3.0
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Computed: true,
+			Computed: !features.ThreePointOhBeta(),
 			ForceNew: true,
 		},
 

--- a/internal/services/portal/portal_dashboard_data_source_test.go
+++ b/internal/services/portal/portal_dashboard_data_source_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -42,25 +44,33 @@ func TestAccDataSourcePortalDashboard_complete(t *testing.T) {
 }
 
 func (PortalDashboardDataSource) basic(data acceptance.TestData) string {
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
 	return fmt.Sprintf(`
 
 %s
 
 data "azurerm_portal_dashboard" "test" {
-  name                = azurerm_dashboard.test.name
+  name                = %s.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, PortalDashboardResource{}.basic(data))
+`, PortalDashboardResource{}.basic(data), resourceName)
 }
 
 func (PortalDashboardDataSource) complete(data acceptance.TestData) string {
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
 	return fmt.Sprintf(`
 
 %s
 
 data "azurerm_portal_dashboard" "test" {
-  name                = azurerm_dashboard.test.name
+  name                = %s.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, PortalDashboardResource{}.complete(data))
+`, PortalDashboardResource{}.complete(data), resourceName)
 }

--- a/internal/services/portal/portal_dashboard_data_source_test.go
+++ b/internal/services/portal/portal_dashboard_data_source_test.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type PortalDashboardDataSource struct{}

--- a/internal/services/portal/portal_dashboard_resource_test.go
+++ b/internal/services/portal/portal_dashboard_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -16,7 +18,11 @@ import (
 type PortalDashboardResource struct{}
 
 func TestAccPortalDashboard_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_dashboard", "test")
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
+	data := acceptance.BuildTestData(t, resourceName, "test")
 	r := PortalDashboardResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -30,7 +36,11 @@ func TestAccPortalDashboard_basic(t *testing.T) {
 }
 
 func TestAccPortalDashboard_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_dashboard", "test")
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
+	data := acceptance.BuildTestData(t, resourceName, "test")
 	r := PortalDashboardResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -58,6 +68,11 @@ func (PortalDashboardResource) Exists(ctx context.Context, clients *clients.Clie
 }
 
 func (PortalDashboardResource) basic(data acceptance.TestData) string {
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -68,7 +83,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
-resource "azurerm_dashboard" "test" {
+resource "%s" "test" {
   name                 = "my-test-dashboard"
   resource_group_name  = azurerm_resource_group.test.name
   location             = azurerm_resource_group.test.location
@@ -105,10 +120,15 @@ resource "azurerm_dashboard" "test" {
 }
 DASH
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, resourceName)
 }
 
 func (PortalDashboardResource) complete(data acceptance.TestData) string {
+	resourceName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		resourceName = "azurerm_dashboard"
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -119,7 +139,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
-resource "azurerm_dashboard" "test" {
+resource "%s" "test" {
   name                = "my-test-dashboard"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
@@ -159,5 +179,5 @@ resource "azurerm_dashboard" "test" {
 }
 DASH
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, resourceName)
 }

--- a/internal/services/portal/portal_dashboard_resource_test.go
+++ b/internal/services/portal/portal_dashboard_resource_test.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/portal/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/portal/registration.go
+++ b/internal/services/portal/registration.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -34,8 +35,12 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	dashboardName := "azurerm_portal_dashboard"
+	if !features.ThreePointOhBeta() {
+		dashboardName = "azurerm_dashboard"
+	}
 	return map[string]*pluginsdk.Resource{
-		"azurerm_dashboard":                   resourceDashboard(), // TODO 3.0 rename to azurerm_portal_dashboard
+		dashboardName:                         resourceDashboard(),
 		"azurerm_portal_tenant_configuration": resourcePortalTenantConfiguration(),
 	}
 }

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -224,10 +224,16 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 			},
 
 			"geo_redundant_backup_enabled": {
-				Type:          pluginsdk.TypeBool,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true, // TODO: remove in 3.0 and default to false
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: !features.ThreePointOhBeta(),
+				Default: func() interface{} {
+					if !features.ThreePointOhBeta() {
+						return nil
+					}
+					return false
+				}(),
 				ConflictsWith: []string{"storage_profile", "storage_profile.0.geo_redundant_backup"},
 			},
 

--- a/internal/services/redisenterprise/redis_enterprise_database_data_source.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_data_source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/sdk/2021-08-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/sdk/2021-08-01/redisenterprise"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +14,35 @@ import (
 )
 
 func dataSourceRedisEnterpriseDatabase() *pluginsdk.Resource {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: redisenterprise.ValidateRedisEnterpriseID,
+		},
+
+		"primary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+	}
+
+	if !features.FourPointOhBeta() {
+		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecated()
+	}
+
 	return &pluginsdk.Resource{
 		Read: dataSourceRedisEnterpriseDatabaseRead,
 
@@ -20,33 +50,7 @@ func dataSourceRedisEnterpriseDatabase() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			// TODO: 3.0 - deprecate me
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"cluster_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: redisenterprise.ValidateRedisEnterpriseID,
-			},
-
-			"primary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-
-			"secondary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-		},
+		Schema: s,
 	}
 }
 
@@ -71,12 +75,15 @@ func dataSourceRedisEnterpriseDatabaseRead(d *pluginsdk.ResourceData, meta inter
 	d.SetId(id.ID())
 
 	d.Set("name", id.DatabaseName)
-	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("cluster_id", clusterId.ID())
 
 	if model := keysResp.Model; model != nil {
 		d.Set("primary_access_key", model.PrimaryKey)
 		d.Set("secondary_access_key", model.SecondaryKey)
+	}
+
+	if !features.FourPointOhBeta() {
+		d.Set("resource_group_name", id.ResourceGroupName)
 	}
 
 	return nil

--- a/internal/services/redisenterprise/redis_enterprise_database_data_source.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_data_source.go
@@ -40,7 +40,7 @@ func dataSourceRedisEnterpriseDatabase() *pluginsdk.Resource {
 	}
 
 	if !features.FourPointOhBeta() {
-		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecated()
+		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecatedComputed()
 	}
 
 	return &pluginsdk.Resource{

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -2,12 +2,12 @@ package redisenterprise
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -194,7 +194,13 @@ func redisEnterpriseDatabaseSchema() map[string]*pluginsdk.Schema {
 	}
 
 	if !features.FourPointOhBeta() {
-		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecated()
+		s["resource_group_name"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: resourcegroups.ValidateName,
+			ForceNew:     true,
+			Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
+		}
 	}
 
 	return s

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -2,7 +2,7 @@ package redisenterprise
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"log"
 	"strings"
 	"time"
@@ -194,13 +194,7 @@ func redisEnterpriseDatabaseSchema() map[string]*pluginsdk.Schema {
 	}
 
 	if !features.FourPointOhBeta() {
-		s["resource_group_name"] = &pluginsdk.Schema{
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: resourcegroups.ValidateName,
-			ForceNew:     true,
-			Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
-		}
+		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecatedComputed()
 	}
 
 	return s

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -2,12 +2,12 @@ package redisenterprise
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/sdk/2021-08-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/sdk/2021-08-01/redisenterprise"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/validate"
@@ -39,157 +40,164 @@ func resourceRedisEnterpriseDatabase() *pluginsdk.Resource {
 
 		// Since update is not currently supported all attribute have to be marked as FORCE NEW
 		// until support for Update comes online in the near future
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      "default",
-				ValidateFunc: validate.RedisEnterpriseDatabaseName,
-			},
+		Schema: redisEnterpriseDatabaseSchema(),
+	}
+}
 
-			// TODO: 3.0 - deprecate/remove this
-			"resource_group_name": azure.SchemaResourceGroupName(),
+func redisEnterpriseDatabaseSchema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      "default",
+			ValidateFunc: validate.RedisEnterpriseDatabaseName,
+		},
 
-			"cluster_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: redisenterprise.ValidateRedisEnterpriseID,
-			},
+		"cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: redisenterprise.ValidateRedisEnterpriseID,
+		},
 
-			"client_protocol": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(redisenterprise.ProtocolEncrypted),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(redisenterprise.ProtocolEncrypted),
-					string(redisenterprise.ProtocolPlaintext),
-				}, false),
-			},
+		"client_protocol": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(redisenterprise.ProtocolEncrypted),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(redisenterprise.ProtocolEncrypted),
+				string(redisenterprise.ProtocolPlaintext),
+			}, false),
+		},
 
-			"clustering_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(redisenterprise.ClusteringPolicyOSSCluster),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(redisenterprise.ClusteringPolicyEnterpriseCluster),
-					string(redisenterprise.ClusteringPolicyOSSCluster),
-				}, false),
-			},
+		"clustering_policy": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(redisenterprise.ClusteringPolicyOSSCluster),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(redisenterprise.ClusteringPolicyEnterpriseCluster),
+				string(redisenterprise.ClusteringPolicyOSSCluster),
+			}, false),
+		},
 
-			"eviction_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(redisenterprise.EvictionPolicyVolatileLRU),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(redisenterprise.EvictionPolicyAllKeysLFU),
-					string(redisenterprise.EvictionPolicyAllKeysLRU),
-					string(redisenterprise.EvictionPolicyAllKeysRandom),
-					string(redisenterprise.EvictionPolicyVolatileLRU),
-					string(redisenterprise.EvictionPolicyVolatileLFU),
-					string(redisenterprise.EvictionPolicyVolatileTTL),
-					string(redisenterprise.EvictionPolicyVolatileRandom),
-					string(redisenterprise.EvictionPolicyNoEviction),
-				}, false),
-			},
+		"eviction_policy": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(redisenterprise.EvictionPolicyVolatileLRU),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(redisenterprise.EvictionPolicyAllKeysLFU),
+				string(redisenterprise.EvictionPolicyAllKeysLRU),
+				string(redisenterprise.EvictionPolicyAllKeysRandom),
+				string(redisenterprise.EvictionPolicyVolatileLRU),
+				string(redisenterprise.EvictionPolicyVolatileLFU),
+				string(redisenterprise.EvictionPolicyVolatileTTL),
+				string(redisenterprise.EvictionPolicyVolatileRandom),
+				string(redisenterprise.EvictionPolicyNoEviction),
+			}, false),
+		},
 
-			"module": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 3,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"RedisBloom",
-								"RedisTimeSeries",
-								"RediSearch",
-							}, false),
-						},
+		"module": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 3,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"RedisBloom",
+							"RedisTimeSeries",
+							"RediSearch",
+						}, false),
+					},
 
-						"args": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Default:  "",
-						},
+					"args": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  "",
+					},
 
-						"version": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			// This attribute is currently in preview and is not returned by the RP
-			// "persistence": {
-			// 	Type:     pluginsdk.TypeList,
-			// 	Optional: true,
-			// 	MaxItems: 1,
-			// 	Elem: &pluginsdk.Resource{
-			// 		Schema: map[string]*pluginsdk.Schema{
-			// 			"aof_enabled": {
-			// 				Type:     pluginsdk.TypeBool,
-			// 				Optional: true,
-			// 			},
+		// This attribute is currently in preview and is not returned by the RP
+		// "persistence": {
+		// 	Type:     pluginsdk.TypeList,
+		// 	Optional: true,
+		// 	MaxItems: 1,
+		// 	Elem: &pluginsdk.Resource{
+		// 		Schema: map[string]*pluginsdk.Schema{
+		// 			"aof_enabled": {
+		// 				Type:     pluginsdk.TypeBool,
+		// 				Optional: true,
+		// 			},
 
-			// 			"aof_frequency": {
-			// 				Type:     pluginsdk.TypeString,
-			// 				Optional: true,
-			// 				ValidateFunc: validation.StringInSlice([]string{
-			// 					string(redisenterprise.Ones),
-			// 					string(redisenterprise.Always),
-			// 				}, false),
-			// 			},
+		// 			"aof_frequency": {
+		// 				Type:     pluginsdk.TypeString,
+		// 				Optional: true,
+		// 				ValidateFunc: validation.StringInSlice([]string{
+		// 					string(redisenterprise.Ones),
+		// 					string(redisenterprise.Always),
+		// 				}, false),
+		// 			},
 
-			// 			"rdb_enabled": {
-			// 				Type:     pluginsdk.TypeBool,
-			// 				Optional: true,
-			// 			},
+		// 			"rdb_enabled": {
+		// 				Type:     pluginsdk.TypeBool,
+		// 				Optional: true,
+		// 			},
 
-			// 			"rdb_frequency": {
-			// 				Type:     pluginsdk.TypeString,
-			// 				Optional: true,
-			// 				ValidateFunc: validation.StringInSlice([]string{
-			// 					string(redisenterprise.Oneh),
-			// 					string(redisenterprise.Sixh),
-			// 					string(redisenterprise.OneTwoh),
-			// 				}, false),
-			// 			},
-			// 		},
-			// 	},
-			// },
+		// 			"rdb_frequency": {
+		// 				Type:     pluginsdk.TypeString,
+		// 				Optional: true,
+		// 				ValidateFunc: validation.StringInSlice([]string{
+		// 					string(redisenterprise.Oneh),
+		// 					string(redisenterprise.Sixh),
+		// 					string(redisenterprise.OneTwoh),
+		// 				}, false),
+		// 			},
+		// 		},
+		// 	},
+		// },
 
-			"port": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      10000,
-				ValidateFunc: validation.IntBetween(0, 65353),
-			},
+		"port": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      10000,
+			ValidateFunc: validation.IntBetween(0, 65353),
+		},
 
-			"primary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+		"primary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
 
-			"secondary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+		"secondary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		s["resource_group_name"] = commonschema.ResourceGroupNameDeprecated()
+	}
+
+	return s
 }
 
 func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -283,9 +291,12 @@ func resourceRedisEnterpriseDatabaseRead(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	d.Set("name", id.DatabaseName)
-	d.Set("resource_group_name", id.ResourceGroupName)
 	clusterId := redisenterprise.NewRedisEnterpriseID(id.SubscriptionId, id.ResourceGroupName, id.ClusterName)
 	d.Set("cluster_id", clusterId.ID())
+
+	if !features.FourPointOhBeta() {
+		d.Set("resource_group_name", id.ResourceGroupName)
+	}
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {


### PR DESCRIPTION
[3.0 Beta] `indexing_mode` values for `cosmosdb_gremlin_graph_resource` are now lower case and case-sensitive.
[3.0 Beta] `location` is no longer computed in `network_watcher_flow_log` resource
[3.0 Beta] `geo_redundant_backup_enabled` of `postgresql_server` resource is no longer a computed attributed, and has a default value of `false`
[3.0 Beta] `resource_group_name` of `redis_enterprise_database` data source is now deprecated.
[3.0 Beta] `resource_group_name` of `redis_enterprise_database` resource is now deprecated.
[3.0 Beta] resource `azurerm_dashboard` has been renamed to `azurerm_portal_dashboard`.
[3.0 Beta] `order` values for `cosmosdb_indexing_policy` are now lower case and case-sensitive.