### PR TITLE
New resource: `azurerm_sentinel_alert_rule_nrt`

### DIFF
--- a/internal/services/sentinel/registration.go
+++ b/internal/services/sentinel/registration.go
@@ -40,6 +40,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_sentinel_alert_rule_machine_learning_behavior_analytics":               resourceSentinelAlertRuleMLBehaviorAnalytics(),
 		"azurerm_sentinel_alert_rule_ms_security_incident":                              resourceSentinelAlertRuleMsSecurityIncident(),
 		"azurerm_sentinel_alert_rule_scheduled":                                         resourceSentinelAlertRuleScheduled(),
+		"azurerm_sentinel_alert_rule_nrt":                                               resourceSentinelAlertRuleNrt(),
 		"azurerm_sentinel_data_connector_aws_cloud_trail":                               resourceSentinelDataConnectorAwsCloudTrail(),
 		"azurerm_sentinel_data_connector_azure_active_directory":                        resourceSentinelDataConnectorAzureActiveDirectory(),
 		"azurerm_sentinel_data_connector_azure_advanced_threat_protection":              resourceSentinelDataConnectorAzureAdvancedThreatProtection(),

--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func alertRuleID(rule securityinsight.BasicAlertRule) *string {
@@ -22,6 +23,8 @@ func alertRuleID(rule securityinsight.BasicAlertRule) *string {
 	case securityinsight.ScheduledAlertRule:
 		return rule.ID
 	case securityinsight.MLBehaviorAnalyticsAlertRule:
+		return rule.ID
+	case securityinsight.NrtAlertRule:
 		return rule.ID
 	default:
 		return nil
@@ -59,9 +62,294 @@ func assertAlertRuleKind(rule securityinsight.BasicAlertRule, expectKind securit
 		kind = securityinsight.AlertRuleKindMicrosoftSecurityIncidentCreation
 	case securityinsight.ScheduledAlertRule:
 		kind = securityinsight.AlertRuleKindScheduled
+	case securityinsight.NrtAlertRule:
+		kind = securityinsight.AlertRuleKindNRT
 	}
 	if expectKind != kind {
 		return fmt.Errorf("Sentinel Alert Rule has mismatched kind, expected: %q, got %q", expectKind, kind)
 	}
 	return nil
+}
+
+func expandAlertRuleTactics(input []interface{}) *[]securityinsight.AttackTactic {
+	result := make([]securityinsight.AttackTactic, 0)
+
+	for _, e := range input {
+		result = append(result, securityinsight.AttackTactic(e.(string)))
+	}
+
+	return &result
+}
+
+func flattenAlertRuleTactics(input *[]securityinsight.AttackTactic) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, e := range *input {
+		output = append(output, string(e))
+	}
+
+	return output
+}
+
+func expandAlertRuleIncidentConfiguration(input []interface{}) *securityinsight.IncidentConfiguration {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	output := &securityinsight.IncidentConfiguration{
+		CreateIncident:        utils.Bool(raw["create_incident"].(bool)),
+		GroupingConfiguration: expandAlertRuleGrouping(raw["grouping"].([]interface{})),
+	}
+
+	return output
+}
+
+func flattenAlertRuleIncidentConfiguration(input *securityinsight.IncidentConfiguration) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	createIncident := false
+	if input.CreateIncident != nil {
+		createIncident = *input.CreateIncident
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"create_incident": createIncident,
+			"grouping":        flattenAlertRuleGrouping(input.GroupingConfiguration),
+		},
+	}
+}
+
+func expandAlertRuleGrouping(input []interface{}) *securityinsight.GroupingConfiguration {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	output := &securityinsight.GroupingConfiguration{
+		Enabled:              utils.Bool(raw["enabled"].(bool)),
+		ReopenClosedIncident: utils.Bool(raw["reopen_closed_incidents"].(bool)),
+		LookbackDuration:     utils.String(raw["lookback_duration"].(string)),
+		MatchingMethod:       securityinsight.MatchingMethod(raw["entity_matching_method"].(string)),
+	}
+
+	groupByEntitiesList := raw["group_by_entities"].([]interface{})
+	groupByEntities := make([]securityinsight.EntityMappingType, len(groupByEntitiesList))
+	for idx, t := range groupByEntitiesList {
+		groupByEntities[idx] = securityinsight.EntityMappingType(t.(string))
+	}
+	output.GroupByEntities = &groupByEntities
+
+	groupByAlertDetailsList := raw["group_by_alert_details"].([]interface{})
+	groupByAlertDetails := make([]securityinsight.AlertDetail, len(groupByAlertDetailsList))
+	for idx, t := range groupByAlertDetailsList {
+		groupByAlertDetails[idx] = securityinsight.AlertDetail(t.(string))
+	}
+	output.GroupByAlertDetails = &groupByAlertDetails
+
+	output.GroupByCustomDetails = utils.ExpandStringSlice(raw["group_by_custom_details"].([]interface{}))
+
+	return output
+}
+
+func flattenAlertRuleGrouping(input *securityinsight.GroupingConfiguration) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	enabled := false
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+
+	lookbackDuration := ""
+	if input.LookbackDuration != nil {
+		lookbackDuration = *input.LookbackDuration
+	}
+
+	reopenClosedIncidents := false
+	if input.ReopenClosedIncident != nil {
+		reopenClosedIncidents = *input.ReopenClosedIncident
+	}
+
+	var groupByEntities []interface{}
+	if input.GroupByEntities != nil {
+		for _, entity := range *input.GroupByEntities {
+			groupByEntities = append(groupByEntities, string(entity))
+		}
+	}
+
+	var groupByAlertDetails []interface{}
+	if input.GroupByAlertDetails != nil {
+		for _, detail := range *input.GroupByAlertDetails {
+			groupByAlertDetails = append(groupByAlertDetails, string(detail))
+		}
+	}
+
+	var groupByCustomDetails []interface{}
+	if input.GroupByCustomDetails != nil {
+		for _, detail := range *input.GroupByCustomDetails {
+			groupByCustomDetails = append(groupByCustomDetails, detail)
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled":                 enabled,
+			"lookback_duration":       lookbackDuration,
+			"reopen_closed_incidents": reopenClosedIncidents,
+			"entity_matching_method":  string(input.MatchingMethod),
+			"group_by_entities":       groupByEntities,
+			"group_by_alert_details":  groupByAlertDetails,
+			"group_by_custom_details": groupByCustomDetails,
+		},
+	}
+}
+
+func expandAlertRuleAlertDetailsOverride(input []interface{}) *securityinsight.AlertDetailsOverride {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	b := input[0].(map[string]interface{})
+	output := &securityinsight.AlertDetailsOverride{}
+
+	if v := b["description_format"]; v != "" {
+		output.AlertDescriptionFormat = utils.String(v.(string))
+	}
+	if v := b["display_name_format"]; v != "" {
+		output.AlertDisplayNameFormat = utils.String(v.(string))
+	}
+	if v := b["severity_column_name"]; v != "" {
+		output.AlertSeverityColumnName = utils.String(v.(string))
+	}
+	if v := b["tactics_column_name"]; v != "" {
+		output.AlertTacticsColumnName = utils.String(v.(string))
+	}
+
+	return output
+}
+
+func flattenAlertRuleAlertDetailsOverride(input *securityinsight.AlertDetailsOverride) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var descriptionFormat string
+	if input.AlertDescriptionFormat != nil {
+		descriptionFormat = *input.AlertDescriptionFormat
+	}
+
+	var displayNameFormat string
+	if input.AlertDisplayNameFormat != nil {
+		displayNameFormat = *input.AlertDisplayNameFormat
+	}
+
+	var severityColumnName string
+	if input.AlertSeverityColumnName != nil {
+		severityColumnName = *input.AlertSeverityColumnName
+	}
+
+	var tacticsColumnName string
+	if input.AlertTacticsColumnName != nil {
+		tacticsColumnName = *input.AlertTacticsColumnName
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"description_format":   descriptionFormat,
+			"display_name_format":  displayNameFormat,
+			"severity_column_name": severityColumnName,
+			"tactics_column_name":  tacticsColumnName,
+		},
+	}
+}
+
+func expandAlertRuleEntityMapping(input []interface{}) *[]securityinsight.EntityMapping {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]securityinsight.EntityMapping, 0)
+
+	for _, e := range input {
+		b := e.(map[string]interface{})
+		result = append(result, securityinsight.EntityMapping{
+			EntityType:    securityinsight.EntityMappingType(b["entity_type"].(string)),
+			FieldMappings: expandAlertRuleFieldMapping(b["field_mapping"].([]interface{})),
+		})
+	}
+
+	return &result
+}
+
+func flattenAlertRuleEntityMapping(input *[]securityinsight.EntityMapping) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, e := range *input {
+		output = append(output, map[string]interface{}{
+			"entity_type":   string(e.EntityType),
+			"field_mapping": flattenAlertRuleFieldMapping(e.FieldMappings),
+		})
+	}
+
+	return output
+}
+
+func expandAlertRuleFieldMapping(input []interface{}) *[]securityinsight.FieldMapping {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]securityinsight.FieldMapping, 0)
+
+	for _, e := range input {
+		b := e.(map[string]interface{})
+		result = append(result, securityinsight.FieldMapping{
+			Identifier: utils.String(b["identifier"].(string)),
+			ColumnName: utils.String(b["column_name"].(string)),
+		})
+	}
+
+	return &result
+}
+
+func flattenAlertRuleFieldMapping(input *[]securityinsight.FieldMapping) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, e := range *input {
+		var identifier string
+		if e.Identifier != nil {
+			identifier = *e.Identifier
+		}
+
+		var columnName string
+		if e.ColumnName != nil {
+			columnName = *e.ColumnName
+		}
+
+		output = append(output, map[string]interface{}{
+			"identifier":  identifier,
+			"column_name": columnName,
+		})
+	}
+
+	return output
 }

--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -128,7 +128,7 @@ func flattenAlertRuleIncidentConfiguration(input *securityinsight.IncidentConfig
 	}
 }
 
-func expandAlertRuleGrouping(input []interface{}, withGroupByPrefix bool) *securityinsight.GroupingConfiguration {
+func expandAlertRuleGrouping(input []interface{}, withGroupPrefix bool) *securityinsight.GroupingConfiguration {
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
@@ -142,9 +142,9 @@ func expandAlertRuleGrouping(input []interface{}, withGroupByPrefix bool) *secur
 		MatchingMethod:       securityinsight.MatchingMethod(raw["entity_matching_method"].(string)),
 	}
 
-	key := "entities"
-	if withGroupByPrefix {
-		key = "group_by_" + key
+	key := "by_entities"
+	if withGroupPrefix {
+		key = "group_" + key
 	}
 	groupByEntitiesList := raw[key].([]interface{})
 	groupByEntities := make([]securityinsight.EntityMappingType, len(groupByEntitiesList))
@@ -153,9 +153,9 @@ func expandAlertRuleGrouping(input []interface{}, withGroupByPrefix bool) *secur
 	}
 	output.GroupByEntities = &groupByEntities
 
-	key = "alert_details"
-	if withGroupByPrefix {
-		key = "group_by_" + key
+	key = "by_alert_details"
+	if withGroupPrefix {
+		key = "group_" + key
 	}
 	groupByAlertDetailsList := raw[key].([]interface{})
 	groupByAlertDetails := make([]securityinsight.AlertDetail, len(groupByAlertDetailsList))
@@ -164,16 +164,16 @@ func expandAlertRuleGrouping(input []interface{}, withGroupByPrefix bool) *secur
 	}
 	output.GroupByAlertDetails = &groupByAlertDetails
 
-	key = "custom_details"
-	if withGroupByPrefix {
-		key = "group_by_" + key
+	key = "by_custom_details"
+	if withGroupPrefix {
+		key = "group_" + key
 	}
 	output.GroupByCustomDetails = utils.ExpandStringSlice(raw[key].([]interface{}))
 
 	return output
 }
 
-func flattenAlertRuleGrouping(input *securityinsight.GroupingConfiguration, withGroupByPrefix bool) []interface{} {
+func flattenAlertRuleGrouping(input *securityinsight.GroupingConfiguration, withGroupPrefix bool) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -215,15 +215,15 @@ func flattenAlertRuleGrouping(input *securityinsight.GroupingConfiguration, with
 	}
 
 	var (
-		k1 = "entities"
-		k2 = "alert_details"
-		k3 = "custom_details"
+		k1 = "by_entities"
+		k2 = "by_alert_details"
+		k3 = "by_custom_details"
 	)
 
-	if withGroupByPrefix {
-		k1 = "group_by_" + k1
-		k2 = "group_by_" + k2
-		k3 = "group_by_" + k3
+	if withGroupPrefix {
+		k1 = "group_" + k1
+		k2 = "group_" + k2
+		k3 = "group_" + k3
 	}
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
@@ -120,7 +120,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 				},
 			},
 
-			"incident_configuration": {
+			"incident": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Computed: true,
@@ -128,7 +128,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"create_incident": {
+						"create_incident_enabled": {
 							Required: true,
 							Type:     pluginsdk.TypeBool,
 						},
@@ -165,7 +165,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 											string(securityinsight.MatchingMethodAllEntities),
 										}, false),
 									},
-									"group_by_entities": {
+									"entities": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
@@ -173,7 +173,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 											ValidateFunc: validation.StringInSlice(entityMappingTypes, false),
 										},
 									},
-									"group_by_alert_details": {
+									"alert_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
@@ -185,7 +185,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 												false),
 										},
 									},
-									"group_by_custom_details": {
+									"custom_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
@@ -343,7 +343,7 @@ func resourceSentinelAlertRuleNrtCreateUpdate(d *pluginsdk.ResourceData, meta in
 			Description:           utils.String(d.Get("description").(string)),
 			DisplayName:           utils.String(d.Get("display_name").(string)),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
-			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident_configuration").([]interface{})),
+			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident").([]interface{}), "create_incident_enabled", false),
 			Severity:              securityinsight.AlertSeverity(d.Get("severity").(string)),
 			Enabled:               utils.Bool(d.Get("enabled").(bool)),
 			Query:                 utils.String(d.Get("query").(string)),
@@ -427,8 +427,8 @@ func resourceSentinelAlertRuleNrtRead(d *pluginsdk.ResourceData, meta interface{
 		if err := d.Set("tactics", flattenAlertRuleTactics(prop.Tactics)); err != nil {
 			return fmt.Errorf("setting `tactics`: %+v", err)
 		}
-		if err := d.Set("incident_configuration", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration)); err != nil {
-			return fmt.Errorf("setting `incident_configuration`: %+v", err)
+		if err := d.Set("incident", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration, "create_incident_enabled", false)); err != nil {
+			return fmt.Errorf("setting `incident`: %+v", err)
 		}
 		d.Set("severity", string(prop.Severity))
 		d.Set("enabled", prop.Enabled)

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
@@ -165,7 +165,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 											string(securityinsight.MatchingMethodAllEntities),
 										}, false),
 									},
-									"entities": {
+									"by_entities": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
@@ -173,7 +173,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 											ValidateFunc: validation.StringInSlice(entityMappingTypes, false),
 										},
 									},
-									"alert_details": {
+									"by_alert_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
@@ -185,7 +185,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 												false),
 										},
 									},
-									"custom_details": {
+									"by_custom_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -155,16 +155,16 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
   tactics                    = ["Collection", "CommandAndControl"]
   severity                   = "Low"
   enabled                    = false
-  incident_configuration {
-    create_incident = true
+  incident {
+    create_incident_enabled = true
     grouping {
       enabled                 = true
       lookback_duration       = "P7D"
       reopen_closed_incidents = true
       entity_matching_method  = "Selected"
-      group_by_entities       = ["Host"]
-      group_by_alert_details  = ["DisplayName"]
-      group_by_custom_details = ["OperatingSystemType", "OperatingSystemName"]
+      entities                = ["Host"]
+      alert_details           = ["DisplayName"]
+      custom_details          = ["OperatingSystemType", "OperatingSystemName"]
     }
   }
   query                = "Heartbeat"

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -1,0 +1,284 @@
+package sentinel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/securityinsight/mgmt/2021-09-01-preview/securityinsight"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type SentinelAlertRuleNrtResource struct{}
+
+func TestAccSentinelAlertRuleNrt_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_nrt", "test")
+	r := SentinelAlertRuleNrtResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelAlertRuleNrt_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_nrt", "test")
+	r := SentinelAlertRuleNrtResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelAlertRuleNrt_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_nrt", "test")
+	r := SentinelAlertRuleNrtResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelAlertRuleNrt_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_nrt", "test")
+	r := SentinelAlertRuleNrtResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_nrt", "test")
+	r := SentinelAlertRuleNrtResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.alertRuleTemplateGuid(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t SentinelAlertRuleNrtResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.AlertRuleID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Sentinel.AlertRulesClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %v", id, err)
+	}
+
+	rule, ok := resp.Value.(securityinsight.NrtAlertRule)
+	if !ok {
+		return nil, fmt.Errorf("the Alert Rule %q is not a NRT Alert Rule", id)
+	}
+
+	return utils.Bool(rule.ID != nil), nil
+}
+
+func (r SentinelAlertRuleNrtResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_alert_rule_nrt" "test" {
+  name                       = "acctest-SentinelAlertRule-NRT-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  display_name               = "Some Rule"
+  severity                   = "High"
+  query                      = <<QUERY
+AzureActivity |
+  where OperationName == "Create or Update Virtual Machine" or OperationName =="Create Deployment" |
+  where ActivityStatus == "Succeeded" |
+  make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
+QUERY
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SentinelAlertRuleNrtResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_alert_rule_nrt" "test" {
+  name                       = "acctest-SentinelAlertRule-NRT-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  display_name               = "Complete Rule"
+  description                = "Some Description"
+  tactics                    = ["Collection", "CommandAndControl"]
+  severity                   = "Low"
+  enabled                    = false
+  incident_configuration {
+    create_incident = true
+    grouping {
+      enabled                 = true
+      lookback_duration       = "P7D"
+      reopen_closed_incidents = true
+      entity_matching_method  = "Selected"
+      group_by_entities       = ["Host"]
+      group_by_alert_details  = ["DisplayName"]
+      group_by_custom_details = ["OperatingSystemType", "OperatingSystemName"]
+    }
+  }
+  query                = "Heartbeat"
+  suppression_enabled  = true
+  suppression_duration = "PT40M"
+  alert_details_override {
+    description_format   = "Alert from {{Compute}}"
+    display_name_format  = "Suspicious activity was made by {{ComputerIP}}"
+    severity_column_name = "Computer"
+    tactics_column_name  = "Computer"
+  }
+  entity_mapping {
+    entity_type = "Host"
+    field_mapping {
+      identifier  = "FullName"
+      column_name = "Computer"
+    }
+  }
+  entity_mapping {
+    entity_type = "IP"
+    field_mapping {
+      identifier  = "Address"
+      column_name = "ComputerIP"
+    }
+  }
+  custom_details = {
+    OperatingSystemName = "OSName"
+    OperatingSystemType = "OSType"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SentinelAlertRuleNrtResource) completeUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_alert_rule_nrt" "test" {
+  name                       = "acctest-SentinelAlertRule-NRT-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  display_name               = "Updated Complete Rule"
+  severity                   = "High"
+  query                      = "Heartbeat"
+  custom_details = {
+    OperatingSystemName = "OSName"
+    OperatingSystemType = "OSType"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SentinelAlertRuleNrtResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_alert_rule_nrt" "import" {
+  name                       = azurerm_sentinel_alert_rule_nrt.test.name
+  log_analytics_workspace_id = azurerm_sentinel_alert_rule_nrt.test.log_analytics_workspace_id
+  display_name               = azurerm_sentinel_alert_rule_nrt.test.display_name
+  severity                   = azurerm_sentinel_alert_rule_nrt.test.severity
+  query                      = azurerm_sentinel_alert_rule_nrt.test.query
+}
+`, r.basic(data))
+}
+
+func (r SentinelAlertRuleNrtResource) alertRuleTemplateGuid(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_sentinel_alert_rule_template" "test" {
+  display_name               = "NRT Base64 encoded Windows process command-lines"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+}
+
+resource "azurerm_sentinel_alert_rule_nrt" "test" {
+  name                       = "acctest-SentinelAlertRule-NRT-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  display_name               = "Some Rule"
+  severity                   = "Low"
+  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+  query                      = "Heartbeat"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (SentinelAlertRuleNrtResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sentinel-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -162,9 +162,9 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
       lookback_duration       = "P7D"
       reopen_closed_incidents = true
       entity_matching_method  = "Selected"
-      entities                = ["Host"]
-      alert_details           = ["DisplayName"]
-      custom_details          = ["OperatingSystemType", "OperatingSystemName"]
+      by_entities                = ["Host"]
+      by_alert_details           = ["DisplayName"]
+      by_custom_details          = ["OperatingSystemType", "OperatingSystemName"]
     }
   }
   query                = "Heartbeat"

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -162,9 +162,9 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
       lookback_duration       = "P7D"
       reopen_closed_incidents = true
       entity_matching_method  = "Selected"
-      by_entities                = ["Host"]
-      by_alert_details           = ["DisplayName"]
-      by_custom_details          = ["OperatingSystemType", "OperatingSystemName"]
+      by_entities             = ["Host"]
+      by_alert_details        = ["DisplayName"]
+      by_custom_details       = ["OperatingSystemType", "OperatingSystemName"]
     }
   }
   query                = "Heartbeat"

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -139,6 +139,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 				},
 			},
 
+			// TODO 4.0 - rename this to "incident"
 			"incident_configuration": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -147,6 +148,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
+						// TODO 4.0 - rename this to "create_incident_enabled"
 						"create_incident": {
 							Required: true,
 							Type:     pluginsdk.TypeBool,
@@ -184,6 +186,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 											string(securityinsight.MatchingMethodAllEntities),
 										}, false),
 									},
+									// TODO 4.0 - rename this to "entities"
 									"group_by_entities": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -192,6 +195,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 											ValidateFunc: validation.StringInSlice(entityMappingTypes, false),
 										},
 									},
+									// TODO 4.0 - rename this to "alert_details"
 									"group_by_alert_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -204,6 +208,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 												false),
 										},
 									},
+									// TODO 4.0 - rename this to "custom_details"
 									"group_by_custom_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -413,7 +418,7 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 			Description:           utils.String(d.Get("description").(string)),
 			DisplayName:           utils.String(d.Get("display_name").(string)),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
-			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident_configuration").([]interface{})),
+			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident_configuration").([]interface{}), "create_incident", true),
 			Severity:              securityinsight.AlertSeverity(d.Get("severity").(string)),
 			Enabled:               utils.Bool(d.Get("enabled").(bool)),
 			Query:                 utils.String(d.Get("query").(string)),
@@ -504,7 +509,7 @@ func resourceSentinelAlertRuleScheduledRead(d *pluginsdk.ResourceData, meta inte
 		if err := d.Set("tactics", flattenAlertRuleTactics(prop.Tactics)); err != nil {
 			return fmt.Errorf("setting `tactics`: %+v", err)
 		}
-		if err := d.Set("incident_configuration", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration)); err != nil {
+		if err := d.Set("incident_configuration", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration, "create_incident", true)); err != nil {
 			return fmt.Errorf("setting `incident_configuration`: %+v", err)
 		}
 		d.Set("severity", string(prop.Severity))

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -186,7 +186,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 											string(securityinsight.MatchingMethodAllEntities),
 										}, false),
 									},
-									// TODO 4.0 - rename this to "entities"
+									// TODO 4.0 - rename this to "by_entities"
 									"group_by_entities": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -195,7 +195,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 											ValidateFunc: validation.StringInSlice(entityMappingTypes, false),
 										},
 									},
-									// TODO 4.0 - rename this to "alert_details"
+									// TODO 4.0 - rename this to "by_alert_details"
 									"group_by_alert_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -208,7 +208,7 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 												false),
 										},
 									},
-									// TODO 4.0 - rename this to "custom_details"
+									// TODO 4.0 - rename this to "by_custom_details"
 									"group_by_custom_details": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
@@ -107,6 +107,34 @@ func dataSourceSentinelAlertRuleTemplate() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"nrt_template": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"description": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"tactics": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+						"severity": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"query": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -146,6 +174,8 @@ func dataSourceSentinelAlertRuleTemplateRead(d *pluginsdk.ResourceData, meta int
 		err = setForMsSecurityIncidentAlertRuleTemplate(d, &template)
 	case securityinsight.ScheduledAlertRuleTemplate:
 		err = setForScheduledAlertRuleTemplate(d, &template)
+	case securityinsight.NrtAlertRuleTemplate:
+		err = setForNrtAlertRuleTemplate(d, &template)
 	default:
 		return fmt.Errorf("unknown template type of Sentinel Alert Rule Template %q (Workspace %q / Resource Group %q) ID", nameToLog, workspaceID.WorkspaceName, workspaceID.ResourceGroup)
 	}
@@ -190,6 +220,10 @@ func getAlertRuleTemplateByDisplayName(ctx context.Context, client *securityinsi
 			if template.DisplayName != nil && *template.DisplayName == name {
 				results = append(results, templates.Value())
 			}
+		case securityinsight.NrtAlertRuleTemplate:
+			if template.DisplayName != nil && *template.DisplayName == name {
+				results = append(results, templates.Value())
+			}
 		}
 
 		if err := templates.NextWithContext(ctx); err != nil {
@@ -218,6 +252,20 @@ func setForScheduledAlertRuleTemplate(d *pluginsdk.ResourceData, template *secur
 	d.Set("name", template.Name)
 	d.Set("display_name", template.DisplayName)
 	return d.Set("scheduled_template", flattenScheduledAlertRuleTemplate(template.ScheduledAlertRuleTemplateProperties))
+}
+
+func setForNrtAlertRuleTemplate(d *pluginsdk.ResourceData, template *securityinsight.NrtAlertRuleTemplate) error {
+	if template.ID == nil || *template.ID == "" {
+		return errors.New("empty or nil ID")
+	}
+	id, err := parse.SentinelAlertRuleTemplateID(*template.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID())
+	d.Set("name", template.Name)
+	d.Set("display_name", template.DisplayName)
+	return d.Set("nrt_template", flattenNrtAlertRuleTemplate(template.NrtAlertRuleTemplateProperties))
 }
 
 func setForMsSecurityIncidentAlertRuleTemplate(d *pluginsdk.ResourceData, template *securityinsight.MicrosoftSecurityIncidentCreationAlertRuleTemplate) error {
@@ -274,7 +322,7 @@ func flattenScheduledAlertRuleTemplate(input *securityinsight.ScheduledAlertRule
 
 	tactics := []interface{}{}
 	if input.Tactics != nil {
-		tactics = flattenAlertRuleScheduledTactics(input.Tactics)
+		tactics = flattenAlertRuleTactics(input.Tactics)
 	}
 
 	query := ""
@@ -307,6 +355,36 @@ func flattenScheduledAlertRuleTemplate(input *securityinsight.ScheduledAlertRule
 			"query_period":      queryPeriod,
 			"trigger_operator":  string(input.TriggerOperator),
 			"trigger_threshold": triggerThreshold,
+		},
+	}
+}
+
+func flattenNrtAlertRuleTemplate(input *securityinsight.NrtAlertRuleTemplateProperties) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	description := ""
+	if input.Description != nil {
+		description = *input.Description
+	}
+
+	tactics := []interface{}{}
+	if input.Tactics != nil {
+		tactics = flattenAlertRuleTactics(input.Tactics)
+	}
+
+	query := ""
+	if input.Query != nil {
+		query = *input.Query
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"description": description,
+			"tactics":     tactics,
+			"severity":    string(input.Severity),
+			"query":       query,
 		},
 	}
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -23,6 +23,8 @@ func TestAccSentinelAlertRuleTemplateDataSource_fusion(t *testing.T) {
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template").DoesNotExist(),
 				check.That(data.ResourceName).Key("security_incident_template").DoesNotExist(),
+				check.That(data.ResourceName).Key("nrt_template").DoesNotExist(),
+				check.That(data.ResourceName).Key("scheduled_template").DoesNotExist(),
 			),
 		},
 	})
@@ -34,13 +36,14 @@ func TestAccSentinelAlertRuleTemplateDataSource_securityIncident(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.byDisplayName(data, "Create incidents based on Azure Defender alerts"),
+			Config: r.byDisplayName(data, "Create incidents based on Azure Active Directory Identity Protection alerts"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("display_name").Exists(),
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("security_incident_template.0.description").Exists(),
 				check.That(data.ResourceName).Key("security_incident_template.0.product_filter").Exists(),
+				check.That(data.ResourceName).Key("nrt_template").DoesNotExist(),
 				check.That(data.ResourceName).Key("scheduled_template").DoesNotExist(),
 			),
 		},
@@ -66,6 +69,28 @@ func TestAccSentinelAlertRuleTemplateDataSource_scheduled(t *testing.T) {
 				check.That(data.ResourceName).Key("scheduled_template.0.trigger_operator").Exists(),
 				check.That(data.ResourceName).Key("scheduled_template.0.trigger_threshold").Exists(),
 				check.That(data.ResourceName).Key("security_incident_template").DoesNotExist(),
+				check.That(data.ResourceName).Key("nrt_template").DoesNotExist(),
+			),
+		},
+	})
+}
+
+func TestAccSentinelAlertRuleTemplateDataSource_nrt(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_sentinel_alert_rule_template", "test")
+	r := SentinelAlertRuleTemplateDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.byDisplayName(data, "NRT Base64 encoded Windows process command-lines"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").Exists(),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("nrt_template.0.description").Exists(),
+				check.That(data.ResourceName).Key("nrt_template.0.severity").Exists(),
+				check.That(data.ResourceName).Key("nrt_template.0.query").Exists(),
+				check.That(data.ResourceName).Key("security_incident_template").DoesNotExist(),
+				check.That(data.ResourceName).Key("scheduled_template").DoesNotExist(),
 			),
 		},
 	})

--- a/website/docs/d/sentinel_alert_rule_template.html.markdown
+++ b/website/docs/d/sentinel_alert_rule_template.html.markdown
@@ -43,9 +43,23 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Sentinel.
 
+* `nrt_template` - A `nrt_template` block as defined below. This only applies to Sentinel NRT Alert Rule Template.
+
 * `security_incident_template` - A `security_incident_template` block as defined below. This only applies to Sentinel MS Security Incident Alert Rule Template.
 
 * `scheduled_template` - A `scheduled_template` block as defined below. This only applies to Sentinel Scheduled Alert Rule Template.
+
+---
+
+A `nrt_template` block exports the following:
+
+* `description` - The description of this Sentinel NRT Alert Rule Template.
+
+* `query` - The query of this Sentinel NRT Alert Rule Template.
+
+* `severity` - The alert severity of this Sentinel NRT Alert Rule Template.
+
+* `tactics` - A list of categories of attacks by which to classify the rule.
 
 ---
 

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -142,11 +142,11 @@ A `grouping` block supports the following:
 
 * `entity_matching_method` - (Optional) The method used to group incidents. Possible values are `AnyAlert`, `Selected` and `AllEntities`. Defaults to `AnyAlert`.
 
-* `entities` - (Optional) A list of entity types to group by, only when the `entity_matching_method` is `Selected`. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
+* `by_entities` - (Optional) A list of entity types to group by, only when the `entity_matching_method` is `Selected`. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
 
-* `alert_details` - (Optional) A list of alert details to group by, only when the `entity_matching_method` is `Selected`.
+* `by_alert_details` - (Optional) A list of alert details to group by, only when the `entity_matching_method` is `Selected`.
 
-* `custom_details` - (Optional) A list of custom details keys to group by, only when the `entity_matching_method` is `Selected`. Only keys defined in the `custom_details` may be used.
+* `by_custom_details` - (Optional) A list of custom details keys to group by, only when the `entity_matching_method` is `Selected`. Only keys defined in the `custom_details` may be used.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `entity_mapping` - (Optional) A list of `entity_mapping` blocks as defined below.
 
-* `incident_configuration` - (Optional) A `incident_configuration` block as defined below.
+* `incident` - (Optional) A `incident` block as defined below.
 
 * `suppression_duration` - (Optional) If `suppression_enabled` is `true`, this is ISO 8601 timespan duration, which specifies the amount of time the query should stop running after alert is generated. Defaults to `PT5H`.
 
@@ -124,9 +124,9 @@ A `field_mapping` block supports the following:
 
 ---
 
-A `incident_configuration` block supports the following:
+A `incident` block supports the following:
 
-* `create_incident` - (Required) Whether to create an incident from alerts triggered by this Sentinel NRT Alert Rule?
+* `create_incident_enabled` - (Required) Whether to create an incident from alerts triggered by this Sentinel NRT Alert Rule?
 
 * `grouping` - (Optional) A `grouping` block as defined below.
 
@@ -142,11 +142,11 @@ A `grouping` block supports the following:
 
 * `entity_matching_method` - (Optional) The method used to group incidents. Possible values are `AnyAlert`, `Selected` and `AllEntities`. Defaults to `AnyAlert`.
 
-* `group_by_entities` - (Optional) A list of entity types to group by, only when the `entity_matching_method` is `Selected`. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
+* `entities` - (Optional) A list of entity types to group by, only when the `entity_matching_method` is `Selected`. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
 
-* `gorup_by_alert_details` - (Optional) A list of alert details to group by, only when the `entity_matching_method` is `Selected`.
+* `alert_details` - (Optional) A list of alert details to group by, only when the `entity_matching_method` is `Selected`.
 
-* `gorup_by_custom_details` - (Optional) A list of custom details keys to group by, only when the `entity_matching_method` is `Selected`. Only keys defined in the `custom_details` may be used.
+* `custom_details` - (Optional) A list of custom details keys to group by, only when the `entity_matching_method` is `Selected`. Only keys defined in the `custom_details` may be used.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -1,0 +1,172 @@
+---
+subcategory: "Sentinel"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sentinel_alert_rule_nrt"
+description: |-
+  Manages a Sentinel NRT (Near-Real-Time) Alert Rule.
+---
+
+# azurerm_sentinel_alert_rule_nrt
+
+Manages a Sentinel NRT Alert Rule.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "pergb2018"
+}
+
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
+resource "azurerm_sentinel_alert_rule_nrt" "example" {
+  name                       = "example"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  display_name               = "example"
+  severity                   = "High"
+  query                      = <<QUERY
+AzureActivity |
+  where OperationName == "Create or Update Virtual Machine" or OperationName =="Create Deployment" |
+  where ActivityStatus == "Succeeded" |
+  make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
+QUERY
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Sentinel NRT Alert Rule. Changing this forces a new Sentinel NRT Alert Rule to be created.
+
+* `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace this Sentinel NRT Alert Rule belongs to. Changing this forces a new Sentinel NRT Alert Rule to be created.
+
+* `display_name` - (Required) The friendly name of this Sentinel NRT Alert Rule.
+
+* `severity` - (Required) The alert severity of this Sentinel NRT Alert Rule. Possible values are `High`, `Medium`, `Low` and `Informational`.
+
+* `query` - (Required) The query of this Sentinel NRT Alert Rule.
+
+---
+
+* `alert_details_override` - (Optional) An `alert_details_override` block as defined below.
+
+* `alert_rule_template_guid` - (Optional) The GUID of the alert rule template which is used for this Sentinel NRT Alert Rule. Changing this forces a new Sentinel NRT Alert Rule to be created.
+
+* `alert_rule_template_version` - (Optional) The version of the alert rule template which is used for this Sentinel NRT Alert Rule. Changing this forces a new Sentinel NRT Alert Rule to be created.
+
+* `custom_details` - (Optional) A map of string key-value pairs of columns to be attached to this Sentinel NRT Alert Rule. The key will appear as the field name in alerts and the value is the event parameter you wish to surface in the alerts.
+
+* `description` - (Optional) The description of this Sentinel NRT Alert Rule.
+
+* `enabled` - (Optional) Should the Sentinel NRT Alert Rule be enabled? Defaults to `true`.
+
+* `entity_mapping` - (Optional) A list of `entity_mapping` blocks as defined below.
+
+* `incident_configuration` - (Optional) A `incident_configuration` block as defined below.
+
+* `suppression_duration` - (Optional) If `suppression_enabled` is `true`, this is ISO 8601 timespan duration, which specifies the amount of time the query should stop running after alert is generated. Defaults to `PT5H`.
+
+* `suppression_enabled` - (Optional) Should the Sentinel NRT Alert Rulea stop running query after alert is generated? Defaults to `false`.
+
+* `tactics` - (Optional) A list of categories of attacks by which to classify the rule. Possible values are `Collection`, `CommandAndControl`, `CredentialAccess`, `DefenseEvasion`, `Discovery`, `Execution`, `Exfiltration`, `Impact`, `InitialAccess`, `LateralMovement`, `Persistence` and `PrivilegeEscalation`.
+
+---
+
+An `alert_details_override` block supports the following:
+
+* `description_format` - (Optional) The format containing columns name(s) to override the description of this Sentinel Alert Rule.
+
+* `display_name_format` - (Optional) The format containing columns name(s) to override the name of this Sentinel Alert Rule.
+
+* `severity_column_name` - (Optional) The column name to take the alert severity from.
+
+* `tactics_column_name` - (Optional) The column name to take the alert tactics from.
+
+---
+
+An `entity_mapping` block supports the following:
+
+* `entity_type` - (Required) The type of the entity. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
+
+* `field_mapping` - (Required) A list of `field_mapping` blocks as defined below.
+
+---
+
+A `field_mapping` block supports the following:
+
+* `identifier` - (Required) The identifier of the entity.
+
+* `column_name` - (Required) The column name to be mapped to the identifier.
+
+---
+
+A `incident_configuration` block supports the following:
+
+* `create_incident` - (Required) Whether to create an incident from alerts triggered by this Sentinel NRT Alert Rule?
+
+* `grouping` - (Optional) A `grouping` block as defined below.
+
+---
+
+A `grouping` block supports the following:
+
+* `enabled` - (Optional) Enable grouping incidents created from alerts triggered by this Sentinel NRT Alert Rule. Defaults to `true`.
+
+* `lookback_duration` - (Optional) Limit the group to alerts created within the lookback duration (in ISO 8601 duration format). Defaults to `PT5M`.
+
+* `reopen_closed_incidents` - (Optional) Whether to re-open closed matching incidents? Defaults to `false`.
+
+* `entity_matching_method` - (Optional) The method used to group incidents. Possible values are `AnyAlert`, `Selected` and `AllEntities`. Defaults to `AnyAlert`.
+
+* `group_by_entities` - (Optional) A list of entity types to group by, only when the `entity_matching_method` is `Selected`. Possible values are `Account`, `AzureResource`, `CloudApplication`, `DNS`, `File`, `FileHash`, `Host`, `IP`, `Mailbox`, `MailCluster`, `MailMessage`, `Malware`, `Process`, `RegistryKey`, `RegistryValue`, `SecurityGroup`, `SubmissionMail`, `URL`.
+
+* `gorup_by_alert_details` - (Optional) A list of alert details to group by, only when the `entity_matching_method` is `Selected`.
+
+* `gorup_by_custom_details` - (Optional) A list of custom details keys to group by, only when the `entity_matching_method` is `Selected`. Only keys defined in the `custom_details` may be used.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Sentinel NRT Alert Rule.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Sentinel NRT Alert Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Sentinel NRT Alert Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the Sentinel NRT Alert Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Sentinel NRT Alert Rule.
+
+## Import
+
+Sentinel NRT Alert Rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sentinel_alert_rule_nrt.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/alertRules/rule1
+```


### PR DESCRIPTION
This PR adds a new resource `azurerm_sentinel_alert_rule_nrt`, which is another alert rule variant. Besides, it adds a new block `nrt_template` in the data source `azurerm_sentinel_alert_rule_template` to allow users to retrieve NRT template, which can be in turn used to create the nrt alert rule.

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel  -run='TestAccSentinelAlertRuleTemplateDataSource_'
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_fusion
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_fusion
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_nrt
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_nrt
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_fusion
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_nrt
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_securityIncident
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_scheduled (307.00s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_securityIncident (325.58s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_fusion (415.01s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_nrt (475.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      475.707s


💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel  -run='TestAccSentinelAlertRuleNrt_'
=== RUN   TestAccSentinelAlertRuleNrt_basic
=== PAUSE TestAccSentinelAlertRuleNrt_basic
=== RUN   TestAccSentinelAlertRuleNrt_complete
=== PAUSE TestAccSentinelAlertRuleNrt_complete
=== RUN   TestAccSentinelAlertRuleNrt_update
=== PAUSE TestAccSentinelAlertRuleNrt_update
=== RUN   TestAccSentinelAlertRuleNrt_requiresImport
=== PAUSE TestAccSentinelAlertRuleNrt_requiresImport
=== RUN   TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== PAUSE TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleNrt_basic
=== CONT  TestAccSentinelAlertRuleNrt_requiresImport
=== CONT  TestAccSentinelAlertRuleNrt_update
=== CONT  TestAccSentinelAlertRuleNrt_complete
=== CONT  TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
--- PASS: TestAccSentinelAlertRuleNrt_update (232.63s)
--- PASS: TestAccSentinelAlertRuleNrt_requiresImport (835.64s)
--- PASS: TestAccSentinelAlertRuleNrt_complete (899.41s)
--- PASS: TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid (1024.94s)
--- PASS: TestAccSentinelAlertRuleNrt_basic (1420.47s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      1420.488s
```