### PR TITLE
reopen #6681 - fix spelling in azurerm_virtual_hub_connection

### DIFF
--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -155,13 +155,13 @@ func resourceVirtualHubConnectionSchema() map[string]*pluginsdk.Schema {
 		},
 	}
 	if !features.ThreePointOhBeta() {
-		out["hub_to_vitual_network_traffic_allowed"] = &pluginsdk.Schema{
+		out["hub_to_virtual_network_traffic_allowed"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,
 			Deprecated: "Due to a breaking behavioural change in the Azure API this property is no longer functional and will be removed in version 3.0 of the provider",
 		}
 
-		out["vitual_network_to_hub_gateways_traffic_allowed"] = &pluginsdk.Schema{
+		out["virtual_network_to_hub_gateways_traffic_allowed"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,
 			Deprecated: "Due to a breaking behavioural change in the Azure API this property is no longer functional and will be removed in version 3.0 of the provider",
@@ -274,8 +274,8 @@ func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{
 		if !features.ThreePointOhBeta() {
 			// The following two attributes are deprecated by API (which will always return `true`).
 			// Hence, we explicitly set them to `false` (as false is the default value when users omit that property).
-			d.Set("hub_to_vitual_network_traffic_allowed", false)
-			d.Set("vitual_network_to_hub_gateways_traffic_allowed", false)
+			d.Set("hub_to_virtual_network_traffic_allowed", false)
+			d.Set("virtual_network_to_hub_gateways_traffic_allowed", false)
 		}
 
 		d.Set("internet_security_enabled", props.EnableInternetSecurity)

--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -1260,9 +1260,9 @@ The resource `azurerm_traffic_manager_endpoint` will be removed in favour of the
 
 ### Resource: `azurerm_virtual_hub_connection`
 
-The deprecated field `hub_to_vitual_network_traffic_allowed` will be removed since it is no longer supported by the Azure API.
+The deprecated field `hub_to_virtual_network_traffic_allowed` will be removed since it is no longer supported by the Azure API.
 
-The deprecated field `vitual_network_to_hub_gateways_traffic_allowed` will be removed since it is no longer supported by the Azure API.
+The deprecated field `virtual_network_to_hub_gateways_traffic_allowed` will be removed since it is no longer supported by the Azure API.
 
 ### Resource: `azurerm_virtual_hub_ip`
 


### PR DESCRIPTION
reopen #6681 to fix #6663. hard rename as they are force-new making deprecation hard.