### PR TITLE
Doc update: app_service_source_control incorrect variable requirements

### DIFF
--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -54,9 +54,9 @@ The following arguments are supported:
 
 ~> **NOTE:** Function apps are not supported at this time. 
 
-* `branch` - (Required) The branch name to use for deployments. Changing this forces a new resource to be created.
+* `branch` - (Optional) The branch name to use for deployments. Changing this forces a new resource to be created.
 
-* `repo_url` - (Required) The URL for the repository. Changing this forces a new resource to be created.
+* `repo_url` - (Optional) The URL for the repository. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
As per the code [here ](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/appservice/source_control_resource.go#L59)& [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/appservice/source_control_resource.go#L47) the `branch` and `repo_url` variables are optional and not required.