### PR TITLE
azurerm_cosmosdb_sql_container: fix issue about removing analytical_storage_ttl needs to force replacement

### DIFF
--- a/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -1,6 +1,7 @@
 package cosmos
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -126,6 +127,13 @@ func resourceCosmosDbSQLContainer() *pluginsdk.Resource {
 			},
 			"indexing_policy": common.CosmosDbIndexingPolicySchema(),
 		},
+
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			// The analytical_storage_ttl cannot be changed back once enabled on an existing container. -> we need ForceNew
+			pluginsdk.ForceNewIfChange("analytical_storage_ttl", func(ctx context.Context, old, new, _ interface{}) bool {
+				return (old.(int) == -1 || old.(int) > 0) && new.(int) == 0
+			}),
+		),
 	}
 }
 

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -73,6 +73,20 @@ func TestAccCosmosDbSqlContainer_analyticalStorageTTL(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.analyticalStorageTTL_removed(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.analyticalStorageTTL(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -321,6 +335,26 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   database_name          = azurerm_cosmosdb_sql_database.test.name
   partition_key_path     = "/definition/id"
   analytical_storage_ttl = 600
+}
+`, CosmosDBAccountResource{}.analyticalStorage(data, "GlobalDocumentDB", documentdb.DefaultConsistencyLevelEventual), data.RandomInteger, data.RandomInteger)
+}
+
+func (CosmosSqlContainerResource) analyticalStorageTTL_removed(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/definition/id"
 }
 `, CosmosDBAccountResource{}.analyticalStorage(data, "GlobalDocumentDB", documentdb.DefaultConsistencyLevelEventual), data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
-* `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this SQL container. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
+* `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this SQL container. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time. Changing this forces a new Cosmos DB SQL Container to be created when removing `analytical_storage_ttl` on an existing Cosmos DB SQL Container.
 
 * `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
 


### PR DESCRIPTION
The purpose of this PR:

> 
> Since the `analytical_storage_ttl` could not be changed back once enabled on an existing container, so it needs to force replacement in this case. 
> 
> Fix issue #16183 .

TestResult:

> PASS: TestAccCosmosDbSqlContainer_analyticalStorageTTL (1306.66s)