### PR TITLE
`azurerm_container_registry` - Validate `georepliactions` to ensure it does not include the location of the ACR

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -168,8 +168,6 @@ The following arguments are supported:
 
 * `quarantine_policy_enabled` - (Optional) Boolean value that indicates whether quarantine policy is enabled. Defaults to `false`.
 
-* `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? Defaults to `false`.
-
 * `retention_policy` - (Optional) A `retention_policy` block as documented below.
 
 * `trust_policy` - (Optional) A `trust_policy` block as documented below.
@@ -195,6 +193,8 @@ The following arguments are supported:
 `georeplications` supports the following:
 
 * `location` - (Required) A location where the container registry should be geo-replicated.
+
+* `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? Defaults to `false`.
 
 * `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication location? Defaults to `false`.
 


### PR DESCRIPTION
Fixes #15787 

## Test

```shell
azurerm/container_registry/georeplication via 💠 default 
💤  cat main.tf 
provider "azurerm" {
  features {}
}
resource "azurerm_resource_group" "test" {
  name     = "acctestRG-acr-220316102238401883"
  location = "eastus"
}
resource "azurerm_container_registry" "test" {
  name                = "testacccr220316102238401883"
  resource_group_name = azurerm_resource_group.test.name
  location            = azurerm_resource_group.test.location
  sku                 = "Premium"
  georeplications {
    location = "eastus"
  }
  georeplications {
    location = "westus2"
  }
}

azurerm/container_registry/georeplication via 💠 default 
💤  tf apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - azure/azapi in /home/magodo/go/bin
│  - magodo/demo in /home/magodo/go/bin
│  - hashicorp/azurerm in /home/magodo/go/bin
│  - hashicorp/azuread in /home/magodo/go/bin
│  - hashicorp/time in /home/magodo/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/****/resourceGroups/acctestRG-acr-220316102238401883]
╷
│ Error: The `georeplications` list cannot contain the location where the Container Registry exists.
│ 
│   with azurerm_container_registry.test,
│   on main.tf line 8, in resource "azurerm_container_registry" "test":
│    8: resource "azurerm_container_registry" "test" {

```