### PR TITLE
Adding to `azurerm_cdn_frontdoor_custom_domain`

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -61,6 +61,11 @@ func resourceCdnFrontdoorCustomDomain() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"domain_validation_token": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"host_name": {
 				Type:     pluginsdk.TypeString,
 				ForceNew: true,
@@ -219,6 +224,7 @@ func resourceCdnFrontdoorCustomDomainRead(d *pluginsdk.ResourceData, meta interf
 
 	if props := resp.AFDDomainProperties; props != nil {
 		d.Set("domain_validation_state", props.DomainValidationState)
+		d.Set("domain_validation_token", props.ValidationProperties.ValidationToken)
 		d.Set("host_name", props.HostName)
 		d.Set("cdn_frontdoor_profile_id", props.ProfileName)
 

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -73,7 +73,7 @@ func resourceCdnFrontdoorCustomDomain() *pluginsdk.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
-			"frontdoor_cdn_profile_name": {
+			"cdn_frontdoor_profile_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -165,7 +165,8 @@ func resourceCdnFrontdoorCustomDomainCreate(d *pluginsdk.ResourceData, meta inte
 
 	props := track1.AFDDomain{
 		AFDDomainProperties: &track1.AFDDomainProperties{
-			AzureDNSZone:                       expandResourceReference(d.Get("azure_dns_zone").(string)),
+			HostName:                           utils.String(d.Get("host_name").(string)),
+			AzureDNSZone:                       expandResourceReference(d.Get("azure_dns_zone_id").(string)),
 			PreValidatedCustomDomainResourceID: expandResourceReference(d.Get("pre_validated_custom_domain_resource_id").(string)),
 			TLSSettings:                        expandCustomDomainAFDDomainHttpsParameters(d.Get("tls_settings").([]interface{})),
 		},
@@ -219,10 +220,10 @@ func resourceCdnFrontdoorCustomDomainRead(d *pluginsdk.ResourceData, meta interf
 	if props := resp.AFDDomainProperties; props != nil {
 		d.Set("domain_validation_state", props.DomainValidationState)
 		d.Set("host_name", props.HostName)
-		d.Set("frontdoor_cdn_profile_name", props.ProfileName)
+		d.Set("cdn_frontdoor_profile_id", props.ProfileName)
 
-		if err := d.Set("azure_dns_zone", flattenResourceReference(props.AzureDNSZone)); err != nil {
-			return fmt.Errorf("setting `azure_dns_zone`: %+v", err)
+		if err := d.Set("azure_dns_zone_id", flattenResourceReference(props.AzureDNSZone)); err != nil {
+			return fmt.Errorf("setting `azure_dns_zone_id`: %+v", err)
 		}
 
 		if err := d.Set("pre_validated_custom_domain_resource_id", flattenResourceReference(props.PreValidatedCustomDomainResourceID)); err != nil {
@@ -253,7 +254,7 @@ func resourceCdnFrontdoorCustomDomainUpdate(d *pluginsdk.ResourceData, meta inte
 
 	props := track1.AFDDomainUpdateParameters{
 		AFDDomainUpdatePropertiesParameters: &track1.AFDDomainUpdatePropertiesParameters{
-			AzureDNSZone:                       expandResourceReference(d.Get("azure_dns_zone").(string)),
+			AzureDNSZone:                       expandResourceReference(d.Get("azure_dns_zone_id").(string)),
 			PreValidatedCustomDomainResourceID: expandResourceReference(d.Get("pre_validated_custom_domain_resource_id").(string)),
 			TLSSettings:                        expandCustomDomainAFDDomainHttpsParameters(d.Get("tls_settings").([]interface{})),
 		},

--- a/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
@@ -153,8 +153,7 @@ func (r CdnFrontdoorProfileEndpointResource) complete(data acceptance.TestData) 
 resource "azurerm_cdn_frontdoor_endpoint" "test" {
   name                            = "acctest-c-%d"
   cdn_frontdoor_profile_id        = azurerm_cdn_frontdoor_profile.test.id
-  enabled_state                   = true
-  origin_response_timeout_seconds = 120
+  enabled                         = true
 
   tags = {
     ENV = "Test"
@@ -171,8 +170,7 @@ func (r CdnFrontdoorProfileEndpointResource) update(data acceptance.TestData) st
 resource "azurerm_cdn_frontdoor_endpoint" "test" {
   name                            = "acctest-c-%d"
   cdn_frontdoor_profile_id        = azurerm_cdn_frontdoor_profile.test.id
-  enabled_state                   = false
-  origin_response_timeout_seconds = 120
+  enabled                         = false
 
   tags = {
     ENV      = "Test"

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -117,11 +117,6 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
   name                = "acctest-c-%d"
   resource_group_name = azurerm_resource_group.test.name
 
-  identity = {
-    type = "SystemAssigned"
-  }
-
-  location                 = "%s"
   response_timeout_seconds = 0
   sku_name                 = ""
 
@@ -130,7 +125,7 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
     ENV = "Test"
   }
 }
-`, template, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r CdnFrontdoorProfileResource) requiresImport(data acceptance.TestData) string {
@@ -142,11 +137,6 @@ resource "azurerm_cdn_frontdoor_profile" "import" {
   name                = azurerm_cdn_frontdoor_profile.test.name
   resource_group_name = azurerm_resource_group.test.name
 
-  identity = {
-    type = "SystemAssigned"
-  }
-
-  location                 = "%s"
   response_timeout_seconds = 0
   sku_name                 = ""
 
@@ -154,7 +144,7 @@ resource "azurerm_cdn_frontdoor_profile" "import" {
     ENV = "Test"
   }
 }
-`, config, data.Locations.Primary)
+`, config)
 }
 
 func (r CdnFrontdoorProfileResource) complete(data acceptance.TestData) string {
@@ -166,11 +156,6 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
   name                = "acctest-c-%d"
   resource_group_name = azurerm_resource_group.test.name
 
-  identity = {
-    type = "SystemAssigned"
-  }
-
-  location                 = "%s"
   response_timeout_seconds = 0
   sku_name                 = ""
 
@@ -178,7 +163,7 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
     ENV = "Test"
   }
 }
-`, template, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r CdnFrontdoorProfileResource) update(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -120,20 +120,9 @@ func resourceCdnFrontdoorRoute() *pluginsdk.Resource {
 			"custom_domains": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-
-						"id": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
-
-						"active": {
-							Type:     pluginsdk.TypeBool,
-							Computed: true,
-						},
-					},
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validate.FrontdoorCustomDomainID,
 				},
 			},
 
@@ -315,7 +304,7 @@ func resourceCdnFrontdoorRouteRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("setting `cdn_frontdoor_origin_group_id`: %+v", err)
 		}
 
-		if err := d.Set("cdn_frontdoor_rule_set_ids", flattenRouteResourceReferenceArry(props.RuleSets)); err != nil {
+		if err := d.Set("cdn_frontdoor_rule_set_ids", flattenRouteResourceReferenceArray(props.RuleSets)); err != nil {
 			return fmt.Errorf("setting `cdn_frontdoor_rule_set_ids`: %+v", err)
 		}
 
@@ -445,13 +434,13 @@ func expandRouteAfdRouteCacheConfiguration(input []interface{}) *track1.AfdRoute
 func expandRouteActivatedResourceReferenceArray(input []interface{}) *[]track1.ActivatedResourceReference {
 	results := make([]track1.ActivatedResourceReference, 0)
 	for _, item := range input {
-		v := item.(map[string]interface{})
 
 		results = append(results, track1.ActivatedResourceReference{
-			ID: utils.String(v["id"].(string)),
+			ID: utils.String(item.(string)),
 		})
 	}
 	return &results
+
 }
 
 func flattenRouteActivatedResourceReferenceArray(inputs *[]track1.ActivatedResourceReference) []interface{} {
@@ -461,22 +450,14 @@ func flattenRouteActivatedResourceReferenceArray(inputs *[]track1.ActivatedResou
 	}
 
 	for _, input := range *inputs {
-		result := make(map[string]interface{})
-
-		if input.ID != nil {
-			result["id"] = *input.ID
-		}
-
-		if input.IsActive != nil {
-			result["active"] = *input.IsActive
-		}
-		results = append(results, result)
+		results = append(results, *input.ID)
 	}
 
 	return results
+
 }
 
-func flattenRouteResourceReferenceArry(input *[]track1.ResourceReference) []interface{} {
+func flattenRouteResourceReferenceArray(input *[]track1.ResourceReference) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results


### PR DESCRIPTION
Awesome work with PR #15140 @WodansSon! 

I couldn't wait for the final release and have started to test the newly added support for Azure Front Door v2 in my environment based on branch r-frontdoor-profile and made a few minor modifications. 

* `azurerm_cdn_frontdoor_custom_domain`
  * I've made `domain_validation_token` a top-level argument as this is required for further processing when for example creating TXT records for custom domains.
  * Renamed `frontdoor_cdn_profile_name` to `cdn_frontdoor_profile_id` to align with the other resources.
  * Smaller fixes by renaming `azure_dns_zone` to `azure_dns_zone_id`
  * Adding missing `host_name` to custom domain creation

* `azurerm_cdn_frontdoor_profile`
  * Updated some tests to reflect the current set of parameters. Like e.g. removed not existing `identity` block and `location` argument.

For sure not complete, yet.

**Update 03/30 PR https://github.com/heoelri/terraform-provider-azurerm/pull/1** 

Added support for Private Link to the `azurerm_cdn_frontdoor_origin` resource.