### PR TITLE
Fix error message for form_parameter

### DIFF
--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -159,7 +159,7 @@ func ExpandApiManagementOperationRepresentation(d *pluginsdk.ResourceData, schem
 		if contentTypeIsFormData {
 			output.FormParameters = formParameters
 		} else if len(*formParameters) > 0 {
-			return nil, fmt.Errorf("`form_parameter` cannot be specified for form data content types (multipart/form-data, application/x-www-form-urlencoded)")
+			return nil, fmt.Errorf("`form_parameter` can only be specified for form data content types (multipart/form-data, application/x-www-form-urlencoded)")
 		}
 
 		// Representation schemaId can only be specified for non form data content types (multipart/form-data, application/x-www-form-urlencoded).


### PR DESCRIPTION
Fixes #15994

Error message is incorrect when specifying a `form_parameter` block when the `content_type` is not set to either `multipart/form-data` or `application/x-www-form-urlencoded`.

Example:

```hcl
representation = {
    content_type = "multipart/form-data"        
    form_parameter {
        name          = "del-fp1"
        required      = false
        type          = "string"
        description   = "my desc for fp1"
        default_value = "abc"
        values        = ["abc", "123"]
    }
}
```