### PR TITLE
Fixing Route Server Example

### DIFF
--- a/website/docs/r/virtual_hub_bgp_connection.html.markdown
+++ b/website/docs/r/virtual_hub_bgp_connection.html.markdown
@@ -29,7 +29,8 @@ resource "azurerm_public_ip" "example" {
   name                = "example-pip"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_virtual_network" "example" {

--- a/website/docs/r/virtual_hub_ip.html.markdown
+++ b/website/docs/r/virtual_hub_ip.html.markdown
@@ -31,7 +31,8 @@ resource "azurerm_public_ip" "example" {
   name                = "example-pip"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_virtual_network" "example" {


### PR DESCRIPTION
This update resolves the following error when deploying Azure Route Server from the example code:

│ Error: waiting on creating/updating future for Virtual Hub Ip Configuration: (Ip Configuration Name "example-vhubip" / Virtual Hub Name "example-vhub" / Resource Group "example-resources"): Code="InvalidOperation" Message="The specified operation 'PutHubIpConfiguration' is not supported. Route Server creation requires a public ip address of Standard SKU. Please recreate Route Server with Standard SKU public ip address." Details=[]