### PR TITLE
`azurerm_data_factory_linked_service_data_lake_storage_gen2` - change validation to allow for adf parameters to be referenced

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
@@ -52,7 +52,7 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2() *pluginsdk.Resource {
 			"url": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
-				ValidateFunc: validation.IsURLWithHTTPS,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"use_managed_identity": {


### PR DESCRIPTION
fixes #16093