### PR TITLE
azurerm_cosmosdb_sql_container,azurerm_cosmosdb_gremlin_graph: fix the case-insensitive issue about indexing_mode property after 3.0 release

### DIFF
--- a/internal/services/cosmos/common/schema.go
+++ b/internal/services/cosmos/common/schema.go
@@ -121,7 +121,7 @@ func CosmosDbIndexingPolicySchema() *pluginsdk.Schema {
 							}
 
 						}
-						return validation.StringInSlice(keys, features.ThreePointOhBeta())
+						return validation.StringInSlice(keys, !features.ThreePointOhBeta())
 					}(),
 				},
 

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -131,7 +131,7 @@ func resourceCosmosDbGremlinGraph() *pluginsdk.Resource {
 										"None",
 									}
 								}
-								return validation.StringInSlice(keys, features.ThreePointOhBeta())
+								return validation.StringInSlice(keys, !features.ThreePointOhBeta())
 							}(),
 						},
 


### PR DESCRIPTION
Fix issue #16086. The `indexing_mode` property should be case-sensitive in 3.0 model. Also, fix the same issue about azurerm_cosmosdb_gremlin_graph resource.



