### PR TITLE
`data.azurerm_management_group` - Add new attributes: `management_group_ids`, `all_management_group_ids` and `all_subscription_ids`

### DIFF
--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -40,7 +40,13 @@ The following attributes are exported:
 
 * `parent_management_group_id` - The ID of any Parent Management Group.
 
-* `subscription_ids` - A list of Subscription IDs which are assigned to the Management Group.
+* `management_group_ids` - A list of Management Group IDs which directly belong to this Management Group.
+
+* `subscription_ids` - A list of Subscription IDs which are directly assigned to this Management Group.
+
+* `all_management_group_ids` - A list of Management Group IDs which directly or indirectly belong to this Management Group.
+
+* `all_subscription_ids` - A list of Subscription IDs which are assigned to this Management Group or its children Management Groups.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #16168 

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/managementgroup -run='TestAccManagementGroupDataSource_nestedManagmentGroup'
=== RUN   TestAccManagementGroupDataSource_nestedManagmentGroup
=== PAUSE TestAccManagementGroupDataSource_nestedManagmentGroup
=== CONT  TestAccManagementGroupDataSource_nestedManagmentGroup
--- PASS: TestAccManagementGroupDataSource_nestedManagmentGroup (190.92s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup       190.928s
```