### PR TITLE
automation_account_resource: make dsc_*_access_key sensitive

### DIFF
--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -68,12 +68,14 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 			"dsc_primary_access_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"dsc_secondary_access_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"public_network_access_enabled": {
 				Type:     pluginsdk.TypeBool,


### PR DESCRIPTION
Access keys are considered sensitive and should be hidden by Terraform