### PR TITLE
Fix `data_source_type` for the resource `Log Analytics Linked Storage Account Type`

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
@@ -131,10 +131,10 @@ func resourceLogAnalyticsLinkedStorageAccountRead(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("retrieving Log Analytics Linked Storage Account %q (Resource Group %q / workspaceName %q): %+v", id.LinkedStorageAccountName, id.ResourceGroup, id.WorkspaceName, err)
 	}
 
-	d.Set("data_source_type", resp.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("workspace_resource_id", parse.NewLogAnalyticsWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName).ID())
 	if props := resp.LinkedStorageAccountsProperties; props != nil {
+		d.Set("data_source_type", string(props.DataSourceType))
 		d.Set("storage_account_ids", utils.FlattenStringSlice(props.StorageAccountIds))
 	}
 


### PR DESCRIPTION
When setting the value for the property `data_source_type`, the value should be `DataSourceType` under the `LinkedStorageAccountsProperties`, instead of the `name`

Fix the issue:https://github.com/hashicorp/terraform-provider-azurerm/issues/16234

acc tests:
```
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_basic (483.80s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_complete (547.73s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_ingestion (548.17s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_requiresImport (563.92s)
--- PASS: TestAcclogAnalyticsLinkedStorageAccount_update (1240.96s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  1241.605s

```