### PR TITLE
`azurerm_cdn_endpoint` -`origin.0.http/https_ports` are now set as the default values of `80`/`443`

### DIFF
--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -627,8 +627,8 @@ func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface
 			}
 
 			hostName := ""
-			httpPort := 0
-			httpsPort := 0
+			httpPort := 80
+			httpsPort := 443
 			if props := i.DeepCreatedOriginProperties; props != nil {
 				if props.HostName != nil {
 					hostName = *props.HostName


### PR DESCRIPTION
When httpPort/httpsPort are set to 80/443 (the default), Azure sets these values to null. As a result, the provider attempts to re-create the cdn endpoint to update the origin ports from 0/0 -> 80/443 even though they are already set that way.

This PR makes it so that null-valued ports are correctly interpreted as 80/443 instead of 0/0.