### PR TITLE
add `init_container` to `azurerm_container_group` resource.

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -175,6 +175,60 @@ func resourceContainerGroup() *pluginsdk.Resource {
 				},
 			},
 
+			"init_container": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"image": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"environment_variables": {
+							Type:     pluginsdk.TypeMap,
+							ForceNew: true,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"secure_environment_variables": {
+							Type:      pluginsdk.TypeMap,
+							Optional:  true,
+							ForceNew:  true,
+							Sensitive: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"commands": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+
+						"volume": containerVolumeSchema(),
+					},
+				},
+			},
 			"container": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
@@ -298,102 +352,7 @@ func resourceContainerGroup() *pluginsdk.Resource {
 							},
 						},
 
-						"volume": {
-							Type:     pluginsdk.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"name": {
-										Type:         pluginsdk.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"mount_path": {
-										Type:         pluginsdk.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"read_only": {
-										Type:     pluginsdk.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Default:  false,
-									},
-
-									"share_name": {
-										Type:         pluginsdk.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"storage_account_name": {
-										Type:         pluginsdk.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"storage_account_key": {
-										Type:         pluginsdk.TypeString,
-										Optional:     true,
-										Sensitive:    true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"empty_dir": {
-										Type:     pluginsdk.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Default:  false,
-									},
-
-									"git_repo": {
-										Type:     pluginsdk.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &pluginsdk.Resource{
-											Schema: map[string]*pluginsdk.Schema{
-												"url": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ForceNew: true,
-												},
-
-												"directory": {
-													Type:     pluginsdk.TypeString,
-													Optional: true,
-													ForceNew: true,
-												},
-
-												"revision": {
-													Type:     pluginsdk.TypeString,
-													Optional: true,
-													ForceNew: true,
-												},
-											},
-										},
-									},
-
-									"secret": {
-										Type:      pluginsdk.TypeMap,
-										ForceNew:  true,
-										Optional:  true,
-										Sensitive: true,
-										Elem: &pluginsdk.Schema{
-											Type: pluginsdk.TypeString,
-										},
-									},
-								},
-							},
-						},
+						"volume": containerVolumeSchema(),
 
 						"liveness_probe": SchemaContainerGroupProbe(),
 
@@ -506,6 +465,105 @@ func resourceContainerGroup() *pluginsdk.Resource {
 	}
 }
 
+func containerVolumeSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"mount_path": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"read_only": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+
+				"share_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"storage_account_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"storage_account_key": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"empty_dir": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+
+				"git_repo": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"url": {
+								Type:     pluginsdk.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+
+							"directory": {
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+
+							"revision": {
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+						},
+					},
+				},
+
+				"secret": {
+					Type:      pluginsdk.TypeMap,
+					ForceNew:  true,
+					Optional:  true,
+					Sensitive: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
 func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Containers.GroupsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
@@ -534,9 +592,21 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	diagnosticsRaw := d.Get("diagnostics").([]interface{})
 	diagnostics := expandContainerGroupDiagnostics(diagnosticsRaw)
 	dnsConfig := d.Get("dns_config").([]interface{})
-	containers, containerGroupPorts, containerGroupVolumes, err := expandContainerGroupContainers(d)
+	addedEmptyDirs := map[string]bool{}
+	initContainers, initContainerVolumes, err := expandContainerGroupInitContainers(d, addedEmptyDirs)
 	if err != nil {
 		return err
+	}
+	containers, containerGroupPorts, containerVolumes, err := expandContainerGroupContainers(d, addedEmptyDirs)
+	if err != nil {
+		return err
+	}
+	var containerGroupVolumes []containerinstance.Volume
+	if initContainerVolumes != nil {
+		containerGroupVolumes = initContainerVolumes
+	}
+	if containerGroupVolumes != nil {
+		containerGroupVolumes = append(containerGroupVolumes, containerVolumes...)
 	}
 
 	containerGroup := containerinstance.ContainerGroup{
@@ -544,11 +614,12 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Location: &location,
 		Tags:     tags.Expand(t),
 		ContainerGroupProperties: &containerinstance.ContainerGroupProperties{
+			InitContainers:           initContainers,
 			Containers:               containers,
 			Diagnostics:              diagnostics,
 			RestartPolicy:            containerinstance.ContainerGroupRestartPolicy(restartPolicy),
 			OsType:                   containerinstance.OperatingSystemTypes(OSType),
-			Volumes:                  containerGroupVolumes,
+			Volumes:                  &containerGroupVolumes,
 			ImageRegistryCredentials: expandContainerImageRegistryCredentials(d),
 			DNSConfig:                expandContainerGroupDnsConfig(dnsConfig),
 		},
@@ -667,6 +738,10 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 		containerConfigs := flattenContainerGroupContainers(d, resp.Containers, props.Volumes)
 		if err := d.Set("container", containerConfigs); err != nil {
 			return fmt.Errorf("setting `container`: %+v", err)
+		}
+		initContainerConfigs := flattenInitContainerGroupInitContainers(d, resp.InitContainers, props.Volumes)
+		if err := d.Set("init_container", initContainerConfigs); err != nil {
+			return fmt.Errorf("setting `init_container`: %+v", err)
 		}
 
 		if err := d.Set("image_registry_credential", flattenContainerImageRegistryCredentials(d, props.ImageRegistryCredentials)); err != nil {
@@ -838,13 +913,79 @@ func containerGroupEnsureDetachedFromNetworkProfileRefreshFunc(ctx context.Conte
 	}
 }
 
-func expandContainerGroupContainers(d *pluginsdk.ResourceData) (*[]containerinstance.Container, *[]containerinstance.Port, *[]containerinstance.Volume, error) {
+func expandContainerGroupInitContainers(d *pluginsdk.ResourceData, addedEmptyDirs map[string]bool) (*[]containerinstance.InitContainerDefinition, []containerinstance.Volume, error) {
+	containersConfig := d.Get("init_container").([]interface{})
+	containers := make([]containerinstance.InitContainerDefinition, 0)
+	containerGroupVolumes := make([]containerinstance.Volume, 0)
+	for _, containerConfig := range containersConfig {
+		data := containerConfig.(map[string]interface{})
+
+		name := data["name"].(string)
+		image := data["image"].(string)
+
+		container := containerinstance.InitContainerDefinition{
+			Name: utils.String(name),
+			InitContainerPropertiesDefinition: &containerinstance.InitContainerPropertiesDefinition{
+				Image: utils.String(image),
+			},
+		}
+
+		// Set both sensitive and non-secure environment variables
+		var envVars *[]containerinstance.EnvironmentVariable
+		var secEnvVars *[]containerinstance.EnvironmentVariable
+
+		// Expand environment_variables into slice
+		if v, ok := data["environment_variables"]; ok {
+			envVars = expandContainerEnvironmentVariables(v, false)
+		}
+
+		// Expand secure_environment_variables into slice
+		if v, ok := data["secure_environment_variables"]; ok {
+			secEnvVars = expandContainerEnvironmentVariables(v, true)
+		}
+
+		// Combine environment variable slices
+		*envVars = append(*envVars, *secEnvVars...)
+
+		// Set both secure and non secure environment variables
+		container.EnvironmentVariables = envVars
+
+		if v, ok := data["commands"]; ok {
+			c := v.([]interface{})
+			command := make([]string, 0)
+			for _, v := range c {
+				command = append(command, v.(string))
+			}
+
+			container.Command = &command
+		}
+
+		if v, ok := data["volume"]; ok {
+			volumeMounts, _, err := expandSingleContainerVolume(v)
+			if err != nil {
+				return nil, nil, err
+			}
+			container.VolumeMounts = volumeMounts
+
+			expandedContainerGroupVolumes, err := expandContainerVolume(v, addedEmptyDirs, containerGroupVolumes)
+			if err != nil {
+				return nil, nil, err
+			}
+			containerGroupVolumes = expandedContainerGroupVolumes
+		}
+
+		containers = append(containers, container)
+	}
+
+	return &containers, containerGroupVolumes, nil
+}
+
+func expandContainerGroupContainers(d *pluginsdk.ResourceData, addedEmptyDirs map[string]bool) (*[]containerinstance.Container, *[]containerinstance.Port, []containerinstance.Volume, error) {
 	containersConfig := d.Get("container").([]interface{})
 	containers := make([]containerinstance.Container, 0)
 	containerInstancePorts := make([]containerinstance.Port, 0)
 	containerGroupPorts := make([]containerinstance.Port, 0)
 	containerGroupVolumes := make([]containerinstance.Volume, 0)
-	addedEmptyDirs := map[string]bool{}
 
 	for _, containerConfig := range containersConfig {
 		data := containerConfig.(map[string]interface{})
@@ -936,24 +1077,17 @@ func expandContainerGroupContainers(d *pluginsdk.ResourceData) (*[]containerinst
 		}
 
 		if v, ok := data["volume"]; ok {
-			volumeMounts, containerGroupVolumesPartial, err := expandContainerVolumes(v)
+			volumeMounts, _, err := expandSingleContainerVolume(v)
 			if err != nil {
 				return nil, nil, nil, err
 			}
 			container.VolumeMounts = volumeMounts
-			if containerGroupVolumesPartial != nil {
-				for _, cgVol := range *containerGroupVolumesPartial {
-					if cgVol.EmptyDir != nil {
-						if addedEmptyDirs[*cgVol.Name] {
-							// empty_dir-volumes are allowed to overlap across containers, in fact that is their primary purpose,
-							// but the containerGroup must not declare same name of such volumes twice.
-							continue
-						}
-						addedEmptyDirs[*cgVol.Name] = true
-					}
-					containerGroupVolumes = append(containerGroupVolumes, cgVol)
-				}
+
+			expandedContainerGroupVolumes, err := expandContainerVolume(v, addedEmptyDirs, containerGroupVolumes)
+			if err != nil {
+				return nil, nil, nil, err
 			}
+			containerGroupVolumes = expandedContainerGroupVolumes
 		}
 
 		if v, ok := data["liveness_probe"]; ok {
@@ -1000,7 +1134,28 @@ func expandContainerGroupContainers(d *pluginsdk.ResourceData) (*[]containerinst
 		containerGroupPorts = containerInstancePorts // remove in 3.0 of the provider
 	}
 
-	return &containers, &containerGroupPorts, &containerGroupVolumes, nil
+	return &containers, &containerGroupPorts, containerGroupVolumes, nil
+}
+
+func expandContainerVolume(v interface{}, addedEmptyDirs map[string]bool, containerGroupVolumes []containerinstance.Volume) ([]containerinstance.Volume, error) {
+	_, containerVolumes, err := expandSingleContainerVolume(v)
+	if err != nil {
+		return nil, err
+	}
+	if containerVolumes != nil {
+		for _, cgVol := range *containerVolumes {
+			if cgVol.EmptyDir != nil {
+				if addedEmptyDirs[*cgVol.Name] {
+					// empty_dir-volumes are allowed to overlap across containers, in fact that is their primary purpose,
+					// but the containerGroup must not declare same name of such volumes twice.
+					continue
+				}
+				addedEmptyDirs[*cgVol.Name] = true
+			}
+			containerGroupVolumes = append(containerGroupVolumes, cgVol)
+		}
+	}
+	return containerGroupVolumes, nil
 }
 
 func expandContainerEnvironmentVariables(input interface{}, secure bool) *[]containerinstance.EnvironmentVariable {
@@ -1071,7 +1226,7 @@ func expandContainerImageRegistryCredentials(d *pluginsdk.ResourceData) *[]conta
 	return &output
 }
 
-func expandContainerVolumes(input interface{}) (*[]containerinstance.VolumeMount, *[]containerinstance.Volume, error) {
+func expandSingleContainerVolume(input interface{}) (*[]containerinstance.VolumeMount, *[]containerinstance.Volume, error) {
 	volumesRaw := input.([]interface{})
 
 	if len(volumesRaw) == 0 {
@@ -1295,6 +1450,55 @@ func flattenContainerImageRegistryCredentials(d *pluginsdk.ResourceData, input *
 	return output
 }
 
+func flattenInitContainerGroupInitContainers(d *pluginsdk.ResourceData, initContainers *[]containerinstance.InitContainerDefinition, containerGroupVolumes *[]containerinstance.Volume) []interface{} {
+	if initContainers == nil {
+		return nil
+	}
+	// map old container names to index so we can look up things up
+	nameIndexMap := map[string]int{}
+	for i, c := range d.Get("init_container").([]interface{}) {
+		cfg := c.(map[string]interface{})
+		nameIndexMap[cfg["name"].(string)] = i
+	}
+
+	containerCfg := make([]interface{}, 0, len(*initContainers))
+	for _, container := range *initContainers {
+		// TODO fix this crash point
+		name := *container.Name
+
+		// get index from name
+		index := nameIndexMap[name]
+
+		containerConfig := make(map[string]interface{})
+		containerConfig["name"] = name
+
+		if v := container.Image; v != nil {
+			containerConfig["image"] = *v
+		}
+
+		if container.EnvironmentVariables != nil {
+			if len(*container.EnvironmentVariables) > 0 {
+				containerConfig["environment_variables"] = flattenContainerEnvironmentVariables(container.EnvironmentVariables, false, d, index)
+				containerConfig["secure_environment_variables"] = flattenContainerEnvironmentVariables(container.EnvironmentVariables, true, d, index)
+			}
+		}
+
+		commands := make([]string, 0)
+		if command := container.Command; command != nil {
+			commands = *command
+		}
+		containerConfig["commands"] = commands
+
+		if containerGroupVolumes != nil && container.VolumeMounts != nil {
+			containersConfigRaw := d.Get("container").([]interface{})
+			flattenContainerVolume(containerConfig, containersConfigRaw, *container.Name, container.VolumeMounts, containerGroupVolumes)
+		}
+		containerCfg = append(containerCfg, containerConfig)
+	}
+
+	return containerCfg
+}
+
 func flattenContainerGroupContainers(d *pluginsdk.ResourceData, containers *[]containerinstance.Container, containerGroupVolumes *[]containerinstance.Volume) []interface{} {
 	// map old container names to index so we can look up things up
 	nameIndexMap := map[string]int{}
@@ -1349,11 +1553,6 @@ func flattenContainerGroupContainers(d *pluginsdk.ResourceData, containers *[]co
 		if container.EnvironmentVariables != nil {
 			if len(*container.EnvironmentVariables) > 0 {
 				containerConfig["environment_variables"] = flattenContainerEnvironmentVariables(container.EnvironmentVariables, false, d, index)
-			}
-		}
-
-		if container.EnvironmentVariables != nil {
-			if len(*container.EnvironmentVariables) > 0 {
 				containerConfig["secure_environment_variables"] = flattenContainerEnvironmentVariables(container.EnvironmentVariables, true, d, index)
 			}
 		}
@@ -1365,22 +1564,8 @@ func flattenContainerGroupContainers(d *pluginsdk.ResourceData, containers *[]co
 		containerConfig["commands"] = commands
 
 		if containerGroupVolumes != nil && container.VolumeMounts != nil {
-			// Also pass in the container volume config from schema
-			var containerVolumesConfig *[]interface{}
 			containersConfigRaw := d.Get("container").([]interface{})
-			for _, containerConfigRaw := range containersConfigRaw {
-				data := containerConfigRaw.(map[string]interface{})
-				nameRaw := data["name"].(string)
-				if nameRaw == *container.Name {
-					// found container config for current container
-					// extract volume mounts from config
-					if v, ok := data["volume"]; ok {
-						containerVolumesRaw := v.([]interface{})
-						containerVolumesConfig = &containerVolumesRaw
-					}
-				}
-			}
-			containerConfig["volume"] = flattenContainerVolumes(container.VolumeMounts, containerGroupVolumes, containerVolumesConfig)
+			flattenContainerVolume(containerConfig, containersConfigRaw, *container.Name, container.VolumeMounts, containerGroupVolumes)
 		}
 
 		containerConfig["liveness_probe"] = flattenContainerProbes(container.LivenessProbe)
@@ -1392,37 +1577,26 @@ func flattenContainerGroupContainers(d *pluginsdk.ResourceData, containers *[]co
 	return containerCfg
 }
 
-func flattenContainerEnvironmentVariables(input *[]containerinstance.EnvironmentVariable, isSecure bool, d *pluginsdk.ResourceData, oldContainerIndex int) map[string]interface{} {
-	output := make(map[string]interface{})
-
-	if input == nil {
-		return output
-	}
-
-	if isSecure {
-		for _, envVar := range *input {
-			if envVar.Name != nil && envVar.Value == nil {
-				envVarValue := d.Get(fmt.Sprintf("container.%d.secure_environment_variables.%s", oldContainerIndex, *envVar.Name))
-				output[*envVar.Name] = envVarValue
-			}
-		}
-	} else {
-		for _, envVar := range *input {
-			if envVar.Name != nil && envVar.Value != nil {
-				log.Printf("[DEBUG] NOT SECURE: Name: %s - Value: %s", *envVar.Name, *envVar.Value)
-				output[*envVar.Name] = *envVar.Value
+func flattenContainerVolume(containerConfig map[string]interface{}, containersConfigRaw []interface{}, containerName string, volumeMounts *[]containerinstance.VolumeMount, containerGroupVolumes *[]containerinstance.Volume) {
+	// Also pass in the container volume config from schema
+	var containerVolumesConfig *[]interface{}
+	for _, containerConfigRaw := range containersConfigRaw {
+		data := containerConfigRaw.(map[string]interface{})
+		nameRaw := data["name"].(string)
+		if nameRaw == containerName {
+			// found container config for current container
+			// extract volume mounts from config
+			if v, ok := data["volume"]; ok {
+				containerVolumesRaw := v.([]interface{})
+				containerVolumesConfig = &containerVolumesRaw
 			}
 		}
 	}
-
-	return output
-}
-
-func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, containerGroupVolumes *[]containerinstance.Volume, containerVolumesConfig *[]interface{}) []interface{} {
 	volumeConfigs := make([]interface{}, 0)
 
 	if volumeMounts == nil {
-		return volumeConfigs
+		containerConfig["volume"] = nil
+		return
 	}
 
 	for _, vm := range *volumeMounts {
@@ -1482,7 +1656,33 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 		volumeConfigs = append(volumeConfigs, volumeConfig)
 	}
 
-	return volumeConfigs
+	containerConfig["volume"] = volumeConfigs
+}
+
+func flattenContainerEnvironmentVariables(input *[]containerinstance.EnvironmentVariable, isSecure bool, d *pluginsdk.ResourceData, oldContainerIndex int) map[string]interface{} {
+	output := make(map[string]interface{})
+
+	if input == nil {
+		return output
+	}
+
+	if isSecure {
+		for _, envVar := range *input {
+			if envVar.Name != nil && envVar.Value == nil {
+				envVarValue := d.Get(fmt.Sprintf("container.%d.secure_environment_variables.%s", oldContainerIndex, *envVar.Name))
+				output[*envVar.Name] = envVarValue
+			}
+		}
+	} else {
+		for _, envVar := range *input {
+			if envVar.Name != nil && envVar.Value != nil {
+				log.Printf("[DEBUG] NOT SECURE: Name: %s - Value: %s", *envVar.Name, *envVar.Value)
+				output[*envVar.Name] = *envVar.Value
+			}
+		}
+	}
+
+	return output
 }
 
 func flattenGitRepoVolume(input *containerinstance.GitRepoVolume) []interface{} {

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -739,7 +739,7 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 		if err := d.Set("container", containerConfigs); err != nil {
 			return fmt.Errorf("setting `container`: %+v", err)
 		}
-		initContainerConfigs := flattenInitContainerGroupInitContainers(d, resp.InitContainers, props.Volumes)
+		initContainerConfigs := flattenContainerGroupInitContainers(d, resp.InitContainers, props.Volumes)
 		if err := d.Set("init_container", initContainerConfigs); err != nil {
 			return fmt.Errorf("setting `init_container`: %+v", err)
 		}
@@ -1450,7 +1450,7 @@ func flattenContainerImageRegistryCredentials(d *pluginsdk.ResourceData, input *
 	return output
 }
 
-func flattenInitContainerGroupInitContainers(d *pluginsdk.ResourceData, initContainers *[]containerinstance.InitContainerDefinition, containerGroupVolumes *[]containerinstance.Volume) []interface{} {
+func flattenContainerGroupInitContainers(d *pluginsdk.ResourceData, initContainers *[]containerinstance.InitContainerDefinition, containerGroupVolumes *[]containerinstance.Volume) []interface{} {
 	if initContainers == nil {
 		return nil
 	}

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -565,6 +565,36 @@ func TestAccContainerGroup_emptyDirVolumeShared(t *testing.T) {
 	})
 }
 
+func TestAccContainerGroup_emptyDirVolumeSharedWithInitContainer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.emptyDirVolumeSharedWithInitContainer(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("ip_address_type"),
+	})
+}
+
+func TestAccContainerGroup_withInitContainer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withInitContainer(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("ip_address_type"),
+	})
+}
+
 func TestAccContainerGroup_secretVolume(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
 	r := ContainerGroupResource{}
@@ -1818,6 +1848,57 @@ resource "azurerm_container_group" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
+func (ContainerGroupResource) emptyDirVolumeSharedWithInitContainer(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroupemptyshared-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "None"
+  os_type             = "Linux"
+  restart_policy      = "Never"
+
+  init_container {
+    name     = "init"
+    image    = "busybox"
+    commands = ["touch", "/sharedempty/file.txt"]
+
+    volume {
+      name       = "logs"
+      mount_path = "/sharedempty"
+      read_only  = false
+      empty_dir  = true
+    }
+  }
+
+  container {
+    name   = "reader"
+    image  = "ubuntu:20.04"
+    cpu    = "1"
+    memory = "1.5"
+
+    volume {
+      name       = "logs"
+      mount_path = "/sharedempty"
+      read_only  = false
+      empty_dir  = true
+    }
+
+    commands = ["/bin/bash", "-c", "timeout 30 watch --interval 1 --errexit \"! cat /sharedempty/file.txt\""]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
 func (ContainerGroupResource) emptyDirVolumeShared(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1866,6 +1947,43 @@ resource "azurerm_container_group" "test" {
     }
 
     commands = ["/bin/bash", "-c", "timeout 30 watch --interval 1 --errexit \"! cat /sharedempty/file.txt\""]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ContainerGroupResource) withInitContainer(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroupemptyshared-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "None"
+  os_type             = "Linux"
+  restart_policy      = "Never"
+
+  init_container {
+    name     = "init"
+    image    = "busybox"
+    commands = ["echo", "hello from init"]
+  }
+
+  container {
+    name   = "hw"
+    image  = "ubuntu:20.04"
+    cpu    = "1"
+    memory = "1.5"
+
+    commands = ["echo", "hello from ubuntu"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
+* `init_container` - (Optional) The definition of an init container that is part of the group as documented in the `init_container` block below. Changing this forces a new resource to be created.
+
 * `container` - (Required) The definition of a container that is part of the group as documented in the `container` block below. Changing this forces a new resource to be created.
 
 * `os_type` - (Required) The OS for the container group. Allowed values are `Linux` and `Windows`. Changing this forces a new resource to be created.
@@ -107,6 +109,22 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Container Group.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
+
+An `init_container` block supports:
+
+* `name` - (Required) Specifies the name of the Container. Changing this forces a new resource to be created.
+
+* `image` - (Required) The container image name. Changing this forces a new resource to be created.
+
+* `environment_variables` - (Optional) A list of environment variables to be set on the container. Specified as a map of name/value pairs. Changing this forces a new resource to be created.
+
+* `secure_environment_variables` - (Optional) A list of sensitive environment variables to be set on the container. Specified as a map of name/value pairs. Changing this forces a new resource to be created.
+
+* `commands` - (Optional) A list of commands which should be run on the container. Changing this forces a new resource to be created.
+
+* `volume` - (Optional) The definition of a volume mount for this container as documented in the `volume` block below. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
An enhancement as #8085 described. 
Two acc tests failed, but they also failed on the main branch, and since these two cases involved no volume at all, I think the failure is irrelevant to this pr.

=== RUN   TestAccContainerGroup_SystemAssignedIdentity
=== PAUSE TestAccContainerGroup_SystemAssignedIdentity
=== CONT  TestAccContainerGroup_SystemAssignedIdentity
--- PASS: TestAccContainerGroup_SystemAssignedIdentity (254.60s)
=== RUN   TestAccContainerGroup_SystemAssignedIdentityNoNetwork
=== PAUSE TestAccContainerGroup_SystemAssignedIdentityNoNetwork
=== CONT  TestAccContainerGroup_SystemAssignedIdentityNoNetwork
--- PASS: TestAccContainerGroup_SystemAssignedIdentityNoNetwork (189.04s)
=== RUN   TestAccContainerGroup_UserAssignedIdentity
=== PAUSE TestAccContainerGroup_UserAssignedIdentity
=== CONT  TestAccContainerGroup_UserAssignedIdentity
--- PASS: TestAccContainerGroup_UserAssignedIdentity (192.73s)
=== RUN   TestAccContainerGroup_multipleAssignedIdentities
=== PAUSE TestAccContainerGroup_multipleAssignedIdentities
=== CONT  TestAccContainerGroup_multipleAssignedIdentities
--- PASS: TestAccContainerGroup_multipleAssignedIdentities (261.77s)
=== RUN   TestAccContainerGroup_imageRegistryCredentials
=== PAUSE TestAccContainerGroup_imageRegistryCredentials
=== CONT  TestAccContainerGroup_imageRegistryCredentials
--- PASS: TestAccContainerGroup_imageRegistryCredentials (198.96s)
=== RUN   TestAccContainerGroup_imageRegistryCredentialsUpdate
=== PAUSE TestAccContainerGroup_imageRegistryCredentialsUpdate
=== CONT  TestAccContainerGroup_imageRegistryCredentialsUpdate
--- PASS: TestAccContainerGroup_imageRegistryCredentialsUpdate (294.66s)
=== RUN   TestAccContainerGroup_logTypeUnset
=== PAUSE TestAccContainerGroup_logTypeUnset
=== CONT  TestAccContainerGroup_logTypeUnset
--- PASS: TestAccContainerGroup_logTypeUnset (257.66s)
=== RUN   TestAccContainerGroup_linuxBasic
=== PAUSE TestAccContainerGroup_linuxBasic
=== CONT  TestAccContainerGroup_linuxBasic
--- PASS: TestAccContainerGroup_linuxBasic (236.79s)
=== RUN   TestAccContainerGroup_exposedPort
=== PAUSE TestAccContainerGroup_exposedPort
=== CONT  TestAccContainerGroup_exposedPort
--- PASS: TestAccContainerGroup_exposedPort (234.27s)
=== RUN   TestAccContainerGroup_requiresImport
=== PAUSE TestAccContainerGroup_requiresImport
=== CONT  TestAccContainerGroup_requiresImport
--- PASS: TestAccContainerGroup_requiresImport (267.85s)
=== RUN   TestAccContainerGroup_linuxBasicUpdate
=== PAUSE TestAccContainerGroup_linuxBasicUpdate
=== CONT  TestAccContainerGroup_linuxBasicUpdate
--- PASS: TestAccContainerGroup_linuxBasicUpdate (345.89s)
=== RUN   TestAccContainerGroup_exposedPortUpdate
=== PAUSE TestAccContainerGroup_exposedPortUpdate
=== CONT  TestAccContainerGroup_exposedPortUpdate
--- PASS: TestAccContainerGroup_exposedPortUpdate (343.57s)
=== RUN   TestAccContainerGroup_linuxBasicTagsUpdate
=== PAUSE TestAccContainerGroup_linuxBasicTagsUpdate
=== CONT  TestAccContainerGroup_linuxBasicTagsUpdate
--- PASS: TestAccContainerGroup_linuxBasicTagsUpdate (245.83s)
=== RUN   TestAccContainerGroup_linuxComplete
=== PAUSE TestAccContainerGroup_linuxComplete
=== CONT  TestAccContainerGroup_linuxComplete
--- PASS: TestAccContainerGroup_linuxComplete (1109.05s)
=== RUN   TestAccContainerGroup_virtualNetwork
=== PAUSE TestAccContainerGroup_virtualNetwork
=== CONT  TestAccContainerGroup_virtualNetwork
--- PASS: TestAccContainerGroup_virtualNetwork (601.34s)
=== RUN   TestAccContainerGroup_virtualNetworkParallel
=== PAUSE TestAccContainerGroup_virtualNetworkParallel
=== CONT  TestAccContainerGroup_virtualNetworkParallel


=== CONT  TestAccContainerGroup_virtualNetworkParallel
    testcase.go:110: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating/updating Container Group: (Name "acctestcontainergroup-3-220401072256128039" / Resource Group "acctestRG-220401072256128039"): containerinstance.ContainerGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: context deadline exceeded
        
          with azurerm_container_group.test[3],
          on terraform_plugin_test.tf line 49, in resource "azurerm_container_group" "test":
          49: resource "azurerm_container_group" "test" {
        
        
        Error: creating/updating Container Group: (Name "acctestcontainergroup-2-220401072256128039" / Resource Group "acctestRG-220401072256128039"): containerinstance.ContainerGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: context deadline exceeded
        
          with azurerm_container_group.test[2],
          on terraform_plugin_test.tf line 49, in resource "azurerm_container_group" "test":
          49: resource "azurerm_container_group" "test" {
        
        
        Error: waiting for creation/update of Container Group: (Name "acctestcontainergroup-0-220401072256128039" / Resource Group "acctestRG-220401072256128039"): Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
        
          with azurerm_container_group.test[0],
          on terraform_plugin_test.tf line 49, in resource "azurerm_container_group" "test":
          49: resource "azurerm_container_group" "test" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Network Profile: (Name "testnetprofile" / Resource Group "acctestRG-220401072256128039"): network.ProfilesClient#Delete: Failure sending request: StatusCode=400 -- Original Error: Code="NetworkProfileAlreadyInUseWithContainerNics" Message="Network profile /subscriptions/#############/resourceGroups/acctestRG-220401072256128039/providers/Microsoft.Network/networkProfiles/testnetprofile is already in use with container nics 78c2a01f-abd3-45c4-89b7-a6cc87bfe452_testcnic; cannot update or delete" Details=[]
        
--- FAIL: TestAccContainerGroup_virtualNetworkParallel (1985.03s)

=== RUN   TestAccContainerGroup_SystemAssignedIdentityVirtualNetwork
=== PAUSE TestAccContainerGroup_SystemAssignedIdentityVirtualNetwork
=== CONT  TestAccContainerGroup_SystemAssignedIdentityVirtualNetwork
--- PASS: TestAccContainerGroup_SystemAssignedIdentityVirtualNetwork (557.03s)
=== RUN   TestAccContainerGroup_windowsBasic
=== PAUSE TestAccContainerGroup_windowsBasic
=== CONT  TestAccContainerGroup_windowsBasic
--- PASS: TestAccContainerGroup_windowsBasic (850.83s)
=== RUN   TestAccContainerGroup_windowsComplete
=== PAUSE TestAccContainerGroup_windowsComplete
=== CONT  TestAccContainerGroup_windowsComplete
--- PASS: TestAccContainerGroup_windowsComplete (1102.55s)
=== RUN   TestAccContainerGroup_withPrivateEmpty
=== PAUSE TestAccContainerGroup_withPrivateEmpty

=== CONT  TestAccContainerGroup_withPrivateEmpty
--- PASS: TestAccContainerGroup_withPrivateEmpty (237.46s)
=== RUN   TestAccContainerGroup_gitRepoVolume
=== PAUSE TestAccContainerGroup_gitRepoVolume
=== CONT  TestAccContainerGroup_gitRepoVolume
=== CONT  TestAccContainerGroup_gitRepoVolume
    testcase.go:110: Step 1/2 error: Error running apply: exit status 1
        
        Error: waiting for creation/update of Container Group: (Name "acctestcontainergroup-220401072256129704" / Resource Group "acctestRG-220401072256129704"): Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
        
          with azurerm_container_group.test,
          on terraform_plugin_test.tf line 11, in resource "azurerm_container_group" "test":
          11: resource "azurerm_container_group" "test" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "acctestRG-220401072256129704": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        * `/subscriptions/#############/resourceGroups/acctestRG-220401072256129704/providers/Microsoft.ContainerInstance/containerGroups/acctestcontainergroup-220401072256129704`
        
        This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some
        other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or
        disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features`
        block when configuring the Provider, for example:
        
        provider "azurerm" {
          features {
            resource_group {
              prevent_deletion_if_contains_resources = false
            }
          }
        }
        
        When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and
        delete this using the Azure API directly (which will clear up any nested resources).
        
        More information on the `features` block can be found in the documentation:
        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#features
        
        
--- FAIL: TestAccContainerGroup_gitRepoVolume (1983.19s)

=== RUN   TestAccContainerGroup_emptyDirVolume
=== PAUSE TestAccContainerGroup_emptyDirVolume
=== CONT  TestAccContainerGroup_emptyDirVolume
--- PASS: TestAccContainerGroup_emptyDirVolume (250.14s)
=== RUN   TestAccContainerGroup_emptyDirVolumeShared
=== PAUSE TestAccContainerGroup_emptyDirVolumeShared
=== CONT  TestAccContainerGroup_emptyDirVolumeShared
--- PASS: TestAccContainerGroup_emptyDirVolumeShared (248.67s)
=== RUN   TestAccContainerGroup_emptyDirVolumeSharedWithInitContainer
=== PAUSE TestAccContainerGroup_emptyDirVolumeSharedWithInitContainer
=== CONT  TestAccContainerGroup_emptyDirVolumeSharedWithInitContainer
--- PASS: TestAccContainerGroup_emptyDirVolumeSharedWithInitContainer (251.73s)
=== RUN   TestAccContainerGroup_withInitContainer
=== PAUSE TestAccContainerGroup_withInitContainer
=== CONT  TestAccContainerGroup_withInitContainer
--- PASS: TestAccContainerGroup_withInitContainer (242.59s)
=== RUN   TestAccContainerGroup_secretVolume
=== PAUSE TestAccContainerGroup_secretVolume
=== CONT  TestAccContainerGroup_secretVolume
--- PASS: TestAccContainerGroup_secretVolume (248.69s)
FAIL