### PR TITLE
App Service - Adds `subnet_id` property to all app resources

### DIFF
--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -46,15 +46,15 @@ type LinuxFunctionAppDataSourceModel struct {
 	SiteConfig                []helpers.SiteConfigLinuxFunctionApp `tfschema:"site_config"`
 	Tags                      map[string]string                    `tfschema:"tags"`
 
-	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
-	DefaultHostname               string   `tfschema:"default_hostname"`
-	Kind                          string   `tfschema:"kind"`
-	OutboundIPAddresses           string   `tfschema:"outbound_ip_addresses"`
-	OutboundIPAddressList         []string `tfschema:"outbound_ip_address_list"`
-	PossibleOutboundIPAddresses   string   `tfschema:"possible_outbound_ip_addresses"`
-	PossibleOutboundIPAddressList []string `tfschema:"possible_outbound_ip_address_list"`
-
-	SiteCredentials []helpers.SiteCredential `tfschema:"site_credential"`
+	CustomDomainVerificationId    string                   `tfschema:"custom_domain_verification_id"`
+	DefaultHostname               string                   `tfschema:"default_hostname"`
+	Kind                          string                   `tfschema:"kind"`
+	OutboundIPAddresses           string                   `tfschema:"outbound_ip_addresses"`
+	OutboundIPAddressList         []string                 `tfschema:"outbound_ip_address_list"`
+	PossibleOutboundIPAddresses   string                   `tfschema:"possible_outbound_ip_addresses"`
+	PossibleOutboundIPAddressList []string                 `tfschema:"possible_outbound_ip_address_list"`
+	SubnetID                      string                   `tfschema:"subnet_id"`
+	SiteCredentials               []helpers.SiteCredential `tfschema:"site_credential"`
 }
 
 func (d LinuxFunctionAppDataSource) ModelObject() interface{} {
@@ -209,6 +209,12 @@ func (r LinuxFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"site_credential": helpers.SiteCredentialSchema(),
+
+		"subnet_id": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "The ID of the Subnet used for regional VNet integration.",
+		},
 	}
 }
 
@@ -289,6 +295,7 @@ func (d LinuxFunctionAppDataSource) Read() sdk.ResourceFunc {
 				DailyMemoryTimeQuota: int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
 				Tags:                 tags.ToTypedObject(functionApp.Tags),
 				Kind:                 utils.NormalizeNilableString(functionApp.Kind),
+				SubnetID:             utils.NormalizeNilableString(props.VirtualNetworkSubnetID),
 			}
 
 			configResp, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -47,6 +47,7 @@ type LinuxWebAppDataSourceModel struct {
 	PossibleOutboundIPAddresses   string                     `tfschema:"possible_outbound_ip_addresses"`
 	PossibleOutboundIPAddressList []string                   `tfschema:"possible_outbound_ip_address_list"`
 	SiteCredentials               []helpers.SiteCredential   `tfschema:"site_credential"`
+	SubnetID                      string                     `tfschema:"subnet_id"`
 }
 
 var _ sdk.DataSource = LinuxWebAppDataSource{}
@@ -184,6 +185,12 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"storage_account": helpers.StorageAccountSchemaComputed(),
 
+		"subnet_id": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "The ID of the Subnet used for regional VNet integration.",
+		},
+
 		"tags": tags.SchemaDataSource(),
 	}
 }
@@ -286,6 +293,7 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 				webApp.OutboundIPAddressList = strings.Split(webApp.OutboundIPAddresses, ",")
 				webApp.PossibleOutboundIPAddresses = utils.NormalizeNilableString(props.PossibleOutboundIPAddresses)
 				webApp.PossibleOutboundIPAddressList = strings.Split(webApp.PossibleOutboundIPAddresses, ",")
+				webApp.SubnetID = utils.NormalizeNilableString(props.VirtualNetworkSubnetID)
 			}
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -40,6 +41,7 @@ type LinuxWebAppSlotModel struct {
 	SiteConfig                    []helpers.SiteConfigLinuxWebAppSlot `tfschema:"site_config"`
 	StorageAccounts               []helpers.StorageAccount            `tfschema:"storage_account"`
 	ConnectionStrings             []helpers.ConnectionString          `tfschema:"connection_string"`
+	SubnetID                      string                              `tfschema:"subnet_id"`
 	Tags                          map[string]string                   `tfschema:"tags"`
 	CustomDomainVerificationId    string                              `tfschema:"custom_domain_verification_id"`
 	DefaultHostname               string                              `tfschema:"default_hostname"`
@@ -144,6 +146,13 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		"site_config": helpers.SiteConfigSchemaLinuxWebAppSlot(),
 
 		"storage_account": helpers.StorageAccountSchema(),
+
+		"subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: networkValidate.SubnetID,
+			Description:  "The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverfarms` delegation to be used.",
+		},
 
 		"tags": tags.Schema(),
 	}
@@ -272,6 +281,10 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 
 			if webAppSlot.KeyVaultReferenceIdentityID != "" {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(webAppSlot.KeyVaultReferenceIdentityID)
+			}
+
+			if webAppSlot.SubnetID != "" {
+				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(webAppSlot.SubnetID)
 			}
 
 			future, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)
@@ -425,6 +438,7 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
 				Enabled:                     utils.NormaliseNilableBool(props.Enabled),
 				HttpsOnly:                   utils.NormaliseNilableBool(props.HTTPSOnly),
+				SubnetID:                    utils.NormalizeNilableString(props.VirtualNetworkSubnetID),
 				Tags:                        tags.ToTypedObject(webApp.Tags),
 			}
 
@@ -543,6 +557,10 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("key_vault_reference_identity_id") {
 				existing.KeyVaultReferenceIdentity = utils.String(state.KeyVaultReferenceIdentityID)
+			}
+
+			if metadata.ResourceData.HasChange("subnet_id") {
+				existing.VirtualNetworkSubnetID = utils.String(state.SubnetID)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -44,6 +44,7 @@ type WindowsFunctionAppDataSourceModel struct {
 	ForceDisableContentShare  bool                                   `tfschema:"content_share_force_disabled"`
 	HttpsOnly                 bool                                   `tfschema:"https_only"`
 	SiteConfig                []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
+	SubnetID                  string                                 `tfschema:"subnet_id"`
 	Tags                      map[string]string                      `tfschema:"tags"`
 
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
@@ -203,6 +204,12 @@ func (d WindowsFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema 
 
 		"site_config": helpers.SiteConfigSchemaWindowsFunctionAppComputed(),
 
+		"subnet_id": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "The ID of the Subnet used for regional VNet integration.",
+		},
+
 		"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
 
 		"tags": tags.SchemaDataSource(),
@@ -245,6 +252,7 @@ func (d WindowsFunctionAppDataSource) Read() sdk.ResourceFunc {
 			functionApp.DailyMemoryTimeQuota = int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota))
 			functionApp.Tags = tags.ToTypedObject(existing.Tags)
 			functionApp.Kind = utils.NormalizeNilableString(existing.Kind)
+			functionApp.SubnetID = utils.NormalizeNilableString(props.VirtualNetworkSubnetID)
 
 			appSettingsResp, err := client.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -50,6 +51,7 @@ type WindowsFunctionAppModel struct {
 	HttpsOnly                   bool                                   `tfschema:"https_only"`
 	KeyVaultReferenceIdentityID string                                 `tfschema:"key_vault_reference_identity_id"`
 	SiteConfig                  []helpers.SiteConfigWindowsFunctionApp `tfschema:"site_config"`
+	SubnetID                    string                                 `tfschema:"subnet_id"`
 	Tags                        map[string]string                      `tfschema:"tags"`
 
 	// Computed
@@ -221,6 +223,13 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"site_config": helpers.SiteConfigSchemaWindowsFunctionApp(),
+
+		"subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: networkValidate.SubnetID,
+			Description:  "The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverfarms` delegation to be used.",
+		},
 
 		"tags": tags.Schema(),
 	}
@@ -423,6 +432,10 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(functionApp.KeyVaultReferenceIdentityID)
 			}
 
+			if functionApp.SubnetID != "" {
+				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(functionApp.SubnetID)
+			}
+
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
 			if err != nil {
 				return fmt.Errorf("creating Windows %s: %+v", id, err)
@@ -547,6 +560,7 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 				Tags:                        tags.ToTypedObject(functionApp.Tags),
 				Kind:                        utils.NormalizeNilableString(functionApp.Kind),
 				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
+				SubnetID:                    utils.NormalizeNilableString(props.VirtualNetworkSubnetID),
 			}
 
 			configResp, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)
@@ -666,6 +680,10 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("key_vault_reference_identity_id") {
 				existing.KeyVaultReferenceIdentity = utils.String(state.KeyVaultReferenceIdentityID)
+			}
+
+			if metadata.ResourceData.HasChange("subnet_id") {
+				existing.VirtualNetworkSubnetID = utils.String(state.SubnetID)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -44,6 +45,7 @@ type WindowsFunctionAppSlotModel struct {
 	HttpsOnly                     bool                                       `tfschema:"https_only"`
 	KeyVaultReferenceIdentityID   string                                     `tfschema:"key_vault_reference_identity_id"`
 	SiteConfig                    []helpers.SiteConfigWindowsFunctionAppSlot `tfschema:"site_config"`
+	SubnetID                      string                                     `tfschema:"subnet_id"`
 	Tags                          map[string]string                          `tfschema:"tags"`
 	CustomDomainVerificationId    string                                     `tfschema:"custom_domain_verification_id"`
 	DefaultHostname               string                                     `tfschema:"default_hostname"`
@@ -205,6 +207,13 @@ func (r WindowsFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema
 		},
 
 		"site_config": helpers.SiteConfigSchemaWindowsFunctionAppSlot(),
+
+		"subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: networkValidate.SubnetID,
+			Description:  "The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverfarms` delegation to be used.",
+		},
 
 		"tags": tags.Schema(),
 	}
@@ -429,6 +438,10 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(functionAppSlot.KeyVaultReferenceIdentityID)
 			}
 
+			if functionAppSlot.SubnetID != "" {
+				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(functionAppSlot.SubnetID)
+			}
+
 			future, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)
 			if err != nil {
 				return fmt.Errorf("creating Windows %s: %+v", id, err)
@@ -551,6 +564,7 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				Tags:                        tags.ToTypedObject(functionAppSlot.Tags),
 				Kind:                        utils.NormalizeNilableString(functionAppSlot.Kind),
 				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
+				SubnetID:                    utils.NormalizeNilableString(props.VirtualNetworkSubnetID),
 			}
 
 			configResp, err := client.GetConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
@@ -666,6 +680,10 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("key_vault_reference_identity_id") {
 				existing.KeyVaultReferenceIdentity = utils.String(state.KeyVaultReferenceIdentityID)
+			}
+
+			if metadata.ResourceData.HasChange("subnet_id") {
+				existing.VirtualNetworkSubnetID = utils.String(state.SubnetID)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -44,6 +44,7 @@ type WindowsWebAppDataSourceModel struct {
 	PossibleOutboundIPAddresses   string                      `tfschema:"possible_outbound_ip_addresses"`
 	PossibleOutboundIPAddressList []string                    `tfschema:"possible_outbound_ip_address_list"`
 	SiteCredentials               []helpers.SiteCredential    `tfschema:"site_credential"`
+	SubnetID                      string                      `tfschema:"subnet_id"`
 	Tags                          map[string]string           `tfschema:"tags"`
 }
 
@@ -169,6 +170,12 @@ func (d WindowsWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"storage_account": helpers.StorageAccountSchemaComputed(),
 
+		"subnet_id": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "The ID of the Subnet used for regional VNet integration.",
+		},
+
 		"tags": tags.SchemaDataSource(),
 	}
 }
@@ -277,6 +284,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				webApp.OutboundIPAddressList = strings.Split(webApp.OutboundIPAddresses, ",")
 				webApp.PossibleOutboundIPAddresses = utils.NormalizeNilableString(props.PossibleOutboundIPAddresses)
 				webApp.PossibleOutboundIPAddressList = strings.Split(webApp.PossibleOutboundIPAddresses, ",")
+				webApp.SubnetID = utils.NormalizeNilableString(props.VirtualNetworkSubnetID)
 			}
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)

--- a/website/docs/d/linux_function_app.html.markdown
+++ b/website/docs/d/linux_function_app.html.markdown
@@ -95,6 +95,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `site_credential` - A `site_credential` block as defined below.
 
+* `subnet_id` - The ID of the Subnet used for regional VNet integration.
+
 ---
 
 An `active_directory` block exports the following:

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -87,6 +87,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `storage_account` - A `storage_account` block as defined below.
 
+* `subnet_id` - The ID of the Subnet used for regional VNet integration.
+
 * `tags` - A mapping of tags assigned to the Linux Web App.
 
 ---

--- a/website/docs/d/windows_function_app.html.markdown
+++ b/website/docs/d/windows_function_app.html.markdown
@@ -93,6 +93,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `storage_uses_managed_identity` - Is the Function App using a Managed Identity to access the storage account?
 
+* `subnet_id` - The ID of the Subnet used for regional VNet integration.
+
 * `tags` - A mapping of tags assigned to the Windows Function App.
 
 ---

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -85,6 +85,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `storage_account` - A `storage_account` block as defined below.
 
+* `subnet_id` - The ID of the Subnet used for regional VNet integration.
+
 * `tags` - A mapping of tags assigned to the Windows Web App.
 
 ---

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported:
 
 ~> **NOTE:** One of `storage_account_access_key` or `storage_uses_managed_identity` must be specified.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Dynamic, Consumption, nor Basic Plans. 
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Linux Function App.
 
 ---

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -108,6 +108,10 @@ The following arguments are supported:
 
 ~> **NOTE:** One of `storage_account_access_key` or `storage_uses_managed_identity` must be specified. 
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Dynamic, Consumption, nor Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Linux Function App.
 
 ---

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -87,6 +87,10 @@ The following arguments are supported:
 
 * `storage_account` - (Optional) One or more `storage_account` blocks as defined below.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Linux Web App.
 
 ---

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -90,6 +90,10 @@ The following arguments are supported:
 
 * `storage_account` - (Optional) One or more `storage_account` blocks as defined below.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Linux Web App.
 
 ---

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported:
 
 ~> **NOTE:** One of `storage_account_access_key` or `storage_uses_managed_identity` must be specified.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Dynamic, Consumption, nor Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Windows Function App.
 
 ---

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -107,6 +107,10 @@ The following arguments are supported:
 
 ~> **NOTE:** One of `storage_account_access_key` or `storage_uses_managed_identity` must be specified.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Dynamic, Consumption, nor Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Windows Function App Slot.
 
 ---

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -83,6 +83,10 @@ The following arguments are supported:
 
 * `storage_account` - (Optional) One or more `storage_account` blocks as defined below.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Windows Web App.
 
 ---

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -90,6 +90,10 @@ The following arguments are supported:
 
 * `storage_account` - (Optional) One or more `storage_account` blocks as defined below.
 
+* `subnet_id` - (Optional) The ID of the Subnet to use for regional VNet integration. This subnet must have the `Microsoft.Web/serverFarms` delegation to be used.
+
+~> **NOTE:** This property is only valid on `Standard` Service Plan SKU's and above, it has no effect on Basic Plans.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Windows Web App Slot.
 
 ---


### PR DESCRIPTION
This change enables support for Virtual Network Subnet integration. 

Use of this feature requires the specified subnet to have a delegation to `Microsoft.Web/serverFarms` and the property only takes effect on Service Plans of `Standard` and above.