### PR TITLE
Adding `oidc_issuer_profile` support to `azurerm_kubernetes_cluster`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -588,21 +588,14 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"oidc_issuer_profile": {
-				Type:     pluginsdk.TypeList,
+			"oidc_issuer_enabled": {
+				Type:     pluginsdk.TypeBool,
 				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"enabled": {
-							Type:     pluginsdk.TypeBool,
-							Computed: true,
-						},
-						"issuer_url": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
+			},
+
+			"oidc_issuer_url": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"role_based_access_control_enabled": {
@@ -973,9 +966,22 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			return fmt.Errorf("setting `network_profile`: %+v", err)
 		}
 
-		oidcIssuerProfile := flattenKubernetesClusterDataSourceOidcIssuerProfile(props.OidcIssuerProfile)
-		if err := d.Set("oidc_issuer_profile", oidcIssuerProfile); err != nil {
-			return fmt.Errorf("setting `oidc_issuer_profile`: %+v", err)
+		oidcIssuerEnabled := false
+		oidcIssuerUrl := ""
+		if props.OidcIssuerProfile != nil {
+			if props.OidcIssuerProfile.Enabled != nil {
+				oidcIssuerEnabled = *props.OidcIssuerProfile.Enabled
+			}
+			if props.OidcIssuerProfile.IssuerURL != nil {
+				oidcIssuerUrl = *props.OidcIssuerProfile.IssuerURL
+			}
+		}
+
+		if err := d.Set("oidc_issuer_enabled", oidcIssuerEnabled); err != nil {
+			return fmt.Errorf("setting `oidc_issuer_enabled`: %+v", err)
+		}
+		if err := d.Set("oidc_issuer_url", oidcIssuerUrl); err != nil {
+			return fmt.Errorf("setting `oidc_issuer_url`: %+v", err)
 		}
 
 		rbacEnabled := true

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -1799,25 +1799,3 @@ func flattenClusterDataSourceIdentity(input *containerservice.ManagedClusterIden
 
 	return identity.FlattenSystemOrUserAssignedMap(transform)
 }
-
-func flattenKubernetesClusterDataSourceOidcIssuerProfile(input *containerservice.ManagedClusterOIDCIssuerProfile) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-
-	enabled := false
-	if input.Enabled != nil {
-		enabled = *input.Enabled
-	}
-
-	issuerUrl := ""
-	if input.IssuerURL != nil {
-		issuerUrl = *input.IssuerURL
-	}
-
-	results := []interface{}{}
-	return append(results, map[string]interface{}{
-		"enabled":    enabled,
-		"issuer_url": issuerUrl,
-	})
-}

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -588,6 +588,23 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"oidc_issuer_profile": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+						"issuer_url": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"role_based_access_control_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
@@ -954,6 +971,11 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 		networkProfile := flattenKubernetesClusterDataSourceNetworkProfile(props.NetworkProfile)
 		if err := d.Set("network_profile", networkProfile); err != nil {
 			return fmt.Errorf("setting `network_profile`: %+v", err)
+		}
+
+		oidcIssuerProfile := flattenKubernetesClusterDataSourceOidcIssuerProfile(props.OidcIssuerProfile)
+		if err := d.Set("oidc_issuer_profile", oidcIssuerProfile); err != nil {
+			return fmt.Errorf("setting `oidc_issuer_profile`: %+v", err)
 		}
 
 		rbacEnabled := true
@@ -1770,4 +1792,26 @@ func flattenClusterDataSourceIdentity(input *containerservice.ManagedClusterIden
 	}
 
 	return identity.FlattenSystemOrUserAssignedMap(transform)
+}
+
+func flattenKubernetesClusterDataSourceOidcIssuerProfile(input *containerservice.ManagedClusterOIDCIssuerProfile) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	enabled := false
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+
+	issuerUrl := ""
+	if input.IssuerURL != nil {
+		issuerUrl = *input.IssuerURL
+	}
+
+	results := []interface{}{}
+	return append(results, map[string]interface{}{
+		"enabled":    enabled,
+		"issuer_url": issuerUrl,
+	})
 }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -677,31 +677,31 @@ func TestAccDataSourceKubernetesCluster_nodePublicIP(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceKubernetesCluster_oidcIssuerProfile(t *testing.T) {
+func TestAccDataSourceKubernetesCluster_oidcIssuerEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.oidcIssuerProfile(data),
+			Config: r.oidcIssuer(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").IsSet(),
+				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("oidc_issuer_url").IsSet(),
 			),
 		},
 	})
 }
 
-func TestAccDataSourceKubernetesCluster_oidcIssuerProfileDisabled(t *testing.T) {
+func TestAccDataSourceKubernetesCluster_oidcIssuerDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.oidcIssuerProfileDisabled(data),
+			Config: r.oidcIssuer(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").HasValue(""),
+				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("oidc_issuer_url").HasValue(""),
 			),
 		},
 	})
@@ -993,7 +993,7 @@ data "azurerm_kubernetes_cluster" "test" {
 `, KubernetesClusterResource{}.nodePublicIPPrefixConfig(data))
 }
 
-func (KubernetesClusterDataSource) oidcIssuerProfile(data acceptance.TestData) string {
+func (KubernetesClusterDataSource) oidcIssuer(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1001,16 +1001,5 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.oidcIssuerProfile(data))
-}
-
-func (KubernetesClusterDataSource) oidcIssuerProfileDisabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_kubernetes_cluster" "test" {
-  name                = azurerm_kubernetes_cluster.test.name
-  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
-}
-`, KubernetesClusterResource{}.oidcIssuerProfileDisabled(data))
+`, KubernetesClusterResource{}.oidcIssuer(data, enabled))
 }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -677,6 +677,36 @@ func TestAccDataSourceKubernetesCluster_nodePublicIP(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceKubernetesCluster_oidcIssuerProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.oidcIssuerProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").IsSet(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKubernetesCluster_oidcIssuerProfileDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.oidcIssuerProfileDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").HasValue(""),
+			),
+		},
+	})
+}
+
 func (KubernetesClusterDataSource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -961,4 +991,26 @@ data "azurerm_kubernetes_cluster" "test" {
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
 `, KubernetesClusterResource{}.nodePublicIPPrefixConfig(data))
+}
+
+func (KubernetesClusterDataSource) oidcIssuerProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.oidcIssuerProfile(data))
+}
+
+func (KubernetesClusterDataSource) oidcIssuerProfileDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.oidcIssuerProfileDisabled(data))
 }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -576,24 +576,7 @@ func TestAccKubernetesCluster_osSku(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_oidcIssuerEnabled(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
-	r := KubernetesClusterResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.oidcIssuer(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("oidc_issuer_url").IsSet(),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccKubernetesCluster_oidcIssuerDisabled(t *testing.T) {
+func TestAccKubernetesCluster_oidcIssuer(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
@@ -604,6 +587,15 @@ func TestAccKubernetesCluster_oidcIssuerDisabled(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("oidc_issuer_url").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.oidcIssuer(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("oidc_issuer_url").IsSet(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -576,34 +576,34 @@ func TestAccKubernetesCluster_osSku(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_oidcIssuerProfile(t *testing.T) {
+func TestAccKubernetesCluster_oidcIssuerEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.oidcIssuerProfile(data),
+			Config: r.oidcIssuer(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").IsSet(),
+				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("oidc_issuer_url").IsSet(),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccKubernetesCluster_oidcIssuerProfileDisabled(t *testing.T) {
+func TestAccKubernetesCluster_oidcIssuerDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.oidcIssuerProfileDisabled(data),
+			Config: r.oidcIssuer(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("oidc_issuer_profile.0.issuer_url").HasValue(""),
+				check.That(data.ResourceName).Key("oidc_issuer_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("oidc_issuer_url").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -1882,7 +1882,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (KubernetesClusterResource) oidcIssuerProfile(data acceptance.TestData) string {
+func (KubernetesClusterResource) oidcIssuer(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1905,39 +1905,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-  oidc_issuer_profile {
-    enabled = true
-  }
+  oidc_issuer_enabled = %t
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (KubernetesClusterResource) oidcIssuerProfileDisabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-aks-%d"
-  location = "%s"
-}
-resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%d"
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_D2s_v3"
-    os_sku     = "Ubuntu"
-  }
-  identity {
-    type = "SystemAssigned"
-  }
-  oidc_issuer_profile {
-    enabled = false
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enabled)
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3239,26 +3239,3 @@ func flattenKubernetesClusterHttpProxyConfig(props *containerservice.ManagedClus
 		"trusted_ca":  trustedCa,
 	})
 }
-
-func flattenKubernetesClusterOidcIssuerProfile(props *containerservice.ManagedClusterProperties) interface{} {
-	if props == nil || props.OidcIssuerProfile == nil {
-		return map[string]interface{}{}
-	}
-
-	oidcIssuerProfile := props.OidcIssuerProfile
-
-	enabled := false
-	if oidcIssuerProfile.Enabled != nil {
-		enabled = *oidcIssuerProfile.Enabled
-	}
-
-	issuerUrl := ""
-	if oidcIssuerProfile.IssuerURL != nil {
-		issuerUrl = *oidcIssuerProfile.IssuerURL
-	}
-
-	return map[string]interface{}{
-		"enabled":    enabled,
-		"issuer_url": issuerUrl,
-	}
-}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3189,13 +3189,13 @@ func expandKubernetesClusterHttpProxyConfig(input []interface{}) *containerservi
 }
 
 func expandKubernetesClusterOidcIssuerProfile(input []interface{}) *containerservice.ManagedClusterOIDCIssuerProfile {
-	oidcIssuerProfile := containerservice.ManagedClusterOIDCIssuerProfile{}
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
 	profile := input[0].(map[string]interface{})
 
+	oidcIssuerProfile := containerservice.ManagedClusterOIDCIssuerProfile{}
 	oidcIssuerProfile.Enabled = utils.Bool(profile["enabled"].(bool))
 
 	return &oidcIssuerProfile

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2021,12 +2021,8 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 		}
 
-		if err := d.Set("oidc_issuer_enabled", oidcIssuerEnabled); err != nil {
-			return fmt.Errorf("setting `oidc_issuer_enabled`: %+v", err)
-		}
-		if err := d.Set("oidc_issuer_url", oidcIssuerUrl); err != nil {
-			return fmt.Errorf("setting `oidc_issuer_url`: %+v", err)
-		}
+		d.Set("oidc_issuer_enabled", oidcIssuerEnabled)
+		d.Set("oidc_issuer_url", oidcIssuerUrl)
 
 		// adminProfile is only available for RBAC enabled clusters with AAD and local account is not disabled
 		if props.AadProfile != nil && (props.DisableLocalAccounts == nil || !*props.DisableLocalAccounts) {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -80,6 +80,8 @@ The following attributes are exported:
 
 * `oidc_issuer_profile` - An `oidc_issuer_profile` block as documented below.
 
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableOIDCIssuerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview) for more information.
+
 * `oms_agent` - An `oms_agent` block as documented below.
 
 * `open_service_mesh_enabled` - Is Open Service Mesh enabled for this managed Kubernetes Cluster?
@@ -242,6 +244,14 @@ A `network_profile` block exports the following:
 * `pod_cidr` - The CIDR used for pod IP addresses.
 
 * `service_cidr` - Network range used by the Kubernetes service.
+
+---
+
+The `oidc_issuer_profile` block exports the following:
+
+* `enabled` - Whether or not the feature is enabled or disabled.
+
+* `oidc_issuer_url` - The oidc issuer url that is associated with the cluster.
 
 ---
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -78,6 +78,8 @@ The following attributes are exported:
 
 * `location` - The Azure Region in which the managed Kubernetes Cluster exists.
 
+* `oidc_issuer_profile` - An `oidc_issuer_profile` block as documented below.
+
 * `oms_agent` - An `oms_agent` block as documented below.
 
 * `open_service_mesh_enabled` - Is Open Service Mesh enabled for this managed Kubernetes Cluster?

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -78,9 +78,9 @@ The following attributes are exported:
 
 * `location` - The Azure Region in which the managed Kubernetes Cluster exists.
 
-* `oidc_issuer_profile` - An `oidc_issuer_profile` block as documented below.
+* `oidc_issuer_enabled` - Whether or not the OIDC feature is enabled or disabled.
 
--> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableOIDCIssuerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview) for more information.
+* `oidc_issuer_url` - The OIDC issuer URL that is associated with the cluster.
 
 * `oms_agent` - An `oms_agent` block as documented below.
 
@@ -244,14 +244,6 @@ A `network_profile` block exports the following:
 * `pod_cidr` - The CIDR used for pod IP addresses.
 
 * `service_cidr` - Network range used by the Kubernetes service.
-
----
-
-The `oidc_issuer_profile` block exports the following:
-
-* `enabled` - Whether or not the feature is enabled or disabled.
-
-* `oidc_issuer_url` - The oidc issuer url that is associated with the cluster.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -140,6 +140,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `oidc_issuer_profile` - (Optional) A `oidc_issuer_profile` block as defined below
 
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableOIDCIssuerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview) for more information.
+
 * `oms_agent` - (Optional) A `oms_agent` block as defined below.
 
 * `open_service_mesh_enabled` - (Optional) Is Open Service Mesh enabled? For more details, please visit [Open Service Mesh for AKS](https://docs.microsoft.com/azure/aks/open-service-mesh-about).

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -138,7 +138,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **Note:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 
-* `oidc_issuer_profile` - (Optional) A `oidc_issuer_profile` block as defined below
+* `oidc_issuer_enabled` - (Required) Enable or Disable the [OIDC issuer URL](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview)
 
 -> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableOIDCIssuerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview) for more information.
 
@@ -547,12 +547,6 @@ A `nat_gateway_profile` block supports the following:
 
 ---
 
-An `oidc_issuer_profile` block supports the following:
-
-* `enabled` - (Required) Enable or Disable the [oidc issuer url](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview)
-
----
-
 An `oms_agent` block supports the following:
 
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace which the OMS Agent should send data to.
@@ -705,7 +699,7 @@ The following attributes are exported:
 
 * `http_application_routing_zone_name` - The Zone Name of the HTTP Application Routing.
 
-* `oidc_issuer_profile` - The `oidc_issuer_profile` block as defined below.
+* `oidc_issuer_url` - The OIDC issuer URL that is associated with the cluster.
 
 * `node_resource_group` - The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster.
 
@@ -775,14 +769,6 @@ The `ingress_application_gateway_identity` block exports the following:
 * `object_id` - The Object ID of the user-defined Managed Identity used by the Application Gateway.
 
 * `user_assigned_identity_id` - The ID of the User Assigned Identity used by the Application Gateway.
-
----
-
-The `oidc_issuer_profile` block exports the following:
-
-* `enabled` - Whether or not the feature is enabled or disabled.
-
-* `oidc_issuer_url` - The oidc issuer url that is associated with the cluster.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -138,6 +138,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **Note:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 
+* `oidc_issuer_profile` - (Optional) A `oidc_issuer_profile` block as defined below
+
 * `oms_agent` - (Optional) A `oms_agent` block as defined below.
 
 * `open_service_mesh_enabled` - (Optional) Is Open Service Mesh enabled? For more details, please visit [Open Service Mesh for AKS](https://docs.microsoft.com/azure/aks/open-service-mesh-about).
@@ -543,6 +545,12 @@ A `nat_gateway_profile` block supports the following:
 
 ---
 
+An `oidc_issuer_profile` block supports the following:
+
+* `enabled` - (Required) Enable or Disable the [oidc issuer url](https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview)
+
+---
+
 An `oms_agent` block supports the following:
 
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace which the OMS Agent should send data to.
@@ -695,6 +703,8 @@ The following attributes are exported:
 
 * `http_application_routing_zone_name` - The Zone Name of the HTTP Application Routing.
 
+* `oidc_issuer_profile` - The `oidc_issuer_profile` block as defined below.
+
 * `node_resource_group` - The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster.
 
 ---
@@ -763,6 +773,14 @@ The `ingress_application_gateway_identity` block exports the following:
 * `object_id` - The Object ID of the user-defined Managed Identity used by the Application Gateway.
 
 * `user_assigned_identity_id` - The ID of the User Assigned Identity used by the Application Gateway.
+
+---
+
+The `oidc_issuer_profile` block exports the following:
+
+* `enabled` - Whether or not the feature is enabled or disabled.
+
+* `oidc_issuer_url` - The oidc issuer url that is associated with the cluster.
 
 ---
 


### PR DESCRIPTION
This PR adds a new `oidc_issuer_profile` block to the `azurerm_kubernetes_cluster` which enables an OIDC Issuer URL for the cluster for use in Azure Workload Identity. 

see #14977