### PR TITLE
`azurerm_cdn_endpoint` - New value for `operator` of `url_path_condition`: `RegEx` and `Wildcard`.

### DIFF
--- a/internal/services/cdn/deliveryruleconditions/url_path.go
+++ b/internal/services/cdn/deliveryruleconditions/url_path.go
@@ -25,6 +25,8 @@ func URLPath() *pluginsdk.Resource {
 					string(cdn.URLPathOperatorGreaterThanOrEqual),
 					string(cdn.URLPathOperatorLessThan),
 					string(cdn.URLPathOperatorLessThanOrEqual),
+					string(cdn.URLPathOperatorRegEx),
+					string(cdn.URLPathOperatorWildcard),
 				}, false),
 			},
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -384,7 +384,7 @@ A `url_file_name_condition` block supports the following:
 
 A `url_path_condition` block supports the following:
 
-* `operator` - (Required) Valid values are `Any`, `BeginsWith`, `Contains`, `EndsWith`, `Equal`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`.
+* `operator` - (Required) Valid values are `Any`, `BeginsWith`, `Contains`, `EndsWith`, `Equal`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `RegEx` and `Wildcard`.
 
 * `negate_condition` - (Optional) Defaults to `false`.
 


### PR DESCRIPTION
Fix #16378

Add new allowed values for `operator` of `url_path_condition`: `RegEx` and `Wildcard`.