### PR TITLE
Add lock for azurerm_cosmosdb_sql_role_assignment and azurerm_cosmosdb_sql_role_definition

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -33,6 +33,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var CosmosDbAccountResourceName = "azurerm_cosmosdb_account"
+
 // If the consistency policy of the Cosmos DB Database Account is not bounded staleness,
 // any changes to the configuration for bounded staleness should be suppressed.
 func suppressConsistencyPolicyStalenessConfiguration(_, _, _ string, d *pluginsdk.ResourceData) bool {

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
@@ -102,8 +102,8 @@ func resourceCosmosDbSQLRoleAssignmentCreate(d *pluginsdk.ResourceData, meta int
 
 	id := parse.NewSqlRoleAssignmentID(subscriptionId, resourceGroup, accountName, name)
 
-	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
 
 	existing, err := client.GetSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
@@ -180,8 +180,8 @@ func resourceCosmosDbSQLRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
 
 	parameters := documentdb.SQLRoleAssignmentCreateUpdateParameters{
 		SQLRoleAssignmentResource: &documentdb.SQLRoleAssignmentResource{
@@ -214,8 +214,8 @@ func resourceCosmosDbSQLRoleAssignmentDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
 
 	future, err := client.DeleteSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
@@ -2,7 +2,6 @@ package cosmos
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"log"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
@@ -19,8 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-var CosmosDbSQLRoleAssignmentResourceName = "azurerm_cosmosdb_sql_role_assignment"
-
 func resourceCosmosDbSQLRoleAssignment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceCosmosDbSQLRoleAssignmentCreate,
@@ -102,8 +100,8 @@ func resourceCosmosDbSQLRoleAssignmentCreate(d *pluginsdk.ResourceData, meta int
 
 	id := parse.NewSqlRoleAssignmentID(subscriptionId, resourceGroup, accountName, name)
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	existing, err := client.GetSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
@@ -180,8 +178,8 @@ func resourceCosmosDbSQLRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	parameters := documentdb.SQLRoleAssignmentCreateUpdateParameters{
 		SQLRoleAssignmentResource: &documentdb.SQLRoleAssignmentResource{
@@ -214,8 +212,8 @@ func resourceCosmosDbSQLRoleAssignmentDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleAssignmentResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	future, err := client.DeleteSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"log"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+var CosmosDbSQLRoleAssignmentResourceName = "azurerm_cosmosdb_sql_role_assignment"
 
 func resourceCosmosDbSQLRoleAssignment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -99,6 +102,9 @@ func resourceCosmosDbSQLRoleAssignmentCreate(d *pluginsdk.ResourceData, meta int
 
 	id := parse.NewSqlRoleAssignmentID(subscriptionId, resourceGroup, accountName, name)
 
+	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+
 	existing, err := client.GetSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
@@ -174,6 +180,9 @@ func resourceCosmosDbSQLRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
+	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+
 	parameters := documentdb.SQLRoleAssignmentCreateUpdateParameters{
 		SQLRoleAssignmentResource: &documentdb.SQLRoleAssignmentResource{
 			PrincipalID:      utils.String(d.Get("principal_id").(string)),
@@ -204,6 +213,9 @@ func resourceCosmosDbSQLRoleAssignmentDelete(d *pluginsdk.ResourceData, meta int
 	if err != nil {
 		return err
 	}
+
+	locks.ByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
+	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleAssignmentResourceName)
 
 	future, err := client.DeleteSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
@@ -206,3 +206,37 @@ resource "azurerm_cosmosdb_sql_role_assignment" "test" {
 }
 `, r.template(data), data.RandomString, roleAssignmentId)
 }
+
+func (r CosmosDbSQLRoleAssignmentResource) multipleAssignments(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cosmosdb_sql_role_assignment" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_cosmosdb_account.test.name
+  role_definition_id  = azurerm_cosmosdb_sql_role_definition.test.id
+  principal_id        = data.azurerm_client_config.current.object_id
+  scope               = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.test.name}"
+}
+
+resource "azurerm_cosmosdb_sql_role_definition" "test2" {
+  name                = "acctestsqlrole2%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_cosmosdb_account.test.name
+  type                = "CustomRole"
+  assignable_scopes   = ["/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.test.name}"]
+
+  permissions {
+    data_actions = ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"]
+  }
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "test2" {
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_cosmosdb_account.test.name
+  role_definition_id  = azurerm_cosmosdb_sql_role_definition.test2.id
+  principal_id        = data.azurerm_client_config.current.object_id
+  scope               = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.test.name}"
+}
+`, r.template(data))
+}

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
@@ -76,6 +76,21 @@ func TestAccCosmosDbSQLRoleAssignment_update(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbSQLRoleAssignment_multiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_role_assignment", "test")
+	r := CosmosDbSQLRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CosmosDbSQLRoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SqlRoleAssignmentID(state.ID)
 	if err != nil {
@@ -207,7 +222,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "test" {
 `, r.template(data), data.RandomString, roleAssignmentId)
 }
 
-func (r CosmosDbSQLRoleAssignmentResource) multipleAssignments(data acceptance.TestData) string {
+func (r CosmosDbSQLRoleAssignmentResource) multiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -238,5 +253,5 @@ resource "azurerm_cosmosdb_sql_role_assignment" "test2" {
   principal_id        = data.azurerm_client_config.current.object_id
   scope               = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.DocumentDB/databaseAccounts/${azurerm_cosmosdb_account.test.name}"
 }
-`, r.template(data))
+`, r.template(data), data.RandomString)
 }

--- a/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
@@ -19,8 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-var CosmosDbSQLRoleDefinitionResourceName = "azurerm_cosmosdb_sql_role_definition"
-
 func resourceCosmosDbSQLRoleDefinition() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceCosmosDbSQLRoleDefinitionCreate,
@@ -125,8 +123,8 @@ func resourceCosmosDbSQLRoleDefinitionCreate(d *pluginsdk.ResourceData, meta int
 
 	id := parse.NewSqlRoleDefinitionID(subscriptionId, resourceGroup, accountName, roleDefinitionId)
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	existing, err := client.GetSQLRoleDefinition(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
@@ -208,8 +206,8 @@ func resourceCosmosDbSQLRoleDefinitionUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	parameters := documentdb.SQLRoleDefinitionCreateUpdateParameters{
 		SQLRoleDefinitionResource: &documentdb.SQLRoleDefinitionResource{
@@ -244,8 +242,8 @@ func resourceCosmosDbSQLRoleDefinitionDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbAccountResourceName)
 
 	future, err := client.DeleteSQLRoleDefinition(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {

--- a/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
@@ -125,8 +125,8 @@ func resourceCosmosDbSQLRoleDefinitionCreate(d *pluginsdk.ResourceData, meta int
 
 	id := parse.NewSqlRoleDefinitionID(subscriptionId, resourceGroup, accountName, roleDefinitionId)
 
-	locks.ByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
 
 	existing, err := client.GetSQLRoleDefinition(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
@@ -208,8 +208,8 @@ func resourceCosmosDbSQLRoleDefinitionUpdate(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
 
 	parameters := documentdb.SQLRoleDefinitionCreateUpdateParameters{
 		SQLRoleDefinitionResource: &documentdb.SQLRoleDefinitionResource{
@@ -244,8 +244,8 @@ func resourceCosmosDbSQLRoleDefinitionDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
-	defer locks.UnlockByName(id.Name, CosmosDbSQLRoleDefinitionResourceName)
+	locks.ByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
+	defer locks.UnlockByName(id.DatabaseAccountName, CosmosDbSQLRoleDefinitionResourceName)
 
 	future, err := client.DeleteSQLRoleDefinition(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/15842

--- PASS: TestAccCosmosDbSQLRoleAssignment_basic (961.50s)
--- PASS: TestAccCosmosDbSQLRoleAssignment_requiresImport (1074.46s)
--- PASS: TestAccCosmosDbSQLRoleAssignment_multiple (1134.17s)
--- PASS: TestAccCosmosDbSQLRoleAssignment_update (1343.81s)
--- PASS: TestAccCosmosDbSQLRoleDefinition_basic (927.11s)
--- PASS: TestAccCosmosDbSQLRoleDefinition_multiple (939.41s)
--- PASS: TestAccCosmosDbSQLRoleDefinition_complete (952.54s)
--- PASS: TestAccCosmosDbSQLRoleDefinition_requiresImport (966.27s)
--- PASS: TestAccCosmosDbSQLRoleDefinition_update (1188.56s)