### PR TITLE
`azurerm_web_application_firewall_policy` Fix #16019 by adding `KNOWN-CVES` to `ValidateWebApplicationFirewallP…

### DIFF
--- a/internal/services/network/validate/web_application_firewall_policy.go
+++ b/internal/services/network/validate/web_application_firewall_policy.go
@@ -16,6 +16,7 @@ var ValidateWebApplicationFirewallPolicyRuleGroupName = validation.StringInSlice
 	"crs_42_tight_security",
 	"crs_45_trojans",
 	"General",
+	"KNOWN-CVES",
 	"REQUEST-911-METHOD-ENFORCEMENT",
 	"REQUEST-913-SCANNER-DETECTION",
 	"REQUEST-920-PROTOCOL-ENFORCEMENT",


### PR DESCRIPTION
According to the [document](https://docs.microsoft.com/en-us/azure/web-application-firewall/ag/application-gateway-crs-rulegroups-rules?tabs=owasp30#owasp-crs-30), we can set `KNOWN-CVES` as the `rule_group_name`. This pr will fix #16019 .

The acc tests failed not only on this branch but also on main branch, I guess I need to set some environment variables to make acc tests pass?