### PR TITLE
azurerm_virtual_network_gateway - not set bgpSettings.BgpPeeringAddress when it isn't specified

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -659,13 +659,11 @@ func expandVirtualNetworkGatewayBgpSettings(id parse.VirtualNetworkGatewayId, d 
 		return nil, err
 	}
 
-	bgpSettings := &network.BgpSettings{
+	return &network.BgpSettings{
 		Asn:                 &asn,
 		PeerWeight:          &peerWeight,
 		BgpPeeringAddresses: peeringAddresses,
-	}
-
-	return bgpSettings, nil
+	}, nil
 }
 
 func expandVirtualNetworkGatewayBgpPeeringAddresses(id parse.VirtualNetworkGatewayId, ipConfig, input []interface{}) (*[]network.IPConfigurationBgpPeeringAddress, error) {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -651,10 +651,6 @@ func expandVirtualNetworkGatewayBgpSettings(id parse.VirtualNetworkGatewayId, d 
 	bgp := bgpSets[0].(map[string]interface{})
 
 	asn := int64(bgp["asn"].(int))
-	var peeringAddress string
-	if !features.ThreePointOhBeta() {
-		peeringAddress = bgp["peering_address"].(string)
-	}
 	peerWeight := int32(bgp["peer_weight"].(int))
 
 	ipConfiguration := d.Get("ip_configuration").([]interface{})
@@ -663,12 +659,19 @@ func expandVirtualNetworkGatewayBgpSettings(id parse.VirtualNetworkGatewayId, d 
 		return nil, err
 	}
 
-	return &network.BgpSettings{
+	bgpSettings := &network.BgpSettings{
 		Asn:                 &asn,
-		BgpPeeringAddress:   &peeringAddress,
 		PeerWeight:          &peerWeight,
 		BgpPeeringAddresses: peeringAddresses,
-	}, nil
+	}
+
+	if !features.ThreePointOhBeta() {
+		var peeringAddress string
+		peeringAddress = bgp["peering_address"].(string)
+		bgpSettings.BgpPeeringAddress = &peeringAddress
+	}
+
+	return bgpSettings, nil
 }
 
 func expandVirtualNetworkGatewayBgpPeeringAddresses(id parse.VirtualNetworkGatewayId, ipConfig, input []interface{}) (*[]network.IPConfigurationBgpPeeringAddress, error) {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -665,12 +665,6 @@ func expandVirtualNetworkGatewayBgpSettings(id parse.VirtualNetworkGatewayId, d 
 		BgpPeeringAddresses: peeringAddresses,
 	}
 
-	if !features.ThreePointOhBeta() {
-		var peeringAddress string
-		peeringAddress = bgp["peering_address"].(string)
-		bgpSettings.BgpPeeringAddress = &peeringAddress
-	}
-
 	return bgpSettings, nil
 }
 
@@ -859,9 +853,6 @@ func flattenVirtualNetworkGatewayBgpSettings(settings *network.BgpSettings) ([]i
 
 		if asn := settings.Asn; asn != nil {
 			flat["asn"] = int(*asn)
-		}
-		if address := settings.BgpPeeringAddress; !features.ThreePointOhBeta() && address != nil {
-			flat["peering_address"] = *address
 		}
 		if weight := settings.PeerWeight; weight != nil {
 			flat["peer_weight"] = int(*weight)

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -372,6 +372,28 @@ func TestAccVirtualNetworkGateway_edgeZone(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkGateway_updateTagsWithBgpSettings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.activeActiveEnableBgpWithAPIPA(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.activeActiveEnableBgpWithAPIPAAndTags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VirtualNetworkGatewayResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	gatewayName := state.Attributes["name"]
 	resourceGroup := state.Attributes["resource_group_name"]
@@ -1611,4 +1633,94 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) activeActiveEnableBgpWithAPIPAAndTags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-ngw-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "first" {
+  name                = "acctestpip1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_public_ip" "second" {
+  name = "acctestpip2-%d"
+
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  depends_on = [
+    azurerm_public_ip.first,
+    azurerm_public_ip.second,
+  ]
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "VpnGw1"
+
+  active_active = true
+  enable_bgp    = true
+
+  ip_configuration {
+    name                 = "gw-ip1"
+    public_ip_address_id = azurerm_public_ip.first.id
+
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  ip_configuration {
+    name                          = "gw-ip2"
+    public_ip_address_id          = azurerm_public_ip.second.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  bgp_settings {
+    asn = "65010"
+    peering_addresses {
+      ip_configuration_name = "gw-ip1"
+      apipa_addresses       = ["169.254.21.1"]
+    }
+    peering_addresses {
+      ip_configuration_name = "gw-ip2"
+      apipa_addresses       = ["169.254.21.2"]
+    }
+  }
+
+  tags = {
+    env = "Test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16285

Symptom:
    At first apply, virtual network gateway resource is created successfully without specifying "bgp_settings.0.peering_address" in TF config. Though this property isn's specified but this property bgpSettings.BgpPeeringAddress would still be set as empty string in request payload based on current TF code. So this property is always set in request body while creating/updating this resource. And then only change the tags property and perform second apply. TF would fail and throw below error message. After investigated, I found the bgpSettings.BgpPeeringAddress has default value while creating this resource with 'bgpSettings.BgpPeeringAddress = ""'. Hence, at second apply, TF is trying to update the bgpSettings.BgpPeeringAddress from default value to emty string but API doesn't allow this operation so that it failed.

Error message:
    network.VirtualNetworkGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="VirtualNetworkGatewayBgpPeeringAddressCannotBeModified" Message="The BgpPeeringAddress for the virtual network gateway /subscriptions/xxxx/resourceGroups/test/providers/Microsoft.Network/virtualNetworkGateways/gw cannot be modified" Details=[]

--- PASS: TestAccVirtualNetworkGateway_edgeZone (614.96s)
--- PASS: TestAccVirtualNetworkGateway_enableBgp (1764.35s)
--- PASS: TestAccVirtualNetworkGateway_generation (1820.26s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfig (1833.48s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth (1881.51s)
--- PASS: TestAccVirtualNetworkGateway_enableBgpWithAPIPA (1895.75s)
--- PASS: TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA (1947.87s)
--- PASS: TestAccVirtualNetworkGateway_updateTagsWithBgpSettings (1990.64s)
--- PASS: TestAccVirtualNetworkGateway_vpnGw3 (1825.05s)
--- PASS: TestAccVirtualNetworkGateway_basic (2645.23s)
--- PASS: TestAccVirtualNetworkGateway_standard (2732.77s)
--- PASS: TestAccVirtualNetworkGateway_expressRoute (2827.16s)
--- PASS: TestAccVirtualNetworkGateway_vpnGw2 (1666.20s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfigMultipleAuthTypes (1927.83s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN (1931.95s)
--- PASS: TestAccVirtualNetworkGateway_vpnGw1 (1917.64s)
--- PASS: TestAccVirtualNetworkGateway_activeActive (1712.41s)
--- PASS: TestAccVirtualNetworkGateway_lowerCaseSubnetName (2677.46s)
--- PASS: TestAccVirtualNetworkGateway_requiresImport (2783.85s)

Below TCs are also failed on Teamcity due to same error.
--- FAIL: TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S (2316.41s)
--- FAIL: TestAccVirtualNetworkGateway_customRoute (2519.14s)
--- FAIL: TestAccVirtualNetworkGateway_privateIpAddressEnabled (2323.57s)