### PR TITLE
Fix svc plan SKU typo

### DIFF
--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_linux_web_app" "example" {

--- a/website/docs/r/app_service_source_control_slot.html.markdown
+++ b/website/docs/r/app_service_source_control_slot.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_linux_web_app" "example" {

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_linux_web_app" "example" {

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_linux_web_app" "example" {

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 ```
 

--- a/website/docs/r/web_app_active_slot.html.markdown
+++ b/website/docs/r/web_app_active_slot.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Windows"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_windows_web_app" "example" {
@@ -71,7 +71,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Linux"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_linux_web_app" "example" {

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_service_plan" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_windows_web_app" "example" {

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_service_plan" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = "West Europe"
   os_type             = "Windows"
-  sku_name            = "P1V2"
+  sku_name            = "P1v2"
 }
 
 resource "azurerm_windows_web_app" "example" {


### PR DESCRIPTION
The example in the latest version of `azurerm.azurerm_linux_web_app`, along with other resources using `azurerm_service_plan`, reference a mistyped App Service SKU (`P1V2 --> P1v2`). This PR fixes the examples.

For instance, if you run `terraform plan` with the referenced SKU, you'll get the following error:

```
╷
│ Error: expected sku_name to be one of [B1 B2 B3 S1 S2 S3 P1v2 P2v2 P3v2 P1v3 P2v3 P3v3 Y1 EP1 EP2 EP3 F1 FREE I1 I2 I3 I1v2 I2v2 I3v2 D1 SHARED WS1 WS2 WS3], got P1V2
│
│   with azurerm_service_plan.sample_oidc_app_svc_plan,
│   on main.tf line 135, in resource "azurerm_service_plan" "sample_oidc_app_svc_plan":
│  135:   sku_name            = "P1V2"
│
╵
```