### PR TITLE
fix: remove deprecated property from documentation

### DIFF
--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -58,8 +58,6 @@ The following arguments are supported:
 
 A `dns` block supports the following:
 
-* `network_rule_fqdn_enabled` - (Optional) Should the network rule fqdn be enabled?
-
 * `proxy_enabled` - (Optional) Whether to enable DNS proxy on Firewalls attached to this Firewall Policy? Defaults to `false`.
 
 * `servers` - (Optional) A list of custom DNS servers' IP addresses.


### PR DESCRIPTION
Remove the deprecated property network_rule_fqdn_enabled from the documentation. This has been deprecated for quite a while and throws a warning when including it.