### PR TITLE
`r\lb_outbound_rule` Allow `0` for `allocated_outbound_ports`

### DIFF
--- a/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
@@ -101,6 +101,28 @@ func TestAccAzureRMLoadBalancerOutboundRule_withPublicIPPrefix(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLoadBalancerOutboundRule_allocatedOutboundPorts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb_outbound_rule", "test")
+	r := LoadBalancerOutboundRule{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allocatedOutboundPortsDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.allocatedOutboundPortsUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LoadBalancerOutboundRule) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LoadBalancerOutboundRuleID(state.ID)
 	if err != nil {
@@ -449,4 +471,104 @@ resource "azurerm_lb_outbound_rule" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, rg, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LoadBalancerOutboundRule) allocatedOutboundPortsDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "test-ip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "arm-test-loadbalancer-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  loadbalancer_id = azurerm_lb.test.id
+  name            = "be-%d"
+}
+
+resource "azurerm_lb_outbound_rule" "test" {
+  loadbalancer_id         = azurerm_lb.test.id
+  name                    = "OutboundRule-%d"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
+  protocol                = "All"
+
+  frontend_ip_configuration {
+    name = "one-%d"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LoadBalancerOutboundRule) allocatedOutboundPortsUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "test-ip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "arm-test-loadbalancer-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  loadbalancer_id = azurerm_lb.test.id
+  name            = "be-%d"
+}
+
+resource "azurerm_lb_outbound_rule" "test" {
+  loadbalancer_id         = azurerm_lb.test.id
+  name                    = "OutboundRule-%d"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
+  protocol                = "All"
+
+  allocated_outbound_ports = 0
+
+  frontend_ip_configuration {
+    name = "one-%d"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/loadbalancer/outbound_rule_resource.go
+++ b/internal/services/loadbalancer/outbound_rule_resource.go
@@ -99,9 +99,10 @@ func resourceArmLoadBalancerOutboundRule() *pluginsdk.Resource {
 			},
 
 			"allocated_outbound_ports": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Default:  1024,
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      1024,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 
 			"idle_timeout_in_minutes": {
@@ -304,7 +305,8 @@ func resourceArmLoadBalancerOutboundRuleDelete(d *pluginsdk.ResourceData, meta i
 
 func expandAzureRmLoadBalancerOutboundRule(d *pluginsdk.ResourceData, lb *network.LoadBalancer) (*network.OutboundRule, error) {
 	properties := network.OutboundRulePropertiesFormat{
-		Protocol: network.LoadBalancerOutboundRuleProtocol(d.Get("protocol").(string)),
+		Protocol:               network.LoadBalancerOutboundRuleProtocol(d.Get("protocol").(string)),
+		AllocatedOutboundPorts: utils.Int32(int32(d.Get("allocated_outbound_ports").(int))),
 	}
 
 	feConfigs := d.Get("frontend_ip_configuration").([]interface{})
@@ -338,10 +340,6 @@ func expandAzureRmLoadBalancerOutboundRule(d *pluginsdk.ResourceData, lb *networ
 
 	if v, ok := d.GetOk("enable_tcp_reset"); ok {
 		properties.EnableTCPReset = utils.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("allocated_outbound_ports"); ok {
-		properties.AllocatedOutboundPorts = utils.Int32(int32(v.(int)))
 	}
 
 	return &network.OutboundRule{

--- a/website/docs/r/lb_outbound_rule.html.markdown
+++ b/website/docs/r/lb_outbound_rule.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `backend_address_pool_id` - (Required) The ID of the Backend Address Pool. Outbound traffic is randomly load balanced across IPs in the backend IPs.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp`, `Tcp` or `All`.
 * `enable_tcp_reset` - (Optional) Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used when the protocol is set to TCP.
-* `allocated_outbound_ports` - (Optional) The number of outbound ports to be used for NAT.
+* `allocated_outbound_ports` - (Optional) The number of outbound ports to be used for NAT. Defaults to `1024`.
 * `idle_timeout_in_minutes` - (Optional) The timeout for the TCP idle connection
 
 ---


### PR DESCRIPTION
Fix #16343
- `0` seems to be a valid input for `allocated_outbound_ports`, adding validation and use `d.Get` instead of `d.GetOk` to include it.
- Adding the missing default value of `1024` in doc
- There seems to be not test around `allocated_outbound_ports`, adding it as well.