### PR TITLE
Bug Fix: azurerm_eventhub - Crash when capture_description of azurerm_eventhub removed 

### DIFF
--- a/internal/services/eventhub/eventhub_resource.go
+++ b/internal/services/eventhub/eventhub_resource.go
@@ -305,6 +305,9 @@ func resourceEventHubDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func expandEventHubCaptureDescription(d *pluginsdk.ResourceData) *eventhubs.CaptureDescription {
 	inputs := d.Get("capture_description").([]interface{})
+	if len(inputs) == 0 || inputs[0] == nil {
+		return nil
+	}
 	input := inputs[0].(map[string]interface{})
 
 	enabled := input["enabled"].(bool)


### PR DESCRIPTION
Add check for func expandEventHubCaptureDescription to avoid "Index out of range [0] with length 0 " error to fix issue [#15898](https://github.com/hashicorp/terraform-provider-azurerm/issues/15898).