### PR TITLE
change custom_subdomain_name from optional to required

### DIFF
--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this Cognitive Service Account. Possible values are `F0`, `F1`, `S`, `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, and `P2`.
 
-* `custom_subdomain_name` - (Optional) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.
+* `custom_subdomain_name` - (Required) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.
 
 * `fqdns` - (Optional) List of FQDNs allowed for the Cognitive Account.
 


### PR DESCRIPTION
custom_subdomain_name for resource [azurerm_cognitive_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account) IS required. 

This PR is changing this argument from "optional" to "required".

---
**More context**
Using Terraform v1.1.7, I see resource azurerm_cognitive_account argument custom_subdomain_name is required (see attached image tf-cli-output.png)

tf-cli-output.png
<img width="806" alt="tf-cli-output" src="https://user-images.githubusercontent.com/91289116/159565565-515a1a88-364f-4561-ba1c-81df1cdda311.png">

In the [Azure provider source code](https://github.com/hashicorp/terraform-provider-azurerm/blob/ed4d59efc200a187c6dab5c5017e91b84e04d5e9/internal/services/cognitive/cognitive_account_resource.go#L734), it's configured as required.

However, the [docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account#custom_subdomain_name) list this argument as Optional.

[Steve Jones, Slack thread](https://hashicorp.slack.com/archives/CFXSTUYE9/p1647948660305769?thread_ts=1647641655.284989&cid=CFXSTUYE9): Hi julie - Could you submit the PR via a fork?