### PR TITLE
Update radius.server_root_certificate of azurerm_vpn_server_configuration to optional

### DIFF
--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -280,7 +280,7 @@ func resourceVPNServerConfiguration() *pluginsdk.Resource {
 
 						"server_root_certificate": {
 							Type:     pluginsdk.TypeSet,
-							Required: true,
+							Optional: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"name": {
@@ -772,7 +772,7 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 }
 
 func flattenVpnServerConfigurationRadius(input *network.VpnServerConfigurationProperties) []interface{} {
-	if input == nil || (input.RadiusServerAddress == nil && input.RadiusServers == nil) || input.RadiusServerRootCertificates == nil || len(*input.RadiusServerRootCertificates) == 0 {
+	if input == nil || (input.RadiusServerAddress == nil && (input.RadiusServers == nil || len(*input.RadiusServers) == 0)) {
 		return []interface{}{}
 	}
 

--- a/internal/services/network/vpn_server_configuration_resource_test.go
+++ b/internal/services/network/vpn_server_configuration_resource_test.go
@@ -181,6 +181,21 @@ func TestAccVPNServerConfiguration_multipleAuthTypes(t *testing.T) {
 	})
 }
 
+func TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withoutRadiusServerRootCertificate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VPNServerConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnServerConfigurationID(state.ID)
 	if err != nil {
@@ -526,6 +541,27 @@ uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
 WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
 M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
 EOF
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VPNServerConfigurationResource) withoutRadiusServerRootCertificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["Radius"]
+
+  radius {
+    server {
+      address = "10.105.1.1"
+      secret  = "vindicators-the-return-of-worldender"
+      score   = 15
+    }
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/website/docs/r/vpn_server_configuration.html.markdown
+++ b/website/docs/r/vpn_server_configuration.html.markdown
@@ -167,7 +167,7 @@ A `radius` block supports the following:
 
 * `client_root_certificate` - (Optional) One or more `client_root_certificate` blocks as defined above.
 
-* `server_root_certificate` - (Required) One or more `server_root_certificate` blocks as defined below.
+* `server_root_certificate` - (Optional) One or more `server_root_certificate` blocks as defined below.
 
 ---
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16359

--- PASS: TestAccVPNServerConfiguration_azureAD (245.85s)
--- PASS: TestAccVPNServerConfiguration_tags (249.44s)
--- PASS: TestAccVPNServerConfiguration_radius (255.30s)
--- PASS: TestAccVPNServerConfiguration_multipleAuthTypes (259.13s)
--- PASS: TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate (272.05s)
--- PASS: TestAccVPNServerConfiguration_requiresImport (290.68s)
--- PASS: TestAccVPNServerConfiguration_certificate (364.22s)
--- PASS: TestAccVPNServerConfiguration_multipleAuth (471.12s)
--- PASS: TestAccVPNServerConfiguration_multipleRadius (575.01s)