### PR TITLE
Mention `se`/`st` fails if has the time offset set, in the document

### DIFF
--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -80,6 +80,8 @@ output "sas_url_query_string" {
 
 * `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
+-> **NOTE:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
+
 * `permissions` - A `permissions` block as defined below.
 
 * `cache_control` - (Optional) The `Cache-Control` response header that is sent when this SAS token is used.

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -86,6 +86,9 @@ output "sas_url_query_string" {
 * `services` - A `services` block as defined below.
 * `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
 * `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+
+-> **NOTE:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
+
 * `permissions` - A `permissions` block as defined below.
 
 ---


### PR DESCRIPTION
When accessing resource via SAS token with `st`/`se` that has time offset, service will return 409 error. This conflicts with the service document: https://docs.microsoft.com/en-us/rest/api/storageservices/formatting-datetime-values. This is tracked in https://github.com/Azure/azure-rest-api-specs/issues/18631.

Mention this in the document.

Fix: #16295