### PR TITLE
azurerm_lb_rule / azurerm_lb_outbound_rule: remove the deprecated resource_group_name property

### DIFF
--- a/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
@@ -212,7 +212,6 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
@@ -232,7 +231,6 @@ func (r LoadBalancerOutboundRule) requiresImport(data acceptance.TestData) strin
 
 resource "azurerm_lb_outbound_rule" "import" {
   name                    = azurerm_lb_outbound_rule.test.name
-  resource_group_name     = azurerm_lb_outbound_rule.test.resource_group_name
   loadbalancer_id         = azurerm_lb_outbound_rule.test.loadbalancer_id
   backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
   protocol                = "All"
@@ -299,7 +297,6 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   protocol                = "Tcp"
@@ -311,7 +308,6 @@ resource "azurerm_lb_outbound_rule" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test2" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   protocol                = "Udp"
@@ -379,7 +375,6 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   protocol                = "All"
@@ -391,7 +386,6 @@ resource "azurerm_lb_outbound_rule" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test2" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   protocol                = "All"
@@ -445,7 +439,6 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 resource "azurerm_lb_outbound_rule" "test" {
-  resource_group_name     = azurerm_resource_group.test.name
   loadbalancer_id         = azurerm_lb.test.id
   name                    = "OutboundRule-%d"
   backend_address_pool_id = azurerm_lb_backend_address_pool.test.id

--- a/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
@@ -306,7 +306,6 @@ func (r LoadBalancerRule) basic(data acceptance.TestData) string {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "LbRule-%s"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
   protocol                       = "Tcp"
@@ -322,9 +321,8 @@ func (r LoadBalancerRule) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_lb_rule" "test" {
-  name                = "LbRule-%s"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name            = "LbRule-%s"
+  loadbalancer_id = azurerm_lb.test.id
 
   protocol      = "Tcp"
   frontend_port = 3389
@@ -348,7 +346,6 @@ func (r LoadBalancerRule) requiresImport(data acceptance.TestData) string {
 
 resource "azurerm_lb_rule" "import" {
   name                           = azurerm_lb_rule.test.name
-  resource_group_name            = azurerm_lb_rule.test.resource_group_name
   loadbalancer_id                = azurerm_lb_rule.test.loadbalancer_id
   frontend_ip_configuration_name = azurerm_lb_rule.test.frontend_ip_configuration_name
   protocol                       = "Tcp"
@@ -371,21 +368,20 @@ func (r LoadBalancerRule) inconsistentRead(data acceptance.TestData) string {
 resource "azurerm_lb_backend_address_pool" "test" {
   name = "%d-address-pool"
   %s
-  loadbalancer_id = "${azurerm_lb.test.id}"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_lb_probe" "test" {
   name                = "probe-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id     = "${azurerm_lb.test.id}"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
   protocol            = "Tcp"
   port                = 443
 }
 
 resource "azurerm_lb_rule" "test" {
   name                           = "LbRule-%s"
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
+  loadbalancer_id                = azurerm_lb.test.id
   protocol                       = "Tcp"
   frontend_port                  = 3389
   backend_port                   = 3389
@@ -400,8 +396,7 @@ func (r LoadBalancerRule) multipleRules(data, data2 acceptance.TestData) string 
 %s
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
+  loadbalancer_id                = azurerm_lb.test.id
   name                           = "LbRule-%s"
   protocol                       = "Udp"
   frontend_port                  = 3389
@@ -410,8 +405,7 @@ resource "azurerm_lb_rule" "test" {
 }
 
 resource "azurerm_lb_rule" "test2" {
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
+  loadbalancer_id                = azurerm_lb.test.id
   name                           = "LbRule-%s"
   protocol                       = "Udp"
   frontend_port                  = 3390
@@ -427,8 +421,7 @@ func (r LoadBalancerRule) multipleRulesUpdate(data, data2 acceptance.TestData) s
 %s
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
+  loadbalancer_id                = azurerm_lb.test.id
   name                           = "LbRule-%s"
   protocol                       = "Udp"
   frontend_port                  = 3389
@@ -437,8 +430,7 @@ resource "azurerm_lb_rule" "test" {
 }
 
 resource "azurerm_lb_rule" "test2" {
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
+  loadbalancer_id                = azurerm_lb.test.id
   name                           = "LbRule-%s"
   protocol                       = "Udp"
   frontend_port                  = 3391
@@ -518,7 +510,6 @@ func (r LoadBalancerRule) vmssBackendPool(data acceptance.TestData, lbRuleName, 
 %s
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   name                           = "%s"
   protocol                       = "Tcp"
@@ -535,7 +526,6 @@ func (r LoadBalancerRule) vmssBackendPoolUpdate(data acceptance.TestData, lbRule
 	return fmt.Sprintf(`
 %s
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   name                           = "%s"
   protocol                       = "Tcp"
@@ -650,12 +640,11 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  loadbalancer_id     = azurerm_lb.test.id
-  name                = "abababa"
-  protocol            = "All"
-  frontend_port       = 0
-  backend_port        = 0
+  loadbalancer_id = azurerm_lb.test.id
+  name            = "abababa"
+  protocol        = "All"
+  frontend_port   = 0
+  backend_port    = 0
   backend_address_pool_ids = [
     azurerm_lb_backend_address_pool.test.id,
   ]
@@ -692,12 +681,11 @@ resource "azurerm_lb_backend_address_pool" "test2" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  loadbalancer_id     = azurerm_lb.test.id
-  name                = "abababa"
-  protocol            = "All"
-  frontend_port       = 0
-  backend_port        = 0
+  loadbalancer_id = azurerm_lb.test.id
+  name            = "abababa"
+  protocol        = "All"
+  frontend_port   = 0
+  backend_port    = 0
   backend_address_pool_ids = [
     azurerm_lb_backend_address_pool.test1.id,
     azurerm_lb_backend_address_pool.test2.id,

--- a/internal/services/loadbalancer/outbound_rule_resource.go
+++ b/internal/services/loadbalancer/outbound_rule_resource.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -49,8 +48,6 @@ func resourceArmLoadBalancerOutboundRule() *pluginsdk.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"loadbalancer_id": {
 				Type:         pluginsdk.TypeString,
@@ -210,7 +207,6 @@ func resourceArmLoadBalancerOutboundRuleRead(d *pluginsdk.ResourceData, meta int
 	}
 
 	d.Set("name", config.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
 
 	if props := config.OutboundRulePropertiesFormat; props != nil {
 		allocatedOutboundPorts := 0

--- a/internal/services/loadbalancer/rule_resource.go
+++ b/internal/services/loadbalancer/rule_resource.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	loadBalancerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
 
@@ -140,7 +139,6 @@ func resourceArmLoadBalancerRuleRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	d.Set("name", config.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
 
 	if props := config.LoadBalancingRulePropertiesFormat; props != nil {
 		d.Set("disable_outbound_snat", props.DisableOutboundSnat)
@@ -367,8 +365,6 @@ func resourceArmLoadBalancerRuleSchema() map[string]*pluginsdk.Schema {
 			ForceNew:     true,
 			ValidateFunc: loadBalancerValidate.RuleName,
 		},
-
-		"resource_group_name": azure.SchemaResourceGroupName(),
 
 		"loadbalancer_id": {
 			Type:         pluginsdk.TypeString,

--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -912,6 +912,10 @@ The deprecated field `backend_address` will be removed since it is no longer fun
 
 The fields `availability_zone` and `zones` will be consolidated into `zones`.
 
+### Resource: `azurerm_lb_outbound_rule`
+
+The deprecated field `resource_group_name` will be removed since it can be inferred from the `loadbalancer_id`.
+
 ### Resource: `azurerm_lb_rule`
 
 The deprecated field `backend_address_pool_id` will be removed in favour of `backend_address_pool_ids`.

--- a/website/docs/r/lb_outbound_rule.html.markdown
+++ b/website/docs/r/lb_outbound_rule.html.markdown
@@ -45,7 +45,6 @@ resource "azurerm_lb_backend_address_pool" "example" {
 }
 
 resource "azurerm_lb_outbound_rule" "example" {
-  resource_group_name     = azurerm_resource_group.example.name
   loadbalancer_id         = azurerm_lb.example.id
   name                    = "OutboundRule"
   protocol                = "Tcp"
@@ -62,7 +61,6 @@ resource "azurerm_lb_outbound_rule" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Outbound Rule. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the resource. Changing this forces a new resource to be created.
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Outbound Rule. Changing this forces a new resource to be created.
 * `frontend_ip_configuration` - (Required) One or more `frontend_ip_configuration` blocks as defined below.
 * `backend_address_pool_id` - (Required) The ID of the Backend Address Pool. Outbound traffic is randomly load balanced across IPs in the backend IPs.

--- a/website/docs/r/lb_rule.html.markdown
+++ b/website/docs/r/lb_rule.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_lb_rule" "example" {
-  resource_group_name            = azurerm_resource_group.example.name
   loadbalancer_id                = azurerm_lb.example.id
   name                           = "LBRule"
   protocol                       = "Tcp"
@@ -54,7 +53,6 @@ resource "azurerm_lb_rule" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the LB Rule.
-* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Rule.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration to which the rule is associated.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Tcp`, `Udp` or `All`.


### PR DESCRIPTION
Closes: #8777