### PR TITLE
`azurerm_service_plan` - remove retiring skus

### DIFF
--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -35,7 +35,7 @@ var sharedSkus = []string{
 }
 
 var consumptionSkus = []string{
-	"PC2", "PC3", "PC4", "Y1",
+	"Y1",
 }
 
 var elasticSkus = []string{


### PR DESCRIPTION
Removing PC2-4 SKUs as they are due to be retired.
Reference: https://azure.microsoft.com/en-us/updates/premiumcontainer/