### PR TITLE
Fix TC TestAccPostgreSQLServer_createPointInTimeRestore

### DIFF
--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -950,7 +950,7 @@ resource "azurerm_postgresql_server" "restore" {
 
   ssl_enforcement_enabled = true
 }
-`, r.basic(data, version), data.RandomInteger, restoreTime, version)
+`, r.gp(data, version), data.RandomInteger, restoreTime, version)
 }
 
 func (PostgreSQLServerResource) emptyAttrs(data acceptance.TestData, version string) string {


### PR DESCRIPTION
This PR is to fix failed TC TestAccPostgreSQLServer_createPointInTimeRestore.

--- PASS: TestAccPostgreSQLServer_createPointInTimeRestore (4925.15s)