### PR TITLE
`azurerm_virtual_network_gateway_connection` - Multiple `traffic_selector_policy` can now be specified

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -166,7 +166,6 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 			"traffic_selector_policy": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"local_address_cidrs": {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -882,7 +882,7 @@ resource "azurerm_subnet" "test" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.66.1.0/24"
+  address_prefixes     = ["10.66.1.0/24"]
 }
 
 resource "azurerm_public_ip" "test" {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -112,6 +112,26 @@ func TestAccVirtualNetworkGatewayConnection_trafficSelectorPolicy(t *testing.T) 
 	})
 }
 
+func TestAccVirtualNetworkGatewayConnection_trafficSelectorPolicyMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
+	r := VirtualNetworkGatewayConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.trafficselectorpolicymultiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("traffic_selector_policy.0.local_address_cidrs.0").HasValue("10.66.18.0/24"),
+				check.That(data.ResourceName).Key("traffic_selector_policy.0.local_address_cidrs.1").HasValue("10.66.17.0/24"),
+				check.That(data.ResourceName).Key("traffic_selector_policy.0.remote_address_cidrs.0").HasValue("10.1.1.0/24"),
+				check.That(data.ResourceName).Key("traffic_selector_policy.1.local_address_cidrs.0").HasValue("10.66.20.0/24"),
+				check.That(data.ResourceName).Key("traffic_selector_policy.1.local_address_cidrs.1").HasValue("10.66.19.0/24"),
+				check.That(data.ResourceName).Key("traffic_selector_policy.1.remote_address_cidrs.0").HasValue("10.1.2.0/24"),
+			),
+		},
+	})
+}
+
 func TestAccVirtualNetworkGatewayConnection_connectionprotocol(t *testing.T) {
 	expectedConnectionProtocol := "IKEv1"
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
@@ -834,6 +854,103 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
   traffic_selector_policy {
     local_address_cidrs  = ["10.66.18.0/24", "10.66.17.0/24"]
     remote_address_cidrs = ["10.1.1.0/24"]
+  }
+
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkGatewayConnectionResource) trafficselectorpolicymultiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+variable "random" {
+  default = "%d"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-${var.random}"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.66.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.66.1.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "VpnGw1"
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctest"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+  address_space   = ["10.1.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  name                = "acctest-${var.random}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "IPsec"
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.test.id
+  local_network_gateway_id   = azurerm_local_network_gateway.test.id
+
+  use_policy_based_traffic_selectors = true
+  routing_weight                     = 20
+
+  ipsec_policy {
+    dh_group         = "DHGroup14"
+    ike_encryption   = "AES256"
+    ike_integrity    = "SHA256"
+    ipsec_encryption = "AES256"
+    ipsec_integrity  = "SHA256"
+    pfs_group        = "PFS2048"
+    sa_datasize      = 102400000
+    sa_lifetime      = 27000
+  }
+
+  shared_key = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+
+  traffic_selector_policy {
+    local_address_cidrs  = ["10.66.18.0/24", "10.66.17.0/24"]
+    remote_address_cidrs = ["10.1.1.0/24"]
+  }
+
+  traffic_selector_policy {
+    local_address_cidrs  = ["10.66.20.0/24", "10.66.19.0/24"]
+    remote_address_cidrs = ["10.1.2.0/24"]
   }
 
 }

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -250,7 +250,7 @@ resource "azurerm_subnet" "test" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "test" {

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -76,9 +76,9 @@ output "virtual_network_gateway_connection_id" {
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` A `traffic_selector_policy` which allows to specify traffic selector policy proposal to be used in a virtual network gateway connection.
-    Only one block can be defined for a connection.
-    For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
+* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` which is documented below.
+  A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
+  For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 
 * `tags` - A mapping of tags to assign to the resource.
 

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -76,7 +76,7 @@ output "virtual_network_gateway_connection_id" {
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` blocks which are documented below.
+* `traffic_selector_policy` One or more `traffic_selector_policy` blocks which are documented below.
   A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
   For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -76,7 +76,7 @@ output "virtual_network_gateway_connection_id" {
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` which is documented below.
+* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` blocks which are documented below.
   A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
   For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -269,8 +269,8 @@ Changing this value will force a resource to be created.
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` A `traffic_selector_policy` which allows to specify traffic selector policy proposal to be used in a virtual network gateway connection.
-    Only one block can be defined for a connection.
+* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` which is documented below. 
+    A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
     For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -302,6 +302,12 @@ The `ipsec_policy` block supports:
 
 * `sa_lifetime` - (Optional) The IPSec SA lifetime in seconds. Must be at least
     `300` seconds. Defaults to `27000` seconds.
+
+The `traffic_selector_policy` block supports:
+
+* `local_address_cidrs` - List of local CIDRs.
+
+* `remote_address_cidrs` - List of remote CIDRs.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -269,7 +269,7 @@ Changing this value will force a resource to be created.
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` which is documented below. 
+* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` blocks which are documented below. 
     A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
     For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 


### PR DESCRIPTION
The changes in this pull request enable the virtual_network_ gateway_ connection resource to have multiple traffic_selector_policy blocks as defined by the corresponding Azure API