### PR TITLE
docs: correct long_term_retention_policy section

### DIFF
--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -158,7 +158,7 @@ A `long_term_retention_policy` block supports the following:
 * `weekly_retention` - (Optional) The weekly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 520 weeks. e.g. `P1Y`, `P1M`, `P1W` or `P7D`.
 * `monthly_retention` - (Optional) The monthly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 120 months. e.g. `P1Y`, `P1M`, `P4W` or `P30D`.
 * `yearly_retention` - (Optional) The yearly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 10 years. e.g. `P1Y`, `P12M`, `P52W` or `P365D`.
-* `week_of_year` - (Optional) The week of year to take the yearly backup in an ISO 8601 format. Value has to be between `1` and `52`.
+* `week_of_year` - (Required) The week of year to take the yearly backup. Value has to be between `1` and `52`.
 
 ---
 


### PR DESCRIPTION
This PR corrects the `long_term_retention_policy section`, as all other values in this section are optional (and by default 0), `week_of_year` is required to be set to avoid this scenario: 


`│ Error: setting Long Term Retention Policies for Database: (Name "xxx" / Server Name "xxx" / Resource Group "xxx"): sql.LongTermRetentionPoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="LongTermRetentionMissingWeekOfYear" Message="WeekOfYear is required to be set between 1 and 52 in order to set yearly retention."`

Furthermore this PR also removes the  ISO 8601 format description from `week_of_year` as this is an integer.