### PR TITLE
`azurerm_sentinel_watchlist` - Add required property `item_search_key`

### DIFF
--- a/examples/sentinel/watchlist-item-from-csv-file/main.tf
+++ b/examples/sentinel/watchlist-item-from-csv-file/main.tf
@@ -32,6 +32,7 @@ resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
   log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   display_name               = "example-wl"
+  item_search_key            = "Key"
 }
 
 locals {

--- a/examples/sentinel/watchlist-item-from-csv-file/main.tf
+++ b/examples/sentinel/watchlist-item-from-csv-file/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
   log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   display_name               = "example-wl"
-  items_search_key           = "Key"
+  item_search_key            = "Key"
 }
 
 locals {

--- a/examples/sentinel/watchlist-item-from-csv-file/main.tf
+++ b/examples/sentinel/watchlist-item-from-csv-file/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
   log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   display_name               = "example-wl"
-  item_search_key            = "Key"
+  items_search_key           = "Key"
 }
 
 locals {

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -170,6 +170,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
+  item_search_key            = "k1"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -170,7 +170,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
-  items_search_key           = "k1"
+  item_search_key            = "k1"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -170,7 +170,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
-  item_search_key            = "k1"
+  items_search_key           = "k1"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_resource.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource.go
@@ -28,6 +28,7 @@ type WatchlistModel struct {
 	Description             string   `tfschema:"description"`
 	Labels                  []string `tfschema:"labels"`
 	DefaultDuration         string   `tfschema:"default_duration"`
+	ItemSearchKey           string   `tfschema:"item_search_key"`
 }
 
 func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
@@ -45,6 +46,12 @@ func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: loganalyticsValidate.LogAnalyticsWorkspaceID,
 		},
 		"display_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"item_search_key": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
@@ -124,10 +131,11 @@ func (r WatchlistResource) Create() sdk.ResourceFunc {
 					// The only supported provider for now is "Microsoft"
 					Provider: utils.String("Microsoft"),
 
-					// The "source" and "contentType" represent the source file name which contains the watchlist items and its content type.
+					// The "source" represent the source file name which contains the watchlist items.
 					// Setting them here is merely to make the API happy.
-					Source:      securityinsight.Source("a.csv"),
-					ContentType: utils.String("Text/Csv"),
+					Source: securityinsight.Source("a.csv"),
+
+					ItemsSearchKey: utils.String(model.ItemSearchKey),
 				},
 			}
 
@@ -188,6 +196,9 @@ func (r WatchlistResource) Read() sdk.ResourceFunc {
 				}
 				if props.DefaultDuration != nil {
 					model.DefaultDuration = *props.DefaultDuration
+				}
+				if props.ItemsSearchKey != nil {
+					model.ItemSearchKey = *props.ItemsSearchKey
 				}
 			}
 

--- a/internal/services/sentinel/sentinel_watchlist_resource.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource.go
@@ -28,7 +28,7 @@ type WatchlistModel struct {
 	Description             string   `tfschema:"description"`
 	Labels                  []string `tfschema:"labels"`
 	DefaultDuration         string   `tfschema:"default_duration"`
-	ItemsSearchKey          string   `tfschema:"items_search_key"`
+	ItemSearchKey           string   `tfschema:"item_search_key"`
 }
 
 func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
@@ -51,7 +51,7 @@ func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
-		"items_search_key": {
+		"item_search_key": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
@@ -135,7 +135,7 @@ func (r WatchlistResource) Create() sdk.ResourceFunc {
 					// Setting them here is merely to make the API happy.
 					Source: securityinsight.Source("a.csv"),
 
-					ItemsSearchKey: utils.String(model.ItemsSearchKey),
+					ItemsSearchKey: utils.String(model.ItemSearchKey),
 				},
 			}
 
@@ -198,7 +198,7 @@ func (r WatchlistResource) Read() sdk.ResourceFunc {
 					model.DefaultDuration = *props.DefaultDuration
 				}
 				if props.ItemsSearchKey != nil {
-					model.ItemsSearchKey = *props.ItemsSearchKey
+					model.ItemSearchKey = *props.ItemsSearchKey
 				}
 			}
 

--- a/internal/services/sentinel/sentinel_watchlist_resource.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource.go
@@ -28,7 +28,7 @@ type WatchlistModel struct {
 	Description             string   `tfschema:"description"`
 	Labels                  []string `tfschema:"labels"`
 	DefaultDuration         string   `tfschema:"default_duration"`
-	ItemSearchKey           string   `tfschema:"item_search_key"`
+	ItemsSearchKey          string   `tfschema:"items_search_key"`
 }
 
 func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
@@ -51,7 +51,7 @@ func (r WatchlistResource) Arguments() map[string]*pluginsdk.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
-		"item_search_key": {
+		"items_search_key": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
@@ -135,7 +135,7 @@ func (r WatchlistResource) Create() sdk.ResourceFunc {
 					// Setting them here is merely to make the API happy.
 					Source: securityinsight.Source("a.csv"),
 
-					ItemsSearchKey: utils.String(model.ItemSearchKey),
+					ItemsSearchKey: utils.String(model.ItemsSearchKey),
 				},
 			}
 
@@ -198,7 +198,7 @@ func (r WatchlistResource) Read() sdk.ResourceFunc {
 					model.DefaultDuration = *props.DefaultDuration
 				}
 				if props.ItemsSearchKey != nil {
-					model.ItemSearchKey = *props.ItemsSearchKey
+					model.ItemsSearchKey = *props.ItemsSearchKey
 				}
 			}
 

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -88,6 +88,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
+  item_search_key            = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -104,6 +105,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
+  item_search_key            = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -117,6 +119,7 @@ resource "azurerm_sentinel_watchlist" "import" {
   name                       = azurerm_sentinel_watchlist.test.name
   log_analytics_workspace_id = azurerm_sentinel_watchlist.test.log_analytics_workspace_id
   display_name               = azurerm_sentinel_watchlist.test.display_name
+  item_search_key            = azurerm_sentinel_watchlist.test.item_search_key
 }
 `, template)
 }
@@ -136,7 +139,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "acctest-workspace-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "pergb2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "sentinel" {

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -88,7 +88,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
-  items_search_key           = "Key"
+  item_search_key            = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -105,7 +105,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
-  items_search_key           = "Key"
+  item_search_key            = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -119,7 +119,7 @@ resource "azurerm_sentinel_watchlist" "import" {
   name                       = azurerm_sentinel_watchlist.test.name
   log_analytics_workspace_id = azurerm_sentinel_watchlist.test.log_analytics_workspace_id
   display_name               = azurerm_sentinel_watchlist.test.display_name
-  items_search_key           = azurerm_sentinel_watchlist.test.items_search_key
+  item_search_key            = azurerm_sentinel_watchlist.test.item_search_key
 }
 `, template)
 }

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -88,7 +88,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
   display_name               = "test"
-  item_search_key            = "Key"
+  items_search_key           = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -105,7 +105,7 @@ resource "azurerm_sentinel_watchlist" "test" {
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
-  item_search_key            = "Key"
+  items_search_key           = "Key"
 }
 `, template, data.RandomInteger)
 }
@@ -119,7 +119,7 @@ resource "azurerm_sentinel_watchlist" "import" {
   name                       = azurerm_sentinel_watchlist.test.name
   log_analytics_workspace_id = azurerm_sentinel_watchlist.test.log_analytics_workspace_id
   display_name               = azurerm_sentinel_watchlist.test.display_name
-  item_search_key            = azurerm_sentinel_watchlist.test.item_search_key
+  items_search_key           = azurerm_sentinel_watchlist.test.items_search_key
 }
 `, template)
 }

--- a/website/docs/r/sentinel_watchlist.html.markdown
+++ b/website/docs/r/sentinel_watchlist.html.markdown
@@ -42,6 +42,7 @@ resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
   log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   display_name               = "example-wl"
+  item_search_key            = "Key"
 }
 ```
 
@@ -54,6 +55,8 @@ The following arguments are supported:
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace where this Sentinel Watchlist resides in. Changing this forces a new Sentinel Watchlist to be created.
 
 * `display_name` - (Required) The display name of this Sentinel Watchlist. Changing this forces a new Sentinel Watchlist to be created.
+
+* `item_search_key` - (Required) The key used to optimize query performance when using Watchlist for joins with other data. Changing this forces a new Sentinel Watchlist to be created.
 
 ---
 

--- a/website/docs/r/sentinel_watchlist.html.markdown
+++ b/website/docs/r/sentinel_watchlist.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The display name of this Sentinel Watchlist. Changing this forces a new Sentinel Watchlist to be created.
 
-* `items_search_key` - (Required) The key used to optimize query performance when using Watchlist for joins with other data. Changing this forces a new Sentinel Watchlist to be created.
+* `item_search_key` - (Required) The key used to optimize query performance when using Watchlist for joins with other data. Changing this forces a new Sentinel Watchlist to be created.
 
 ---
 

--- a/website/docs/r/sentinel_watchlist.html.markdown
+++ b/website/docs/r/sentinel_watchlist.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The display name of this Sentinel Watchlist. Changing this forces a new Sentinel Watchlist to be created.
 
-* `item_search_key` - (Required) The key used to optimize query performance when using Watchlist for joins with other data. Changing this forces a new Sentinel Watchlist to be created.
+* `items_search_key` - (Required) The key used to optimize query performance when using Watchlist for joins with other data. Changing this forces a new Sentinel Watchlist to be created.
 
 ---
 


### PR DESCRIPTION
Since March, the sentinel API now requires the `itemSearchey` in the `PUT` request. Meanwhile, the `contentType` is now not needed here as we don't actually send any content, but delegate it to the `azurerm_sentinel_watchlist_item`.

Fixes #15851.
Superseds: #15856.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel  -run='TestAccWatchlist'
=== RUN   TestAccWatchlistItem_basic
=== PAUSE TestAccWatchlistItem_basic
=== RUN   TestAccWatchlistItem_update
=== PAUSE TestAccWatchlistItem_update
=== RUN   TestAccWatchlistItem_requiresImport
=== PAUSE TestAccWatchlistItem_requiresImport
=== RUN   TestAccWatchlist_basic
=== PAUSE TestAccWatchlist_basic
=== RUN   TestAccWatchlist_complete
=== PAUSE TestAccWatchlist_complete
=== RUN   TestAccWatchlist_requiresImport
=== PAUSE TestAccWatchlist_requiresImport
=== CONT  TestAccWatchlistItem_basic
=== CONT  TestAccWatchlist_requiresImport
=== CONT  TestAccWatchlist_basic
=== CONT  TestAccWatchlistItem_requiresImport
=== CONT  TestAccWatchlist_complete
=== CONT  TestAccWatchlistItem_update
--- PASS: TestAccWatchlist_basic (124.25s)
--- PASS: TestAccWatchlistItem_requiresImport (150.89s)
--- PASS: TestAccWatchlistItem_basic (184.24s)
--- PASS: TestAccWatchlistItem_update (228.30s)
--- PASS: TestAccWatchlist_requiresImport (784.88s)
--- PASS: TestAccWatchlist_complete (820.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      820.092s
```