### PR TITLE
Remove duplicated `os_type` in `service_plan` doc

### DIFF
--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -28,7 +28,6 @@ resource "azurerm_service_plan" "example" {
   location            = "West Europe"
   os_type             = "Linux"
   sku_name            = "P1V2"
-  os_type             = "Windows"
 }
 ```
 


### PR DESCRIPTION
Fixing to broken Website Linting
Issue seems to be introduced by co-commit of [594bb52](https://github.com/hashicorp/terraform-provider-azurerm/commit/594bb5282e67645a75b8d97b7efaad2e045e20d3) and [5c69a7c](https://github.com/hashicorp/terraform-provider-azurerm/commit/5c69a7c897bcfc036f42d0049a393f2701e3bad7#diff-ea584da06d190d53315b37ce05a247402b72e7b6a8784e7bb87124757bdbaaa9)