### PR TITLE
function apps: updating the read timeout to 5m

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -477,7 +477,7 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 
 func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 25 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.AppService.WebAppsClient
 			id, err := parse.FunctionAppID(metadata.ResourceData.Id())

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -476,7 +476,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 func (r LinuxFunctionAppSlotResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 25 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.AppService.WebAppsClient
 			id, err := parse.FunctionAppSlotID(metadata.ResourceData.Id())

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -476,7 +476,7 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 
 func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 25 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.AppService.WebAppsClient
 			id, err := parse.FunctionAppID(metadata.ResourceData.Id())

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -482,7 +482,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 25 * time.Minute,
+		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.AppService.WebAppsClient
 			id, err := parse.FunctionAppSlotID(metadata.ResourceData.Id())

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -478,7 +478,7 @@ A `site_credential` block exports the following:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Linux Function App.
-* `read` - (Defaults to 25 minutes) Used when retrieving the Linux Function App.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Linux Function App.
 * `update` - (Defaults to 30 minutes) Used when updating the Linux Function App.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Linux Function App.
 

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -503,7 +503,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Linux Function App Slot.
 * `update` - (Defaults to 30 minutes) Used when updating the Linux Function App Slot.
-* `read` - (Defaults to 25 minutes) Used when retrieving the Linux Function App Slot.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Linux Function App Slot.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Linux Function App Slot.
 
 ## Import

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -450,7 +450,7 @@ A `site_credential` block exports the following:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Windows Function App.
-* `read` - (Defaults to 25 minutes) Used when retrieving the Windows Function App.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Windows Function App.
 * `update` - (Defaults to 30 minutes) Used when updating the Windows Function App.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Windows Function App.
 

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -476,7 +476,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Windows Function App Slot.
 * `update` - (Defaults to 30 minutes) Used when updating the Windows Function App Slot.
-* `read` - (Defaults to 25 minutes) Used when retrieving the Windows Function App Slot.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Windows Function App Slot.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Windows Function App Slot.
 
 ## Import


### PR DESCRIPTION
This is currently set to 25m but should be fine within 5m by default, which enables the unit test to pass - which is currently blocking #15800