### PR TITLE
Test Fixes - Post 3.0

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
@@ -219,7 +219,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -625,7 +624,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -1697,7 +1697,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -1806,7 +1805,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2004,7 +2002,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2291,7 +2288,6 @@ resource "azurerm_lb_probe" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2398,7 +2394,6 @@ resource "azurerm_lb_probe" "test2" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2498,7 +2493,6 @@ resource "azurerm_lb_probe" "test2" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test2.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]

--- a/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
@@ -231,7 +231,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -628,7 +627,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -2139,7 +2139,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2246,7 +2245,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2436,7 +2434,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2793,7 +2790,6 @@ resource "azurerm_lb_probe" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2899,7 +2895,6 @@ resource "azurerm_lb_probe" "test2" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
@@ -2997,7 +2992,6 @@ resource "azurerm_lb_probe" "test2" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test2.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]

--- a/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
@@ -275,6 +275,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = true
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 

--- a/internal/services/legacy/virtual_machine_scale_set_resource_test.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource_test.go
@@ -4994,7 +4994,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   name                           = "AccTestLBRule"
   protocol                       = "Tcp"
@@ -5138,7 +5137,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   name                           = "AccTestLBRule"
   protocol                       = "Tcp"

--- a/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
+++ b/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
@@ -86,9 +86,8 @@ resource "azurerm_lb_probe" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  name                = "LbRule-%s"
-  resource_group_name = azurerm_resource_group.test.name
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "LbRule-%s"
+  loadbalancer_id = azurerm_lb.test.id
 
   protocol      = "Tcp"
   frontend_port = 3389

--- a/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
@@ -326,6 +326,10 @@ resource "azurerm_synapse_workspace" "test" {
   storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_synapse_spark_pool" "test" {

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource_test.go
@@ -127,7 +127,6 @@ resource "azurerm_lb_probe" "test" {
 
 resource "azurerm_lb_rule" "test" {
   name                           = "AccTestLBRule"
-  resource_group_name            = azurerm_resource_group.test.name
   loadbalancer_id                = azurerm_lb.test.id
   probe_id                       = azurerm_lb_probe.test.id
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]

--- a/internal/services/mariadb/mariadb_server_data_source_test.go
+++ b/internal/services/mariadb/mariadb_server_data_source_test.go
@@ -44,10 +44,9 @@ resource "azurerm_mariadb_server" "test" {
 
   sku_name = "B_Gen5_2"
 
-  storage_mb            = 51200
-  backup_retention_days = 7
-  geo_redundant_backup  = "Disabled"
-
+  storage_mb                   = 51200
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
 
   administrator_login          = "acctestun"
   administrator_login_password = "H@Sh1CoR3!"

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -889,6 +889,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   administrator_password       = "QAZwsx123"
   sku_name                     = "GP_Standard_D4ds_v4"
   geo_redundant_backup_enabled = true
+  version                      = "8.0.21"
 
   storage {
     size_gb           = %d

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -890,6 +890,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   sku_name                     = "GP_Standard_D4ds_v4"
   geo_redundant_backup_enabled = true
   version                      = "8.0.21"
+  zone                         = "1"
 
   storage {
     size_gb           = %d

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -753,6 +753,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
+  version                = "8.0.21"
 
   high_availability {
     mode                      = "ZoneRedundant"
@@ -775,6 +776,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
+  version                = "8.0.21"
 
   high_availability {
     mode                      = "ZoneRedundant"
@@ -814,6 +816,8 @@ resource "azurerm_mysql_flexible_server" "test" {
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
   sku_name               = "GP_Standard_D4ds_v4"
+  version                = "8.0.21"
+  zone                   = "1"
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -828,6 +832,8 @@ resource "azurerm_mysql_flexible_server" "replica" {
   location            = azurerm_resource_group.test.location
   create_mode         = "Replica"
   source_server_id    = azurerm_mysql_flexible_server.test.id
+  version             = "8.0.21"
+  zone                = "1"
 }
 `, r.source(data), data.RandomInteger)
 }
@@ -843,6 +849,8 @@ resource "azurerm_mysql_flexible_server" "replica" {
   create_mode         = "Replica"
   source_server_id    = azurerm_mysql_flexible_server.test.id
   replication_role    = "None"
+  version             = "8.0.21"
+  zone                = "1"
 }
 `, r.source(data), data.RandomInteger)
 }
@@ -913,6 +921,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   administrator_password = "QAZwsx123"
   sku_name               = "GP_Standard_D2ds_v4"
   zone                   = "%s"
+  version                = "8.0.21"
 
   high_availability {
     mode                      = "ZoneRedundant"

--- a/internal/services/mysql/mysql_server_data_source_test.go
+++ b/internal/services/mysql/mysql_server_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceMySQLServerDataSourceMySQLServer_basicFiveSeven(t *testing
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
 				check.That(data.ResourceName).Key("administrator_login").HasValue("acctestun"),
-				check.That(data.ResourceName).Key("auto_grow_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("auto_grow_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("ssl_minimal_tls_version_enforced").HasValue("TLS1_1"),
 				check.That(data.ResourceName).Key("storage_mb").HasValue("51200"),
 				check.That(data.ResourceName).Key("version").HasValue("5.7"),
@@ -39,7 +39,7 @@ func TestAccDataSourceMySQLServerDataSourceMySQLServer_basicEightZero(t *testing
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
 				check.That(data.ResourceName).Key("administrator_login").HasValue("acctestun"),
-				check.That(data.ResourceName).Key("auto_grow_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("auto_grow_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("ssl_minimal_tls_version_enforced").HasValue("TLS1_1"),
 				check.That(data.ResourceName).Key("storage_mb").HasValue("51200"),
 				check.That(data.ResourceName).Key("version").HasValue("8.0"),

--- a/internal/services/network/express_route_gateway_resource_test.go
+++ b/internal/services/network/express_route_gateway_resource_test.go
@@ -160,7 +160,7 @@ resource "azurerm_virtual_hub" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   virtual_wan_id      = azurerm_virtual_wan.test.id
-  address_prefixes    = ["10.0.1.0/24"]
+  address_prefix    = "10.0.1.0/24"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/express_route_gateway_resource_test.go
+++ b/internal/services/network/express_route_gateway_resource_test.go
@@ -160,7 +160,7 @@ resource "azurerm_virtual_hub" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   virtual_wan_id      = azurerm_virtual_wan.test.id
-  address_prefix    = "10.0.1.0/24"
+  address_prefix      = "10.0.1.0/24"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/vpn_gateway_connection_resource_test.go
+++ b/internal/services/network/vpn_gateway_connection_resource_test.go
@@ -599,6 +599,7 @@ resource "azurerm_vpn_site" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   virtual_wan_id      = azurerm_virtual_wan.test.id
+  address_cidrs       = ["10.0.0.0/24"]
   link {
     name       = "link1"
     ip_address = "10.0.0.1"

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -131,7 +131,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		resourceClient := meta.(*clients.Client).Resource.ResourcesClient
 		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
-		err = pluginsdk.Retry(2*time.Minute, func() *pluginsdk.RetryError {
+		err = pluginsdk.Retry(7*time.Minute, func() *pluginsdk.RetryError {
 			results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "provisioningState", utils.Int32(500))
 			if err != nil {
 				return pluginsdk.NonRetryableError(fmt.Errorf("listing resources in %s: %v", *id, err))

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -131,7 +131,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		resourceClient := meta.(*clients.Client).Resource.ResourcesClient
 		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
-		err = pluginsdk.Retry(7*time.Minute, func() *pluginsdk.RetryError {
+		err = pluginsdk.Retry(5*time.Minute, func() *pluginsdk.RetryError {
 			results, err := resourceClient.ListByResourceGroupComplete(ctx, id.ResourceGroup, "", "provisioningState", utils.Int32(500))
 			if err != nil {
 				return pluginsdk.NonRetryableError(fmt.Errorf("listing resources in %s: %v", *id, err))

--- a/internal/services/web/app_service_resource_test.go
+++ b/internal/services/web/app_service_resource_test.go
@@ -2495,6 +2495,8 @@ data "azurerm_storage_account_sas" "test" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }
 


### PR DESCRIPTION
This PR extends the timeout to check for existing resources when deleting resource groups from 2 minutes to 7 minutes