### PR TITLE
Updating legacy ServiceBus Subscription id issue

### DIFF
--- a/internal/services/servicebus/migration/subscription.go
+++ b/internal/services/servicebus/migration/subscription.go
@@ -2,10 +2,10 @@ package migration
 
 import (
 	"context"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"log"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )

--- a/internal/services/servicebus/migration/subscription.go
+++ b/internal/services/servicebus/migration/subscription.go
@@ -1,0 +1,132 @@
+package migration
+
+import (
+	"context"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ServiceBusSubscriptionV0ToV1{}
+
+type ServiceBusSubscriptionV0ToV1 struct{}
+
+func (ServiceBusSubscriptionV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"auto_delete_on_idle": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"default_message_ttl": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"lock_duration": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"dead_lettering_on_message_expiration": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"dead_lettering_on_filter_evaluation_error": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"enable_batched_operations": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"max_delivery_count": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"requires_session": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"forward_to": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"forward_dead_lettered_messages_to": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"status": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+	}
+
+	if !features.ThreePointOhBeta() {
+		s["topic_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			Deprecated:    `Deprecated in favor of "topic_id"`,
+			ConflictsWith: []string{"topic_id"},
+		}
+
+		s["namespace_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			Deprecated:    `Deprecated in favor of "topic_id"`,
+			ConflictsWith: []string{"topic_id"},
+		}
+
+		s["resource_group_name"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ValidateFunc:  resourcegroups.ValidateName,
+			Deprecated:    `Deprecated in favor of "topic_id"`,
+			ConflictsWith: []string{"topic_id"},
+		}
+	}
+	return s
+}
+
+func (ServiceBusSubscriptionV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Printf("[DEBUG] Updating 'id' if resource identifier is not in camel-case")
+
+		oldId := rawState["id"].(string)
+		id, err := parse.SubscriptionID(oldId)
+		if err != nil {
+			return nil, err
+		}
+
+		rawState["id"] = id.ID()
+
+		return rawState, nil
+	}
+}

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -2,7 +2,6 @@ package servicebus
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/migration"
 	"log"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -2,6 +2,7 @@ package servicebus
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/migration"
 	"log"
 	"time"
 
@@ -24,6 +25,11 @@ func resourceServiceBusSubscription() *pluginsdk.Resource {
 		Read:   resourceServiceBusSubscriptionRead,
 		Update: resourceServiceBusSubscriptionCreateUpdate,
 		Delete: resourceServiceBusSubscriptionDelete,
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ServiceBusSubscriptionV0ToV1{},
+		}),
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.SubscriptionID(id)

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -66,6 +66,7 @@ func resourceServicebusSubscriptionRuleSchema() map[string]*pluginsdk.Schema {
 				}
 				return []string{}
 			}(),
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"filter_type": {


### PR DESCRIPTION
The resource locator `Microsoft.ServiceBus` of service bus subscription id is not camel-cased. 

Migrating the previous state to correct the resource id issue.

Fixing the issue:https://github.com/hashicorp/terraform-provider-azurerm/issues/16166