### PR TITLE
Fix issue - the get throughput api should not be called when cosmos account is serverless

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource_test.go
@@ -103,6 +103,21 @@ func TestAccCosmosDbCassandraKeyspace_autoscale(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbCassandraKeyspace_serverless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_keyspace", "test")
+	r := CosmosDbCassandraKeyspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serverless(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t CosmosDbCassandraKeyspaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.CassandraKeyspaceID(state.ID)
 	if err != nil {
@@ -156,4 +171,16 @@ resource "azurerm_cosmosdb_cassandra_keyspace" "test" {
   }
 }
 `, CosmosDBAccountResource{}.capabilities(data, documentdb.DatabaseAccountKindGlobalDocumentDB, []string{"EnableCassandra"}), data.RandomInteger, maxThroughput)
+}
+
+func (CosmosDbCassandraKeyspaceResource) serverless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_cassandra_keyspace" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+`, CosmosDBAccountResource{}.capabilities(data, documentdb.DatabaseAccountKindGlobalDocumentDB, []string{"EnableCassandra", "EnableServerless"}), data.RandomInteger)
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -74,6 +74,21 @@ func TestAccCosmosDbCassandraTable_autoScaleSetting(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbCassandraTable_serverless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
+	r := CosmosDBCassandraTableResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serverless(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCosmosDbCassandraTable_analyticalStorageTTL(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_table", "test")
 	r := CosmosDBCassandraTableResource{}
@@ -242,4 +257,31 @@ resource "azurerm_cosmosdb_cassandra_table" "test" {
   }
 }
 `, r.analyticalStorageTTLTemplate(data), data.RandomInteger)
+}
+
+func (CosmosDBCassandraTableResource) serverless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_cassandra_table" "test" {
+  name                  = "acctest-CCASST-%[2]d"
+  cassandra_keyspace_id = azurerm_cosmosdb_cassandra_keyspace.test.id
+
+  schema {
+    column {
+      name = "test1"
+      type = "ascii"
+    }
+
+    column {
+      name = "test2"
+      type = "int"
+    }
+
+    partition_key {
+      name = "test1"
+    }
+  }
+}
+`, CosmosDbCassandraKeyspaceResource{}.serverless(data), data.RandomInteger)
 }


### PR DESCRIPTION
 A customer is facing an issue when trying to deploy a Cosmos DB + Gremlin API account with serverless enabled. 
The error is as follows:

> `Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Message: {\"code\":\"BadRequest\",\"message\":\"Reading or replacing offers is not supported for serverless accounts.\\r\\nActivityId: 0c5be017-0686-425e-9483-aa3b982379f1, Microsoft.Azure.Documents.Common/2.14.0\"}, Request URI: /offers, RequestStats: , SDK: Microsoft.Azure.Documents.Common/2.14.0"`

Affected Resource: 

> azurerm_cosmosdb_gremlin_database.

Per the second description below in the [doc ](https://docs.microsoft.com/en-us/azure/cosmos-db/serverless#using-serverless-resources) about using serverless resources, azurerm_cosmosdb_gremlin_database should not call get throughput api when cosmos account is serverless. So, based on the [#8673](https://github.com/hashicorp/terraform-provider-azurerm/pull/8673), [#9187](https://github.com/hashicorp/terraform-provider-azurerm/pull/9187), [#9311](https://github.com/hashicorp/terraform-provider-azurerm/pull/9311), this PR would skip the "get throughput api" in `resourceCosmosGremlinDatabaseRead` when cosmos account is serverless to fix the above error that customer is facing. Also, fix the same issue for azurerm_cosmosdb_gremlin_graph, azurerm_cosmosdb_cassandra_table and azurerm_cosmosdb_cassandra_keyspace resources together.

>  Provisioning throughput is not required on serverless containers, so the following statements are applicable:
> 
> - > You can't pass any throughput when creating a serverless container and doing so returns an error.
> 
> - > **You can't read or update the throughput on a serverless container and doing so returns an error.**
> 
> - > You can't create a shared throughput database in a serverless account and doing so returns an error.

Test results:

> PASS: TestAccCosmosGremlinDatabase_serverless (996.38s)
> PASS: TestAccCosmosDbGremlinGraph_serverless (1103.18s)
> PASS: TestAccCosmosDbCassandraKeyspace_serverless (1024.82s)
> PASS: TestAccCosmosDbCassandraTable_serverless (1082.60s)