### PR TITLE
Update resource address of import command

### DIFF
--- a/website/docs/r/data_factory_linked_custom_service.html.markdown
+++ b/website/docs/r/data_factory_linked_custom_service.html.markdown
@@ -108,5 +108,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Data Factory Linked Service's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_data_factory_linked_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+terraform import azurerm_data_factory_linked_custom_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
 ```


### PR DESCRIPTION
Insert the missing "custom" in to the terraform resource address of the import command since the terraform resource is called "azurerm_data_factory_linked_custom_service".