### PR TITLE
CI: `validate-example` uses local built provider

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ tools:
 	go install mvdan.cc/gofumpt@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.45.0
 
-build: fmtcheck gdenerate
+build: fmtcheck generate
 	go install
 
 fmt:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ tools:
 	go install mvdan.cc/gofumpt@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.45.0
 
-build: fmtcheck generate
+build: fmtcheck gdenerate
 	go install
 
 fmt:
@@ -129,7 +129,7 @@ teamcity-test:
 	@$(MAKE) -C .teamcity tools
 	@$(MAKE) -C .teamcity test
 
-validate-examples:
+validate-examples: build
 	./scripts/validate-examples.sh
 
 pr-check: generate build test lint tflint website-lint

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -23,7 +23,7 @@ for d in $exampleDirs; do
   exampleHasErrors=false
   # Though we are using the local built azurerm provider to validate example,
   # we still need to call `terraform init` here as examples might contain other providers.
-  terraform -chdir=$d init > /dev/null || exampleHasErrors=true
+  TF_CLI_CONFIG_FILE=$terraformrc terraform -chdir=$d init > /dev/null || exampleHasErrors=true
   if ! ${exampleHasErrors}; then
     # Always use the local built azurerm provider to validate examples, to avoid examples using
     # unreleased features leading to error during CI.

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -6,13 +6,28 @@ exampleDirs=$(find ./examples -mindepth 2 -maxdepth 2 -type d '!' -exec test -e 
 examplesWithErrors=()
 hasError=false
 
+# Setup a local Terraform config file for setting up the dev_overrides for this provider.
+terraformrc=$(mktemp)
+cat << EOF > $terraformrc
+provider_installation {
+  dev_overrides {
+    "hashicorp/azurerm" = "$(go env GOPATH)/bin"
+  }
+  direct {}
+}
+EOF
+
 # first check each example validates via `terraform validate`..
 for d in $exampleDirs; do
   echo "Validating $d.."
   exampleHasErrors=false
+  # Though we are using the local built azurerm provider to validate example,
+  # we still need to call `terraform init` here as examples might contain other providers.
   terraform -chdir=$d init > /dev/null || exampleHasErrors=true
   if ! ${exampleHasErrors}; then
-    terraform -chdir=$d validate > /dev/null || exampleHasErrors=true
+    # Always use the local built azurerm provider to validate examples, to avoid examples using
+    # unreleased features leading to error during CI.
+    TF_CLI_CONFIG_FILE=$terraformrc terraform -chdir=$d validate > /dev/null || exampleHasErrors=true
   fi
   if ${exampleHasErrors}; then
     examplesWithErrors[${#examplesWithErrors[@]}]=$d


### PR DESCRIPTION
`validate-example` uses local built provider to avoid unexpected error
during CI due to incosistency between the example and the latest
released provider version.