### PR TITLE
virtual_machine_resource: force new on storage_os_disk.name change

### DIFF
--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -246,6 +246,7 @@ func resourceVirtualMachine() *pluginsdk.Resource {
 						"name": {
 							Type:     pluginsdk.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"vhd_uri": {


### PR DESCRIPTION
I get following error when I only change the `name`
in the `storage_os_disk` block:


Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="PropertyChangeNotAllowed" Message="Changing property 'osDisk.name' is not allowed." Target="osDisk.name"
with azurerm_virtual_machine.vm

Forcing recreation of the VM would fix this as the name is set on creation.