### PR TITLE
`r\cognitive_account`: Add support for `custom_question_answering_search_service_id`

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	networkParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	searchValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/search/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -285,6 +286,7 @@ func resourceCognitiveAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			if apiProps := props.ApiProperties; apiProps != nil {
 				d.Set("qna_runtime_endpoint", apiProps.QnaRuntimeEndpoint)
+				d.Set("qna_search_endpoint_id", apiProps.QnaAzureSearchEndpointId)
 				d.Set("metrics_advisor_aad_client_id", apiProps.AadClientId)
 				d.Set("metrics_advisor_aad_tenant_id", apiProps.AadTenantId)
 				d.Set("metrics_advisor_super_user_name", apiProps.SuperUser)
@@ -500,6 +502,13 @@ func expandCognitiveAccountAPIProperties(d *pluginsdk.ResourceData) (*cognitives
 			props.QnaRuntimeEndpoint = utils.String(v.(string))
 		} else {
 			return nil, fmt.Errorf("the QnAMaker runtime endpoint `qna_runtime_endpoint` is required when kind is set to `QnAMaker`")
+		}
+	}
+	if v, ok := d.GetOk("qna_search_endpoint_id"); ok {
+		if kind == "TextAnalytics" {
+			props.QnaAzureSearchEndpointId = utils.String(v.(string))
+		} else {
+			return nil, fmt.Errorf("qna_search_endpoint_id can only used set when kind is set to `TextAnalytics`")
 		}
 	}
 	if v, ok := d.GetOk("metrics_advisor_aad_client_id"); ok {
@@ -805,6 +814,12 @@ func resourceCognitiveAccountSchema() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+
+		"qna_search_endpoint_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: searchValidate.SearchServiceID,
 		},
 
 		"storage": {

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -286,7 +286,7 @@ func resourceCognitiveAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			if apiProps := props.ApiProperties; apiProps != nil {
 				d.Set("qna_runtime_endpoint", apiProps.QnaRuntimeEndpoint)
-				d.Set("qna_search_endpoint_id", apiProps.QnaAzureSearchEndpointId)
+				d.Set("custom_question_answering_search_service_id", apiProps.QnaAzureSearchEndpointId)
 				d.Set("metrics_advisor_aad_client_id", apiProps.AadClientId)
 				d.Set("metrics_advisor_aad_tenant_id", apiProps.AadTenantId)
 				d.Set("metrics_advisor_super_user_name", apiProps.SuperUser)
@@ -504,11 +504,11 @@ func expandCognitiveAccountAPIProperties(d *pluginsdk.ResourceData) (*cognitives
 			return nil, fmt.Errorf("the QnAMaker runtime endpoint `qna_runtime_endpoint` is required when kind is set to `QnAMaker`")
 		}
 	}
-	if v, ok := d.GetOk("qna_search_endpoint_id"); ok {
+	if v, ok := d.GetOk("custom_question_answering_search_service_id"); ok {
 		if kind == "TextAnalytics" {
 			props.QnaAzureSearchEndpointId = utils.String(v.(string))
 		} else {
-			return nil, fmt.Errorf("qna_search_endpoint_id can only used set when kind is set to `TextAnalytics`")
+			return nil, fmt.Errorf("the Search Service ID `custom_question_answering_search_service_id` can only be set when kind is set to `TextAnalytics`")
 		}
 	}
 	if v, ok := d.GetOk("metrics_advisor_aad_client_id"); ok {
@@ -816,7 +816,7 @@ func resourceCognitiveAccountSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 		},
 
-		"qna_search_endpoint_id": {
+		"custom_question_answering_search_service_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: searchValidate.SearchServiceID,

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -183,27 +183,27 @@ func TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified(t *testing.T) {
 	})
 }
 
-func TestAccCognitiveAccount_qnaSearchEndpointId(t *testing.T) {
+func TestAccCognitiveAccount_customQuestionAnsweringSearchServiceId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
 	r := CognitiveAccountResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.qnaSearchEndpointId(data),
+			Config: r.customQuestionAnsweringSearchServiceId(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.qnaSearchEndpointIdUpdated(data),
+			Config: r.customQuestionAnsweringSearchServiceIdUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.qnaSearchEndpointIdRemoved(data),
+			Config: r.customQuestionAnsweringSearchServiceIdRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -625,7 +625,7 @@ resource "azurerm_cognitive_account" "test" {
 `, data.RandomInteger, "West US", data.RandomInteger) // QnAMaker only available in West US
 }
 
-func (CognitiveAccountResource) qnaSearchEndpointId(data acceptance.TestData) string {
+func (CognitiveAccountResource) customQuestionAnsweringSearchServiceId(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -644,17 +644,17 @@ resource "azurerm_search_service" "test" {
 }
 
 resource "azurerm_cognitive_account" "test" {
-  name                   = "acctestcogacc-%[1]d"
-  location               = azurerm_resource_group.test.location
-  resource_group_name    = azurerm_resource_group.test.name
-  kind                   = "TextAnalytics"
-  sku_name               = "F0"
-  qna_search_endpoint_id = azurerm_search_service.test.id
+  name                                        = "acctestcogacc-%[1]d"
+  location                                    = azurerm_resource_group.test.location
+  resource_group_name                         = azurerm_resource_group.test.name
+  kind                                        = "TextAnalytics"
+  sku_name                                    = "F0"
+  custom_question_answering_search_service_id = azurerm_search_service.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (CognitiveAccountResource) qnaSearchEndpointIdUpdated(data acceptance.TestData) string {
+func (CognitiveAccountResource) customQuestionAnsweringSearchServiceIdUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -680,17 +680,17 @@ resource "azurerm_search_service" "test2" {
 }
 
 resource "azurerm_cognitive_account" "test" {
-  name                   = "acctestcogacc-%[1]d"
-  location               = azurerm_resource_group.test.location
-  resource_group_name    = azurerm_resource_group.test.name
-  kind                   = "TextAnalytics"
-  sku_name               = "F0"
-  qna_search_endpoint_id = azurerm_search_service.test2.id
+  name                                        = "acctestcogacc-%[1]d"
+  location                                    = azurerm_resource_group.test.location
+  resource_group_name                         = azurerm_resource_group.test.name
+  kind                                        = "TextAnalytics"
+  sku_name                                    = "F0"
+  custom_question_answering_search_service_id = azurerm_search_service.test2.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (CognitiveAccountResource) qnaSearchEndpointIdRemoved(data acceptance.TestData) string {
+func (CognitiveAccountResource) customQuestionAnsweringSearchServiceIdRemoved(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -183,6 +183,35 @@ func TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified(t *testing.T) {
 	})
 }
 
+func TestAccCognitiveAccount_qnaSearchEndpointId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
+	r := CognitiveAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.qnaSearchEndpointId(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.qnaSearchEndpointIdUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.qnaSearchEndpointIdRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCognitiveAccount_cognitiveServices(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
 	r := CognitiveAccountResource{}
@@ -594,6 +623,106 @@ resource "azurerm_cognitive_account" "test" {
   sku_name            = "S0"
 }
 `, data.RandomInteger, "West US", data.RandomInteger) // QnAMaker only available in West US
+}
+
+func (CognitiveAccountResource) qnaSearchEndpointId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_search_service" "test" {
+  name                = "acctestsearchacc-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                   = "acctestcogacc-%[1]d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  kind                   = "TextAnalytics"
+  sku_name               = "F0"
+  qna_search_endpoint_id = azurerm_search_service.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (CognitiveAccountResource) qnaSearchEndpointIdUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_search_service" "test" {
+  name                = "acctestsearchacc-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_search_service" "test2" {
+  name                = "acctestsearchacc2-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                   = "acctestcogacc-%[1]d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  kind                   = "TextAnalytics"
+  sku_name               = "F0"
+  qna_search_endpoint_id = azurerm_search_service.test2.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (CognitiveAccountResource) qnaSearchEndpointIdRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_search_service" "test" {
+  name                = "acctestsearchacc-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_search_service" "test2" {
+  name                = "acctestsearchacc2-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "TextAnalytics"
+  sku_name            = "F0"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (CognitiveAccountResource) cognitiveServices(data acceptance.TestData) string {

--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -43,11 +43,6 @@ The following attributes are exported:
 * `endpoint` - The endpoint of the Cognitive Services Account
 
 * `qna_runtime_endpoint` - If `kind` is `QnAMaker` the link to the QNA runtime.
-
-* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` the ID to the Search service.
-
--> **NOTE:** `custom_question_answering_search_service_id` is used for [Custom Question Answering, the renamed version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
-
 * `primary_access_key` - The primary access key of the Cognitive Services Account
 
 * `secondary_access_key` - The secondary access key of the Cognitive Services Account

--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -43,6 +43,11 @@ The following attributes are exported:
 * `endpoint` - The endpoint of the Cognitive Services Account
 
 * `qna_runtime_endpoint` - If `kind` is `QnAMaker` the link to the QNA runtime.
+
+* `qna_search_endpoint_id` - If `kind` is `TextAnalytics` the ID to the Search service.
+
+-> **NOTE:** `qna_search_endpoint_id` is used for [the new version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
+
 * `primary_access_key` - The primary access key of the Cognitive Services Account
 
 * `secondary_access_key` - The secondary access key of the Cognitive Services Account

--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -44,9 +44,9 @@ The following attributes are exported:
 
 * `qna_runtime_endpoint` - If `kind` is `QnAMaker` the link to the QNA runtime.
 
-* `qna_search_endpoint_id` - If `kind` is `TextAnalytics` the ID to the Search service.
+* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` the ID to the Search service.
 
--> **NOTE:** `qna_search_endpoint_id` is used for [the new version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
+-> **NOTE:** `custom_question_answering_search_service_id` is used for [Custom Question Answering, the renamed version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
 
 * `primary_access_key` - The primary access key of the Cognitive Services Account
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -76,6 +76,10 @@ The following arguments are supported:
 
 * `qna_runtime_endpoint` - (Optional) A URL to link a QnAMaker cognitive account to a QnA runtime.
 
+* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` the ID to the Search service.
+
+-> **NOTE:** `custom_question_answering_search_service_id` is used for [Custom Question Answering, the renamed version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
+
 * `storage` - (Optional) A `storage` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `qna_runtime_endpoint` - (Optional) A URL to link a QnAMaker cognitive account to a QnA runtime.
 
-* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` the ID to the Search service.
+* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` this specifies the ID of the Search service.
 
 -> **NOTE:** `custom_question_answering_search_service_id` is used for [Custom Question Answering, the renamed version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
 


### PR DESCRIPTION
Fix #14011 and #9271