### PR TITLE
Update go-azure-helpers to v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-azure-helpers v0.26.0
+	github.com/hashicorp/go-azure-helpers v0.27.0
 	github.com/hashicorp/go-getter v1.5.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.26.0 h1:uaxqRBGqxe4/60GMEcsHFt2rFp20+aeTAONubWT67aM=
-github.com/hashicorp/go-azure-helpers v0.26.0/go.mod h1:Z2IvHhrwmpdDU5Mdld+vETChcenndWcY1bws4Hsn+Wk=
+github.com/hashicorp/go-azure-helpers v0.27.0 h1:HjGZZjEFktC3FrFQ6XPadacobVQVTK0kYYBroqcG3cg=
+github.com/hashicorp/go-azure-helpers v0.27.0/go.mod h1:Z2IvHhrwmpdDU5Mdld+vETChcenndWcY1bws4Hsn+Wk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
@@ -134,6 +134,13 @@ func (c Config) MSALBearerAuthorizerCallback(ctx context.Context, api environmen
 		})
 	}
 
+	// For compatibility with Azure CLI which still uses ADAL, first check if we got an autorest.BearerAuthorizer
+	if cast, ok := authorizer.(*autorest.BearerAuthorizer); ok {
+		return autorest.NewBearerAuthorizerCallback(sender, func(_, _ string) (*autorest.BearerAuthorizer, error) {
+			return cast, nil
+		})
+	}
+
 	cast, ok := authorizer.(*auth.CachedAuthorizer)
 	if !ok {
 		return autorest.NewBearerAuthorizerCallback(nil, func(_, _ string) (*autorest.BearerAuthorizer, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.26.0
+# github.com/hashicorp/go-azure-helpers v0.27.0
 ## explicit
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates


### PR DESCRIPTION
Fixes the `authorizer was not an auth.CachedAuthorizer for https://vault.azure.net` error reported in #16052