### PR TITLE
Fix documentation on azurerm_public_ip

### DIFF
--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 ---
 
-* `availability_zone` - (Optional) The availability zone to allocate the Public IP in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`.
+* `zones` - (Optional) A collection containing the availability zone to allocate the Public IP in.
 
 -> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Public IP Addresses that do not specify a zone are zone redundant by default.
 


### PR DESCRIPTION
According to https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#resource-azurerm_public_ip, the fields `availability_zone` and `zones` will be consolidated into `zones`. This change was not reflected in the docs so far.