### PR TITLE
App Service - add dotnet-isolated runtime support

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -984,21 +984,23 @@ func SiteConfigSchemaWindowsFunctionAppComputed() *pluginsdk.Schema {
 
 type ApplicationStackLinuxFunctionApp struct {
 	// Note - Function Apps differ to Web Apps here. They do not use the named properties in the SiteConfig block and exclusively use the app_settings map
-	DotNetVersion         string                   `tfschema:"dotnet_version"`          // Supported values `3.1`. Version 6 is in preview on Windows Only
-	NodeVersion           string                   `tfschema:"node_version"`            // Supported values `12LTS`, `14LTS`
-	PythonVersion         string                   `tfschema:"python_version"`          // Supported values `3.9`, `3.8`, `3.7`
-	PowerShellCoreVersion string                   `tfschema:"powershell_core_version"` // Supported values are `7.0`
-	JavaVersion           string                   `tfschema:"java_version"`            // Supported values `8`, `11`
-	CustomHandler         bool                     `tfschema:"use_custom_runtime"`      // Supported values `true`
-	Docker                []ApplicationStackDocker `tfschema:"docker"`                  // Needs ElasticPremium or Basic (B1) Standard (S 1-3) or Premium(PxV2 or PxV3) LINUX Service Plan
+	DotNetVersion         string                   `tfschema:"dotnet_version"`              // Supported values `3.1`, `6`.
+	DotNetIsolated        bool                     `tfschema:"use_dotnet_isolated_runtime"` // Supported values `true` for `dotnet-isolated`, `false` otherwise
+	NodeVersion           string                   `tfschema:"node_version"`                // Supported values `12LTS`, `14LTS`
+	PythonVersion         string                   `tfschema:"python_version"`              // Supported values `3.9`, `3.8`, `3.7`
+	PowerShellCoreVersion string                   `tfschema:"powershell_core_version"`     // Supported values are `7.0`
+	JavaVersion           string                   `tfschema:"java_version"`                // Supported values `8`, `11`
+	CustomHandler         bool                     `tfschema:"use_custom_runtime"`          // Supported values `true`
+	Docker                []ApplicationStackDocker `tfschema:"docker"`                      // Needs ElasticPremium or Basic (B1) Standard (S 1-3) or Premium(PxV2 or PxV3) LINUX Service Plan
 }
 
 type ApplicationStackWindowsFunctionApp struct {
-	DotNetVersion         string `tfschema:"dotnet_version"`          // Supported values `3.1`. Version 6 is in preview on Windows Only
-	NodeVersion           string `tfschema:"node_version"`            // Supported values `12LTS`, `14LTS`
-	JavaVersion           string `tfschema:"java_version"`            // Supported values `8`, `11`
-	PowerShellCoreVersion string `tfschema:"powershell_core_version"` // Supported values are `7.0`
-	CustomHandler         bool   `tfschema:"use_custom_runtime"`      // Supported values `true`
+	DotNetVersion         string `tfschema:"dotnet_version"`              // Supported values `3.1`. Version 6 is in preview on Windows Only
+	DotNetIsolated        bool   `tfschema:"use_dotnet_isolated_runtime"` // Supported values `true` for `dotnet-isolated`, `false` otherwise
+	NodeVersion           string `tfschema:"node_version"`                // Supported values `12LTS`, `14LTS`
+	JavaVersion           string `tfschema:"java_version"`                // Supported values `8`, `11`
+	PowerShellCoreVersion string `tfschema:"powershell_core_version"`     // Supported values are `7.0`
+	CustomHandler         bool   `tfschema:"use_custom_runtime"`          // Supported values `true`
 }
 
 type ApplicationStackDocker struct {
@@ -1021,7 +1023,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"3.1",
-						"6",
+						"6.0",
 					}, false),
 					ExactlyOneOf: []string{
 						"site_config.0.application_stack.0.dotnet_version",
@@ -1032,7 +1034,22 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.docker",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
-					Description: "The version of .Net. Possible values are `3.1` and `6`",
+					Description: "The version of .Net. Possible values are `3.1` and `6.0`",
+				},
+
+				"use_dotnet_isolated_runtime": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+					ConflictsWith: []string{
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.use_custom_runtime",
+					},
+					Description: "Should the DotNet process use an isolated runtime. Defaults to `false`.",
 				},
 
 				"python_version": {
@@ -1195,6 +1212,11 @@ func linuxFunctionAppStackSchemaComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
+				"use_dotnet_isolated_runtime": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+
 				"python_version": {
 					Type:     pluginsdk.TypeString,
 					Computed: true,
@@ -1281,6 +1303,19 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 					Description: "The version of .Net. Possible values are `3.1` and `6`",
 				},
 
+				"use_dotnet_isolated_runtime": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+					ConflictsWith: []string{
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.use_custom_runtime",
+					},
+					Description: "Should the DotNet process use an isolated runtime. Defaults to `false`.",
+				},
+
 				"node_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
@@ -1357,6 +1392,11 @@ func windowsFunctionAppStackSchemaComputed() *pluginsdk.Schema {
 			Schema: map[string]*pluginsdk.Schema{
 				"dotnet_version": {
 					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"use_dotnet_isolated_runtime": {
+					Type:     pluginsdk.TypeBool,
 					Computed: true,
 				},
 
@@ -1515,11 +1555,19 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 		if len(linuxSiteConfig.ApplicationStack) > 0 {
 			linuxAppStack := linuxSiteConfig.ApplicationStack[0]
 			if linuxAppStack.DotNetVersion != "" {
-				appSettings = append(appSettings, web.NameValuePair{
-					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
-					Value: utils.String("dotnet"),
-				})
-				linuxSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+				if linuxAppStack.DotNetIsolated {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet-isolated"),
+					})
+					linuxSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET-ISOLATED|%s", linuxAppStack.DotNetVersion)
+				} else {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet"),
+					})
+					linuxSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+				}
 			}
 
 			if linuxAppStack.NodeVersion != "" {
@@ -1773,44 +1821,53 @@ func ExpandSiteConfigWindowsFunctionApp(siteConfig []SiteConfigWindowsFunctionAp
 
 	if metadata.ResourceData.HasChange("site_config.0.application_stack") && len(windowsSiteConfig.ApplicationStack) > 0 {
 		if len(windowsSiteConfig.ApplicationStack) > 0 {
-			linuxAppStack := windowsSiteConfig.ApplicationStack[0]
-			if linuxAppStack.DotNetVersion != "" {
-				appSettings = append(appSettings, web.NameValuePair{
-					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
-					Value: utils.String("dotnet"),
-				})
-				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+			windowsAppStack := windowsSiteConfig.ApplicationStack[0]
+			if windowsAppStack.DotNetVersion != "" {
+				if windowsAppStack.DotNetIsolated {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet-isolated"),
+					})
+					windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET-ISOLATED|%s", windowsAppStack.DotNetVersion)
+
+				} else {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet"),
+					})
+					windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET|%s", windowsAppStack.DotNetVersion)
+				}
 			}
 
-			if linuxAppStack.NodeVersion != "" {
+			if windowsAppStack.NodeVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("node"),
 				})
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("WEBSITE_NODE_DEFAULT_VERSION"),
-					Value: utils.String(linuxAppStack.NodeVersion),
+					Value: utils.String(windowsAppStack.NodeVersion),
 				})
-				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("Node|%s", linuxAppStack.NodeVersion)
+				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("Node|%s", windowsAppStack.NodeVersion)
 			}
 
-			if linuxAppStack.JavaVersion != "" {
+			if windowsAppStack.JavaVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("java"),
 				})
-				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("Java|%s", linuxAppStack.JavaVersion)
+				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("Java|%s", windowsAppStack.JavaVersion)
 			}
 
-			if linuxAppStack.PowerShellCoreVersion != "" {
+			if windowsAppStack.PowerShellCoreVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("powershell"),
 				})
-				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("PowerShell|%s", linuxAppStack.PowerShellCoreVersion)
+				windowsSiteConfig.WindowsFxVersion = fmt.Sprintf("PowerShell|%s", windowsAppStack.PowerShellCoreVersion)
 			}
 
-			if linuxAppStack.CustomHandler {
+			if windowsAppStack.CustomHandler {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("custom"),

--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -727,44 +727,53 @@ func ExpandSiteConfigWindowsFunctionAppSlot(siteConfig []SiteConfigWindowsFuncti
 
 	if metadata.ResourceData.HasChange("site_config.0.application_stack") && len(windowsSlotSiteConfig.ApplicationStack) > 0 {
 		if len(windowsSlotSiteConfig.ApplicationStack) > 0 {
-			linuxAppStack := windowsSlotSiteConfig.ApplicationStack[0]
-			if linuxAppStack.DotNetVersion != "" {
-				appSettings = append(appSettings, web.NameValuePair{
-					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
-					Value: utils.String("dotnet"),
-				})
-				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+			windowsAppStack := windowsSlotSiteConfig.ApplicationStack[0]
+			if windowsAppStack.DotNetVersion != "" {
+				if windowsAppStack.DotNetIsolated {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet-isolated"),
+					})
+					windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET-ISOLATED|%s", windowsAppStack.DotNetVersion)
+
+				} else {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet"),
+					})
+					windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("DOTNET|%s", windowsAppStack.DotNetVersion)
+				}
 			}
 
-			if linuxAppStack.NodeVersion != "" {
+			if windowsAppStack.NodeVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("node"),
 				})
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("WEBSITE_NODE_DEFAULT_VERSION"),
-					Value: utils.String(linuxAppStack.NodeVersion),
+					Value: utils.String(windowsAppStack.NodeVersion),
 				})
-				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("Node|%s", linuxAppStack.NodeVersion)
+				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("Node|%s", windowsAppStack.NodeVersion)
 			}
 
-			if linuxAppStack.JavaVersion != "" {
+			if windowsAppStack.JavaVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("java"),
 				})
-				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("Java|%s", linuxAppStack.JavaVersion)
+				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("Java|%s", windowsAppStack.JavaVersion)
 			}
 
-			if linuxAppStack.PowerShellCoreVersion != "" {
+			if windowsAppStack.PowerShellCoreVersion != "" {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("powershell"),
 				})
-				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("PowerShell|%s", linuxAppStack.PowerShellCoreVersion)
+				windowsSlotSiteConfig.WindowsFxVersion = fmt.Sprintf("PowerShell|%s", windowsAppStack.PowerShellCoreVersion)
 			}
 
-			if linuxAppStack.CustomHandler {
+			if windowsAppStack.CustomHandler {
 				appSettings = append(appSettings, web.NameValuePair{
 					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
 					Value: utils.String("custom"),
@@ -1024,11 +1033,19 @@ func ExpandSiteConfigLinuxFunctionAppSlot(siteConfig []SiteConfigLinuxFunctionAp
 		if len(linuxSlotSiteConfig.ApplicationStack) > 0 {
 			linuxAppStack := linuxSlotSiteConfig.ApplicationStack[0]
 			if linuxAppStack.DotNetVersion != "" {
-				appSettings = append(appSettings, web.NameValuePair{
-					Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
-					Value: utils.String("dotnet"),
-				})
-				linuxSlotSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+				if linuxAppStack.DotNetIsolated {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet-isolated"),
+					})
+					linuxSlotSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET-ISOLATED|%s", linuxAppStack.DotNetVersion)
+				} else {
+					appSettings = append(appSettings, web.NameValuePair{
+						Name:  utils.String("FUNCTIONS_WORKER_RUNTIME"),
+						Value: utils.String("dotnet"),
+					})
+					linuxSlotSiteConfig.LinuxFxVersion = fmt.Sprintf("DOTNET|%s", linuxAppStack.DotNetVersion)
+				}
 			}
 
 			if linuxAppStack.NodeVersion != "" {

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -61,22 +61,31 @@ func EncodeFunctionAppLinuxFxVersion(input []ApplicationStackLinuxFunctionApp) *
 	var appType, appString string
 	switch {
 	case appStack.NodeVersion != "":
-		appType = "Node"
+		appType = "NODE"
 		appString = appStack.NodeVersion
+
 	case appStack.DotNetVersion != "":
-		appType = "DotNet"
+		if appStack.DotNetIsolated {
+			appType = "DOTNET-ISOLATED"
+		} else {
+			appType = "DOTNET"
+		}
 		appString = appStack.DotNetVersion
+
 	case appStack.PythonVersion != "":
-		appType = "Python"
+		appType = "PYTHON"
 		appString = appStack.PythonVersion
+
 	case appStack.JavaVersion != "":
-		appType = "Java"
+		appType = "JAVA"
 		appString = appStack.JavaVersion
+
 	case appStack.PowerShellCoreVersion != "":
-		appType = "PowerShell"
+		appType = "POWERSHELL"
 		appString = appStack.PowerShellCoreVersion
+
 	case len(appStack.Docker) > 0 && appStack.Docker[0].ImageName != "":
-		appType = "Docker"
+		appType = "DOCKER"
 		dockerCfg := appStack.Docker[0]
 		if dockerCfg.RegistryURL != "" {
 			appString = fmt.Sprintf("%s/%s:%s", strings.Trim(dockerCfg.RegistryURL, "/"), dockerCfg.ImageName, dockerCfg.ImageTag)
@@ -104,6 +113,10 @@ func DecodeFunctionAppLinuxFxVersion(input string) ([]ApplicationStackLinuxFunct
 	switch strings.ToLower(parts[0]) {
 	case "dotnet":
 		appStack := ApplicationStackLinuxFunctionApp{DotNetVersion: parts[1]}
+		result = append(result, appStack)
+
+	case "dotnet-isolated":
+		appStack := ApplicationStackLinuxFunctionApp{DotNetVersion: parts[1], DotNetIsolated: true}
 		result = append(result, appStack)
 
 	case "node":
@@ -166,12 +179,19 @@ func EncodeFunctionAppWindowsFxVersion(input []ApplicationStackWindowsFunctionAp
 	case appStack.NodeVersion != "":
 		appType = "Node"
 		appString = appStack.NodeVersion
+
 	case appStack.DotNetVersion != "":
-		appType = "DotNet"
+		if appStack.DotNetIsolated {
+			appType = "DotNet-Isolated"
+		} else {
+			appType = "DotNet"
+		}
 		appString = appStack.DotNetVersion
+
 	case appStack.JavaVersion != "":
 		appType = "Java"
 		appString = appStack.JavaVersion
+
 	case appStack.PowerShellCoreVersion != "":
 		appType = "PowerShell"
 		appString = appStack.PowerShellCoreVersion
@@ -196,6 +216,10 @@ func DecodeFunctionAppWindowsFxVersion(input string) ([]ApplicationStackWindowsF
 	switch strings.ToLower(parts[0]) {
 	case "dotnet":
 		appStack := ApplicationStackWindowsFunctionApp{DotNetVersion: parts[1]}
+		result = append(result, appStack)
+
+	case "dotnet-isolated":
+		appStack := ApplicationStackWindowsFunctionApp{DotNetVersion: parts[1], DotNetIsolated: true}
 		result = append(result, appStack)
 
 	case "node":

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -1085,6 +1085,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 						"2.1",
 						"3.1",
 						"5.0",
+						"6.0",
 					}, false),
 					ConflictsWith: []string{
 						"site_config.0.application_stack.0.php_version",

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -641,10 +641,27 @@ func TestAccLinuxFunctionApp_appStackDotNet6(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.appStackDotNet(data, SkuBasicPlan, "6"),
+			Config: r.appStackDotNet(data, SkuBasicPlan, "6.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxFunctionApp_appStackDotNet6Isolated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appStackDotNetIsolated(data, SkuBasicPlan, "6.0"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+				check.That(data.ResourceName).Key("site_config.0.linux_fx_version").HasValue("DOTNET-ISOLATED|6.0"),
 			),
 		},
 		data.ImportStep(),
@@ -1430,6 +1447,35 @@ resource "azurerm_linux_function_app" "test" {
   site_config {
     application_stack {
       dotnet_version = "%s"
+    }
+  }
+}
+`, r.template(data, planSku), data.RandomInteger, version)
+}
+
+func (r LinuxFunctionAppResource) appStackDotNetIsolated(data acceptance.TestData, planSku string, version string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    always_on = true
+
+    application_stack {
+      dotnet_version              = "%s"
+      use_dotnet_isolated_runtime = true
     }
   }
 }

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -602,6 +602,22 @@ func TestAccLinuxFunctionAppSlot_appStackDotNet6(t *testing.T) {
 	})
 }
 
+func TestAccLinuxFunctionAppSlot_appStackDotNet6Isolated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
+	r := LinuxFunctionAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appStackDotNetIsolated(data, SkuStandardPlan, "6"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxFunctionAppSlot_appStackPython(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
 	r := LinuxFunctionAppSlotResource{}
@@ -1254,6 +1270,30 @@ resource "azurerm_linux_function_app_slot" "test" {
   site_config {
     application_stack {
       dotnet_version = "%s"
+    }
+  }
+}
+`, r.template(data, planSku), data.RandomInteger, version)
+}
+
+func (r LinuxFunctionAppSlotResource) appStackDotNetIsolated(data acceptance.TestData, planSku string, version string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app_slot" "test" {
+  name                       = "acctest-LFAS-%d"
+  function_app_id            = azurerm_linux_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    application_stack {
+      dotnet_version              = "%s"
+      use_dotnet_isolated_runtime = true
     }
   }
 }

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -592,7 +592,7 @@ func TestAccLinuxFunctionAppSlot_appStackDotNet6(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.appStackDotNet(data, SkuStandardPlan, "6"),
+			Config: r.appStackDotNet(data, SkuStandardPlan, "6.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
@@ -608,7 +608,7 @@ func TestAccLinuxFunctionAppSlot_appStackDotNet6Isolated(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.appStackDotNetIsolated(data, SkuStandardPlan, "6"),
+			Config: r.appStackDotNetIsolated(data, SkuStandardPlan, "6.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -692,6 +692,22 @@ func TestAccWindowsFunctionApp_appStackDotNet6(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+func TestAccWindowsFunctionApp_appStackDotNet6Isolated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
+	r := WindowsFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appStackDotNetIsolated(data, SkuBasicPlan, "6"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DotNet-Isolated|6"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
 
 func TestAccWindowsFunctionApp_appStackNode(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
@@ -1804,6 +1820,33 @@ resource "azurerm_windows_function_app" "test" {
   site_config {
     application_stack {
       dotnet_version = "%s"
+    }
+  }
+}
+`, r.template(data, planSku), data.RandomInteger, version)
+}
+
+func (r WindowsFunctionAppResource) appStackDotNetIsolated(data acceptance.TestData, planSku string, version string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app" "test" {
+  name                = "acctest-WFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    application_stack {
+      dotnet_version              = "%s"
+      use_dotnet_isolated_runtime = true
     }
   }
 }

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -602,6 +602,22 @@ func TestAccWindowsFunctionAppSlot_appStackDotNet6(t *testing.T) {
 	})
 }
 
+func TestAccWindowsFunctionAppSlot_appStackDotNet6Isolated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app_slot", "test")
+	r := WindowsFunctionAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.appStackDotNetIsolated(data, SkuStandardPlan, "6"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccWindowsFunctionAppSlot_appStackNode(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_function_app_slot", "test")
 	r := WindowsFunctionAppSlotResource{}
@@ -1677,6 +1693,30 @@ resource "azurerm_windows_function_app_slot" "test" {
   site_config {
     application_stack {
       dotnet_version = "%s"
+    }
+  }
+}
+`, r.template(data, planSku), data.RandomInteger, version)
+}
+
+func (r WindowsFunctionAppSlotResource) appStackDotNetIsolated(data acceptance.TestData, planSku string, version string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_function_app_slot" "test" {
+  name                       = "acctest-WFAS-%d"
+  function_app_id            = azurerm_windows_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    application_stack {
+      dotnet_version              = "%s"
+      use_dotnet_isolated_runtime = true
     }
   }
 }

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -130,7 +130,9 @@ A `application_stack` block supports the following:
 
 * `docker` - (Optional) One or more `docker` blocks as defined below.
 
-* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `3.1` and `6`.
+* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `3.1` and `6.0`.
+
+* `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 
 * `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, and `11`.
 

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -378,9 +378,11 @@ An `application_stack` block supports the following:
 
 * `docker` - (Optional) a `docker` block as detailed below.
 
-* `dotnet_version` - (Optional) The version of .Net. Possible values are `3.1` and `6`
+* `dotnet_version` - (Optional) The version of .Net. Possible values are `3.1` and `6.0`.
 
-* `java_version` - (Optional) The version of Java to use. Possible values are `8`, and `11`
+* `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
+
+* `java_version` - (Optional) The version of Java to use. Possible values are `8`, and `11`.
 
 * `node_version` - (Optional) The version of Node to use. Possible values include `12`, and `14`
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -123,9 +123,9 @@ A `application_stack` block supports the following:
 
 * `docker_image` - (Optional) The Docker image reference, including repository host as needed. 
 
-* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`
+* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`.
 
-* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `2.1`, `3.1`, and `5.0`.
+* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `2.1`, `3.1`, `5.0`, and `6.0`.
 
 * `java_server` - (Optional) The java server type. Possible values include `JAVA`, `TOMCAT`, and `JBOSSEAP`.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -126,9 +126,9 @@ A `application_stack` block supports the following:
 
 * `docker_image` - (Optional) The Docker image reference, including repository host as needed. 
 
-* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`
+* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`.
 
-* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `2.1`, `3.1`, and `5.0`.
+* `dotnet_version` - (Optional) The version of .Net to use. Possible values include `2.1`, `3.1`, `5.0`, and `6.0`.
 
 * `java_server` - (Optional) The java server type. Possible values include `JAVA`, `TOMCAT`, and `JBOSSEAP`.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -130,6 +130,8 @@ A `application_stack` block supports the following:
 
 * `dotnet_version` - (Optional) The version of .Net to use. Possible values include `3.1` and `6`.
 
+* `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
+
 * `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, and `11`.
 
 * `node_version` - (Optional) The version of Node to run. Possible values include `~12`, `~14`, and `~16`.

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -373,6 +373,8 @@ An `application_stack` block supports the following:
 
 * `dotnet_version` - (Optional) The version of .Net. Possible values are `3.1` and `6`
 
+* `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
+
 * `java_version` - (Optional) The version of Java to use. Possible values are `8`, and `11`
 
 * `node_version` - (Optional) The version of Node to use. Possible values include `12`, and `14`


### PR DESCRIPTION
* `azurerm_linux_function_app` - add support for `use_dotnet_isolated_runtime`
* `azurerm_linux_function_app_slot` - add support for `use_dotnet_isolated_runtime`
* `azurerm_windows_function_app` - add support for `use_dotnet_isolated_runtime`
* `azurerm_windows_function_app_slot` - add support for `use_dotnet_isolated_runtime`

closes #15823