### PR TITLE
`r\iothub`: Add support for identity-based `file_upload`

### DIFF
--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -178,11 +178,69 @@ func TestAccIotHub_fileUpload(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.fileUpload(data),
+			Config: r.fileUploadBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("file_upload.#").HasValue("1"),
 				check.That(data.ResourceName).Key("file_upload.0.lock_duration").HasValue("PT5M"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHub_fileUploadAuthenticationTypeUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	r := IotHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fileUploadAuthenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHub_fileUploadAuthenticationTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+	r := IotHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fileUploadAuthenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadAuthenticationTypeUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadAuthenticationTypeSystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.fileUploadAuthenticationTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -399,7 +457,7 @@ func TestAccIotHub_identityUpdate(t *testing.T) {
 	})
 }
 
-func TestAccIotHub_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
+func TestAccIotHub_endpointAuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
 	r := IotHubResource{}
 
@@ -414,7 +472,7 @@ func TestAccIotHub_AuthenticationTypeUserAssignedIdentity(t *testing.T) {
 	})
 }
 
-func TestAccIotHub_AuthenticationTypeUpdate(t *testing.T) {
+func TestAccIotHub_endpointAuthenticationTypeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
 	r := IotHubResource{}
 
@@ -1057,7 +1115,50 @@ resource "azurerm_iothub" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (IotHubResource) fileUpload(data acceptance.TestData) string {
+func (IotHubResource) fileUploadBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "test"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  file_upload {
+    connection_string = azurerm_storage_account.test.primary_blob_connection_string
+    container_name    = azurerm_storage_container.test.name
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (IotHubResource) fileUploadUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1101,6 +1202,155 @@ resource "azurerm_iothub" "test" {
     default_ttl        = "PT3H"
     lock_duration      = "PT5M"
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r IotHubResource) fileUploadAuthenticationTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  file_upload {
+    connection_string = azurerm_storage_account.test.primary_blob_connection_string
+    container_name    = azurerm_storage_container.test.name
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+  ]
+}
+`, r.fileUploadAuthenticationTypeTemplate(data), data.RandomInteger)
+}
+
+func (r IotHubResource) fileUploadAuthenticationTypeSystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  file_upload {
+    connection_string = azurerm_storage_account.test.primary_blob_connection_string
+    container_name    = azurerm_storage_container.test.name
+
+    authentication_type = "identityBased"
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+  ]
+}
+`, r.fileUploadAuthenticationTypeTemplate(data), data.RandomInteger)
+}
+
+func (r IotHubResource) fileUploadAuthenticationTypeUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  file_upload {
+    connection_string = azurerm_storage_account.test.primary_blob_connection_string
+    container_name    = azurerm_storage_container.test.name
+
+    authentication_type = "identityBased"
+    identity_id         = azurerm_user_assigned_identity.test.id
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test_storage_blob_data_contrib_user,
+  ]
+}
+`, r.fileUploadAuthenticationTypeTemplate(data), data.RandomInteger)
+}
+
+func (IotHubResource) fileUploadAuthenticationTypeTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "test"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_user" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test_storage_blob_data_contrib_system" {
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.test.id
+  principal_id         = azurerm_iothub.test.identity[0].principal_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -294,6 +294,14 @@ A `fallback_route` block supports the following:
 
 A `file_upload` block supports the following:
 
+* `authentication_type` - (Optional) The type used to authenticate against the storage account. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
+
+* `identity_id` - (Optional) The ID of the User Managed Identity used to authenticate against the storage account.
+
+-> **NOTE:** `identity_id` can only be specified when `authentication_type` is `identityBased`. It must be one of the `identity_ids` of the Iot Hub. If `identity_id`is omitted when `authentication_type` is `identityBased`, then the System Assigned Managed Identity of the Iot Hub will be used.
+
+~> **NOTE:** An IoT Hub can only be updated to use the System Assigned Managed Identity for `file_upload` since it is not possible to grant access to the endpoint until after creation.
+
 * `connection_string` - (Required) The connection string for the Azure Storage account to which files are uploaded.
 
 * `container_name` - (Required) The name of the root container where you upload files. The container need not exist but should be creatable using the connection_string specified.


### PR DESCRIPTION
Only kept the embedded properties from #15466 and removed the new resource as we don't need an extracted resource.