### PR TITLE
Fix `azurerm_public_ip` docs around default zone redundant behavior

### DIFF
--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `zones` - (Optional) A collection containing the availability zone to allocate the Public IP in.
 
--> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Public IP Addresses that do not specify a zone are zone redundant by default.
+-> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Public IP Addresses that do not specify a zone are **not** zone-redundant by default.
 
 * `domain_name_label` - (Optional) Label for the Domain Name. Will be used to make up the FQDN.  If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
 


### PR DESCRIPTION
This was a breaking change in 3.0 and the docs do not reflect this.

Mentioned here https://github.com/hashicorp/terraform-provider-azurerm/issues/16125#issuecomment-1081798939

I also wonder if this should be mentioned more clearly in the upgrading guide. Its not like most of the other instances where `terraform validate` will show you what to change. If you don't change your template code here, you automatically end up with very much undesired new state.