### PR TITLE
`azurerm_application_gateway` - update docs and upgrade guide for `match` block properties

### DIFF
--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -339,6 +339,12 @@ The `azurerm_api_management_property` resource will be removed in favour of the 
 
 The deprecated field `security.enabled_triple_des_ciphers` will be removed in favour of the `security.triple_des_ciphers_enabled` property.
 
+### Resource: `azurerm_application_gateway`
+
+The field `probe.match.body` will become Required.
+
+The field `probe.match.status_code` will become Required.
+
 ### Resource: `azurerm_app_service`
 
 The `azurerm_app_service` resource has been superseded by the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -361,9 +361,9 @@ An `ip_configuration` block supports the following:
 
 A `match` block supports the following:
 
-* `body` - (Optional) A snippet from the Response Body which must be present in the Response..
+* `body` - (Required) A snippet from the Response Body which must be present in the Response.
 
-* `status_code` - (Optional) A list of allowed status codes for this Health Probe.
+* `status_code` - (Required) A list of allowed status codes for this Health Probe.
 
 ---
 


### PR DESCRIPTION
Closes #16050

Arguments became Required so that Computed could be removed from the block and changes could be tracked by the provider.