### PR TITLE
azure_storage_table_entity: support propoerty data types

### DIFF
--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -163,7 +164,7 @@ func resourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{})
 	input := entities.GetEntityInput{
 		PartitionKey:  id.PartitionKey,
 		RowKey:        id.RowKey,
-		MetaDataLevel: entities.NoMetaData,
+		MetaDataLevel: entities.FullMetaData,
 	}
 
 	result, err := client.Get(ctx, id.AccountName, id.TableName, input)
@@ -223,5 +224,53 @@ func flattenEntity(entity map[string]interface{}) map[string]interface{} {
 	delete(entity, "RowKey")
 	delete(entity, "Timestamp")
 
-	return entity
+	result := map[string]interface{}{}
+	for k, v := range entity {
+		// skip ODATA annotation returned with fullmetadata
+		if strings.HasPrefix(k, "odata.") || strings.HasSuffix(k, "@odata.type") {
+			continue
+		}
+		if dtype, ok := entity[k+"@odata.type"]; ok {
+			switch dtype {
+			case "Edm.Boolean":
+				result[k] = fmt.Sprint(v)
+			case "Edm.Double":
+				result[k] = fmt.Sprintf("%f", v)
+			case "Edm.Int32":
+				fallthrough
+			case "Edm.Int64":
+				result[k] = fmt.Sprintf("%d", int64(v.(float64)))
+			case "Edm.String":
+				result[k] = v
+			default:
+				log.Printf("[WARN] key %q with unexpected @odata.type %q", k, dtype)
+				continue
+			}
+
+			result[k+"@odata.type"] = dtype
+		} else {
+			// special handling for property types that do not require the annotation to be present
+			// https://docs.microsoft.com/en-us/rest/api/storageservices/payload-format-for-table-service-operations#property-types-in-a-json-feed
+			switch c := v.(type) {
+			case bool:
+				result[k] = fmt.Sprint(v)
+				result[k+"@odata.type"] = "Edm.Boolean"
+			case float64:
+				f64 := v.(float64)
+				if v == float64(int64(f64)) {
+					result[k] = fmt.Sprintf("%d", int64(f64))
+					result[k+"@odata.type"] = "Edm.Int32"
+				} else {
+					result[k] = fmt.Sprintf("%f", v)
+					result[k+"@odata.type"] = "Edm.Double"
+				}
+			case string:
+				result[k] = v
+			default:
+				log.Printf("[WARN] key %q with unexpected type %T", k, c)
+			}
+		}
+	}
+
+	return result
 }

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -67,6 +67,28 @@ func TestAccTableEntity_update(t *testing.T) {
 	})
 }
 
+func TestAccTableEntity_update_typed(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_table_entity", "test")
+	r := StorageTableEntityResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updated_typed(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageTableEntityResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := entities.ParseResourceID(state.ID)
 	if err != nil {
@@ -149,6 +171,26 @@ resource "azurerm_storage_table_entity" "test" {
   row_key       = "test_row%d"
   entity = {
     Foo  = "Bar"
+    Test = "Updated"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StorageTableEntityResource) updated_typed(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_account_name = azurerm_storage_account.test.name
+  table_name           = azurerm_storage_table.test.name
+
+  partition_key = "test_partition%d"
+  row_key       = "test_row%d"
+  entity = {
+    Foo = 123
+	"Foo@odata.type" = "Edm.Int32"
     Test = "Updated"
   }
 }

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -189,9 +189,9 @@ resource "azurerm_storage_table_entity" "test" {
   partition_key = "test_partition%d"
   row_key       = "test_row%d"
   entity = {
-    Foo = 123
+    Foo              = 123
     "Foo@odata.type" = "Edm.Int32"
-    Test = "Updated"
+    Test             = "Updated"
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -190,7 +190,7 @@ resource "azurerm_storage_table_entity" "test" {
   row_key       = "test_row%d"
   entity = {
     Foo = 123
-	"Foo@odata.type" = "Edm.Int32"
+    "Foo@odata.type" = "Edm.Int32"
     Test = "Updated"
   }
 }


### PR DESCRIPTION
This change makes flattenEntity parse OData Data Types and persist them
in the Terraform state.

Fixes #5286 #12337