### PR TITLE
Allow service principal creds to be used with service endpoint

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -303,10 +303,10 @@ func resourceDataFactoryLinkedServiceBlobStorageRead(d *pluginsdk.ResourceData, 
 			d.Set("tenant_id", blobStorage.Tenant)
 		}
 
+		d.Set("use_managed_identity", false)
 		if blobStorage.ServicePrincipalID != nil {
 			d.Set("service_principal_id", blobStorage.ServicePrincipalID)
-			d.Set("use_managed_identity", false)
-		} else {
+		} else if blobStorage.ServiceEndpoint != nil {
 			d.Set("service_endpoint", blobStorage.ServiceEndpoint)
 			d.Set("use_managed_identity", true)
 		}

--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -227,9 +227,6 @@ func resourceDataFactoryLinkedServiceBlobStorageCreateUpdate(d *pluginsdk.Resour
 		blobStorageProperties.ServicePrincipalID = utils.String(d.Get("service_principal_id").(string))
 		blobStorageProperties.Tenant = utils.String(d.Get("tenant_id").(string))
 		blobStorageProperties.ServicePrincipalKey = &secureString
-		if v, ok := d.GetOk("service_endpoint"); ok {
-			blobStorageProperties.ServiceEndpoint = utils.String(v.(string))
-		}
 	}
 
 	blobStorageLinkedService := &datafactory.AzureBlobStorageLinkedService{


### PR DESCRIPTION
Azure allows to create links between a data factory and a storage blob by using a combination of SP key/id and storage endpoint.

This PR updates the schema and resource logic to reflect that.