### PR TITLE
fix import a connected synapse workspace

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -484,7 +484,7 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 	sqlAdmin, err := sqlAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		// Sql AAD admin is not supported in a synapse workspace created from a Dedicated SQL pool (formerly SQL DW)
+		// NOTE: SQL Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
 		if !utils.ResponseWasNotFound(sqlAdmin.Response) && !utils.ResponseWasConflict(sqlAdmin.Response) {
 			return fmt.Errorf("retrieving Sql Admin for %s: %+v", *id, err)
 		}

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -477,7 +477,7 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	aadAdmin, err := aadAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		// AAD admin is not supported in a synapse workspace created from a Dedicated SQL pool (formerly SQL DW)
+		// NOTE: AAD Admin isn't supported for a Workspace created from a Dedicated SQL Pool / SQL DataWarehouse and returns a Conflict
 		if !utils.ResponseWasNotFound(aadAdmin.Response) && !utils.ResponseWasConflict(aadAdmin.Response) {
 			return fmt.Errorf("retrieving AzureAD Admin for %s: %+v", *id, err)
 		}

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -477,12 +477,14 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	aadAdmin, err := aadAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
+		// AAD admin is not supported in a synapse workspace created from a Dedicated SQL pool (formerly SQL DW)
 		if !utils.ResponseWasNotFound(aadAdmin.Response) && !utils.ResponseWasConflict(aadAdmin.Response) {
 			return fmt.Errorf("retrieving AzureAD Admin for %s: %+v", *id, err)
 		}
 	}
 	sqlAdmin, err := sqlAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
+		// Sql AAD admin is not supported in a synapse workspace created from a Dedicated SQL pool (formerly SQL DW)
 		if !utils.ResponseWasNotFound(sqlAdmin.Response) && !utils.ResponseWasConflict(sqlAdmin.Response) {
 			return fmt.Errorf("retrieving Sql Admin for %s: %+v", *id, err)
 		}

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -477,13 +477,13 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	aadAdmin, err := aadAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		if !utils.ResponseWasNotFound(aadAdmin.Response) {
+		if !utils.ResponseWasNotFound(aadAdmin.Response) && !utils.ResponseWasConflict(aadAdmin.Response) {
 			return fmt.Errorf("retrieving AzureAD Admin for %s: %+v", *id, err)
 		}
 	}
 	sqlAdmin, err := sqlAdminClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		if !utils.ResponseWasNotFound(sqlAdmin.Response) {
+		if !utils.ResponseWasNotFound(sqlAdmin.Response) && !utils.ResponseWasConflict(sqlAdmin.Response) {
 			return fmt.Errorf("retrieving Sql Admin for %s: %+v", *id, err)
 		}
 	}


### PR DESCRIPTION
A synapse workspace can be created from a dedicated SQL pool(formly SQL DW). And it can not perform GET aad admin/ sql aad admin operations.

To address: https://github.com/hashicorp/terraform-provider-azurerm/issues/9845

Fixes #9845