### PR TITLE
docs: *_virtual_machine: add note about provision_vm_agent

### DIFF
--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 
+~> **NOTE:** If `provision_vm_agent` is set to `false` then `allow_extension_operations` must also be set to `false`.
+
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group which the Virtual Machine should be assigned to.
 
 * `secret` - (Optional) One or more `secret` blocks as defined below.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -163,6 +163,8 @@ The following arguments are supported:
 
 * `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 
+~> **NOTE:** If `provision_vm_agent` is set to `false` then `allow_extension_operations` must also be set to `false`.
+
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group which the Virtual Machine should be assigned to.
 
 * `secret` - (Optional) One or more `secret` blocks as defined below.


### PR DESCRIPTION
Following error happens when `provision_vm_agent` is `false` but
`allow_extension_operations` is `true` (which is the default):

  Error: `allow_extension_operations` cannot be set to `true` when `provision_vm_agent` is set to `false`
  with azurerm_linux_virtual_machine.vm

Setting `allow_extension_operations` to `false` fixes the error.

Test: manual