### PR TITLE
Data Source: azurerm_storage_account_sas  - support for tag and filter

### DIFF
--- a/internal/services/storage/storage_account_sas_data_source.go
+++ b/internal/services/storage/storage_account_sas_data_source.go
@@ -167,6 +167,16 @@ func dataSourceStorageAccountSharedAccessSignature() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Required: true,
 						},
+
+						"tag": {
+							Type:     pluginsdk.TypeBool,
+							Required: true,
+						},
+
+						"filter": {
+							Type:     pluginsdk.TypeBool,
+							Required: true,
+						},
 					},
 				},
 			},
@@ -258,6 +268,14 @@ func BuildPermissionsString(perms map[string]interface{}) string {
 
 	if val, pres := perms["process"].(bool); pres && val {
 		retVal += "p"
+	}
+
+	if val, pres := perms["tag"].(bool); pres && val {
+		retVal += "t"
+	}
+
+	if val, pres := perms["filter"].(bool); pres && val {
+		retVal += "f"
 	}
 
 	return retVal

--- a/internal/services/storage/storage_account_sas_data_source_test.go
+++ b/internal/services/storage/storage_account_sas_data_source_test.go
@@ -89,6 +89,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = true
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, ipAddresses, startDate, endDate)
@@ -146,6 +148,8 @@ func TestAccDataSourceStorageAccountSas_permissionsString(t *testing.T) {
 		{map[string]interface{}{"create": true}, "c"},
 		{map[string]interface{}{"update": true}, "u"},
 		{map[string]interface{}{"process": true}, "p"},
+		{map[string]interface{}{"tag": true}, "t"},
+		{map[string]interface{}{"filter": true}, "f"},
 		{map[string]interface{}{"read": true, "write": true, "add": true, "create": true}, "rwac"},
 	}
 

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -66,6 +66,8 @@ data "azurerm_storage_account_sas" "example" {
     create  = true
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 
@@ -122,6 +124,8 @@ A `permissions` block contains:
 * `create` - Should Create permissions be enabled for this SAS?
 * `update` - Should Update permissions be enabled for this SAS?
 * `process` - Should Process permissions be enabled for this SAS?
+* `tag` - Should Get / Set Index Tags permissions be enabled for this SAS?
+* `filter` - Should Filter by Index Tags permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas)
 for additional details on the fields above.


### PR DESCRIPTION
Fixes #14317 and additionally adds the ability to add the `tag` permissions to account sas tokens.

See also: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs?tabs=azure-portal#service-sas-for-a-blob

