### PR TITLE
`azurerm_application_insights` - Remove disable logic for the Azure created Action Group

### DIFF
--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -106,7 +106,7 @@ The `api_management` block supports the following:
 
 The `application_insights` block supports the following:
 
-* `disable_generated_rule` - (Optional) Should the `azurerm_application_insights` resources disable the Azure generated Alert Rule and Action Group during the create step? Defaults to `false`.
+* `disable_generated_rule` - (Optional) Should the `azurerm_application_insights` resources disable the Azure generated Alert Rule during the create step? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
Fixes #16124 

Context: #10563 and #15892

The Action Group can take more than an hour to show up and disabling it doesn't provide much value since it's the Rule triggering the Action Group that caused #10563. Just disabling the Rule should be sufficient for #10563