### PR TITLE
`azurerm_static_site_custom_domain` - make `validation_type` optional

### DIFF
--- a/internal/services/web/static_site_custom_domain_resource.go
+++ b/internal/services/web/static_site_custom_domain_resource.go
@@ -55,7 +55,7 @@ func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 
 			"validation_type": {
 				Type:     pluginsdk.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					txtValidationType,
@@ -102,6 +102,9 @@ func resourceStaticSiteCustomDomainCreateOrUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	validationMethod := d.Get("validation_type").(string)
+	if validationMethod == "" {
+		return fmt.Errorf("`validation_type` can't be empty string")
+	}
 
 	siteEnvelope := web.StaticSiteCustomDomainRequestPropertiesARMResource{
 		StaticSiteCustomDomainRequestPropertiesARMResourceProperties: &web.StaticSiteCustomDomainRequestPropertiesARMResourceProperties{


### PR DESCRIPTION
This is to allow the imported `azurerm_static_site_custom_domain` not suffering force replacement issue.

Fixes #15837.