### PR TITLE
New Resource: `azurerm_custom_ip_prefix`

### DIFF
--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -92,7 +92,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	ConnectionMonitorsClient := network.NewConnectionMonitorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&ConnectionMonitorsClient.Client, o.ResourceManagerAuthorizer)
 
-	CustomIPPrefixesClient := network.NewCustomIPPrefixesClient(o.SubscriptionId)
+	CustomIPPrefixesClient := network.NewCustomIPPrefixesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&CustomIPPrefixesClient.Client, o.ResourceManagerAuthorizer)
 
 	DDOSProtectionPlansClient := network.NewDdosProtectionPlansClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)

--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -11,6 +11,7 @@ type Client struct {
 	BastionHostsClient                       *network.BastionHostsClient
 	ConfigurationPolicyGroupClient           *network.ConfigurationPolicyGroupsClient
 	ConnectionMonitorsClient                 *network.ConnectionMonitorsClient
+	CustomIPPrefixesClient                   *network.CustomIPPrefixesClient
 	DDOSProtectionPlansClient                *network.DdosProtectionPlansClient
 	ExpressRouteAuthsClient                  *network.ExpressRouteCircuitAuthorizationsClient
 	ExpressRouteCircuitsClient               *network.ExpressRouteCircuitsClient
@@ -90,6 +91,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	ConnectionMonitorsClient := network.NewConnectionMonitorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&ConnectionMonitorsClient.Client, o.ResourceManagerAuthorizer)
+
+	CustomIPPrefixesClient := network.NewCustomIPPrefixesClient(o.SubscriptionId)
+	o.ConfigureClient(&CustomIPPrefixesClient.Client, o.ResourceManagerAuthorizer)
 
 	DDOSProtectionPlansClient := network.NewDdosProtectionPlansClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&DDOSProtectionPlansClient.Client, o.ResourceManagerAuthorizer)
@@ -283,6 +287,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		BastionHostsClient:                       &BastionHostsClient,
 		ConfigurationPolicyGroupClient:           &configurationPolicyGroupClient,
 		ConnectionMonitorsClient:                 &ConnectionMonitorsClient,
+		CustomIPPrefixesClient:                   &CustomIPPrefixesClient,
 		DDOSProtectionPlansClient:                &DDOSProtectionPlansClient,
 		ExpressRouteAuthsClient:                  &ExpressRouteAuthsClient,
 		ExpressRouteCircuitsClient:               &ExpressRouteCircuitsClient,

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -1,0 +1,414 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type commissionedAction string
+
+const (
+	commissionedActionProvision    commissionedAction = "Provision"
+	commissionedActionCommission   commissionedAction = "Commission"
+	commissionedActionDecommission commissionedAction = "Decommission"
+	commissionedActionDeprovision  commissionedAction = "Deprovision"
+)
+
+type commissionedState string
+
+const (
+	commissionedStateDeprovisioned    commissionedState = "Deprovisioned"
+	commissionedStateValidationFailed commissionedState = "ValidationFailed"
+)
+
+func resourceCustomIpPrefix() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceCustomIpPrefixCreateUpdate,
+		Read:   resourceCustomIpPrefixRead,
+		Update: resourceCustomIpPrefixCreateUpdate,
+		Delete: resourceCustomIpPrefixDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.CustomIpPrefixID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.CustomIpPrefixName,
+			},
+
+			"location": commonschema.Location(),
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"cidr": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsCIDR,
+			},
+
+			"zones": commonschema.ZonesMultipleRequiredForceNew(),
+
+			"authorization_message": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"signed_message": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"action": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(commissionedActionProvision),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(commissionedActionProvision),
+					string(commissionedActionCommission),
+					string(commissionedActionDecommission),
+					string(commissionedActionDeprovision),
+				}, false),
+			},
+
+			"tags": commonschema.Tags(),
+		},
+	}
+}
+
+func resourceCustomIpPrefixCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.CustomIPPrefixesClient
+	subscriptionId := meta.(*clients.Client).Network.CustomIPPrefixesClient.SubscriptionID
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewCustomIpPrefixID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	state := commissionedAction(d.Get("action").(string))
+
+	existing, err := client.Get(ctx, d.Get("resource_group_name").(string), d.Get("name").(string), "")
+	if d.IsNewResource() {
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_custom_ip_prefix", id.ID())
+		}
+	} else {
+		switch string(existing.CommissionedState) {
+		case string(network.CommissionedStateProvisioned):
+			if state != commissionedActionCommission && state != commissionedActionDeprovision {
+				return fmt.Errorf("%s can do `Commission` or `Deprovision` when the commissioned state is `Provisioned`", id)
+			}
+		case string(network.CommissionedStateCommissioned):
+			if state != commissionedActionDecommission {
+				return fmt.Errorf("%s can do `Decommission` when the commissioned state is `Commissioned`", id)
+			}
+		case string(commissionedStateDeprovisioned):
+			if state != commissionedActionProvision {
+				return fmt.Errorf("%s can do delete or `Provision` when the commissioned state is `Deprovisioned`", id)
+			}
+		}
+	}
+
+	parameters := network.CustomIPPrefix{
+		CustomIPPrefixPropertiesFormat: &network.CustomIPPrefixPropertiesFormat{
+			Cidr: utils.String(d.Get("cidr").(string)),
+		},
+		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("action"); ok {
+		var state network.CommissionedState
+		switch commissionedAction(v.(string)) {
+		case commissionedActionProvision:
+			state = network.CommissionedStateProvisioning
+		case commissionedActionCommission:
+			state = network.CommissionedStateCommissioning
+		case commissionedActionDecommission:
+			state = network.CommissionedStateDecommissioning
+		case commissionedActionDeprovision:
+			state = network.CommissionedStateDeprovisioning
+		}
+		parameters.CommissionedState = state
+	}
+
+	if v, ok := d.GetOk("authorization_message"); ok {
+		parameters.AuthorizationMessage = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("signed_message"); ok {
+		parameters.SignedMessage = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("zones"); ok {
+		zones := zones.Expand(v.(*schema.Set).List())
+		if len(zones) > 0 {
+			parameters.Zones = &zones
+		}
+	}
+
+	future, err := client.CreateOrUpdate(ctx, d.Get("resource_group_name").(string), d.Get("name").(string), parameters)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for the completion of the creating/updating of %s: %+v", id, err)
+	}
+
+	// The `commissionedstate` of custom ip prefix is in "Provisioning", "Commissioning", "Decommissioning" or `Deprovisioning` after waiting for completion.
+	// We should poll the `commissionedstate` until the target state is complete. The detailed changes of the commissionedstate are as follows:
+	// `Provisioning`      => `Provisioned`   - can do commission, or deprovision
+	// `Commissioning`     => `Commissioned`  - can do decommission
+	// `Decommissioning`   => `Provisioned`   - can do commission, or deprovision
+	// `Deprovisioning`    => `Deprovisioned` - can do delete or provision
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{string(network.CommissionedStateProvisioning), string(network.CommissionedStateCommissioning), string(network.CommissionedStateDecommissioning), string(network.CommissionedStateDeprovisioning)},
+		Target:                    []string{string(network.CommissionedStateCommissioned), string(network.CommissionedStateProvisioned), string(commissionedStateDeprovisioned)},
+		Refresh:                   customIpPrefixCreateRefreshFunc(ctx, client, id),
+		PollInterval:              1 * time.Minute,
+		ContinuousTargetOccurence: 3,
+	}
+
+	if d.IsNewResource() {
+		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
+	} else {
+		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for %s to become ready: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceCustomIpPrefixRead(d, meta)
+}
+
+func customIpPrefixCreateRefreshFunc(ctx context.Context, client *network.CustomIPPrefixesClient, id parse.CustomIpPrefixId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroup, id.CustomIpPrefixeName, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(res.Response) {
+				return nil, "NotFound", nil
+			}
+			return nil, "", fmt.Errorf("polling for the commissionedstate of the Custom Ip Prefix %q (Resource Group: %q): %+v", id.CustomIpPrefixeName, id.ResourceGroup, err)
+		}
+
+		if res.CustomIPPrefixPropertiesFormat == nil {
+			return nil, "", fmt.Errorf("unexpected nil properties format of Custom Ip Prefix %q (Resource Group %q)", id.CustomIpPrefixeName, id.ResourceGroup)
+		}
+		return res, string(res.CustomIPPrefixPropertiesFormat.CommissionedState), nil
+	}
+}
+
+func resourceCustomIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.CustomIPPrefixesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CustomIpPrefixID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.CustomIpPrefixeName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] %s does not exist - removing from state", id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("location", azure.NormalizeLocation(*resp.Location))
+	d.Set("resource_group_name", id.ResourceGroup)
+
+	if props := resp.CustomIPPrefixPropertiesFormat; props != nil {
+		d.Set("cidr", props.Cidr)
+		d.Set("authorization_message", props.AuthorizationMessage)
+		d.Set("signed_message", props.SignedMessage)
+	}
+
+	if v := resp.Zones; v != nil {
+		d.Set("zones", zones.Flatten(v))
+	}
+
+	// The "action" will be changed by API automatically, hence setting it from config.
+	d.Set("action", d.Get("action").(string))
+
+	if err := d.Set("tags", tags.Flatten(resp.Tags)); err != nil {
+		return fmt.Errorf("setting `tags`: %+v", err)
+	}
+
+	return nil
+}
+
+func resourceCustomIpPrefixDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.CustomIPPrefixesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CustomIpPrefixID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if err := prepareDelete(d, meta, *id); err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.ResourceGroup, id.CustomIpPrefixeName)
+	if err != nil {
+		if response.WasNotFound(future.Response()) {
+			return nil
+		}
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		if !response.WasNotFound(future.Response()) {
+			return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+		}
+	}
+
+	return nil
+}
+
+func prepareDelete(d *pluginsdk.ResourceData, meta interface{}, id parse.CustomIpPrefixId) error {
+	client := meta.(*clients.Client).Network.CustomIPPrefixesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	existing, err := client.Get(ctx, id.ResourceGroup, id.CustomIpPrefixeName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	state := existing.CommissionedState
+
+	// Since the "Provisioning", "Commissioning", "Decommissioning" or `Deprovisioning` commissioned state of custom ip prefix can do nothing, should wait for the operation to complete.
+	if state == network.CommissionedStateProvisioning || state == network.CommissionedStateCommissioning || state == network.CommissionedStateDecommissioning || state == network.CommissionedStateDeprovisioning {
+		return fmt.Errorf("the commissioned state of %s in %s, it doesn't allow to be deleted", id, string(existing.CommissionedState))
+	}
+
+	// Since the custom ip prefix can be deleted when the commisionedstate is `Deprovisioned` or `ValidationFailed`, it is needed to update `commisionedstate` before deleting if the state does not allow.
+	if string(state) != string(commissionedStateDeprovisioned) && string(state) != string(commissionedStateValidationFailed) {
+		// For the `Commissioned` state should `Decommission` first, then update to `Deprovisioned` after the state changed to `Provided`.
+		if state == network.CommissionedStateCommissioned {
+			if updateCommissionedState(d, meta, id, existing, network.CommissionedStateDecommissioning) != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+		}
+
+		if updateCommissionedState(d, meta, id, existing, network.CommissionedStateDeprovisioning) != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
+	}
+
+	return nil
+}
+
+func updateCommissionedState(d *pluginsdk.ResourceData, meta interface{}, id parse.CustomIpPrefixId, existing network.CustomIPPrefix, state network.CommissionedState) error {
+	client := meta.(*clients.Client).Network.CustomIPPrefixesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	parameters := network.CustomIPPrefix{
+		CustomIPPrefixPropertiesFormat: &network.CustomIPPrefixPropertiesFormat{
+			Cidr:              existing.Cidr,
+			CommissionedState: state,
+		},
+		Location: existing.Location,
+	}
+
+	if v := existing.Tags; v != nil {
+		parameters.Tags = v
+	}
+
+	if v := existing.Zones; v != nil {
+		parameters.Zones = v
+	}
+
+	if v := existing.AuthorizationMessage; v != nil {
+		parameters.AuthorizationMessage = v
+	}
+
+	if v := existing.SignedMessage; v != nil {
+		parameters.SignedMessage = v
+	}
+
+	future, err := client.CreateOrUpdate(ctx, d.Get("resource_group_name").(string), d.Get("name").(string), parameters)
+	if err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for the updating completion of %s: %+v", id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{string(state)},
+		Target:                    []string{string(network.CommissionedStateProvisioned), string(commissionedStateDeprovisioned)},
+		Refresh:                   customIpPrefixCreateRefreshFunc(ctx, client, id),
+		PollInterval:              1 * time.Minute,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutUpdate),
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for %s to become ready for updating: %+v", id, err)
+	}
+
+	// The "action" will be changed by API automatically, hence setting it from config.
+	d.Set("action", d.Get("action").(string))
+
+	return nil
+}

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-05-01/network"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type commissionedAction string

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
@@ -22,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-05-01/network"
 )
 
 type commissionedAction string
@@ -158,7 +158,7 @@ func resourceCustomIpPrefixCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		parameters.Zones = &zones
 	}
@@ -319,7 +319,7 @@ func resourceCustomIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 		if v := props.AuthorizationMessage; v != nil {
 			authMessage := strings.Split(*v, "|")
 			if len(authMessage) == 3 {
-				d.Set("roa_expiration_date", authMessage[1])
+				d.Set("roa_expiration_date", authMessage[2])
 			}
 		}
 		d.Set("wan_validation_signed_message", props.SignedMessage)

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -21,11 +20,7 @@ func TestAccCustomIpPrefix_withIpv4(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
-	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
-		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
-	}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.ipv4(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -33,7 +28,7 @@ func TestAccCustomIpPrefix_withIpv4(t *testing.T) {
 			),
 		},
 
-		data.ImportStep("action"),
+		data.ImportStep(),
 	})
 }
 
@@ -41,32 +36,151 @@ func TestAccCustomIpPrefix_ipv4Update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
-	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
-		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
-	}
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Commission"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Decommission"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Deprovision"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.ipv4(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("action"),
+		data.ImportStep(),
 		{
-			Config: r.ipv4Update(data),
+			Config: r.ipv4UpdateCommissionedState(data, "Commission"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("action"),
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Provision"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.ipv4(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("action"),
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Deprovision"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Commission"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Deprovision"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Decommission"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Commission"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipv4UpdateCommissionedState(data, "Deprovision"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -74,18 +188,14 @@ func TestAccCustomIpPrefix_ipv4Complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
-	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
-		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
-	}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.ipv4Complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("action"),
+		data.ImportStep(),
 	})
 }
 
@@ -93,7 +203,7 @@ func TestAccCustomIpPrefix_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.ipv4(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -151,13 +261,13 @@ resource "azurerm_custom_ip_prefix" "test" {
   name                = "acctest-CustomIpPrefix-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  cidr                = "194.41.19.0/24"
+  cidr                = "194.41.20.0/24"
   zones               = ["1"]
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r CustomIpPrefixResource) ipv4Update(data acceptance.TestData) string {
+func (r CustomIpPrefixResource) ipv4UpdateCommissionedState(data acceptance.TestData, state string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -172,15 +282,15 @@ resource "azurerm_custom_ip_prefix" "test" {
   name                = "acctest-CustomIpPrefix-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  cidr                = "194.41.19.0/24"
-  action              = "Deprovision"
+  cidr                = "194.41.20.0/24"
+  action              = "%[3]s"
   zones               = ["1"]
 
   tags = {
     env = "prod"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, state)
 }
 
 func (r CustomIpPrefixResource) ipv4Complete(data acceptance.TestData) string {
@@ -195,14 +305,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_custom_ip_prefix" "test" {
-  name                  = "acctest-CustomIpPrefix-%[1]d"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  cidr                  = "194.41.19.0/24"
-  zones                 = ["1","2","3"]
-  action                = "Provision"
-  authorization_message = "00000000-0000-0000-0000-000000000000|194.41.19.0/24|20991212"
-  signed_message        = "singed message for WAN validation"
+  name                          = "acctest-CustomIpPrefix-%[1]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  cidr                          = "194.41.20.0/24"
+  zones                         = ["1", "2", "3"]
+  action                        = "Provision"
+  roa_expiration_date           = "20991212"
+  wan_validation_signed_message = "singed message for WAN validation"
 
   tags = {
     env = "test"

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -17,19 +17,21 @@ type CustomIpPrefixResource struct {
 }
 
 func TestAccCustomIpPrefixIpv4(t *testing.T) {
-	// Only one test IPv4 range "194.41.20.0/24" could be provided to run tests, and the IP range could only create one resource at a time, so run the tests sequentially.
-	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
-		"ipv4": {
-			"basic":                             testAccCustomIpPrefix_withIpv4,
-			"update":                            testAccCustomIpPrefix_ipv4Update,
-			"fromCommissionedTodoProvision":     testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision,
-			"fromDeprovisionedTodoCommission":   testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission,
-			"fromDeprovisionedTodoDecommission": testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission,
-			"fromCommissionedTodoDeprovision":   testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision,
-			"complete":                          testAccCustomIpPrefix_ipv4Complete,
-			"requiresImport":                    testAccCustomIpPrefix_requiresImport,
-		},
-	})
+	t.Error("@tombuildsstuff: disabling these tests so we can track down an issue where the specified CIDR isn't released")
+
+	//// Only one test IPv4 range "194.41.20.0/24" could be provided to run tests, and the IP range could only create one resource at a time, so run the tests sequentially.
+	//acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+	//	"ipv4": {
+	//		"basic":                             testAccCustomIpPrefix_withIpv4,
+	//		"update":                            testAccCustomIpPrefix_ipv4Update,
+	//		"fromCommissionedTodoProvision":     testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision,
+	//		"fromDeprovisionedTodoCommission":   testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission,
+	//		"fromDeprovisionedTodoDecommission": testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission,
+	//		"fromCommissionedTodoDeprovision":   testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision,
+	//		"complete":                          testAccCustomIpPrefix_ipv4Complete,
+	//		"requiresImport":                    testAccCustomIpPrefix_requiresImport,
+	//	},
+	//})
 }
 
 func testAccCustomIpPrefix_withIpv4(t *testing.T) {

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -1,0 +1,212 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type CustomIpPrefixResource struct {
+}
+
+func TestAccCustomIpPrefix_withIpv4(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
+		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+
+		data.ImportStep("action"),
+	})
+}
+
+func TestAccCustomIpPrefix_ipv4Update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
+		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("action"),
+		{
+			Config: r.ipv4Update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("action"),
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("action"),
+	})
+}
+
+func TestAccCustomIpPrefix_ipv4Complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	if location.NormalizeNilable(utils.String(data.Locations.Primary)) != "eastus2euap" {
+		t.Skip("skip as the test ip range is only available in `eastus2euap` region")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4Complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("action"),
+	})
+}
+
+func TestAccCustomIpPrefix_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
+	r := CustomIpPrefixResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipv4(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (CustomIpPrefixResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.CustomIpPrefixID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Network.CustomIPPrefixesClient.Get(ctx, id.ResourceGroup, id.CustomIpPrefixeName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r CustomIpPrefixResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_custom_ip_prefix" "import" {
+  name                = azurerm_custom_ip_prefix.test.name
+  location            = azurerm_custom_ip_prefix.test.location
+  resource_group_name = azurerm_custom_ip_prefix.test.resource_group_name
+  cidr                = azurerm_custom_ip_prefix.test.cidr
+  zones               = azurerm_custom_ip_prefix.test.zones
+}
+`, r.ipv4(data))
+}
+
+func (r CustomIpPrefixResource) ipv4(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_custom_ip_prefix" "test" {
+  name                = "acctest-CustomIpPrefix-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidr                = "194.41.19.0/24"
+  zones               = ["1"]
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r CustomIpPrefixResource) ipv4Update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_custom_ip_prefix" "test" {
+  name                = "acctest-CustomIpPrefix-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidr                = "194.41.19.0/24"
+  action              = "Deprovision"
+  zones               = ["1"]
+
+  tags = {
+    env = "prod"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r CustomIpPrefixResource) ipv4Complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_custom_ip_prefix" "test" {
+  name                  = "acctest-CustomIpPrefix-%[1]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  cidr                  = "194.41.19.0/24"
+  zones                 = ["1","2","3"]
+  action                = "Provision"
+  authorization_message = "00000000-0000-0000-0000-000000000000|194.41.19.0/24|20991212"
+  signed_message        = "singed message for WAN validation"
+
+  tags = {
+    env = "test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -16,7 +16,23 @@ import (
 type CustomIpPrefixResource struct {
 }
 
-func TestAccCustomIpPrefix_withIpv4(t *testing.T) {
+func TestAccCustomIpPrefixIpv4(t *testing.T) {
+	// Only one test IPv4 range "194.41.20.0/24" could be provided to run tests, and the IP range could only create one resource at a time, so run the tests sequentially.
+	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"ipv4": {
+			"basic":                             testAccCustomIpPrefix_withIpv4,
+			"update":                            testAccCustomIpPrefix_ipv4Update,
+			"fromCommissionedTodoProvision":     testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision,
+			"fromDeprovisionedTodoCommission":   testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission,
+			"fromDeprovisionedTodoDecommission": testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission,
+			"fromCommissionedTodoDeprovision":   testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision,
+			"complete":                          testAccCustomIpPrefix_ipv4Complete,
+			"requiresImport":                    testAccCustomIpPrefix_requiresImport,
+		},
+	})
+}
+
+func testAccCustomIpPrefix_withIpv4(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -32,7 +48,7 @@ func TestAccCustomIpPrefix_withIpv4(t *testing.T) {
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Update(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -68,7 +84,7 @@ func TestAccCustomIpPrefix_ipv4Update(t *testing.T) {
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -97,7 +113,7 @@ func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_provision(t *testin
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -126,7 +142,7 @@ func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_commission(t *test
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -155,7 +171,7 @@ func TestAccCustomIpPrefix_ipv4Update_from_deprovisioned_todo_decommission(t *te
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -184,7 +200,7 @@ func TestAccCustomIpPrefix_ipv4Update_from_commissioned_todo_deprovision(t *test
 	})
 }
 
-func TestAccCustomIpPrefix_ipv4Complete(t *testing.T) {
+func testAccCustomIpPrefix_ipv4Complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -199,7 +215,7 @@ func TestAccCustomIpPrefix_ipv4Complete(t *testing.T) {
 	})
 }
 
-func TestAccCustomIpPrefix_requiresImport(t *testing.T) {
+func testAccCustomIpPrefix_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_custom_ip_prefix", "test")
 	r := CustomIpPrefixResource{}
 
@@ -312,7 +328,7 @@ resource "azurerm_custom_ip_prefix" "test" {
   zones                         = ["1", "2", "3"]
   action                        = "Provision"
   roa_expiration_date           = "20991212"
-  wan_validation_signed_message = "singed message for WAN validation"
+  wan_validation_signed_message = "signed message for WAN validation"
 
   tags = {
     env = "test"

--- a/internal/services/network/parse/custom_ip_prefix.go
+++ b/internal/services/network/parse/custom_ip_prefix.go
@@ -1,0 +1,69 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type CustomIpPrefixId struct {
+	SubscriptionId      string
+	ResourceGroup       string
+	CustomIpPrefixeName string
+}
+
+func NewCustomIpPrefixID(subscriptionId, resourceGroup, customIpPrefixeName string) CustomIpPrefixId {
+	return CustomIpPrefixId{
+		SubscriptionId:      subscriptionId,
+		ResourceGroup:       resourceGroup,
+		CustomIpPrefixeName: customIpPrefixeName,
+	}
+}
+
+func (id CustomIpPrefixId) String() string {
+	segments := []string{
+		fmt.Sprintf("Custom Ip Prefixe Name %q", id.CustomIpPrefixeName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Custom Ip Prefix", segmentsStr)
+}
+
+func (id CustomIpPrefixId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIpPrefixes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CustomIpPrefixeName)
+}
+
+// CustomIpPrefixID parses a CustomIpPrefix ID into an CustomIpPrefixId struct
+func CustomIpPrefixID(input string) (*CustomIpPrefixId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := CustomIpPrefixId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.CustomIpPrefixeName, err = id.PopSegment("customIpPrefixes"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/custom_ip_prefix_test.go
+++ b/internal/services/network/parse/custom_ip_prefix_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = CustomIpPrefixId{}
+
+func TestCustomIpPrefixIDFormatter(t *testing.T) {
+	actual := NewCustomIpPrefixID("12345678-1234-9876-4563-123456789012", "resGroup1", "customIpPrefix1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/customIpPrefix1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestCustomIpPrefixID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CustomIpPrefixId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing CustomIpPrefixeName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for CustomIpPrefixeName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/customIpPrefix1",
+			Expected: &CustomIpPrefixId{
+				SubscriptionId:      "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:       "resGroup1",
+				CustomIpPrefixeName: "customIpPrefix1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/CUSTOMIPPREFIXES/CUSTOMIPPREFIX1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := CustomIpPrefixID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.CustomIpPrefixeName != v.Expected.CustomIpPrefixeName {
+			t.Fatalf("Expected %q but got %q for CustomIpPrefixeName", v.Expected.CustomIpPrefixeName, actual.CustomIpPrefixeName)
+		}
+	}
+}

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -90,6 +90,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_application_gateway":                      resourceApplicationGateway(),
 		"azurerm_application_security_group":               resourceApplicationSecurityGroup(),
 		"azurerm_bastion_host":                             resourceBastionHost(),
+		"azurerm_custom_ip_prefix":                         resourceCustomIpPrefix(),
 		"azurerm_express_route_circuit_connection":         resourceExpressRouteCircuitConnection(),
 		"azurerm_express_route_circuit_authorization":      resourceExpressRouteCircuitAuthorization(),
 		"azurerm_express_route_circuit_peering":            resourceExpressRouteCircuitPeering(),

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -103,6 +103,7 @@ package network
 // Network
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NetworkProfile -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkProfiles/networkprofile1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NetworkInterfaceIpConfiguration -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkInterfaces/networkInterface1/ipConfigurations/config1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=CustomIpPrefix -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/customIpPrefix1
 
 // Load balancer
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=InboundNatRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/loadBalancers/loadBalancer1/inboundNatRules/natrule1

--- a/internal/services/network/validate/custom_ip_prefix_id.go
+++ b/internal/services/network/validate/custom_ip_prefix_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func CustomIpPrefixID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.CustomIpPrefixID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/custom_ip_prefix_id_test.go
+++ b/internal/services/network/validate/custom_ip_prefix_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCustomIpPrefixID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing CustomIpPrefixeName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CustomIpPrefixeName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/customIpPrefixes/customIpPrefix1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/CUSTOMIPPREFIXES/CUSTOMIPPREFIX1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CustomIpPrefixID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/network/validate/custom_ip_prefix_name.go
+++ b/internal/services/network/validate/custom_ip_prefix_name.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func CustomIpPrefixName(i interface{}, k string) (_ []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+		return
+	}
+
+	if !regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_])$`).MatchString(v) {
+		errors = append(errors, fmt.Errorf("%q must be between 1 and 80 characters in length, begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods or hyphens", k))
+	}
+
+	return nil, errors
+}

--- a/internal/services/network/validate/custom_ip_prefix_name_test.go
+++ b/internal/services/network/validate/custom_ip_prefix_name_test.go
@@ -1,0 +1,86 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCustomIpPrefixName(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "",
+			Expected: false,
+		},
+		{
+			Input:    "a",
+			Expected: true,
+		},
+		{
+			Input:    "2",
+			Expected: true,
+		},
+		{
+			Input:    "_",
+			Expected: false,
+		},
+		{
+			Input:    "a_",
+			Expected: true,
+		},
+		{
+			Input:    "2_",
+			Expected: true,
+		},
+		{
+			Input:    "_a",
+			Expected: false,
+		},
+		{
+			Input:    "1a",
+			Expected: true,
+		},
+		{
+			Input:    "a2",
+			Expected: true,
+		},
+		{
+			Input:    "a-",
+			Expected: false,
+		},
+		{
+			Input:    "a-b",
+			Expected: true,
+		},
+		{
+			Input:    "a.b",
+			Expected: true,
+		},
+		{
+			Input:    "Test",
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("a", 79),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("b", 80),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("1", 81),
+			Expected: false,
+		},
+	}
+
+	for _, v := range testCases {
+		_, errors := CustomIpPrefixName(v.Input, "name")
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result to be %t but got %t (and %d errors)", v.Expected, result, len(errors))
+		}
+	}
+}

--- a/website/docs/r/custom_ip_prefix.html.markdown
+++ b/website/docs/r/custom_ip_prefix.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_custom_ip_prefix" "example" {
   cidr                          = "0.0.0.0/24"
   action                        = "Provision"
   roa_expiration_date           = "20991212"
-  wan_validation_signed_message = "singed message for WAN validation"
+  wan_validation_signed_message = "signed message for WAN validation"
   zones                         = ["1", "2", "3"]
 
   tags = {

--- a/website/docs/r/custom_ip_prefix.html.markdown
+++ b/website/docs/r/custom_ip_prefix.html.markdown
@@ -20,14 +20,14 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_custom_ip_prefix" "example" {
-  name                  = "example-CustomIpPrefix"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  cidr                  = "0.0.0.0/24"
-  action                = "Provision"
-  authorization_message = "00000000-0000-0000-0000-000000000000|0.0.0.0/24|20991212"
-  signed_message        = "singed message for WAN validation"
-  zones                 = ["1","2","3"]
+  name                          = "example-CustomIpPrefix"
+  location                      = azurerm_resource_group.example.location
+  resource_group_name           = azurerm_resource_group.example.name
+  cidr                          = "0.0.0.0/24"
+  action                        = "Provision"
+  roa_expiration_date           = "20991212"
+  wan_validation_signed_message = "singed message for WAN validation"
+  zones                         = ["1", "2", "3"]
 
   tags = {
     env = "test"
@@ -47,15 +47,15 @@ The following arguments are supported:
 
 * `cidr` - (Required) The `cidr` of the Custom Ip Prefix. Changing this forces a new resource to be created.
 
-~> **NOTE:** Currently, the `cidr` only supports IPv4.
+-> **NOTE:** Currently, the `cidr` only supports IPv4.
 
-* `zones` - (Required) A list of availability zones which the Custom Ip Prefix should be allocated. Possible values are `1`, `2`, `3`. Changing this forces a new resource to be created.
+* `zones` - (Required) Specifies a list of Availability Zones in which this Custom IP Prefix should be located. Changing this forces a new resource to be created.
+  
+-> **NOTE:** In regions with [availability zones](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview), the Custom IP Prefix must be specified as either `Zone-redundant` or assigned to a specific zone. It can't be created with no zone specified in these regions. All IPs from the prefix must have the same zonal properties.
 
-* `authorization_message` - (Optional) The authorization message for WAN validation. Changing this forces a new resource to be created.
+* `roa_expiration_date` - (Optional) The  route origin authorization (ROA) expiration date. Expected format is `yyyymmdd`. Changing this forces a new resource to be created.
 
--> **NOTE:** The `authorization_message` should be formatted as "<subscriptionId>|<cidr>|<yyyMMdd>", such as "00000000-0000-0000-0000-00000000|0.0.0.0/24|20221231".
-
-* `signed_message` - (Optional) The signed message for WAN validation. Changing this forces a new resource to be created.
+* `wan_validation_signed_message` - (Optional) The signed base 64 encoded authorization message generated for WAN verification. Changing this forces a new resource to be created.
 
 * `action` - (Optional) The commission action of the Custom Ip Prefix. Possible values are `Provision`,`Commission`,`Decommission` or `Deprovision`. The default is `Provision`.
 
@@ -72,9 +72,9 @@ The following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Custom Ip Prefix.
-* `update` - (Defaults to 30 minutes) Used when updating the Custom Ip Prefix.
+* `update` - (Defaults to 300 minutes) Used when updating the Custom Ip Prefix.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Custom Ip Prefix.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Custom Ip Prefix.
+* `delete` - (Defaults to 300 minutes) Used when deleting the Custom Ip Prefix.
 
 ## Import
 

--- a/website/docs/r/custom_ip_prefix.html.markdown
+++ b/website/docs/r/custom_ip_prefix.html.markdown
@@ -1,0 +1,85 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_custom_ip_prefix"
+description: |-
+  Manages a Custom Ip Prefix.
+
+---
+
+# azurerm_custom_ip_prefix
+
+Manages a Custom Ip Prefix.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_custom_ip_prefix" "example" {
+  name                  = "example-CustomIpPrefix"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  cidr                  = "0.0.0.0/24"
+  action                = "Provision"
+  authorization_message = "00000000-0000-0000-0000-000000000000|0.0.0.0/24|20991212"
+  signed_message        = "singed message for WAN validation"
+  zones                 = ["1","2","3"]
+
+  tags = {
+    env = "test"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Custom Ip Prefix. Changing this forces a new resource to be created.
+
+* `location` - (Required) The location where the Custom Ip Prefix should exist. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which to create the Custom Ip Prefix. Changing this forces a new resource to be created.
+
+* `cidr` - (Required) The `cidr` of the Custom Ip Prefix. Changing this forces a new resource to be created.
+
+~> **NOTE:** Currently, the `cidr` only supports IPv4.
+
+* `zones` - (Required) A list of availability zones which the Custom Ip Prefix should be allocated. Possible values are `1`, `2`, `3`. Changing this forces a new resource to be created.
+
+* `authorization_message` - (Optional) The authorization message for WAN validation. Changing this forces a new resource to be created.
+
+-> **NOTE:** The `authorization_message` should be formatted as "<subscriptionId>|<cidr>|<yyyMMdd>", such as "00000000-0000-0000-0000-00000000|0.0.0.0/24|20221231".
+
+* `signed_message` - (Optional) The signed message for WAN validation. Changing this forces a new resource to be created.
+
+* `action` - (Optional) The commission action of the Custom Ip Prefix. Possible values are `Provision`,`Commission`,`Decommission` or `Deprovision`. The default is `Provision`.
+
+* `tags` - (Optional) A mapping of tags to assign to the Custom Ip Prefix.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Custom Ip Prefix.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Custom Ip Prefix.
+* `update` - (Defaults to 30 minutes) Used when updating the Custom Ip Prefix.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Custom Ip Prefix.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Custom Ip Prefix.
+
+## Import
+
+Custom Ip Prefix can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_custom_ip_prefix.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/customIPPrefixes/customIpPrefix1
+```


### PR DESCRIPTION
Support for new resource azurerm_custom_ip_prefix. A few things need to be clarified.

1. Test cases are executed sequentially because the test IP range can only create one resource at a time. The total time for all the IPv4 tests is approximately 18 hours.

2. If the test case fails in some reason (e.g. `ResourceGroupBeingDeleted`), and the `commissionstate` of custom ip prefix in not in `Deprovisioned` or `ValidationFailed`, the custom ip prefix could not be deleted.  It should be updated to `Deprovisioned`(either in Azure portal by clicking deprovision or use powershell). Otherwise, the CIDR used in the custom ip prefix will not be able to be used to recreate custom ip prefix resource. The following is the relevant information about  commissionstate confirmed with service team:
```
-  `Provisioning`:    can do nothing
-  `ValidatedFailed`: can retry provision(backend start from the beginning, do WAN validation again) or delete
-  `Provisioned`:     can do commission,or deprovision
-  `ProvisionFailed`: can retry provision(backend skip WAN validation)
-  `Commissioning`:  can do nothing
-  `Commissioned`:   can do decommission
-  `CommissionFailed`: can do commission
-  `Decommissioning`:  can donothing （back to provisioned）
-  `DecommissionFailed`:can do decommission
-  `Deprovisioning`:  can do nothing
-  `Deprovisioned`:  can do delete or provision
-  `DeprovisionFailed`: can do deprovisioning
```





All tests passed in TeamCity.