### PR TITLE
fix  #15851

### DIFF
--- a/internal/services/sentinel/sentinel_watchlist_resource.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource.go
@@ -28,6 +28,9 @@ type WatchlistModel struct {
 	Description             string   `tfschema:"description"`
 	Labels                  []string `tfschema:"labels"`
 	DefaultDuration         string   `tfschema:"default_duration"`
+	ItemsSearchKey          string   `tfschema:"items_search_key"`
+	RawContent              string   `tfschema:"raw_content"`
+	Source                  string   `tfschema:"source"`
 }
 
 func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
@@ -70,6 +73,24 @@ func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: commonValidate.ISO8601Duration,
+		},
+		"items_search_key": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"source": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"raw_content": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }
@@ -126,8 +147,11 @@ func (r WatchlistResource) Create() sdk.ResourceFunc {
 
 					// The "source" and "contentType" represent the source file name which contains the watchlist items and its content type.
 					// Setting them here is merely to make the API happy.
-					Source:      securityinsight.Source("a.csv"),
+					Source:      securityinsight.Source(model.Source),
 					ContentType: utils.String("Text/Csv"),
+
+					ItemsSearchKey: utils.String(model.ItemsSearchKey),
+					RawContent:     utils.String(model.RawContent),
 				},
 			}
 
@@ -189,6 +213,13 @@ func (r WatchlistResource) Read() sdk.ResourceFunc {
 				if props.DefaultDuration != nil {
 					model.DefaultDuration = *props.DefaultDuration
 				}
+				if props.ItemsSearchKey != nil {
+					model.ItemsSearchKey = *props.ItemsSearchKey
+				}
+				if props.RawContent != nil {
+					model.RawContent = *props.RawContent
+				}
+				model.Source = string(props.Source)
 			}
 
 			return metadata.Encode(&model)

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -88,6 +88,9 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
+  items_search_key           = "User"
+  raw_content                = "User\nJohn Doe"
+  source                     = "users.csv"
 }
 `, template, data.RandomInteger)
 }
@@ -104,6 +107,10 @@ resource "azurerm_sentinel_watchlist" "test" {
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
+
+  items_search_key           = "User"
+  raw_content                = "User\nJohn Doe"
+  source                     = "users.csv"
 }
 `, template, data.RandomInteger)
 }
@@ -117,6 +124,10 @@ resource "azurerm_sentinel_watchlist" "import" {
   name                       = azurerm_sentinel_watchlist.test.name
   log_analytics_workspace_id = azurerm_sentinel_watchlist.test.log_analytics_workspace_id
   display_name               = azurerm_sentinel_watchlist.test.display_name
+
+  items_search_key           = "User"
+  raw_content                = "User\nJohn Doe"
+  source                     = "users.csv"
 }
 `, template)
 }


### PR DESCRIPTION
This is my attempt at fixing #15851, however this is not exactly how it should be:

It
  - manages to create watchlists without errors
  - does **not** properly implement updates: somehow the provider always recognizes a diff for `raw_content` (ie. running `terraform apply` initially will create the watchlist, but (without changing anything in the config) running it again plans to destroy and re-create the watchlist because `raw_content` seems to have changed)

I tried implementing `DiffSuppressFunc` but there `old` is always `""` and `new`/`d.Get(k).(string)` don't match (as far as I can tell not just re-ordering the list contents). Can someone let me know about

  - How can I solve this problem in a clean way?
  - What exactly are the semantics of `old`, `new` and `d.Get(k).(string)`? How come that the contents of the latter two don't match (without changing anything in the config)
  - What the Terraform way is to manage list contents (eyeing `azurerm_sentinel_watchlist_item` but keeping in mind that we cannot create empty lists to begin with)?