### PR TITLE
`azurerm_resource_group` - Wait for eventual consistency when deleting

### DIFF
--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -130,25 +130,30 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	// conditionally check for nested resources and error if they exist
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		resourceClient := meta.(*clients.Client).Resource.ResourcesClient
-		results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "", utils.Int32(500))
-		if err != nil {
-			return fmt.Errorf("listing resources in %s: %v", *id, err)
-		}
-		nestedResourceIds := make([]string, 0)
-		for results.NotDone() {
-			val := results.Value()
-			if val.ID != nil {
-				nestedResourceIds = append(nestedResourceIds, *val.ID)
+		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
+		err = pluginsdk.Retry(time.Minute*5, func() *pluginsdk.RetryError {
+			results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "provisioningState", utils.Int32(500))
+			if err != nil {
+				return pluginsdk.NonRetryableError(fmt.Errorf("listing resources in %s: %v", *id, err))
+			}
+			nestedResourceIds := make([]string, 0)
+			for results.NotDone() {
+				val := results.Value()
+				if val.ID != nil {
+					nestedResourceIds = append(nestedResourceIds, *val.ID)
+				}
+
+				if err := results.NextWithContext(ctx); err != nil {
+					return pluginsdk.NonRetryableError(fmt.Errorf("retrieving next page of nested items for %s: %+v", id, err))
+				}
 			}
 
-			if err := results.NextWithContext(ctx); err != nil {
-				return fmt.Errorf("retrieving next page of nested items for %s: %+v", id, err)
+			if len(nestedResourceIds) > 0 {
+				time.Sleep(15 * time.Second)
+				return pluginsdk.RetryableError(resourceGroupContainsItemsError(id.ResourceGroup, nestedResourceIds))
 			}
-		}
-
-		if len(nestedResourceIds) > 0 {
-			return resourceGroupContainsItemsError(id.ResourceGroup, nestedResourceIds)
-		}
+			return nil
+		})
 	}
 
 	deleteFuture, err := client.Delete(ctx, id.ResourceGroup, "")

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -154,6 +154,9 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 			}
 			return nil
 		})
+		if err != nil {
+			return err
+		}
 	}
 
 	deleteFuture, err := client.Delete(ctx, id.ResourceGroup, "")

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -131,7 +131,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		resourceClient := meta.(*clients.Client).Resource.ResourcesClient
 		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
-		err = pluginsdk.Retry(2 * time.Minute, func() *pluginsdk.RetryError {
+		err = pluginsdk.Retry(2*time.Minute, func() *pluginsdk.RetryError {
 			results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "provisioningState", utils.Int32(500))
 			if err != nil {
 				return pluginsdk.NonRetryableError(fmt.Errorf("listing resources in %s: %v", *id, err))

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -131,7 +131,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		resourceClient := meta.(*clients.Client).Resource.ResourcesClient
 		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
-		err = pluginsdk.Retry(time.Minute*5, func() *pluginsdk.RetryError {
+		err = pluginsdk.Retry(2 * time.Minute, func() *pluginsdk.RetryError {
 			results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "provisioningState", utils.Int32(500))
 			if err != nil {
 				return pluginsdk.NonRetryableError(fmt.Errorf("listing resources in %s: %v", *id, err))
@@ -149,7 +149,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 			}
 
 			if len(nestedResourceIds) > 0 {
-				time.Sleep(15 * time.Second)
+				time.Sleep(30 * time.Second)
 				return pluginsdk.RetryableError(resourceGroupContainsItemsError(id.ResourceGroup, nestedResourceIds))
 			}
 			return nil


### PR DESCRIPTION
A new feature was added in 3.0 that checks to see if there are any resources being managed by a resource group before deleting that resource group. Unfortunately, it seems there is a bit of eventual consistency that causes the resource group to think those resources are still around when they have been deleted. 

To fix that, we'll do that check a few times before we actually error out because the resources are still around.

Fixes #16069