### PR TITLE
Rollback issues introduced in 48d9aadb1e1397d99fe3dc535a2e7c4928f441ae

### DIFF
--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -903,7 +903,7 @@ func TestExpandFeaturesLogAnalyticsWorkspace(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
-					PermanentlyDeleteOnDestroy: false,
+					PermanentlyDeleteOnDestroy: true,
 				},
 			},
 		},

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -212,10 +212,18 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		}
 	}
 
-	if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
-		parameters.WorkspaceProperties.Sku.CapacityReservationLevel = utils.Int32(int32(d.Get("reservation_capacity_in_gb_per_day").(int)))
+	propName := "reservation_capacity_in_gb_per_day"
+	capacityReservationLevel, ok := d.GetOk(propName)
+	if ok {
+		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
+			parameters.WorkspaceProperties.Sku.CapacityReservationLevel = utils.Int32((int32(capacityReservationLevel.(int))))
+		} else {
+			return fmt.Errorf("`%s` can only be used with the `CapacityReservation` SKU", propName)
+		}
 	} else {
-		return fmt.Errorf("`reservation_capacity_in_gb_per_day` can only be used with the `CapacityReservation` SKU")
+		if strings.EqualFold(skuName, string(operationalinsights.WorkspaceSkuNameEnumCapacityReservation)) {
+			return fmt.Errorf("`%s` must be set when using the `CapacityReservation` SKU", propName)
+		}
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)


### PR DESCRIPTION
This PR rolls back a bug introduced in https://github.com/hashicorp/terraform-provider-azurerm/commit/48d9aadb1e1397d99fe3dc535a2e7c4928f441ae, which causes the following config:

```hcl
resource "azurerm_log_analytics_workspace" "test" {
  name                = "acctestLAW-220119092533317533"
  location            = azurerm_resource_group.test.location
  resource_group_name = azurerm_resource_group.test.name
  sku                 = "PerGB2018"
}
```

raises error:

```
│ Error: `reservation_capacity_in_gb_per_day` can only be used with the `CapacityReservation` SKU
```