### PR TITLE
update function apps and app slots to correctly maintain content settings

### DIFF
--- a/internal/services/appservice/function_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource.go
@@ -337,7 +337,7 @@ func (r FunctionAppHybridConnectionResource) CustomImporter() sdk.ResourceRunFun
 			return err
 		}
 
-		if helpers.PlanIsConsumption(*sku) || helpers.PlanIsElastic(*sku) {
+		if helpers.PlanIsConsumption(sku) || helpers.PlanIsElastic(sku) {
 			return fmt.Errorf("unsupported plan type. Hybrid Connections are not supported on Consumption or Elastic service plans")
 		}
 

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -2153,3 +2153,22 @@ func FlattenFunctionAppAppServiceLogs(input web.SiteLogsConfig) []FunctionAppApp
 
 	return []FunctionAppAppServiceLogs{}
 }
+
+func ParseContentSettings(input web.StringDictionary, existing map[string]string) map[string]string {
+	if input.Properties == nil {
+		return nil
+	}
+
+	out := existing
+	for k, v := range input.Properties {
+		switch k {
+		case "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":
+			out[k] = utils.NormalizeNilableString(v)
+
+		case "WEBSITE_CONTENTSHARE":
+			out[k] = utils.NormalizeNilableString(v)
+		}
+	}
+
+	return out
+}

--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -65,9 +65,12 @@ func AllKnownServicePlanSkus() []string {
 	return allSkus
 }
 
-func PlanIsConsumption(input string) bool {
+func PlanIsConsumption(input *string) bool {
+	if input == nil {
+		return false
+	}
 	for _, v := range consumptionSkus {
-		if strings.EqualFold(input, v) {
+		if strings.EqualFold(*input, v) {
 			return true
 		}
 	}
@@ -75,9 +78,12 @@ func PlanIsConsumption(input string) bool {
 	return false
 }
 
-func PlanIsElastic(input string) bool {
+func PlanIsElastic(input *string) bool {
+	if input == nil {
+		return false
+	}
 	for _, v := range elasticSkus {
-		if strings.EqualFold(input, v) {
+		if strings.EqualFold(*input, v) {
 			return true
 		}
 	}
@@ -85,9 +91,12 @@ func PlanIsElastic(input string) bool {
 	return false
 }
 
-func PlanIsIsolated(input string) bool {
+func PlanIsIsolated(input *string) bool {
+	if input == nil {
+		return false
+	}
 	for _, v := range isolatedSkus {
-		if strings.EqualFold(input, v) {
+		if strings.EqualFold(*input, v) {
 			return true
 		}
 	}
@@ -95,9 +104,12 @@ func PlanIsIsolated(input string) bool {
 	return false
 }
 
-func PlanIsAppPlan(input string) bool {
+func PlanIsAppPlan(input *string) bool {
+	if input == nil {
+		return false
+	}
 	for _, v := range appServicePlanSkus {
-		if strings.EqualFold(input, v) {
+		if strings.EqualFold(*input, v) {
 			return true
 		}
 	}
@@ -106,19 +118,19 @@ func PlanIsAppPlan(input string) bool {
 }
 
 func PlanTypeFromSku(input string) string {
-	if PlanIsConsumption(input) {
+	if PlanIsConsumption(&input) {
 		return ServicePlanTypeConsumption
 	}
 
-	if PlanIsElastic(input) {
+	if PlanIsElastic(&input) {
 		return ServicePlanTypeElastic
 	}
 
-	if PlanIsIsolated(input) {
+	if PlanIsIsolated(&input) {
 		return ServicePlanTypeIsolated
 	}
 
-	if PlanIsAppPlan(input) {
+	if PlanIsAppPlan(&input) {
 		return ServicePlanTypeAppPlan
 	}
 

--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -131,12 +131,17 @@ func ServicePlanInfoForApp(ctx context.Context, metadata sdk.ResourceMetaData, i
 	servicePlanClient := metadata.Client.AppService.ServicePlanClient
 	var rg, siteName string
 
-	if appId, ok := id.(parse.WebAppId); ok {
+	switch appId := id.(type) {
+	case parse.WebAppId:
 		rg = appId.ResourceGroup
 		siteName = appId.SiteName
-	}
-
-	if appId, ok := id.(parse.FunctionAppId); ok {
+	case parse.WebAppSlotId:
+		rg = appId.ResourceGroup
+		siteName = appId.SiteName
+	case parse.FunctionAppId:
+		rg = appId.ResourceGroup
+		siteName = appId.SiteName
+	case parse.FunctionAppSlotId:
 		rg = appId.ResourceGroup
 		siteName = appId.SiteName
 	}

--- a/internal/services/appservice/helpers/service_plan_test.go
+++ b/internal/services/appservice/helpers/service_plan_test.go
@@ -4,148 +4,149 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestPlanIsConsumption(t *testing.T) {
 	input := []struct {
-		name          string
+		name          *string
 		isConsumption bool
 	}{
 		{
-			name:          "",
+			name:          utils.String(""),
 			isConsumption: false,
 		},
 		{
-			name:          "Y1",
+			name:          utils.String("Y1"),
 			isConsumption: true,
 		},
 		{
-			name:          "EP1",
+			name:          utils.String("EP1"),
 			isConsumption: false,
 		},
 		{
-			name:          "S1",
+			name:          utils.String("S1"),
 			isConsumption: false,
 		},
 	}
 
 	for _, v := range input {
 		if actual := helpers.PlanIsConsumption(v.name); actual != v.isConsumption {
-			t.Fatalf("expected %s to be %t, got %t", v.name, v.isConsumption, actual)
+			t.Fatalf("expected %s to be %t, got %t", *v.name, v.isConsumption, actual)
 		}
 	}
 }
 
 func TestPlanIsElastic(t *testing.T) {
 	input := []struct {
-		name      string
+		name      *string
 		isElastic bool
 	}{
 		{
-			name:      "",
+			name:      utils.String(""),
 			isElastic: false,
 		},
 		{
-			name:      "Y1",
+			name:      utils.String("Y1"),
 			isElastic: false,
 		},
 		{
-			name:      "EP1",
+			name:      utils.String("EP1"),
 			isElastic: true,
 		},
 		{
-			name:      "S1",
+			name:      utils.String("S1"),
 			isElastic: false,
 		},
 	}
 
 	for _, v := range input {
 		if actual := helpers.PlanIsElastic(v.name); actual != v.isElastic {
-			t.Fatalf("expected %s to be %t, got %t", v.name, v.isElastic, actual)
+			t.Fatalf("expected %s to be %t, got %t", *v.name, v.isElastic, actual)
 		}
 	}
 }
 
 func TestPlanIsIsolated(t *testing.T) {
 	input := []struct {
-		name       string
+		name       *string
 		isIsolated bool
 	}{
 		{
-			name:       "",
+			name:       utils.String(""),
 			isIsolated: false,
 		},
 		{
-			name:       "Y1",
+			name:       utils.String("Y1"),
 			isIsolated: false,
 		},
 		{
-			name:       "EP1",
+			name:       utils.String("EP1"),
 			isIsolated: false,
 		},
 		{
-			name:       "S1",
+			name:       utils.String("S1"),
 			isIsolated: false,
 		},
 		{
-			name:       "I1",
+			name:       utils.String("I1"),
 			isIsolated: true,
 		},
 		{
-			name:       "I1v2",
+			name:       utils.String("I1v2"),
 			isIsolated: true,
 		},
 	}
 
 	for _, v := range input {
 		if actual := helpers.PlanIsIsolated(v.name); actual != v.isIsolated {
-			t.Fatalf("expected %s to be %t, got %t", v.name, v.isIsolated, actual)
+			t.Fatalf("expected %s to be %t, got %t", *v.name, v.isIsolated, actual)
 		}
 	}
 }
 
 func TestPlanIsAppPlan(t *testing.T) {
 	input := []struct {
-		name      string
+		name      *string
 		isAppPlan bool
 	}{
 		{
-			name:      "",
+			name:      utils.String(""),
 			isAppPlan: false,
 		},
 		{
-			name:      "Y1",
+			name:      utils.String("Y1"),
 			isAppPlan: false,
 		},
 		{
-			name:      "EP1",
+			name:      utils.String("EP1"),
 			isAppPlan: false,
 		},
 		{
-			name:      "B1",
+			name:      utils.String("B1"),
 			isAppPlan: true,
 		},
 		{
-			name:      "S1",
+			name:      utils.String("S1"),
 			isAppPlan: true,
 		},
 		{
-			name:      "P1v3",
+			name:      utils.String("P1v3"),
 			isAppPlan: true,
 		},
 		{
-			name:      "I1",
+			name:      utils.String("I1"),
 			isAppPlan: false,
 		},
 		{
-			name:      "I1v2",
+			name:      utils.String("I1v2"),
 			isAppPlan: false,
 		},
 	}
 
 	for _, v := range input {
 		if actual := helpers.PlanIsAppPlan(v.name); actual != v.isAppPlan {
-			t.Fatalf("expected %s to be %t, got %t", v.name, v.isAppPlan, actual)
+			t.Fatalf("expected %s to be %t, got %t", *v.name, v.isAppPlan, actual)
 		}
 	}
 }

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -664,7 +664,7 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 			}
 
 			// Only send for ElasticPremium
-			sendContentSettings := helpers.PlanIsElastic(*planSKU)
+			sendContentSettings := helpers.PlanIsElastic(planSKU)
 
 			// Some service plan updates are allowed - see customiseDiff for exceptions
 			if metadata.ResourceData.HasChange("service_plan_id") {

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -2573,6 +2573,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.template(data, planSku))

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -211,6 +211,32 @@ func TestAccLinuxFunctionApp_withAppSettingsStandardPlan(t *testing.T) {
 	})
 }
 
+func TestAccLinuxFunctionApp_withAppSettingsUserSettingUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsUserSettings(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.appSettingsUserSettingsUpdate(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // backup by plan type
 
 func TestAccLinuxFunctionApp_withBackupElasticPremiumPlan(t *testing.T) {
@@ -1092,6 +1118,57 @@ resource "azurerm_linux_function_app" "test" {
 }
 
 func (r LinuxFunctionAppResource) appSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo    = "bar"
+    secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppResource) appSettingsUserSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {}
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppResource) appSettingsUserSettingsUpdate(data acceptance.TestData, planSku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -655,6 +655,13 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("reading Linux %s: %v", id, err)
 			}
 
+			_, planSKU, err := helpers.ServicePlanInfoForApp(ctx, metadata, *id)
+			if err != nil {
+				return err
+			}
+
+			sendContentSettings := !helpers.PlanIsElastic(*planSKU)
+
 			if metadata.ResourceData.HasChange("enabled") {
 				existing.SiteProperties.Enabled = utils.Bool(state.Enabled)
 			}
@@ -696,13 +703,29 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			if sendContentSettings {
+				appSettingsResp, err := client.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+				if err != nil {
+					return fmt.Errorf("reading App Settings for Windows %s: %+v", id, err)
+				}
+				if state.AppSettings == nil {
+					state.AppSettings = make(map[string]string)
+				}
+				state.AppSettings = helpers.ParseContentSettings(appSettingsResp, state.AppSettings)
+			}
+
 			// Note: We process this regardless to give us a "clean" view of service-side app_settings, so we can reconcile the user-defined entries later
 			siteConfig, err := helpers.ExpandSiteConfigLinuxFunctionAppSlot(state.SiteConfig, existing.SiteConfig, metadata, state.FunctionExtensionsVersion, storageString, state.StorageUsesMSI)
 			if state.BuiltinLogging {
 				if state.AppSettings == nil && !state.StorageUsesMSI {
 					state.AppSettings = make(map[string]string)
 				}
-				state.AppSettings["AzureWebJobsDashboard"] = storageString
+				if !state.StorageUsesMSI {
+					state.AppSettings["AzureWebJobsDashboard"] = storageString
+				} else {
+					state.AppSettings["AzureWebJobsDashboard__accountName"] = state.StorageAccountName
+				}
+
 			}
 
 			if metadata.ResourceData.HasChange("site_config") {

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -660,7 +660,7 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			sendContentSettings := !helpers.PlanIsElastic(*planSKU)
+			sendContentSettings := !helpers.PlanIsElastic(planSKU)
 
 			if metadata.ResourceData.HasChange("enabled") {
 				existing.SiteProperties.Enabled = utils.Bool(state.Enabled)

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -2333,6 +2333,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.template(data, planSku))

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -170,6 +170,32 @@ func TestAccLinuxFunctionAppSlot_withAppSettingsStandardPlan(t *testing.T) {
 	})
 }
 
+func TestAccLinuxFunctionAppSlot_withAppSettingsUserSettingUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
+	r := LinuxFunctionAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsUserSettings(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.appSettingsUserSettingsUpdate(data, SkuElasticPremiumPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // backup by plan type
 
 func TestAccLinuxFunctionAppSlot_withBackupElasticPremiumPlan(t *testing.T) {
@@ -1014,6 +1040,51 @@ resource "azurerm_linux_function_app_slot" "test" {
     foo                  = "bar"
     secret               = "sauce"
     WEBSITE_CONTENTSHARE = "test-acc-custom-content-share"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppSlotResource) appSettingsUserSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app_slot" "test" {
+  name                       = "acctest-LFAS-%d"
+  function_app_id            = azurerm_linux_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {}
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppSlotResource) appSettingsUserSettingsUpdate(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app_slot" "test" {
+  name                       = "acctest-LFAS-%d"
+  function_app_id            = azurerm_linux_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo    = "bar"
+    secret = "sauce"
   }
 
   site_config {}

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -2512,6 +2512,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.standardPlanTemplate(data), data.RandomInteger, data.RandomString)

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -1988,6 +1988,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, data.RandomString)

--- a/internal/services/appservice/web_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource.go
@@ -336,7 +336,7 @@ func (r WebAppHybridConnectionResource) CustomImporter() sdk.ResourceRunFunc {
 			return err
 		}
 
-		if helpers.PlanIsConsumption(*sku) || helpers.PlanIsElastic(*sku) {
+		if helpers.PlanIsConsumption(sku) || helpers.PlanIsElastic(sku) {
 			return fmt.Errorf("unsupported plan type. Hybrid Connections are not supported on Consumption or Elastic service plans")
 		}
 

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -661,7 +661,7 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			sendContentSettings := !helpers.PlanIsAppPlan(*planSKU)
+			sendContentSettings := !helpers.PlanIsAppPlan(planSKU)
 
 			// Some service plan updates are allowed - see customiseDiff for exceptions
 			if metadata.ResourceData.HasChange("service_plan_id") {

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -657,6 +657,12 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("reading Windows %s: %v", id, err)
 			}
 
+			_, planSKU, err := helpers.ServicePlanInfoForApp(ctx, metadata, *id)
+			if err != nil {
+				return err
+			}
+			sendContentSettings := !helpers.PlanIsAppPlan(*planSKU)
+
 			// Some service plan updates are allowed - see customiseDiff for exceptions
 			if metadata.ResourceData.HasChange("service_plan_id") {
 				existing.SiteProperties.ServerFarmID = utils.String(state.ServicePlanId)
@@ -703,13 +709,28 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			if sendContentSettings {
+				appSettingsResp, err := client.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+				if err != nil {
+					return fmt.Errorf("reading App Settings for Windows %s: %+v", id, err)
+				}
+				if state.AppSettings == nil {
+					state.AppSettings = make(map[string]string)
+				}
+				state.AppSettings = helpers.ParseContentSettings(appSettingsResp, state.AppSettings)
+			}
+
 			// Note: We process this regardless to give us a "clean" view of service-side app_settings, so we can reconcile the user-defined entries later
 			siteConfig, err := helpers.ExpandSiteConfigWindowsFunctionApp(state.SiteConfig, existing.SiteConfig, metadata, state.FunctionExtensionsVersion, storageString, state.StorageUsesMSI)
 			if state.BuiltinLogging {
 				if state.AppSettings == nil && !state.StorageUsesMSI {
 					state.AppSettings = make(map[string]string)
 				}
-				state.AppSettings["AzureWebJobsDashboard"] = storageString
+				if !state.StorageUsesMSI {
+					state.AppSettings["AzureWebJobsDashboard"] = storageString
+				} else {
+					state.AppSettings["AzureWebJobsDashboard__accountName"] = state.StorageAccountName
+				}
 			}
 
 			if metadata.ResourceData.HasChange("site_config") {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -2315,6 +2315,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -202,6 +202,32 @@ func TestAccWindowsFunctionApp_withAppSettingsStandardPlan(t *testing.T) {
 	})
 }
 
+func TestAccWindowsFunctionApp_withAppSettingsUserSettingUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
+	r := WindowsFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsUserSettings(data, SkuConsumptionPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("app_settings.%").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.appSettingsUserSettingsUpdate(data, SkuConsumptionPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // backup by plan type
 
 func TestAccWindowsFunctionApp_withBackupElasticPremiumPlan(t *testing.T) {
@@ -914,6 +940,57 @@ resource "azurerm_windows_function_app" "test" {
 }
 
 func (r WindowsFunctionAppResource) appSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo    = "bar"
+    secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r WindowsFunctionAppResource) appSettingsUserSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {}
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r WindowsFunctionAppResource) appSettingsUserSettingsUpdate(data acceptance.TestData, planSku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -661,6 +661,12 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("reading Windows %s: %v", id, err)
 			}
 
+			_, planSKU, err := helpers.ServicePlanInfoForApp(ctx, metadata, *id)
+			if err != nil {
+				return err
+			}
+			sendContentSettings := !helpers.PlanIsAppPlan(*planSKU)
+
 			// Some service plan updates are allowed - see customiseDiff for exceptions
 			if metadata.ResourceData.HasChange("enabled") {
 				existing.SiteProperties.Enabled = utils.Bool(state.Enabled)
@@ -703,13 +709,28 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			if sendContentSettings {
+				appSettingsResp, err := client.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+				if err != nil {
+					return fmt.Errorf("reading App Settings for Windows %s: %+v", id, err)
+				}
+				if state.AppSettings == nil {
+					state.AppSettings = make(map[string]string)
+				}
+				state.AppSettings = helpers.ParseContentSettings(appSettingsResp, state.AppSettings)
+			}
+
 			// Note: We process this regardless to give us a "clean" view of service-side app_settings, so we can reconcile the user-defined entries later
 			siteConfig, err := helpers.ExpandSiteConfigWindowsFunctionAppSlot(state.SiteConfig, existing.SiteConfig, metadata, state.FunctionExtensionsVersion, storageString, state.StorageUsesMSI)
 			if state.BuiltinLogging {
 				if state.AppSettings == nil && !state.StorageUsesMSI {
 					state.AppSettings = make(map[string]string)
 				}
-				state.AppSettings["AzureWebJobsDashboard"] = storageString
+				if !state.StorageUsesMSI {
+					state.AppSettings["AzureWebJobsDashboard"] = storageString
+				} else {
+					state.AppSettings["AzureWebJobsDashboard__accountName"] = state.StorageAccountName
+				}
 			}
 
 			if metadata.ResourceData.HasChange("site_config") {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -665,7 +665,7 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			sendContentSettings := !helpers.PlanIsAppPlan(*planSKU)
+			sendContentSettings := !helpers.PlanIsAppPlan(planSKU)
 
 			// Some service plan updates are allowed - see customiseDiff for exceptions
 			if metadata.ResourceData.HasChange("enabled") {

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -2158,6 +2158,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -170,6 +170,32 @@ func TestAccWindowsFunctionAppSlot_withCustomContentShareElasticPremiumPlan(t *t
 	})
 }
 
+func TestAccWindowsFunctionAppSlot_withAppSettingsUserSettingUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app_slot", "test")
+	r := WindowsFunctionAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appSettingsUserSettings(data, SkuConsumptionPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("app_settings.%").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.appSettingsUserSettingsUpdate(data, SkuConsumptionPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("app_settings.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // backup by plan type
 
 func TestAccWindowsFunctionAppSlot_withBackupElasticPremiumPlan(t *testing.T) {
@@ -864,6 +890,51 @@ resource "azurerm_windows_function_app_slot" "test" {
 }
 
 func (r WindowsFunctionAppSlotResource) appSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app_slot" "test" {
+  name                       = "acctest-WFAS-%d"
+  function_app_id            = azurerm_windows_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {
+    foo    = "bar"
+    secret = "sauce"
+  }
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r WindowsFunctionAppSlotResource) appSettingsUserSettings(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app_slot" "test" {
+  name                       = "acctest-WFAS-%d"
+  function_app_id            = azurerm_windows_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  app_settings = {}
+
+  site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r WindowsFunctionAppSlotResource) appSettingsUserSettingsUpdate(data acceptance.TestData, planSku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -608,7 +608,7 @@ func TestAccWindowsFunctionAppSlot_appStackNode(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.appStackNode(data, SkuStandardPlan, "14"),
+			Config: r.appStackNode(data, SkuStandardPlan, "~14"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
@@ -624,7 +624,7 @@ func TestAccWindowsFunctionAppSlot_appStackNodeUpdate(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.appStackNode(data, SkuStandardPlan, "12"),
+			Config: r.appStackNode(data, SkuStandardPlan, "~12"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
@@ -632,7 +632,7 @@ func TestAccWindowsFunctionAppSlot_appStackNodeUpdate(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.appStackNode(data, SkuStandardPlan, "14"),
+			Config: r.appStackNode(data, SkuStandardPlan, "~14"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2447,6 +2447,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, data.RandomString)

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1820,6 +1820,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, data.RandomString)


### PR DESCRIPTION
fixes #15855

* `azurerm_linux_function_app` - fixed update handling of `app_settings` for `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`
* `azurerm_linux_function_app_slot` - fixed update handling of `app_settings` for `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`
* `azurerm_windows_function_app` - fixed update handling of `app_settings` for `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`
* `azurerm_windows_function_app_slot` - fixed update handling of `app_settings` for `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`

Tests passing:
![image](https://user-images.githubusercontent.com/11830746/159238490-1652e49b-7fe6-4b25-970d-9545c48c477b.png)
