### PR TITLE
New Data Source `azurerm_managed_api` & New Resource: `azurerm_api_connection`

### DIFF
--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -20,6 +20,7 @@ var services = mapOf(
         "cognitive" to "Cognitive Services",
         "communication" to "Communication",
         "compute" to "Compute",
+        "connections" to "Connections",
         "consumption" to "Consumption",
         "containers" to "Container Services",
         "cosmos" to "CosmosDB",

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -25,6 +25,7 @@ import (
 	cognitiveServices "github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive/client"
 	communication "github.com/hashicorp/terraform-provider-azurerm/internal/services/communication/client"
 	compute "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/client"
+	connections "github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/client"
 	consumption "github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/client"
 	containerServices "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/client"
 	cosmosdb "github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/client"
@@ -136,6 +137,7 @@ type Client struct {
 	Cognitive             *cognitiveServices.Client
 	Communication         *communication.Client
 	Compute               *compute.Client
+	Connections           *connections.Client
 	Consumption           *consumption.Client
 	Containers            *containerServices.Client
 	Cosmos                *cosmosdb.Client
@@ -249,6 +251,7 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	client.Cognitive = cognitiveServices.NewClient(o)
 	client.Communication = communication.NewClient(o)
 	client.Compute = compute.NewClient(o)
+	client.Connections = connections.NewClient(o)
 	client.Consumption = consumption.NewClient(o)
 	client.Containers = containerServices.NewClient(o)
 	client.Cosmos = cosmosdb.NewClient(o)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/communication"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos"
@@ -155,6 +156,7 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 			cognitive.Registration{},
 			communication.Registration{},
 			compute.Registration{},
+			connections.Registration{},
 			containers.Registration{},
 			consumption.Registration{},
 			cosmos.Registration{},

--- a/internal/services/connections/api_connection_resource.go
+++ b/internal/services/connections/api_connection_resource.go
@@ -1,0 +1,244 @@
+package connections
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/connections"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/managedapis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceConnection() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceConnectionCreate,
+		Read:   resourceConnectionRead,
+		Update: resourceConnectionUpdate,
+		Delete: resourceConnectionDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := connections.ParseConnectionID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"managed_api_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: managedapis.ValidateManagedApiID,
+			},
+
+			"display_name": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				// @tombuildsstuff: this can't be patched in API version 2016-06-01 and there isn't Swagger for
+				// API version 2018-07-01-preview, so I guess this is ForceNew for now
+				//
+				// > Status=400 Code="PatchApiConnectionPropertiesNotSupported"
+				// > Message="The request to patch API connection 'acctestconn-220307135205093274' is not supported.
+				// > None of the fields inside the properties object can be patched."
+				ForceNew: true,
+			},
+
+			"parameter_values": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				// @tombuildsstuff: this can't be patched in API version 2016-06-01 and there isn't Swagger for
+				// API version 2018-07-01-preview, so I guess this is ForceNew for now
+				//
+				// > Status=400 Code="PatchApiConnectionPropertiesNotSupported"
+				// > Message="The request to patch API connection 'acctestconn-220307135205093274' is not supported.
+				// > None of the fields inside the properties object can be patched."
+				ForceNew: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"tags": commonschema.Tags(),
+		},
+	}
+}
+
+func resourceConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Connections.ConnectionsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := connections.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	existing, err := client.Get(ctx, id)
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+		}
+	}
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_api_connection", id.ID())
+	}
+
+	managedAppId, err := managedapis.ParseManagedApiID(d.Get("managed_api_id").(string))
+	if err != nil {
+		return fmt.Errorf("parsing `managed_app_id`: %+v", err)
+	}
+	location := location.Normalize(managedAppId.Location)
+	parameterValues := expandConnectionParameterValues(d.Get("parameter_values").(map[string]interface{}))
+	model := connections.ApiConnectionDefinition{
+		Location: utils.String(location),
+		Properties: &connections.ApiConnectionDefinitionProperties{
+			Api: &connections.ApiReference{
+				Id: utils.String(managedAppId.ID()),
+			},
+			DisplayName:     utils.String(d.Get("display_name").(string)),
+			ParameterValues: parameterValues,
+		},
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+	if v := d.Get("display_name").(string); v != "" {
+		model.Properties.DisplayName = utils.String(v)
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id, model); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceConnectionRead(d, meta)
+}
+
+func resourceConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Connections.ConnectionsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := connections.ParseConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[DEBUG] %s was not found - removing from state", *id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("name", id.ConnectionName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("display_name", props.DisplayName)
+
+			apiId := ""
+			if props.Api != nil && props.Api.Id != nil {
+				apiId = *props.Api.Id
+			}
+			d.Set("managed_api_id", apiId)
+
+			parameterValues := flattenConnectionParameterValues(props.ParameterValues)
+			if err := d.Set("parameter_values", parameterValues); err != nil {
+				return fmt.Errorf("setting `parameter_values`: %+v", err)
+			}
+		}
+
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Connections.ConnectionsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := connections.ParseConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	model := connections.ApiConnectionDefinition{
+		// @tombuildsstuff: this can't be patched in API version 2016-06-01 and there isn't Swagger for
+		// API version 2018-07-01-preview, so I guess this is ForceNew for now. The following error is returned
+		// for both CreateOrUpdate and Update:
+		//
+		// > Status=400 Code="PatchApiConnectionPropertiesNotSupported"
+		// > Message="The request to patch API connection 'acctestconn-220307135205093274' is not supported.
+		// > None of the fields inside the properties object can be patched."
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+	if _, err := client.Update(ctx, *id, model); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
+	}
+
+	return resourceConnectionRead(d, meta)
+}
+
+func resourceConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Connections.ConnectionsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := connections.ParseConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	return nil
+}
+
+func expandConnectionParameterValues(input map[string]interface{}) *map[string]string {
+	parameterValues := make(map[string]string)
+	for k, v := range input {
+		parameterValues[k] = v.(string)
+	}
+	return &parameterValues
+}
+
+func flattenConnectionParameterValues(input *map[string]string) map[string]interface{} {
+	parameterValues := make(map[string]interface{})
+	if input != nil {
+		for k, v := range *input {
+			parameterValues[k] = v
+		}
+	}
+	return parameterValues
+}

--- a/internal/services/connections/api_connection_resource_test.go
+++ b/internal/services/connections/api_connection_resource_test.go
@@ -1,0 +1,205 @@
+package connections_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/connections"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ApiConnectionTestResource struct {
+}
+
+func TestAccApiConnection_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_connection", "test")
+	r := ApiConnectionTestResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiConnection_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_connection", "test")
+	r := ApiConnectionTestResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccApiConnection_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_connection", "test")
+	r := ApiConnectionTestResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parameter_values"),
+		{
+			// re-add
+			Config: r.completeUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("parameter_values"),
+	})
+}
+
+func (t ApiConnectionTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := connections.ParseConnectionID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Connections.ConnectionsClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (t ApiConnectionTestResource) basic(data acceptance.TestData) string {
+	template := t.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_api_connection" "test" {
+  name                = "acctestconn-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  managed_api_id      = data.azurerm_managed_api.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func (t ApiConnectionTestResource) requiresImport(data acceptance.TestData) string {
+	template := t.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_api_connection" "import" {
+  name                = azurerm_api_connection.test.name
+  resource_group_name = azurerm_api_connection.test.resource_group_name
+  managed_api_id      = azurerm_api_connection.test.managed_api_id
+}
+`, template)
+}
+
+func (t ApiConnectionTestResource) complete(data acceptance.TestData) string {
+	template := t.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_api_connection" "test" {
+  name                = "acctestconn-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  managed_api_id      = data.azurerm_managed_api.test.id
+  display_name        = "Example 1"
+
+  parameter_values = {
+    connectionString = azurerm_servicebus_namespace.test.default_primary_connection_string
+  }
+
+  tags = {
+    Hello = "World"
+  }
+
+  lifecycle {
+    ignore_changes = ["parameter_values"] # not returned from the API
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (t ApiConnectionTestResource) completeUpdated(data acceptance.TestData) string {
+	template := t.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_api_connection" "test" {
+  name                = "acctestconn-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  managed_api_id      = data.azurerm_managed_api.test.id
+  display_name        = "Example 1"
+
+  parameter_values = {
+    connectionString = azurerm_servicebus_namespace.test.default_primary_connection_string
+  }
+
+  tags = {
+    Another = "Tag"
+    Hello   = "World"
+  }
+
+  lifecycle {
+    ignore_changes = ["parameter_values"] # not returned from the API
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (ApiConnectionTestResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-conn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_logic_app_workflow" "test" {
+  name                = "acctestlaw-conn-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestsbn-conn-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+data "azurerm_managed_api" "test" {
+  name     = "servicebus"
+  location = azurerm_resource_group.test.location
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/connections/client/client.go
+++ b/internal/services/connections/client/client.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+type Client struct {
+}
+
+func NewClient(o *common.ClientOptions) *Client {
+	return &Client{}
+}

--- a/internal/services/connections/client/client.go
+++ b/internal/services/connections/client/client.go
@@ -3,17 +3,23 @@ package client
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/connections"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/managedapis"
 )
 
 type Client struct {
 	ConnectionsClient *connections.ConnectionsClient
+	ManagedApisClient *managedapis.ManagedAPIsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
 	connectionsClient := connections.NewConnectionsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&connectionsClient.Client, o.ResourceManagerAuthorizer)
 
+	managedApisClient := managedapis.NewManagedAPIsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&managedApisClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		ConnectionsClient: &connectionsClient,
+		ManagedApisClient: &managedApisClient,
 	}
 }

--- a/internal/services/connections/client/client.go
+++ b/internal/services/connections/client/client.go
@@ -2,11 +2,18 @@ package client
 
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/connections"
 )
 
 type Client struct {
+	ConnectionsClient *connections.ConnectionsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
-	return &Client{}
+	connectionsClient := connections.NewConnectionsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&connectionsClient.Client, o.ResourceManagerAuthorizer)
+
+	return &Client{
+		ConnectionsClient: &connectionsClient,
+	}
 }

--- a/internal/services/connections/managed_api_data_source.go
+++ b/internal/services/connections/managed_api_data_source.go
@@ -1,0 +1,67 @@
+package connections
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/sdk/2016-06-01/managedapis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func dataSourceManagedApi() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceManagedApiRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"location": commonschema.LocationWithoutForceNew(),
+
+			"tags": commonschema.TagsDataSource(),
+		},
+	}
+}
+
+func dataSourceManagedApiRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Connections.ManagedApisClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	location := location.Normalize(d.Get("location").(string))
+	id := managedapis.NewManagedApiID(subscriptionId, location, d.Get("name").(string))
+	resp, err := client.ManagedApisGet(ctx, id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", err)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	if model := resp.Model; model != nil {
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/services/connections/managed_api_data_source_test.go
+++ b/internal/services/connections/managed_api_data_source_test.go
@@ -1,0 +1,38 @@
+package connections_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ManagedApiTestDataSource struct{}
+
+func TestAccDataSourceManagedApi_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_api", "test")
+	r := ManagedApiTestDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+			),
+		},
+	})
+}
+
+func (ManagedApiTestDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_managed_api" "test" {
+  name     = "servicebus"
+  location = %q
+}
+`, data.Locations.Primary)
+}

--- a/internal/services/connections/registration.go
+++ b/internal/services/connections/registration.go
@@ -20,7 +20,9 @@ func (r Registration) WebsiteCategories() []string {
 }
 
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
+	return map[string]*pluginsdk.Resource{
+		"azurerm_managed_api": dataSourceManagedApi(),
+	}
 }
 
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {

--- a/internal/services/connections/registration.go
+++ b/internal/services/connections/registration.go
@@ -1,0 +1,28 @@
+package connections
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ sdk.UntypedServiceRegistration = Registration{}
+
+type Registration struct{}
+
+func (r Registration) Name() string {
+	return "Connections"
+}
+
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Connections",
+	}
+}
+
+func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{}
+}
+
+func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{}
+}

--- a/internal/services/connections/registration.go
+++ b/internal/services/connections/registration.go
@@ -26,5 +26,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 }
 
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
+	return map[string]*pluginsdk.Resource{
+		"azurerm_api_connection": resourceConnection(),
+	}
 }

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/client.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/client.go
@@ -1,0 +1,15 @@
+package connectiongateways
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ConnectionGatewaysClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewConnectionGatewaysClientWithBaseURI(endpoint string) ConnectionGatewaysClient {
+	return ConnectionGatewaysClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongateway.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongateway.go
@@ -1,0 +1,124 @@
+package connectiongateways
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionGatewayId{}
+
+// ConnectionGatewayId is a struct representing the Resource ID for a Connection Gateway
+type ConnectionGatewayId struct {
+	SubscriptionId        string
+	ResourceGroupName     string
+	ConnectionGatewayName string
+}
+
+// NewConnectionGatewayID returns a new ConnectionGatewayId struct
+func NewConnectionGatewayID(subscriptionId string, resourceGroupName string, connectionGatewayName string) ConnectionGatewayId {
+	return ConnectionGatewayId{
+		SubscriptionId:        subscriptionId,
+		ResourceGroupName:     resourceGroupName,
+		ConnectionGatewayName: connectionGatewayName,
+	}
+}
+
+// ParseConnectionGatewayID parses 'input' into a ConnectionGatewayId
+func ParseConnectionGatewayID(input string) (*ConnectionGatewayId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionGatewayId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionGatewayId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ConnectionGatewayName, ok = parsed.Parsed["connectionGatewayName"]; !ok {
+		return nil, fmt.Errorf("the segment 'connectionGatewayName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseConnectionGatewayIDInsensitively parses 'input' case-insensitively into a ConnectionGatewayId
+// note: this method should only be used for API response data and not user input
+func ParseConnectionGatewayIDInsensitively(input string) (*ConnectionGatewayId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionGatewayId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionGatewayId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ConnectionGatewayName, ok = parsed.Parsed["connectionGatewayName"]; !ok {
+		return nil, fmt.Errorf("the segment 'connectionGatewayName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateConnectionGatewayID checks that 'input' can be parsed as a Connection Gateway ID
+func ValidateConnectionGatewayID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseConnectionGatewayID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Connection Gateway ID
+func (id ConnectionGatewayId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/connectionGateways/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ConnectionGatewayName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Connection Gateway ID
+func (id ConnectionGatewayId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticConnectionGateways", "connectionGateways", "connectionGateways"),
+		resourceids.UserSpecifiedSegment("connectionGatewayName", "connectionGatewayValue"),
+	}
+}
+
+// String returns a human-readable description of this Connection Gateway ID
+func (id ConnectionGatewayId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Connection Gateway Name: %q", id.ConnectionGatewayName),
+	}
+	return fmt.Sprintf("Connection Gateway (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongateway_test.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongateway_test.go
@@ -1,0 +1,279 @@
+package connectiongateways
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionGatewayId{}
+
+func TestNewConnectionGatewayID(t *testing.T) {
+	id := NewConnectionGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "connectionGatewayValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.ConnectionGatewayName != "connectionGatewayValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ConnectionGatewayName'", id.ConnectionGatewayName, "connectionGatewayValue")
+	}
+}
+
+func TestFormatConnectionGatewayID(t *testing.T) {
+	actual := NewConnectionGatewayID("12345678-1234-9876-4563-123456789012", "example-resource-group", "connectionGatewayValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways/connectionGatewayValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseConnectionGatewayID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionGatewayId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways/connectionGatewayValue",
+			Expected: &ConnectionGatewayId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:     "example-resource-group",
+				ConnectionGatewayName: "connectionGatewayValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways/connectionGatewayValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionGatewayID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ConnectionGatewayName != v.Expected.ConnectionGatewayName {
+			t.Fatalf("Expected %q but got %q for ConnectionGatewayName", v.Expected.ConnectionGatewayName, actual.ConnectionGatewayName)
+		}
+
+	}
+}
+
+func TestParseConnectionGatewayIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionGatewayId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNgAtEwAyS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways/connectionGatewayValue",
+			Expected: &ConnectionGatewayId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:     "example-resource-group",
+				ConnectionGatewayName: "connectionGatewayValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connectionGateways/connectionGatewayValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNgAtEwAyS/cOnNeCtIoNgAtEwAyVaLuE",
+			Expected: &ConnectionGatewayId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:     "eXaMpLe-rEsOuRcE-GrOuP",
+				ConnectionGatewayName: "cOnNeCtIoNgAtEwAyVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNgAtEwAyS/cOnNeCtIoNgAtEwAyVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionGatewayIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ConnectionGatewayName != v.Expected.ConnectionGatewayName {
+			t.Fatalf("Expected %q but got %q for ConnectionGatewayName", v.Expected.ConnectionGatewayName, actual.ConnectionGatewayName)
+		}
+
+	}
+}
+
+func TestSegmentsForConnectionGatewayId(t *testing.T) {
+	segments := ConnectionGatewayId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ConnectionGatewayId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongatewayinstallation.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongatewayinstallation.go
@@ -1,0 +1,124 @@
+package connectiongateways
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionGatewayInstallationId{}
+
+// ConnectionGatewayInstallationId is a struct representing the Resource ID for a Connection Gateway Installation
+type ConnectionGatewayInstallationId struct {
+	SubscriptionId string
+	Location       string
+	GatewayId      string
+}
+
+// NewConnectionGatewayInstallationID returns a new ConnectionGatewayInstallationId struct
+func NewConnectionGatewayInstallationID(subscriptionId string, location string, gatewayId string) ConnectionGatewayInstallationId {
+	return ConnectionGatewayInstallationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+		GatewayId:      gatewayId,
+	}
+}
+
+// ParseConnectionGatewayInstallationID parses 'input' into a ConnectionGatewayInstallationId
+func ParseConnectionGatewayInstallationID(input string) (*ConnectionGatewayInstallationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionGatewayInstallationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionGatewayInstallationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	if id.GatewayId, ok = parsed.Parsed["gatewayId"]; !ok {
+		return nil, fmt.Errorf("the segment 'gatewayId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseConnectionGatewayInstallationIDInsensitively parses 'input' case-insensitively into a ConnectionGatewayInstallationId
+// note: this method should only be used for API response data and not user input
+func ParseConnectionGatewayInstallationIDInsensitively(input string) (*ConnectionGatewayInstallationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionGatewayInstallationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionGatewayInstallationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	if id.GatewayId, ok = parsed.Parsed["gatewayId"]; !ok {
+		return nil, fmt.Errorf("the segment 'gatewayId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateConnectionGatewayInstallationID checks that 'input' can be parsed as a Connection Gateway Installation ID
+func ValidateConnectionGatewayInstallationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseConnectionGatewayInstallationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Connection Gateway Installation ID
+func (id ConnectionGatewayInstallationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Web/locations/%s/connectionGatewayInstallations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location, id.GatewayId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Connection Gateway Installation ID
+func (id ConnectionGatewayInstallationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+		resourceids.StaticSegment("staticConnectionGatewayInstallations", "connectionGatewayInstallations", "connectionGatewayInstallations"),
+		resourceids.UserSpecifiedSegment("gatewayId", "gatewayIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Connection Gateway Installation ID
+func (id ConnectionGatewayInstallationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+		fmt.Sprintf("Gateway: %q", id.GatewayId),
+	}
+	return fmt.Sprintf("Connection Gateway Installation (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongatewayinstallation_test.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_connectiongatewayinstallation_test.go
@@ -1,0 +1,279 @@
+package connectiongateways
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionGatewayInstallationId{}
+
+func TestNewConnectionGatewayInstallationID(t *testing.T) {
+	id := NewConnectionGatewayInstallationID("12345678-1234-9876-4563-123456789012", "locationValue", "gatewayIdValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+
+	if id.GatewayId != "gatewayIdValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'GatewayId'", id.GatewayId, "gatewayIdValue")
+	}
+}
+
+func TestFormatConnectionGatewayInstallationID(t *testing.T) {
+	actual := NewConnectionGatewayInstallationID("12345678-1234-9876-4563-123456789012", "locationValue", "gatewayIdValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations/gatewayIdValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseConnectionGatewayInstallationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionGatewayInstallationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations/gatewayIdValue",
+			Expected: &ConnectionGatewayInstallationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+				GatewayId:      "gatewayIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations/gatewayIdValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionGatewayInstallationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+		if actual.GatewayId != v.Expected.GatewayId {
+			t.Fatalf("Expected %q but got %q for GatewayId", v.Expected.GatewayId, actual.GatewayId)
+		}
+
+	}
+}
+
+func TestParseConnectionGatewayInstallationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionGatewayInstallationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/cOnNeCtIoNgAtEwAyInStAlLaTiOnS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations/gatewayIdValue",
+			Expected: &ConnectionGatewayInstallationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+				GatewayId:      "gatewayIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/connectionGatewayInstallations/gatewayIdValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/cOnNeCtIoNgAtEwAyInStAlLaTiOnS/gAtEwAyIdVaLuE",
+			Expected: &ConnectionGatewayInstallationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+				GatewayId:      "gAtEwAyIdVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/cOnNeCtIoNgAtEwAyInStAlLaTiOnS/gAtEwAyIdVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionGatewayInstallationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+		if actual.GatewayId != v.Expected.GatewayId {
+			t.Fatalf("Expected %q but got %q for GatewayId", v.Expected.GatewayId, actual.GatewayId)
+		}
+
+	}
+}
+
+func TestSegmentsForConnectionGatewayInstallationId(t *testing.T) {
+	segments := ConnectionGatewayInstallationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ConnectionGatewayInstallationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_location.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_location.go
@@ -1,0 +1,111 @@
+package connectiongateways
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	Location       string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, location string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Web/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/id_location_test.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/id_location_test.go
@@ -1,0 +1,234 @@
+package connectiongateways
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+func TestNewLocationID(t *testing.T) {
+	id := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+}
+
+func TestFormatLocationID(t *testing.T) {
+	actual := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseLocationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestParseLocationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestSegmentsForLocationId(t *testing.T) {
+	segments := LocationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("LocationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayinstallationsget_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayinstallationsget_autorest.go
@@ -1,0 +1,64 @@
+package connectiongateways
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewayInstallationsGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayInstallationDefinition
+}
+
+// ConnectionGatewayInstallationsGet ...
+func (c ConnectionGatewaysClient) ConnectionGatewayInstallationsGet(ctx context.Context, id ConnectionGatewayInstallationId) (result ConnectionGatewayInstallationsGetOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewayInstallationsGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewayInstallationsGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewayInstallationsGet prepares the ConnectionGatewayInstallationsGet request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewayInstallationsGet(ctx context.Context, id ConnectionGatewayInstallationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewayInstallationsGet handles the response to the ConnectionGatewayInstallationsGet request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewayInstallationsGet(resp *http.Response) (result ConnectionGatewayInstallationsGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayinstallationslist_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayinstallationslist_autorest.go
@@ -1,0 +1,65 @@
+package connectiongateways
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewayInstallationsListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayInstallationDefinitionCollection
+}
+
+// ConnectionGatewayInstallationsList ...
+func (c ConnectionGatewaysClient) ConnectionGatewayInstallationsList(ctx context.Context, id LocationId) (result ConnectionGatewayInstallationsListOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewayInstallationsList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsList", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsList", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewayInstallationsList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewayInstallationsList", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewayInstallationsList prepares the ConnectionGatewayInstallationsList request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewayInstallationsList(ctx context.Context, id LocationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/connectionGatewayInstallations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewayInstallationsList handles the response to the ConnectionGatewayInstallationsList request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewayInstallationsList(resp *http.Response) (result ConnectionGatewayInstallationsListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayscreateorupdate_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayscreateorupdate_autorest.go
@@ -1,0 +1,65 @@
+package connectiongateways
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewaysCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayDefinition
+}
+
+// ConnectionGatewaysCreateOrUpdate ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysCreateOrUpdate(ctx context.Context, id ConnectionGatewayId, input ConnectionGatewayDefinition) (result ConnectionGatewaysCreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysCreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysCreateOrUpdate prepares the ConnectionGatewaysCreateOrUpdate request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysCreateOrUpdate(ctx context.Context, id ConnectionGatewayId, input ConnectionGatewayDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysCreateOrUpdate handles the response to the ConnectionGatewaysCreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysCreateOrUpdate(resp *http.Response) (result ConnectionGatewaysCreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysdelete_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysdelete_autorest.go
@@ -1,0 +1,62 @@
+package connectiongateways
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewaysDeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// ConnectionGatewaysDelete ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysDelete(ctx context.Context, id ConnectionGatewayId) (result ConnectionGatewaysDeleteOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysDelete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysDelete prepares the ConnectionGatewaysDelete request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysDelete(ctx context.Context, id ConnectionGatewayId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysDelete handles the response to the ConnectionGatewaysDelete request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysDelete(resp *http.Response) (result ConnectionGatewaysDeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysget_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysget_autorest.go
@@ -1,0 +1,64 @@
+package connectiongateways
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewaysGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayDefinition
+}
+
+// ConnectionGatewaysGet ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysGet(ctx context.Context, id ConnectionGatewayId) (result ConnectionGatewaysGetOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysGet prepares the ConnectionGatewaysGet request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysGet(ctx context.Context, id ConnectionGatewayId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysGet handles the response to the ConnectionGatewaysGet request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysGet(resp *http.Response) (result ConnectionGatewaysGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayslist_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayslist_autorest.go
@@ -1,0 +1,66 @@
+package connectiongateways
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type ConnectionGatewaysListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayDefinitionCollection
+}
+
+// ConnectionGatewaysList ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysList(ctx context.Context, id commonids.SubscriptionId) (result ConnectionGatewaysListOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysList", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysList", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysList", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysList prepares the ConnectionGatewaysList request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Web/connectionGateways", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysList handles the response to the ConnectionGatewaysList request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysList(resp *http.Response) (result ConnectionGatewaysListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayslistbyresourcegroup_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewayslistbyresourcegroup_autorest.go
@@ -1,0 +1,66 @@
+package connectiongateways
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type ConnectionGatewaysListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayDefinitionCollection
+}
+
+// ConnectionGatewaysListByResourceGroup ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ConnectionGatewaysListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysListByResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysListByResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysListByResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysListByResourceGroup prepares the ConnectionGatewaysListByResourceGroup request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Web/connectionGateways", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysListByResourceGroup handles the response to the ConnectionGatewaysListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysListByResourceGroup(resp *http.Response) (result ConnectionGatewaysListByResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysupdate_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/method_connectiongatewaysupdate_autorest.go
@@ -1,0 +1,65 @@
+package connectiongateways
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConnectionGatewaysUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConnectionGatewayDefinition
+}
+
+// ConnectionGatewaysUpdate ...
+func (c ConnectionGatewaysClient) ConnectionGatewaysUpdate(ctx context.Context, id ConnectionGatewayId, input ConnectionGatewayDefinition) (result ConnectionGatewaysUpdateOperationResponse, err error) {
+	req, err := c.preparerForConnectionGatewaysUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConnectionGatewaysUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connectiongateways.ConnectionGatewaysClient", "ConnectionGatewaysUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConnectionGatewaysUpdate prepares the ConnectionGatewaysUpdate request.
+func (c ConnectionGatewaysClient) preparerForConnectionGatewaysUpdate(ctx context.Context, id ConnectionGatewayId, input ConnectionGatewayDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConnectionGatewaysUpdate handles the response to the ConnectionGatewaysUpdate request. The method always
+// closes the http.Response Body.
+func (c ConnectionGatewaysClient) responderForConnectionGatewaysUpdate(resp *http.Response) (result ConnectionGatewaysUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinition.go
@@ -1,0 +1,11 @@
+package connectiongateways
+
+type ConnectionGatewayDefinition struct {
+	Etag       *string                                `json:"etag,omitempty"`
+	Id         *string                                `json:"id,omitempty"`
+	Location   *string                                `json:"location,omitempty"`
+	Name       *string                                `json:"name,omitempty"`
+	Properties *ConnectionGatewayDefinitionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                     `json:"tags,omitempty"`
+	Type       *string                                `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinitioncollection.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinitioncollection.go
@@ -1,0 +1,5 @@
+package connectiongateways
+
+type ConnectionGatewayDefinitionCollection struct {
+	Value *[]ConnectionGatewayDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinitionproperties.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewaydefinitionproperties.go
@@ -1,0 +1,11 @@
+package connectiongateways
+
+type ConnectionGatewayDefinitionProperties struct {
+	BackendUri                    *string                     `json:"backendUri,omitempty"`
+	ConnectionGatewayInstallation *ConnectionGatewayReference `json:"connectionGatewayInstallation,omitempty"`
+	ContactInformation            *[]string                   `json:"contactInformation,omitempty"`
+	Description                   *string                     `json:"description,omitempty"`
+	DisplayName                   *string                     `json:"displayName,omitempty"`
+	MachineName                   *string                     `json:"machineName,omitempty"`
+	Status                        *interface{}                `json:"status,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinition.go
@@ -1,0 +1,11 @@
+package connectiongateways
+
+type ConnectionGatewayInstallationDefinition struct {
+	Etag       *string                                            `json:"etag,omitempty"`
+	Id         *string                                            `json:"id,omitempty"`
+	Location   *string                                            `json:"location,omitempty"`
+	Name       *string                                            `json:"name,omitempty"`
+	Properties *ConnectionGatewayInstallationDefinitionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                                 `json:"tags,omitempty"`
+	Type       *string                                            `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinitioncollection.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinitioncollection.go
@@ -1,0 +1,5 @@
+package connectiongateways
+
+type ConnectionGatewayInstallationDefinitionCollection struct {
+	Value *[]ConnectionGatewayInstallationDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinitionproperties.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayinstallationdefinitionproperties.go
@@ -1,0 +1,11 @@
+package connectiongateways
+
+type ConnectionGatewayInstallationDefinitionProperties struct {
+	BackendUri         *string                     `json:"backendUri,omitempty"`
+	ConnectionGateway  *ConnectionGatewayReference `json:"connectionGateway,omitempty"`
+	ContactInformation *[]string                   `json:"contactInformation,omitempty"`
+	Description        *string                     `json:"description,omitempty"`
+	DisplayName        *string                     `json:"displayName,omitempty"`
+	MachineName        *string                     `json:"machineName,omitempty"`
+	Status             *interface{}                `json:"status,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayreference.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/model_connectiongatewayreference.go
@@ -1,0 +1,8 @@
+package connectiongateways
+
+type ConnectionGatewayReference struct {
+	Id       *string `json:"id,omitempty"`
+	Location *string `json:"location,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Type     *string `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connectiongateways/version.go
+++ b/internal/services/connections/sdk/2016-06-01/connectiongateways/version.go
@@ -1,0 +1,9 @@
+package connectiongateways
+
+import "fmt"
+
+const defaultApiVersion = "2016-06-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/connectiongateways/%s", defaultApiVersion)
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/client.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/client.go
@@ -1,0 +1,15 @@
+package connections
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ConnectionsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewConnectionsClientWithBaseURI(endpoint string) ConnectionsClient {
+	return ConnectionsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/constants.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/constants.go
@@ -1,0 +1,34 @@
+package connections
+
+import "strings"
+
+type LinkState string
+
+const (
+	LinkStateAuthenticated   LinkState = "Authenticated"
+	LinkStateError           LinkState = "Error"
+	LinkStateUnauthenticated LinkState = "Unauthenticated"
+)
+
+func PossibleValuesForLinkState() []string {
+	return []string{
+		string(LinkStateAuthenticated),
+		string(LinkStateError),
+		string(LinkStateUnauthenticated),
+	}
+}
+
+func parseLinkState(input string) (*LinkState, error) {
+	vals := map[string]LinkState{
+		"authenticated":   LinkStateAuthenticated,
+		"error":           LinkStateError,
+		"unauthenticated": LinkStateUnauthenticated,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LinkState(input)
+	return &out, nil
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/id_connection.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/id_connection.go
@@ -1,0 +1,124 @@
+package connections
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionId{}
+
+// ConnectionId is a struct representing the Resource ID for a Connection
+type ConnectionId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ConnectionName    string
+}
+
+// NewConnectionID returns a new ConnectionId struct
+func NewConnectionID(subscriptionId string, resourceGroupName string, connectionName string) ConnectionId {
+	return ConnectionId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ConnectionName:    connectionName,
+	}
+}
+
+// ParseConnectionID parses 'input' into a ConnectionId
+func ParseConnectionID(input string) (*ConnectionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
+		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseConnectionIDInsensitively parses 'input' case-insensitively into a ConnectionId
+// note: this method should only be used for API response data and not user input
+func ParseConnectionIDInsensitively(input string) (*ConnectionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ConnectionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ConnectionId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
+		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateConnectionID checks that 'input' can be parsed as a Connection ID
+func ValidateConnectionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseConnectionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Connection ID
+func (id ConnectionId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/connections/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ConnectionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Connection ID
+func (id ConnectionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticConnections", "connections", "connections"),
+		resourceids.UserSpecifiedSegment("connectionName", "connectionValue"),
+	}
+}
+
+// String returns a human-readable description of this Connection ID
+func (id ConnectionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Connection Name: %q", id.ConnectionName),
+	}
+	return fmt.Sprintf("Connection (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/id_connection_test.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/id_connection_test.go
@@ -1,0 +1,279 @@
+package connections
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ConnectionId{}
+
+func TestNewConnectionID(t *testing.T) {
+	id := NewConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "connectionValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.ConnectionName != "connectionValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ConnectionName'", id.ConnectionName, "connectionValue")
+	}
+}
+
+func TestFormatConnectionID(t *testing.T) {
+	actual := NewConnectionID("12345678-1234-9876-4563-123456789012", "example-resource-group", "connectionValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections/connectionValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseConnectionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections/connectionValue",
+			Expected: &ConnectionId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				ConnectionName:    "connectionValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections/connectionValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ConnectionName != v.Expected.ConnectionName {
+			t.Fatalf("Expected %q but got %q for ConnectionName", v.Expected.ConnectionName, actual.ConnectionName)
+		}
+
+	}
+}
+
+func TestParseConnectionIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConnectionId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections/connectionValue",
+			Expected: &ConnectionId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				ConnectionName:    "connectionValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/connections/connectionValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNs/cOnNeCtIoNvAlUe",
+			Expected: &ConnectionId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				ConnectionName:    "cOnNeCtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cOnNeCtIoNs/cOnNeCtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseConnectionIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ConnectionName != v.Expected.ConnectionName {
+			t.Fatalf("Expected %q but got %q for ConnectionName", v.Expected.ConnectionName, actual.ConnectionName)
+		}
+
+	}
+}
+
+func TestSegmentsForConnectionId(t *testing.T) {
+	segments := ConnectionId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ConnectionId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_confirmconsentcode_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_confirmconsentcode_autorest.go
@@ -1,0 +1,66 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ConfirmConsentCodeOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConfirmConsentCodeDefinition
+}
+
+// ConfirmConsentCode ...
+func (c ConnectionsClient) ConfirmConsentCode(ctx context.Context, id ConnectionId, input ConfirmConsentCodeDefinition) (result ConfirmConsentCodeOperationResponse, err error) {
+	req, err := c.preparerForConfirmConsentCode(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ConfirmConsentCode", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ConfirmConsentCode", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForConfirmConsentCode(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ConfirmConsentCode", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForConfirmConsentCode prepares the ConfirmConsentCode request.
+func (c ConnectionsClient) preparerForConfirmConsentCode(ctx context.Context, id ConnectionId, input ConfirmConsentCodeDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/confirmConsentCode", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForConfirmConsentCode handles the response to the ConfirmConsentCode request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForConfirmConsentCode(resp *http.Response) (result ConfirmConsentCodeOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_createorupdate_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_createorupdate_autorest.go
@@ -1,0 +1,65 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ApiConnectionDefinition
+}
+
+// CreateOrUpdate ...
+func (c ConnectionsClient) CreateOrUpdate(ctx context.Context, id ConnectionId, input ApiConnectionDefinition) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c ConnectionsClient) preparerForCreateOrUpdate(ctx context.Context, id ConnectionId, input ApiConnectionDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_delete_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_delete_autorest.go
@@ -1,0 +1,62 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ConnectionsClient) Delete(ctx context.Context, id ConnectionId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ConnectionsClient) preparerForDelete(ctx context.Context, id ConnectionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForDelete(resp *http.Response) (result DeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_get_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_get_autorest.go
@@ -1,0 +1,64 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ApiConnectionDefinition
+}
+
+// Get ...
+func (c ConnectionsClient) Get(ctx context.Context, id ConnectionId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ConnectionsClient) preparerForGet(ctx context.Context, id ConnectionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_list_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_list_autorest.go
@@ -1,0 +1,100 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ApiConnectionDefinitionCollection
+}
+
+type ListOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o ListOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// List ...
+func (c ConnectionsClient) List(ctx context.Context, id commonids.ResourceGroupId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "List", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "List", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ConnectionsClient) preparerForList(ctx context.Context, id commonids.ResourceGroupId, options ListOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Web/connections", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_listconsentlinks_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_listconsentlinks_autorest.go
@@ -1,0 +1,66 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListConsentLinksOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ConsentLinkCollection
+}
+
+// ListConsentLinks ...
+func (c ConnectionsClient) ListConsentLinks(ctx context.Context, id ConnectionId, input ListConsentLinksDefinition) (result ListConsentLinksOperationResponse, err error) {
+	req, err := c.preparerForListConsentLinks(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ListConsentLinks", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ListConsentLinks", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForListConsentLinks(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "ListConsentLinks", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForListConsentLinks prepares the ListConsentLinks request.
+func (c ConnectionsClient) preparerForListConsentLinks(ctx context.Context, id ConnectionId, input ListConsentLinksDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listConsentLinks", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListConsentLinks handles the response to the ListConsentLinks request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForListConsentLinks(resp *http.Response) (result ListConsentLinksOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/method_update_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/method_update_autorest.go
@@ -1,0 +1,65 @@
+package connections
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ApiConnectionDefinition
+}
+
+// Update ...
+func (c ConnectionsClient) Update(ctx context.Context, id ConnectionId, input ApiConnectionDefinition) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "connections.ConnectionsClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ConnectionsClient) preparerForUpdate(ctx context.Context, id ConnectionId, input ApiConnectionDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c ConnectionsClient) responderForUpdate(resp *http.Response) (result UpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinition.go
@@ -1,0 +1,11 @@
+package connections
+
+type ApiConnectionDefinition struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *ApiConnectionDefinitionProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinitioncollection.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinitioncollection.go
@@ -1,0 +1,5 @@
+package connections
+
+type ApiConnectionDefinitionCollection struct {
+	Value *[]ApiConnectionDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinitionproperties.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiondefinitionproperties.go
@@ -1,0 +1,43 @@
+package connections
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+type ApiConnectionDefinitionProperties struct {
+	Api                      *ApiReference                 `json:"api,omitempty"`
+	ChangedTime              *string                       `json:"changedTime,omitempty"`
+	CreatedTime              *string                       `json:"createdTime,omitempty"`
+	CustomParameterValues    *map[string]string            `json:"customParameterValues,omitempty"`
+	DisplayName              *string                       `json:"displayName,omitempty"`
+	NonSecretParameterValues *map[string]string            `json:"nonSecretParameterValues,omitempty"`
+	ParameterValues          *map[string]string            `json:"parameterValues,omitempty"`
+	Statuses                 *[]ConnectionStatusDefinition `json:"statuses,omitempty"`
+	TestLinks                *[]ApiConnectionTestLink      `json:"testLinks,omitempty"`
+}
+
+func (o ApiConnectionDefinitionProperties) GetChangedTimeAsTime() (*time.Time, error) {
+	if o.ChangedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ChangedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o ApiConnectionDefinitionProperties) SetChangedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ChangedTime = &formatted
+}
+
+func (o ApiConnectionDefinitionProperties) GetCreatedTimeAsTime() (*time.Time, error) {
+	if o.CreatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o ApiConnectionDefinitionProperties) SetCreatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTime = &formatted
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiontestlink.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_apiconnectiontestlink.go
@@ -1,0 +1,6 @@
+package connections
+
+type ApiConnectionTestLink struct {
+	Method     *string `json:"method,omitempty"`
+	RequestUri *string `json:"requestUri,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_apireference.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_apireference.go
@@ -1,0 +1,12 @@
+package connections
+
+type ApiReference struct {
+	BrandColor  *string      `json:"brandColor,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	DisplayName *string      `json:"displayName,omitempty"`
+	IconUri     *string      `json:"iconUri,omitempty"`
+	Id          *string      `json:"id,omitempty"`
+	Name        *string      `json:"name,omitempty"`
+	Swagger     *interface{} `json:"swagger,omitempty"`
+	Type        *string      `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_confirmconsentcodedefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_confirmconsentcodedefinition.go
@@ -1,0 +1,7 @@
+package connections
+
+type ConfirmConsentCodeDefinition struct {
+	Code     *string `json:"code,omitempty"`
+	ObjectId *string `json:"objectId,omitempty"`
+	TenantId *string `json:"tenantId,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_connectionerror.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_connectionerror.go
@@ -1,0 +1,11 @@
+package connections
+
+type ConnectionError struct {
+	Etag       *string                    `json:"etag,omitempty"`
+	Id         *string                    `json:"id,omitempty"`
+	Location   *string                    `json:"location,omitempty"`
+	Name       *string                    `json:"name,omitempty"`
+	Properties *ConnectionErrorProperties `json:"properties,omitempty"`
+	Tags       *map[string]string         `json:"tags,omitempty"`
+	Type       *string                    `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_connectionerrorproperties.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_connectionerrorproperties.go
@@ -1,0 +1,6 @@
+package connections
+
+type ConnectionErrorProperties struct {
+	Code    *string `json:"code,omitempty"`
+	Message *string `json:"message,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_connectionstatusdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_connectionstatusdefinition.go
@@ -1,0 +1,7 @@
+package connections
+
+type ConnectionStatusDefinition struct {
+	Error  *ConnectionError `json:"error,omitempty"`
+	Status *string          `json:"status,omitempty"`
+	Target *string          `json:"target,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkcollection.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkcollection.go
@@ -1,0 +1,5 @@
+package connections
+
+type ConsentLinkCollection struct {
+	Value *[]ConsentLinkDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkdefinition.go
@@ -1,0 +1,8 @@
+package connections
+
+type ConsentLinkDefinition struct {
+	DisplayName        *string    `json:"displayName,omitempty"`
+	FirstPartyLoginUri *string    `json:"firstPartyLoginUri,omitempty"`
+	Link               *string    `json:"link,omitempty"`
+	Status             *LinkState `json:"status,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkparameterdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_consentlinkparameterdefinition.go
@@ -1,0 +1,8 @@
+package connections
+
+type ConsentLinkParameterDefinition struct {
+	ObjectId      *string `json:"objectId,omitempty"`
+	ParameterName *string `json:"parameterName,omitempty"`
+	RedirectUrl   *string `json:"redirectUrl,omitempty"`
+	TenantId      *string `json:"tenantId,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/model_listconsentlinksdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/model_listconsentlinksdefinition.go
@@ -1,0 +1,5 @@
+package connections
+
+type ListConsentLinksDefinition struct {
+	Parameters *[]ConsentLinkParameterDefinition `json:"parameters,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/connections/version.go
+++ b/internal/services/connections/sdk/2016-06-01/connections/version.go
@@ -1,0 +1,9 @@
+package connections
+
+import "fmt"
+
+const defaultApiVersion = "2016-06-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/connections/%s", defaultApiVersion)
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/client.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/client.go
@@ -1,0 +1,15 @@
+package customapis
+
+import "github.com/Azure/go-autorest/autorest"
+
+type CustomAPIsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewCustomAPIsClientWithBaseURI(endpoint string) CustomAPIsClient {
+	return CustomAPIsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/constants.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/constants.go
@@ -1,0 +1,114 @@
+package customapis
+
+import "strings"
+
+type ApiType string
+
+const (
+	ApiTypeNotSpecified ApiType = "NotSpecified"
+	ApiTypeRest         ApiType = "Rest"
+	ApiTypeSoap         ApiType = "Soap"
+)
+
+func PossibleValuesForApiType() []string {
+	return []string{
+		string(ApiTypeNotSpecified),
+		string(ApiTypeRest),
+		string(ApiTypeSoap),
+	}
+}
+
+func parseApiType(input string) (*ApiType, error) {
+	vals := map[string]ApiType{
+		"notspecified": ApiTypeNotSpecified,
+		"rest":         ApiTypeRest,
+		"soap":         ApiTypeSoap,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ApiType(input)
+	return &out, nil
+}
+
+type ConnectionParameterType string
+
+const (
+	ConnectionParameterTypeArray        ConnectionParameterType = "array"
+	ConnectionParameterTypeBool         ConnectionParameterType = "bool"
+	ConnectionParameterTypeConnection   ConnectionParameterType = "connection"
+	ConnectionParameterTypeInt          ConnectionParameterType = "int"
+	ConnectionParameterTypeOauthSetting ConnectionParameterType = "oauthSetting"
+	ConnectionParameterTypeObject       ConnectionParameterType = "object"
+	ConnectionParameterTypeSecureobject ConnectionParameterType = "secureobject"
+	ConnectionParameterTypeSecurestring ConnectionParameterType = "securestring"
+	ConnectionParameterTypeString       ConnectionParameterType = "string"
+)
+
+func PossibleValuesForConnectionParameterType() []string {
+	return []string{
+		string(ConnectionParameterTypeArray),
+		string(ConnectionParameterTypeBool),
+		string(ConnectionParameterTypeConnection),
+		string(ConnectionParameterTypeInt),
+		string(ConnectionParameterTypeOauthSetting),
+		string(ConnectionParameterTypeObject),
+		string(ConnectionParameterTypeSecureobject),
+		string(ConnectionParameterTypeSecurestring),
+		string(ConnectionParameterTypeString),
+	}
+}
+
+func parseConnectionParameterType(input string) (*ConnectionParameterType, error) {
+	vals := map[string]ConnectionParameterType{
+		"array":        ConnectionParameterTypeArray,
+		"bool":         ConnectionParameterTypeBool,
+		"connection":   ConnectionParameterTypeConnection,
+		"int":          ConnectionParameterTypeInt,
+		"oauthsetting": ConnectionParameterTypeOauthSetting,
+		"object":       ConnectionParameterTypeObject,
+		"secureobject": ConnectionParameterTypeSecureobject,
+		"securestring": ConnectionParameterTypeSecurestring,
+		"string":       ConnectionParameterTypeString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectionParameterType(input)
+	return &out, nil
+}
+
+type WsdlImportMethod string
+
+const (
+	WsdlImportMethodNotSpecified    WsdlImportMethod = "NotSpecified"
+	WsdlImportMethodSoapPassThrough WsdlImportMethod = "SoapPassThrough"
+	WsdlImportMethodSoapToRest      WsdlImportMethod = "SoapToRest"
+)
+
+func PossibleValuesForWsdlImportMethod() []string {
+	return []string{
+		string(WsdlImportMethodNotSpecified),
+		string(WsdlImportMethodSoapPassThrough),
+		string(WsdlImportMethodSoapToRest),
+	}
+}
+
+func parseWsdlImportMethod(input string) (*WsdlImportMethod, error) {
+	vals := map[string]WsdlImportMethod{
+		"notspecified":    WsdlImportMethodNotSpecified,
+		"soappassthrough": WsdlImportMethodSoapPassThrough,
+		"soaptorest":      WsdlImportMethodSoapToRest,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WsdlImportMethod(input)
+	return &out, nil
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/id_customapi.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/id_customapi.go
@@ -1,0 +1,124 @@
+package customapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = CustomApiId{}
+
+// CustomApiId is a struct representing the Resource ID for a Custom Api
+type CustomApiId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ApiName           string
+}
+
+// NewCustomApiID returns a new CustomApiId struct
+func NewCustomApiID(subscriptionId string, resourceGroupName string, apiName string) CustomApiId {
+	return CustomApiId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ApiName:           apiName,
+	}
+}
+
+// ParseCustomApiID parses 'input' into a CustomApiId
+func ParseCustomApiID(input string) (*CustomApiId, error) {
+	parser := resourceids.NewParserFromResourceIdType(CustomApiId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := CustomApiId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ApiName, ok = parsed.Parsed["apiName"]; !ok {
+		return nil, fmt.Errorf("the segment 'apiName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseCustomApiIDInsensitively parses 'input' case-insensitively into a CustomApiId
+// note: this method should only be used for API response data and not user input
+func ParseCustomApiIDInsensitively(input string) (*CustomApiId, error) {
+	parser := resourceids.NewParserFromResourceIdType(CustomApiId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := CustomApiId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ApiName, ok = parsed.Parsed["apiName"]; !ok {
+		return nil, fmt.Errorf("the segment 'apiName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateCustomApiID checks that 'input' can be parsed as a Custom Api ID
+func ValidateCustomApiID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCustomApiID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Custom Api ID
+func (id CustomApiId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/customApis/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ApiName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Custom Api ID
+func (id CustomApiId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticCustomApis", "customApis", "customApis"),
+		resourceids.UserSpecifiedSegment("apiName", "apiValue"),
+	}
+}
+
+// String returns a human-readable description of this Custom Api ID
+func (id CustomApiId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Api Name: %q", id.ApiName),
+	}
+	return fmt.Sprintf("Custom Api (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/id_customapi_test.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/id_customapi_test.go
@@ -1,0 +1,279 @@
+package customapis
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = CustomApiId{}
+
+func TestNewCustomApiID(t *testing.T) {
+	id := NewCustomApiID("12345678-1234-9876-4563-123456789012", "example-resource-group", "apiValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.ApiName != "apiValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ApiName'", id.ApiName, "apiValue")
+	}
+}
+
+func TestFormatCustomApiID(t *testing.T) {
+	actual := NewCustomApiID("12345678-1234-9876-4563-123456789012", "example-resource-group", "apiValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis/apiValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseCustomApiID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CustomApiId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis/apiValue",
+			Expected: &CustomApiId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				ApiName:           "apiValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis/apiValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseCustomApiID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ApiName != v.Expected.ApiName {
+			t.Fatalf("Expected %q but got %q for ApiName", v.Expected.ApiName, actual.ApiName)
+		}
+
+	}
+}
+
+func TestParseCustomApiIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CustomApiId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cUsToMaPiS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis/apiValue",
+			Expected: &CustomApiId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				ApiName:           "apiValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Web/customApis/apiValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cUsToMaPiS/aPiVaLuE",
+			Expected: &CustomApiId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				ApiName:           "aPiVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.wEb/cUsToMaPiS/aPiVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseCustomApiIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.ApiName != v.Expected.ApiName {
+			t.Fatalf("Expected %q but got %q for ApiName", v.Expected.ApiName, actual.ApiName)
+		}
+
+	}
+}
+
+func TestSegmentsForCustomApiId(t *testing.T) {
+	segments := CustomApiId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("CustomApiId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/id_location.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/id_location.go
@@ -1,0 +1,111 @@
+package customapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	Location       string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, location string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Web/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/id_location_test.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/id_location_test.go
@@ -1,0 +1,234 @@
+package customapis
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+func TestNewLocationID(t *testing.T) {
+	id := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+}
+
+func TestFormatLocationID(t *testing.T) {
+	actual := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseLocationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestParseLocationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestSegmentsForLocationId(t *testing.T) {
+	segments := LocationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("LocationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapiscreateorupdate_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapiscreateorupdate_autorest.go
@@ -1,0 +1,65 @@
+package customapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CustomApiDefinition
+}
+
+// CustomApisCreateOrUpdate ...
+func (c CustomAPIsClient) CustomApisCreateOrUpdate(ctx context.Context, id CustomApiId, input CustomApiDefinition) (result CustomApisCreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCustomApisCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisCreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisCreateOrUpdate prepares the CustomApisCreateOrUpdate request.
+func (c CustomAPIsClient) preparerForCustomApisCreateOrUpdate(ctx context.Context, id CustomApiId, input CustomApiDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisCreateOrUpdate handles the response to the CustomApisCreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisCreateOrUpdate(resp *http.Response) (result CustomApisCreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapisdelete_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapisdelete_autorest.go
@@ -1,0 +1,62 @@
+package customapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisDeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// CustomApisDelete ...
+func (c CustomAPIsClient) CustomApisDelete(ctx context.Context, id CustomApiId) (result CustomApisDeleteOperationResponse, err error) {
+	req, err := c.preparerForCustomApisDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisDelete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisDelete prepares the CustomApisDelete request.
+func (c CustomAPIsClient) preparerForCustomApisDelete(ctx context.Context, id CustomApiId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisDelete handles the response to the CustomApisDelete request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisDelete(resp *http.Response) (result CustomApisDeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapisextractapidefinitionfromwsdl_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapisextractapidefinitionfromwsdl_autorest.go
@@ -1,0 +1,66 @@
+package customapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisExtractApiDefinitionFromWsdlOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *interface{}
+}
+
+// CustomApisExtractApiDefinitionFromWsdl ...
+func (c CustomAPIsClient) CustomApisExtractApiDefinitionFromWsdl(ctx context.Context, id LocationId, input WsdlDefinition) (result CustomApisExtractApiDefinitionFromWsdlOperationResponse, err error) {
+	req, err := c.preparerForCustomApisExtractApiDefinitionFromWsdl(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisExtractApiDefinitionFromWsdl", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisExtractApiDefinitionFromWsdl", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisExtractApiDefinitionFromWsdl(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisExtractApiDefinitionFromWsdl", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisExtractApiDefinitionFromWsdl prepares the CustomApisExtractApiDefinitionFromWsdl request.
+func (c CustomAPIsClient) preparerForCustomApisExtractApiDefinitionFromWsdl(ctx context.Context, id LocationId, input WsdlDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/extractApiDefinitionFromWsdl", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisExtractApiDefinitionFromWsdl handles the response to the CustomApisExtractApiDefinitionFromWsdl request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisExtractApiDefinitionFromWsdl(resp *http.Response) (result CustomApisExtractApiDefinitionFromWsdlOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapisget_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapisget_autorest.go
@@ -1,0 +1,64 @@
+package customapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CustomApiDefinition
+}
+
+// CustomApisGet ...
+func (c CustomAPIsClient) CustomApisGet(ctx context.Context, id CustomApiId) (result CustomApisGetOperationResponse, err error) {
+	req, err := c.preparerForCustomApisGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisGet prepares the CustomApisGet request.
+func (c CustomAPIsClient) preparerForCustomApisGet(ctx context.Context, id CustomApiId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisGet handles the response to the CustomApisGet request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisGet(resp *http.Response) (result CustomApisGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapislist_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapislist_autorest.go
@@ -1,0 +1,100 @@
+package customapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type CustomApisListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CustomApiDefinitionCollection
+}
+
+type CustomApisListOperationOptions struct {
+	Skiptoken *string
+	Top       *int64
+}
+
+func DefaultCustomApisListOperationOptions() CustomApisListOperationOptions {
+	return CustomApisListOperationOptions{}
+}
+
+func (o CustomApisListOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o CustomApisListOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Skiptoken != nil {
+		out["skiptoken"] = *o.Skiptoken
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// CustomApisList ...
+func (c CustomAPIsClient) CustomApisList(ctx context.Context, id commonids.SubscriptionId, options CustomApisListOperationOptions) (result CustomApisListOperationResponse, err error) {
+	req, err := c.preparerForCustomApisList(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisList", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisList", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisList", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisList prepares the CustomApisList request.
+func (c CustomAPIsClient) preparerForCustomApisList(ctx context.Context, id commonids.SubscriptionId, options CustomApisListOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Web/customApis", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisList handles the response to the CustomApisList request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisList(resp *http.Response) (result CustomApisListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapislistbyresourcegroup_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapislistbyresourcegroup_autorest.go
@@ -1,0 +1,100 @@
+package customapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type CustomApisListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CustomApiDefinitionCollection
+}
+
+type CustomApisListByResourceGroupOperationOptions struct {
+	Skiptoken *string
+	Top       *int64
+}
+
+func DefaultCustomApisListByResourceGroupOperationOptions() CustomApisListByResourceGroupOperationOptions {
+	return CustomApisListByResourceGroupOperationOptions{}
+}
+
+func (o CustomApisListByResourceGroupOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o CustomApisListByResourceGroupOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Skiptoken != nil {
+		out["skiptoken"] = *o.Skiptoken
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// CustomApisListByResourceGroup ...
+func (c CustomAPIsClient) CustomApisListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options CustomApisListByResourceGroupOperationOptions) (result CustomApisListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForCustomApisListByResourceGroup(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListByResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisListByResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListByResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisListByResourceGroup prepares the CustomApisListByResourceGroup request.
+func (c CustomAPIsClient) preparerForCustomApisListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options CustomApisListByResourceGroupOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Web/customApis", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisListByResourceGroup handles the response to the CustomApisListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisListByResourceGroup(resp *http.Response) (result CustomApisListByResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapislistwsdlinterfaces_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapislistwsdlinterfaces_autorest.go
@@ -1,0 +1,66 @@
+package customapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisListWsdlInterfacesOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WsdlServiceCollection
+}
+
+// CustomApisListWsdlInterfaces ...
+func (c CustomAPIsClient) CustomApisListWsdlInterfaces(ctx context.Context, id LocationId, input WsdlDefinition) (result CustomApisListWsdlInterfacesOperationResponse, err error) {
+	req, err := c.preparerForCustomApisListWsdlInterfaces(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListWsdlInterfaces", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListWsdlInterfaces", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisListWsdlInterfaces(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisListWsdlInterfaces", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisListWsdlInterfaces prepares the CustomApisListWsdlInterfaces request.
+func (c CustomAPIsClient) preparerForCustomApisListWsdlInterfaces(ctx context.Context, id LocationId, input WsdlDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listWsdlInterfaces", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisListWsdlInterfaces handles the response to the CustomApisListWsdlInterfaces request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisListWsdlInterfaces(resp *http.Response) (result CustomApisListWsdlInterfacesOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapismove_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapismove_autorest.go
@@ -1,0 +1,64 @@
+package customapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisMoveOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// CustomApisMove ...
+func (c CustomAPIsClient) CustomApisMove(ctx context.Context, id CustomApiId, input CustomApiReference) (result CustomApisMoveOperationResponse, err error) {
+	req, err := c.preparerForCustomApisMove(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisMove", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisMove", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisMove(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisMove", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisMove prepares the CustomApisMove request.
+func (c CustomAPIsClient) preparerForCustomApisMove(ctx context.Context, id CustomApiId, input CustomApiReference) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/move", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisMove handles the response to the CustomApisMove request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisMove(resp *http.Response) (result CustomApisMoveOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/method_customapisupdate_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/method_customapisupdate_autorest.go
@@ -1,0 +1,65 @@
+package customapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CustomApisUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CustomApiDefinition
+}
+
+// CustomApisUpdate ...
+func (c CustomAPIsClient) CustomApisUpdate(ctx context.Context, id CustomApiId, input CustomApiDefinition) (result CustomApisUpdateOperationResponse, err error) {
+	req, err := c.preparerForCustomApisUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCustomApisUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "customapis.CustomAPIsClient", "CustomApisUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCustomApisUpdate prepares the CustomApisUpdate request.
+func (c CustomAPIsClient) preparerForCustomApisUpdate(ctx context.Context, id CustomApiId, input CustomApiDefinition) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCustomApisUpdate handles the response to the CustomApisUpdate request. The method always
+// closes the http.Response Body.
+func (c CustomAPIsClient) responderForCustomApisUpdate(resp *http.Response) (result CustomApisUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_apioauthsettings.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_apioauthsettings.go
@@ -1,0 +1,11 @@
+package customapis
+
+type ApiOAuthSettings struct {
+	ClientId         *string                               `json:"clientId,omitempty"`
+	ClientSecret     *string                               `json:"clientSecret,omitempty"`
+	CustomParameters *map[string]ApiOAuthSettingsParameter `json:"customParameters,omitempty"`
+	IdentityProvider *string                               `json:"identityProvider,omitempty"`
+	Properties       *interface{}                          `json:"properties,omitempty"`
+	RedirectUrl      *string                               `json:"redirectUrl,omitempty"`
+	Scopes           *[]string                             `json:"scopes,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_apioauthsettingsparameter.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_apioauthsettingsparameter.go
@@ -1,0 +1,7 @@
+package customapis
+
+type ApiOAuthSettingsParameter struct {
+	Options      *interface{} `json:"options,omitempty"`
+	UiDefinition *interface{} `json:"uiDefinition,omitempty"`
+	Value        *string      `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_apiresourcebackendservice.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_apiresourcebackendservice.go
@@ -1,0 +1,5 @@
+package customapis
+
+type ApiResourceBackendService struct {
+	ServiceUrl *string `json:"serviceUrl,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_apiresourcedefinitions.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_apiresourcedefinitions.go
@@ -1,0 +1,6 @@
+package customapis
+
+type ApiResourceDefinitions struct {
+	ModifiedSwaggerUrl *string `json:"modifiedSwaggerUrl,omitempty"`
+	OriginalSwaggerUrl *string `json:"originalSwaggerUrl,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_connectionparameter.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_connectionparameter.go
@@ -1,0 +1,6 @@
+package customapis
+
+type ConnectionParameter struct {
+	OAuthSettings *ApiOAuthSettings        `json:"oAuthSettings,omitempty"`
+	Type          *ConnectionParameterType `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_customapidefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_customapidefinition.go
@@ -1,0 +1,11 @@
+package customapis
+
+type CustomApiDefinition struct {
+	Etag       *string                        `json:"etag,omitempty"`
+	Id         *string                        `json:"id,omitempty"`
+	Location   *string                        `json:"location,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *CustomApiPropertiesDefinition `json:"properties,omitempty"`
+	Tags       *map[string]string             `json:"tags,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_customapidefinitioncollection.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_customapidefinitioncollection.go
@@ -1,0 +1,5 @@
+package customapis
+
+type CustomApiDefinitionCollection struct {
+	Value *[]CustomApiDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_customapipropertiesdefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_customapipropertiesdefinition.go
@@ -1,0 +1,16 @@
+package customapis
+
+type CustomApiPropertiesDefinition struct {
+	ApiDefinitions       *ApiResourceDefinitions         `json:"apiDefinitions,omitempty"`
+	ApiType              *ApiType                        `json:"apiType,omitempty"`
+	BackendService       *ApiResourceBackendService      `json:"backendService,omitempty"`
+	BrandColor           *string                         `json:"brandColor,omitempty"`
+	Capabilities         *[]string                       `json:"capabilities,omitempty"`
+	ConnectionParameters *map[string]ConnectionParameter `json:"connectionParameters,omitempty"`
+	Description          *string                         `json:"description,omitempty"`
+	DisplayName          *string                         `json:"displayName,omitempty"`
+	IconUri              *string                         `json:"iconUri,omitempty"`
+	RuntimeUrls          *[]string                       `json:"runtimeUrls,omitempty"`
+	Swagger              *interface{}                    `json:"swagger,omitempty"`
+	WsdlDefinition       *WsdlDefinition                 `json:"wsdlDefinition,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_customapireference.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_customapireference.go
@@ -1,0 +1,12 @@
+package customapis
+
+type CustomApiReference struct {
+	BrandColor  *string      `json:"brandColor,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	DisplayName *string      `json:"displayName,omitempty"`
+	IconUri     *string      `json:"iconUri,omitempty"`
+	Id          *string      `json:"id,omitempty"`
+	Name        *string      `json:"name,omitempty"`
+	Swagger     *interface{} `json:"swagger,omitempty"`
+	Type        *string      `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_wsdldefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_wsdldefinition.go
@@ -1,0 +1,8 @@
+package customapis
+
+type WsdlDefinition struct {
+	Content      *string           `json:"content,omitempty"`
+	ImportMethod *WsdlImportMethod `json:"importMethod,omitempty"`
+	Service      *WsdlService      `json:"service,omitempty"`
+	Url          *string           `json:"url,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_wsdlservice.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_wsdlservice.go
@@ -1,0 +1,6 @@
+package customapis
+
+type WsdlService struct {
+	EndpointQualifiedNames *[]string `json:"endpointQualifiedNames,omitempty"`
+	QualifiedName          string    `json:"qualifiedName"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/model_wsdlservicecollection.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/model_wsdlservicecollection.go
@@ -1,0 +1,5 @@
+package customapis
+
+type WsdlServiceCollection struct {
+	Value *[]WsdlService `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/customapis/version.go
+++ b/internal/services/connections/sdk/2016-06-01/customapis/version.go
@@ -1,0 +1,9 @@
+package customapis
+
+import "fmt"
+
+const defaultApiVersion = "2016-06-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/customapis/%s", defaultApiVersion)
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/client.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/client.go
@@ -1,0 +1,15 @@
+package managedapis
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ManagedAPIsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewManagedAPIsClientWithBaseURI(endpoint string) ManagedAPIsClient {
+	return ManagedAPIsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/constants.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/constants.go
@@ -1,0 +1,114 @@
+package managedapis
+
+import "strings"
+
+type ApiType string
+
+const (
+	ApiTypeNotSpecified ApiType = "NotSpecified"
+	ApiTypeRest         ApiType = "Rest"
+	ApiTypeSoap         ApiType = "Soap"
+)
+
+func PossibleValuesForApiType() []string {
+	return []string{
+		string(ApiTypeNotSpecified),
+		string(ApiTypeRest),
+		string(ApiTypeSoap),
+	}
+}
+
+func parseApiType(input string) (*ApiType, error) {
+	vals := map[string]ApiType{
+		"notspecified": ApiTypeNotSpecified,
+		"rest":         ApiTypeRest,
+		"soap":         ApiTypeSoap,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ApiType(input)
+	return &out, nil
+}
+
+type ConnectionParameterType string
+
+const (
+	ConnectionParameterTypeArray        ConnectionParameterType = "array"
+	ConnectionParameterTypeBool         ConnectionParameterType = "bool"
+	ConnectionParameterTypeConnection   ConnectionParameterType = "connection"
+	ConnectionParameterTypeInt          ConnectionParameterType = "int"
+	ConnectionParameterTypeOauthSetting ConnectionParameterType = "oauthSetting"
+	ConnectionParameterTypeObject       ConnectionParameterType = "object"
+	ConnectionParameterTypeSecureobject ConnectionParameterType = "secureobject"
+	ConnectionParameterTypeSecurestring ConnectionParameterType = "securestring"
+	ConnectionParameterTypeString       ConnectionParameterType = "string"
+)
+
+func PossibleValuesForConnectionParameterType() []string {
+	return []string{
+		string(ConnectionParameterTypeArray),
+		string(ConnectionParameterTypeBool),
+		string(ConnectionParameterTypeConnection),
+		string(ConnectionParameterTypeInt),
+		string(ConnectionParameterTypeOauthSetting),
+		string(ConnectionParameterTypeObject),
+		string(ConnectionParameterTypeSecureobject),
+		string(ConnectionParameterTypeSecurestring),
+		string(ConnectionParameterTypeString),
+	}
+}
+
+func parseConnectionParameterType(input string) (*ConnectionParameterType, error) {
+	vals := map[string]ConnectionParameterType{
+		"array":        ConnectionParameterTypeArray,
+		"bool":         ConnectionParameterTypeBool,
+		"connection":   ConnectionParameterTypeConnection,
+		"int":          ConnectionParameterTypeInt,
+		"oauthsetting": ConnectionParameterTypeOauthSetting,
+		"object":       ConnectionParameterTypeObject,
+		"secureobject": ConnectionParameterTypeSecureobject,
+		"securestring": ConnectionParameterTypeSecurestring,
+		"string":       ConnectionParameterTypeString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectionParameterType(input)
+	return &out, nil
+}
+
+type WsdlImportMethod string
+
+const (
+	WsdlImportMethodNotSpecified    WsdlImportMethod = "NotSpecified"
+	WsdlImportMethodSoapPassThrough WsdlImportMethod = "SoapPassThrough"
+	WsdlImportMethodSoapToRest      WsdlImportMethod = "SoapToRest"
+)
+
+func PossibleValuesForWsdlImportMethod() []string {
+	return []string{
+		string(WsdlImportMethodNotSpecified),
+		string(WsdlImportMethodSoapPassThrough),
+		string(WsdlImportMethodSoapToRest),
+	}
+}
+
+func parseWsdlImportMethod(input string) (*WsdlImportMethod, error) {
+	vals := map[string]WsdlImportMethod{
+		"notspecified":    WsdlImportMethodNotSpecified,
+		"soappassthrough": WsdlImportMethodSoapPassThrough,
+		"soaptorest":      WsdlImportMethodSoapToRest,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WsdlImportMethod(input)
+	return &out, nil
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/id_location.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/id_location.go
@@ -1,0 +1,111 @@
+package managedapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	Location       string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, location string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := LocationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Web/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/id_location_test.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/id_location_test.go
@@ -1,0 +1,234 @@
+package managedapis
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = LocationId{}
+
+func TestNewLocationID(t *testing.T) {
+	id := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+}
+
+func TestFormatLocationID(t *testing.T) {
+	actual := NewLocationID("12345678-1234-9876-4563-123456789012", "locationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseLocationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestParseLocationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *LocationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe",
+			Expected: &LocationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseLocationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+	}
+}
+
+func TestSegmentsForLocationId(t *testing.T) {
+	segments := LocationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("LocationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/id_managedapi.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/id_managedapi.go
@@ -1,0 +1,124 @@
+package managedapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ManagedApiId{}
+
+// ManagedApiId is a struct representing the Resource ID for a Managed Api
+type ManagedApiId struct {
+	SubscriptionId string
+	Location       string
+	ApiName        string
+}
+
+// NewManagedApiID returns a new ManagedApiId struct
+func NewManagedApiID(subscriptionId string, location string, apiName string) ManagedApiId {
+	return ManagedApiId{
+		SubscriptionId: subscriptionId,
+		Location:       location,
+		ApiName:        apiName,
+	}
+}
+
+// ParseManagedApiID parses 'input' into a ManagedApiId
+func ParseManagedApiID(input string) (*ManagedApiId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagedApiId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagedApiId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	if id.ApiName, ok = parsed.Parsed["apiName"]; !ok {
+		return nil, fmt.Errorf("the segment 'apiName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseManagedApiIDInsensitively parses 'input' case-insensitively into a ManagedApiId
+// note: this method should only be used for API response data and not user input
+func ParseManagedApiIDInsensitively(input string) (*ManagedApiId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagedApiId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagedApiId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.Location, ok = parsed.Parsed["location"]; !ok {
+		return nil, fmt.Errorf("the segment 'location' was not found in the resource id %q", input)
+	}
+
+	if id.ApiName, ok = parsed.Parsed["apiName"]; !ok {
+		return nil, fmt.Errorf("the segment 'apiName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateManagedApiID checks that 'input' can be parsed as a Managed Api ID
+func ValidateManagedApiID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseManagedApiID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Managed Api ID
+func (id ManagedApiId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Web/locations/%s/managedApis/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.Location, id.ApiName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Managed Api ID
+func (id ManagedApiId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftWeb", "Microsoft.Web", "Microsoft.Web"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("location", "locationValue"),
+		resourceids.StaticSegment("staticManagedApis", "managedApis", "managedApis"),
+		resourceids.UserSpecifiedSegment("apiName", "apiValue"),
+	}
+}
+
+// String returns a human-readable description of this Managed Api ID
+func (id ManagedApiId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location: %q", id.Location),
+		fmt.Sprintf("Api Name: %q", id.ApiName),
+	}
+	return fmt.Sprintf("Managed Api (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/id_managedapi_test.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/id_managedapi_test.go
@@ -1,0 +1,279 @@
+package managedapis
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ManagedApiId{}
+
+func TestNewManagedApiID(t *testing.T) {
+	id := NewManagedApiID("12345678-1234-9876-4563-123456789012", "locationValue", "apiValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.Location != "locationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'Location'", id.Location, "locationValue")
+	}
+
+	if id.ApiName != "apiValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ApiName'", id.ApiName, "apiValue")
+	}
+}
+
+func TestFormatManagedApiID(t *testing.T) {
+	actual := NewManagedApiID("12345678-1234-9876-4563-123456789012", "locationValue", "apiValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis/apiValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseManagedApiID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ManagedApiId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis/apiValue",
+			Expected: &ManagedApiId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+				ApiName:        "apiValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis/apiValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseManagedApiID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+		if actual.ApiName != v.Expected.ApiName {
+			t.Fatalf("Expected %q but got %q for ApiName", v.Expected.ApiName, actual.ApiName)
+		}
+
+	}
+}
+
+func TestParseManagedApiIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ManagedApiId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/mAnAgEdApIs",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis/apiValue",
+			Expected: &ManagedApiId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "locationValue",
+				ApiName:        "apiValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Web/locations/locationValue/managedApis/apiValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/mAnAgEdApIs/aPiVaLuE",
+			Expected: &ManagedApiId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				Location:       "lOcAtIoNvAlUe",
+				ApiName:        "aPiVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.wEb/lOcAtIoNs/lOcAtIoNvAlUe/mAnAgEdApIs/aPiVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseManagedApiIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.Location != v.Expected.Location {
+			t.Fatalf("Expected %q but got %q for Location", v.Expected.Location, actual.Location)
+		}
+
+		if actual.ApiName != v.Expected.ApiName {
+			t.Fatalf("Expected %q but got %q for ApiName", v.Expected.ApiName, actual.ApiName)
+		}
+
+	}
+}
+
+func TestSegmentsForManagedApiId(t *testing.T) {
+	segments := ManagedApiId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ManagedApiId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/method_managedapisget_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/method_managedapisget_autorest.go
@@ -1,0 +1,64 @@
+package managedapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ManagedApisGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ManagedApiDefinition
+}
+
+// ManagedApisGet ...
+func (c ManagedAPIsClient) ManagedApisGet(ctx context.Context, id ManagedApiId) (result ManagedApisGetOperationResponse, err error) {
+	req, err := c.preparerForManagedApisGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForManagedApisGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForManagedApisGet prepares the ManagedApisGet request.
+func (c ManagedAPIsClient) preparerForManagedApisGet(ctx context.Context, id ManagedApiId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForManagedApisGet handles the response to the ManagedApisGet request. The method always
+// closes the http.Response Body.
+func (c ManagedAPIsClient) responderForManagedApisGet(resp *http.Response) (result ManagedApisGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/method_managedapislist_autorest.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/method_managedapislist_autorest.go
@@ -1,0 +1,65 @@
+package managedapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ManagedApisListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ManagedApiDefinitionCollection
+}
+
+// ManagedApisList ...
+func (c ManagedAPIsClient) ManagedApisList(ctx context.Context, id LocationId) (result ManagedApisListOperationResponse, err error) {
+	req, err := c.preparerForManagedApisList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisList", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisList", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForManagedApisList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedapis.ManagedAPIsClient", "ManagedApisList", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForManagedApisList prepares the ManagedApisList request.
+func (c ManagedAPIsClient) preparerForManagedApisList(ctx context.Context, id LocationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/managedApis", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForManagedApisList handles the response to the ManagedApisList request. The method always
+// closes the http.Response Body.
+func (c ManagedAPIsClient) responderForManagedApisList(resp *http.Response) (result ManagedApisListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apioauthsettings.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apioauthsettings.go
@@ -1,0 +1,11 @@
+package managedapis
+
+type ApiOAuthSettings struct {
+	ClientId         *string                               `json:"clientId,omitempty"`
+	ClientSecret     *string                               `json:"clientSecret,omitempty"`
+	CustomParameters *map[string]ApiOAuthSettingsParameter `json:"customParameters,omitempty"`
+	IdentityProvider *string                               `json:"identityProvider,omitempty"`
+	Properties       *interface{}                          `json:"properties,omitempty"`
+	RedirectUrl      *string                               `json:"redirectUrl,omitempty"`
+	Scopes           *[]string                             `json:"scopes,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apioauthsettingsparameter.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apioauthsettingsparameter.go
@@ -1,0 +1,7 @@
+package managedapis
+
+type ApiOAuthSettingsParameter struct {
+	Options      *interface{} `json:"options,omitempty"`
+	UiDefinition *interface{} `json:"uiDefinition,omitempty"`
+	Value        *string      `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcebackendservice.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcebackendservice.go
@@ -1,0 +1,5 @@
+package managedapis
+
+type ApiResourceBackendService struct {
+	ServiceUrl *string `json:"serviceUrl,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcedefinitions.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcedefinitions.go
@@ -1,0 +1,6 @@
+package managedapis
+
+type ApiResourceDefinitions struct {
+	ModifiedSwaggerUrl *string `json:"modifiedSwaggerUrl,omitempty"`
+	OriginalSwaggerUrl *string `json:"originalSwaggerUrl,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcegeneralinformation.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcegeneralinformation.go
@@ -1,0 +1,9 @@
+package managedapis
+
+type ApiResourceGeneralInformation struct {
+	Description   *string `json:"description,omitempty"`
+	DisplayName   *string `json:"displayName,omitempty"`
+	IconUrl       *string `json:"iconUrl,omitempty"`
+	ReleaseTag    *string `json:"releaseTag,omitempty"`
+	TermsOfUseUrl *string `json:"termsOfUseUrl,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcemetadata.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcemetadata.go
@@ -1,0 +1,12 @@
+package managedapis
+
+type ApiResourceMetadata struct {
+	ApiType          *ApiType           `json:"apiType,omitempty"`
+	BrandColor       *string            `json:"brandColor,omitempty"`
+	ConnectionType   *string            `json:"connectionType,omitempty"`
+	HideKey          *string            `json:"hideKey,omitempty"`
+	Source           *string            `json:"source,omitempty"`
+	Tags             *map[string]string `json:"tags,omitempty"`
+	WsdlImportMethod *WsdlImportMethod  `json:"wsdlImportMethod,omitempty"`
+	WsdlService      *WsdlService       `json:"wsdlService,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcepolicies.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourcepolicies.go
@@ -1,0 +1,6 @@
+package managedapis
+
+type ApiResourcePolicies struct {
+	Content     *string `json:"content,omitempty"`
+	ContentLink *string `json:"contentLink,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourceproperties.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_apiresourceproperties.go
@@ -1,0 +1,15 @@
+package managedapis
+
+type ApiResourceProperties struct {
+	ApiDefinitionUrl     *string                         `json:"apiDefinitionUrl,omitempty"`
+	ApiDefinitions       *ApiResourceDefinitions         `json:"apiDefinitions,omitempty"`
+	BackendService       *ApiResourceBackendService      `json:"backendService,omitempty"`
+	Capabilities         *[]string                       `json:"capabilities,omitempty"`
+	ConnectionParameters *map[string]ConnectionParameter `json:"connectionParameters,omitempty"`
+	GeneralInformation   *ApiResourceGeneralInformation  `json:"generalInformation,omitempty"`
+	Metadata             *ApiResourceMetadata            `json:"metadata,omitempty"`
+	Name                 *string                         `json:"name,omitempty"`
+	Policies             *ApiResourcePolicies            `json:"policies,omitempty"`
+	RuntimeUrls          *[]string                       `json:"runtimeUrls,omitempty"`
+	Swagger              *interface{}                    `json:"swagger,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_connectionparameter.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_connectionparameter.go
@@ -1,0 +1,6 @@
+package managedapis
+
+type ConnectionParameter struct {
+	OAuthSettings *ApiOAuthSettings        `json:"oAuthSettings,omitempty"`
+	Type          *ConnectionParameterType `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_managedapidefinition.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_managedapidefinition.go
@@ -1,0 +1,11 @@
+package managedapis
+
+type ManagedApiDefinition struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Location   *string                `json:"location,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *ApiResourceProperties `json:"properties,omitempty"`
+	Tags       *map[string]string     `json:"tags,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_managedapidefinitioncollection.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_managedapidefinitioncollection.go
@@ -1,0 +1,5 @@
+package managedapis
+
+type ManagedApiDefinitionCollection struct {
+	Value *[]ManagedApiDefinition `json:"value,omitempty"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/model_wsdlservice.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/model_wsdlservice.go
@@ -1,0 +1,6 @@
+package managedapis
+
+type WsdlService struct {
+	EndpointQualifiedNames *[]string `json:"endpointQualifiedNames,omitempty"`
+	QualifiedName          string    `json:"qualifiedName"`
+}

--- a/internal/services/connections/sdk/2016-06-01/managedapis/version.go
+++ b/internal/services/connections/sdk/2016-06-01/managedapis/version.go
@@ -1,0 +1,9 @@
+package managedapis
+
+import "fmt"
+
+const defaultApiVersion = "2016-06-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/managedapis/%s", defaultApiVersion)
+}

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -19,6 +19,7 @@ CDN
 Cognitive Services
 Communication
 Compute
+Connections
 Consumption
 Container
 CosmosDB (DocumentDB)

--- a/website/docs/d/managed_api.html.markdown
+++ b/website/docs/d/managed_api.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Managed API"
+subcategory: "Connections"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_managed_api"
 description: |-
@@ -13,7 +13,7 @@ Uses this data source to access information about an existing Managed API.
 ## Example Usage
 
 ```hcl
-data "azurerm_managed_api" "test" {
+data "azurerm_managed_api" "example" {
   name     = "servicebus"
   location = "West Europe"
 }

--- a/website/docs/d/managed_api.html.markdown
+++ b/website/docs/d/managed_api.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Managed API"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_managed_api"
+description: |-
+    Gets information about an existing Managed API.
+---
+
+# Data Source: azurerm_managed_api
+
+Uses this data source to access information about an existing Managed API.
+
+## Example Usage
+
+```hcl
+data "azurerm_managed_api" "test" {
+  name     = "servicebus"
+  location = "West Europe"
+}
+
+output "id" {
+  value = data.azurerm_managed_api.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Managed API.
+
+* `location` - (Required) The Azure location for this Managed API.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Managed API.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Managed API.

--- a/website/docs/r/api_connection.html.markdown
+++ b/website/docs/r/api_connection.html.markdown
@@ -13,14 +13,24 @@ Manages an API Connection.
 ## Example Usage
 
 ```hcl
-resource "azurerm_api_connection" "test" {
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+data "azurerm_managed_api" "example" {
+  name     = "servicebus"
+  location = azurerm_resource_group.example.location
+}
+
+resource "azurerm_api_connection" "example" {
   name                = "example-connection"
-  resource_group_name = azurerm_resource_group.test.name
-  managed_api_id      = data.azurerm_managed_api.test.id
+  resource_group_name = azurerm_resource_group.example.name
+  managed_api_id      = data.azurerm_managed_api.example.id
   display_name        = "Example 1"
 
   parameter_values = {
-    connectionString = azurerm_servicebus_namespace.test.default_primary_connection_string
+    connectionString = azurerm_servicebus_namespace.example.default_primary_connection_string
   }
 
   tags = {
@@ -32,4 +42,47 @@ resource "azurerm_api_connection" "test" {
     ignore_changes = ["parameter_values"]
   }
 }
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `managed_api_id` - (Required) The ID of the Managed API which this API Connection is linked to. Changing this forces a new API Connection to be created.
+
+* `name` - (Required) The Name which should be used for this API Connection. Changing this forces a new API Connection to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where this API Connection should exist. Changing this forces a new API Connection to be created.
+
+---
+
+* `display_name` - (Optional) A display name for this API Connection. Changing this forces a new API Connection to be created.
+
+* `parameter_values` - (Optional) A map of parameter values associated with this API Connection. Changing this forces a new API Connection to be created.
+
+-> **Note:** The Azure API doesn't return sensitive parameters in the API response which can lead to a diff, as such you may need to use Terraform's `ignore_changes` functionality on this field as shown in the Example Usage above.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the API Connection.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the API Connection.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Connection.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Connection.
+* `update` - (Defaults to 30 minutes) Used when updating the API Connection.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Connection.
+
+## Import
+
+API Connections can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.Web/connections/example-connection
 ```

--- a/website/docs/r/api_connection.html.markdown
+++ b/website/docs/r/api_connection.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Connections"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_connection"
+description: |-
+  Manages an API Connection.
+---
+
+# azurerm_api_connection
+
+Manages an API Connection.
+
+## Example Usage
+
+```hcl
+resource "azurerm_api_connection" "test" {
+  name                = "example-connection"
+  resource_group_name = azurerm_resource_group.test.name
+  managed_api_id      = data.azurerm_managed_api.test.id
+  display_name        = "Example 1"
+
+  parameter_values = {
+    connectionString = azurerm_servicebus_namespace.test.default_primary_connection_string
+  }
+
+  tags = {
+    Hello = "World"
+  }
+
+  lifecycle {
+    # NOTE: since the connectionString is a secure value it's not returned from the API
+    ignore_changes = ["parameter_values"]
+  }
+}
+```


### PR DESCRIPTION
This PR introduces support for creating API Connections, which also required creating a Data Source to retrieve the Managed API information.

Whilst this creates the API Connection resource this doesn't handle linking these to other resources (such as Logic Apps) - which'll need to be tracked in a separate issue, but allowing the creation of these is a step forward at any rate.

Unfortunately the API Version used in the Azure Portal doesn't have associated Swagger in the Azure Rest API Specs repository, as such I've had to use an older API version which doesn't allow the update of Parameters - which (whilst obviously not ideal) seemed like a worthwhile trade-off here.

Fixes #1691