### PR TITLE
`azurerm_media_streaming_endpoint` support Standard Streaming Endpoint

### DIFF
--- a/internal/services/media/media_streaming_endpoint_resource.go
+++ b/internal/services/media/media_streaming_endpoint_resource.go
@@ -67,7 +67,7 @@ func resourceMediaStreamingEndpoint() *pluginsdk.Resource {
 			"scale_units": {
 				Type:         pluginsdk.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 10),
+				ValidateFunc: validation.IntBetween(0, 10),
 			},
 
 			"access_control": {

--- a/internal/services/media/media_streaming_endpoint_resource_test.go
+++ b/internal/services/media/media_streaming_endpoint_resource_test.go
@@ -76,6 +76,21 @@ func TestAccMediaStreamingEndpoint_shouldStopWhenStarted(t *testing.T) {
 	})
 }
 
+func TestAccMediaStreamingEndpoint_standard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_streaming_endpoint", "test")
+	r := MediaStreamingEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.standard(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).Key("scale_units").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r MediaStreamingEndpointResource) Start(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 	id, err := parse.StreamingEndpointID(state.ID)
 	if err != nil {
@@ -171,6 +186,19 @@ resource "azurerm_media_streaming_endpoint" "test" {
   }
   max_cache_age_seconds = 60
 
+}
+`, r.template(data))
+}
+
+func (r MediaStreamingEndpointResource) standard(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_media_streaming_endpoint" "test" {
+  name                        = "endpoint1"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  media_services_account_name = azurerm_media_services_account.test.name
+  scale_units                 = 0
 }
 `, r.template(data))
 }

--- a/website/docs/r/media_streaming_endpoint.html.markdown
+++ b/website/docs/r/media_streaming_endpoint.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Streaming Endpoint should exist. Changing this forces a new Streaming Endpoint to be created.
 
-* `scale_units` - (Required) The number of scale units.
+* `scale_units` - (Required) The number of scale units. To create a Standard Streaming Endpoint set 0. For Premium Streaming Endpoint valid values are between 1 and 10.
 
 ---
 


### PR DESCRIPTION
Hi team

fixes #12684

There is no additional field to set type standard in streaming endpoint, standard streaming endpoint requires to set `scale_unit` = 0. So I am modifying the validation to allow 0 scale units
