### PR TITLE
`cognitive_account`: Fix `virtual_network_rules` update

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -433,18 +433,17 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 			networkRules = append(networkRules, rule)
 		}
 	}
-	if d.HasChange("network_acls.0.virtual_network_rules") {
-		networkRulesRaw := v["virtual_network_rules"]
-		for _, v := range networkRulesRaw.(*pluginsdk.Set).List() {
-			value := v.(map[string]interface{})
-			subnetId := value["subnet_id"].(string)
-			subnetIds = append(subnetIds, subnetId)
-			rule := cognitiveservicesaccounts.VirtualNetworkRule{
-				Id:                               subnetId,
-				IgnoreMissingVnetServiceEndpoint: utils.Bool(value["ignore_missing_vnet_service_endpoint"].(bool)),
-			}
-			networkRules = append(networkRules, rule)
+
+	networkRulesRaw := v["virtual_network_rules"]
+	for _, v := range networkRulesRaw.(*pluginsdk.Set).List() {
+		value := v.(map[string]interface{})
+		subnetId := value["subnet_id"].(string)
+		subnetIds = append(subnetIds, subnetId)
+		rule := cognitiveservicesaccounts.VirtualNetworkRule{
+			Id:                               subnetId,
+			IgnoreMissingVnetServiceEndpoint: utils.Bool(value["ignore_missing_vnet_service_endpoint"].(bool)),
 		}
+		networkRules = append(networkRules, rule)
 	}
 
 	ruleSet := cognitiveservicesaccounts.NetworkRuleSet{


### PR DESCRIPTION
Removed the `if` clause, this is a nested property and needs to be present in the update body. otherwise the value will become empty after update (This can be verified by the failing test `TestAccCognitiveAccount_networkAcls`). This also fixes the failed test `TestAccCognitiveAccount_networkAcls`. Earlier the test was updated to use this new property in 3.0 and the issue seems not captured at that time.

Same fix should also be applied to the deprecated `virtual_network_subnet_ids` I believe. But since it's already deprecated in 3.0 plus all test cases are not testing this property any more, I didn't change its behavior in this pr. The old test for it didn't catch the issue because in old test `virtual_network_subnet_ids` is changed as well in the updated config, and in new test  `virtual_network_rules` didn't, which is instead correct as it verifies the update without changing the property (https://github.com/hashicorp/terraform-provider-azurerm/pull/15796/files#diff-5d91adb9b50f8375c3a8ba3de800561c35bdb1cfc4ef8019edbe39f705810714)