### PR TITLE
Bug fix `azurerm_api_management_api_operation_tag` get tag by operation 

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_tag_resource.go
+++ b/internal/services/apimanagement/api_management_api_operation_tag_resource.go
@@ -74,7 +74,7 @@ func resourceApiManagementApiOperationTagCreateUpdate(d *pluginsdk.ResourceData,
 	id := parse.NewOperationTagID(subscriptionId, apiOperationId.ResourceGroup, apiOperationId.ServiceName, apiOperationId.ApiName, apiOperationId.OperationName, name)
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, apiOperationId.ResourceGroup, apiOperationId.ServiceName, name)
+		existing, err := client.GetByOperation(ctx, apiOperationId.ResourceGroup, apiOperationId.ServiceName, apiOperationId.ApiName, apiOperationId.OperationName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("checking for presence of existing Tag %q: %s", id, err)


### PR DESCRIPTION
Issue: #15921 
Get operation tags by operation instead of  by API.
Acctest:
```
=== RUN   TestAccApiManagementApiOperationTag_basic
=== PAUSE TestAccApiManagementApiOperationTag_basic
=== RUN   TestAccApiManagementApiOperationTag_requiresImport
=== PAUSE TestAccApiManagementApiOperationTag_requiresImport
=== RUN   TestAccApiManagementApiOperationTag_update
=== PAUSE TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperationTag_basic
=== CONT  TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperationTag_requiresImport
--- PASS: TestAccApiManagementApiOperationTag_basic (650.00s)
--- PASS: TestAccApiManagementApiOperationTag_requiresImport (676.57s)
--- PASS: TestAccApiManagementApiOperationTag_update (937.32s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 939.161
```