### PR TITLE
Fix for azurerm_api_management_api_operation with default sample representations

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -379,7 +379,7 @@ resource "azurerm_api_management_api_operation" "test" {
       content_type = "application/xml"
 
       example {
-        name  = "sample"
+        name  = "default"
         value = <<SAMPLE
 <response>
   <user name="bravo24">

--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -379,7 +379,7 @@ resource "azurerm_api_management_api_operation" "test" {
       content_type = "application/xml"
 
       example {
-        name  = "default"
+        name  = "sample"
         value = <<SAMPLE
 <response>
   <user name="bravo24">

--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -202,14 +202,6 @@ func FlattenApiManagementOperationRepresentation(input *[]apimanagement.Represen
 				return nil, err
 			}
 			output["example"] = example
-
-			if !features.ThreePointOhBeta() && v.Examples["default"] != nil && v.Examples["default"].Value != nil {
-				value, err := convert2Json(v.Examples["default"].Value)
-				if err != nil {
-					return nil, err
-				}
-				output["sample"] = value
-			}
 		}
 
 		if v.SchemaID != nil {


### PR DESCRIPTION
This PR comes in a series of 3 commits:
* first, change the tests, so they start to fail (with `panic: Invalid address to set: []string{"response", "0", "representation", "0", "sample"}`)
* fix the code (or rather remove)
* restore the original test case, as special case handling was removed from the code

```
==> Fixing source code with gofmt...
# This logic should match the search logic in scripts/gofmtcheck.sh
find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
go generate ./internal/services/...
go generate ./internal/provider/
go install
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/apimanagement -run=TestAccApiManagementApiOperation -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementApiOperation_basic
=== PAUSE TestAccApiManagementApiOperation_basic
=== RUN   TestAccApiManagementApiOperation_requiresImport
=== PAUSE TestAccApiManagementApiOperation_requiresImport
=== RUN   TestAccApiManagementApiOperation_customMethod
=== PAUSE TestAccApiManagementApiOperation_customMethod
=== RUN   TestAccApiManagementApiOperation_headers
=== PAUSE TestAccApiManagementApiOperation_headers
=== RUN   TestAccApiManagementApiOperation_requestRepresentations
=== PAUSE TestAccApiManagementApiOperation_requestRepresentations
=== RUN   TestAccApiManagementApiOperation_representations
=== PAUSE TestAccApiManagementApiOperation_representations
=== RUN   TestAccApiManagementApiOperationTag_basic
=== PAUSE TestAccApiManagementApiOperationTag_basic
=== RUN   TestAccApiManagementApiOperationTag_requiresImport
=== PAUSE TestAccApiManagementApiOperationTag_requiresImport
=== RUN   TestAccApiManagementApiOperationTag_update
=== PAUSE TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperation_basic
=== CONT  TestAccApiManagementApiOperation_representations
=== CONT  TestAccApiManagementApiOperation_headers
=== CONT  TestAccApiManagementApiOperationTag_basic
=== CONT  TestAccApiManagementApiOperation_requestRepresentations
=== CONT  TestAccApiManagementApiOperationTag_requiresImport
=== CONT  TestAccApiManagementApiOperationTag_update
=== CONT  TestAccApiManagementApiOperation_customMethod
--- PASS: TestAccApiManagementApiOperation_basic (348.17s)
=== CONT  TestAccApiManagementApiOperation_requiresImport
--- PASS: TestAccApiManagementApiOperation_headers (348.55s)
--- PASS: TestAccApiManagementApiOperation_customMethod (349.86s)
--- PASS: TestAccApiManagementApiOperationTag_basic (351.53s)
--- PASS: TestAccApiManagementApiOperationTag_requiresImport (367.25s)
--- PASS: TestAccApiManagementApiOperation_requestRepresentations (391.96s)
--- PASS: TestAccApiManagementApiOperation_representations (398.59s)
--- PASS: TestAccApiManagementApiOperationTag_update (448.37s)
--- PASS: TestAccApiManagementApiOperation_requiresImport (357.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 705.803s

```

Closes #16271