### PR TITLE
`azurerm_static_site` - `identity` supports `SystemAssigned, UserAssigned`

### DIFF
--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -77,7 +77,7 @@ func resourceStaticSite() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"api_key": {
 				Type:     pluginsdk.TypeString,
@@ -235,7 +235,7 @@ func resourceStaticSiteDelete(d *pluginsdk.ResourceData, meta interface{}) error
 }
 
 func expandStaticSiteIdentity(input []interface{}) (*web.ManagedServiceIdentity, error) {
-	config, err := identity.ExpandSystemOrUserAssignedMap(input)
+	config, err := identity.ExpandSystemAndUserAssignedMap(input)
 	if err != nil {
 		return nil, err
 	}
@@ -259,10 +259,10 @@ func expandStaticSiteIdentity(input []interface{}) (*web.ManagedServiceIdentity,
 }
 
 func flattenStaticSiteIdentity(input *web.ManagedServiceIdentity) (*[]interface{}, error) {
-	var transform *identity.SystemOrUserAssignedMap
+	var transform *identity.SystemAndUserAssignedMap
 
 	if input != nil {
-		transform = &identity.SystemOrUserAssignedMap{
+		transform = &identity.SystemAndUserAssignedMap{
 			Type:        identity.Type(string(input.Type)),
 			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
 		}
@@ -281,5 +281,5 @@ func flattenStaticSiteIdentity(input *web.ManagedServiceIdentity) (*[]interface{
 		}
 	}
 
-	return identity.FlattenSystemOrUserAssignedMap(transform)
+	return identity.FlattenSystemAndUserAssignedMap(transform)
 }

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -77,7 +77,7 @@ func TestAccAzureStaticSite_identity(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		// There is API issue to downgrade the sku to Free with identity configured: https://github.com/Azure/azure-rest-api-specs/issues/18253
+		// TODO: re-enable this once the API issue is resolved: https://github.com/Azure/azure-rest-api-specs/issues/18253
 		// {
 		// 	Config: r.basic(data),
 		// 	Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -77,13 +77,14 @@ func TestAccAzureStaticSite_identity(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
+		// There is API issue to downgrade the sku to Free with identity configured: https://github.com/Azure/azure-rest-api-specs/issues/18253
+		// {
+		// 	Config: r.basic(data),
+		// 	Check: acceptance.ComposeTestCheckFunc(
+		// 		check.That(data.ResourceName).ExistsInAzure(r),
+		// 	),
+		// },
+		// data.ImportStep(),
 	})
 }
 

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -71,7 +71,7 @@ func TestAccAzureStaticSite_identity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.withSystemAssignedUserAssignedIdentity(data),
+			Config: r.withUserAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) The Type of Managed Identity assigned to this Static Site resource. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The Type of Managed Identity assigned to this Static Site resource. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
 
 * `identity_ids` - (Optional) A list of Managed Identity ID's which should be assigned to this Static Site resource.
 


### PR DESCRIPTION
Fix #15794

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/web  -run='TestAccAzureStaticSite_with|TestAccAzureStaticSite_identity'
=== RUN   TestAccAzureStaticSite_withSystemAssignedIdentity
=== PAUSE TestAccAzureStaticSite_withSystemAssignedIdentity
=== RUN   TestAccAzureStaticSite_identity
=== PAUSE TestAccAzureStaticSite_identity
=== RUN   TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity
=== PAUSE TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity
=== RUN   TestAccAzureStaticSite_withUserAssignedIdentity
=== PAUSE TestAccAzureStaticSite_withUserAssignedIdentity
=== CONT  TestAccAzureStaticSite_withSystemAssignedIdentity
=== CONT  TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity
=== CONT  TestAccAzureStaticSite_identity
=== CONT  TestAccAzureStaticSite_withUserAssignedIdentity
--- PASS: TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity (131.75s)
--- PASS: TestAccAzureStaticSite_withSystemAssignedIdentity (182.29s)
--- PASS: TestAccAzureStaticSite_identity (227.74s)
--- PASS: TestAccAzureStaticSite_withUserAssignedIdentity (807.10s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/web   807.112s
```