### PR TITLE
Add support for columns_to_remove of azurerm_stream_analytics_output_table

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_table_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource.go
@@ -21,15 +21,16 @@ type OutputTableResource struct{}
 var _ sdk.ResourceWithCustomImporter = OutputTableResource{}
 
 type OutputTableResourceModel struct {
-	Name               string `tfschema:"name"`
-	StreamAnalyticsJob string `tfschema:"stream_analytics_job_name"`
-	ResourceGroup      string `tfschema:"resource_group_name"`
-	StorageAccount     string `tfschema:"storage_account_name"`
-	StorageAccountKey  string `tfschema:"storage_account_key"`
-	Table              string `tfschema:"table"`
-	PartitionKey       string `tfschema:"partition_key"`
-	RowKey             string `tfschema:"row_key"`
-	BatchSize          int32  `tfschema:"batch_size"`
+	Name               string   `tfschema:"name"`
+	StreamAnalyticsJob string   `tfschema:"stream_analytics_job_name"`
+	ResourceGroup      string   `tfschema:"resource_group_name"`
+	StorageAccount     string   `tfschema:"storage_account_name"`
+	StorageAccountKey  string   `tfschema:"storage_account_key"`
+	Table              string   `tfschema:"table"`
+	PartitionKey       string   `tfschema:"partition_key"`
+	RowKey             string   `tfschema:"row_key"`
+	BatchSize          int32    `tfschema:"batch_size"`
+	ColumnsToRemove    []string `tfschema:"columns_to_remove"`
 }
 
 func (r OutputTableResource) Arguments() map[string]*pluginsdk.Schema {
@@ -86,6 +87,15 @@ func (r OutputTableResource) Arguments() map[string]*pluginsdk.Schema {
 			Required:     true,
 			ValidateFunc: validation.IntBetween(1, 100),
 		},
+
+		"columns_to_remove": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
 	}
 }
 
@@ -135,6 +145,10 @@ func (r OutputTableResource) Create() sdk.ResourceFunc {
 				PartitionKey: utils.String(model.PartitionKey),
 				RowKey:       utils.String(model.RowKey),
 				BatchSize:    utils.Int32(model.BatchSize),
+			}
+
+			if v := model.ColumnsToRemove; v != nil && len(v) > 0 {
+				tableOutputProps.ColumnsToRemove = &v
 			}
 
 			props := streamanalytics.Output{
@@ -197,6 +211,13 @@ func (r OutputTableResource) Read() sdk.ResourceFunc {
 					RowKey:             *v.RowKey,
 					BatchSize:          *v.BatchSize,
 				}
+
+				var columnsToRemove []string
+				if columns := v.ColumnsToRemove; columns != nil && len(*columns) > 0 {
+					columnsToRemove = *columns
+				}
+				state.ColumnsToRemove = columnsToRemove
+
 				return metadata.Encode(&state)
 			}
 			return nil
@@ -234,6 +255,16 @@ func (r OutputTableResource) Update() sdk.ResourceFunc {
 						},
 					},
 				},
+			}
+
+			tableOutput, ok := props.OutputProperties.Datasource.AsAzureTableOutputDataSource()
+			if !ok {
+				return fmt.Errorf("converting output data source to a table output: %+v", err)
+			}
+			if v := state.ColumnsToRemove; v != nil && len(v) > 0 {
+				tableOutput.ColumnsToRemove = &v
+			} else {
+				tableOutput.ColumnsToRemove = &[]string{}
 			}
 
 			if _, err = client.Update(ctx, props, id.ResourceGroup, id.StreamingjobName, id.Name, ""); err != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_table_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource.go
@@ -89,7 +89,7 @@ func (r OutputTableResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"columns_to_remove": {
-			Type:     pluginsdk.TypeSet,
+			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
@@ -257,14 +257,12 @@ func (r OutputTableResource) Update() sdk.ResourceFunc {
 				},
 			}
 
-			tableOutput, ok := props.OutputProperties.Datasource.AsAzureTableOutputDataSource()
-			if !ok {
-				return fmt.Errorf("converting output data source to a table output: %+v", err)
-			}
-			if v := state.ColumnsToRemove; v != nil && len(v) > 0 {
-				tableOutput.ColumnsToRemove = &v
-			} else {
-				tableOutput.ColumnsToRemove = &[]string{}
+			if metadata.ResourceData.HasChange("columns_to_remove") {
+				tableOutput, ok := props.OutputProperties.Datasource.AsAzureTableOutputDataSource()
+				if !ok {
+					return fmt.Errorf("converting output data source to a table output: %+v", err)
+				}
+				tableOutput.ColumnsToRemove = &state.ColumnsToRemove
 			}
 
 			if _, err = client.Update(ctx, props, id.ResourceGroup, id.StreamingjobName, id.Name, ""); err != nil {

--- a/website/docs/r/stream_analytics_output_table.html.markdown
+++ b/website/docs/r/stream_analytics_output_table.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
 
 * `batch_size` - (Required) The number of records for a batch operation. Must be between `1` and `100`.
 
+* `columns_to_remove` - (Optional) A list of the column names to be removed from output event entities.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 


### PR DESCRIPTION
This PR is to support new property columns_to_remove of azurerm_stream_analytics_output_table.

--- PASS: TestAccStreamAnalyticsOutputTable_basic (273.80s)
--- PASS: TestAccStreamAnalyticsOutputTable_requiresImport (304.54s)
--- PASS: TestAccStreamAnalyticsOutputTable_update (354.57s)
--- PASS: TestAccStreamAnalyticsOutputTable_columnsToRemove (633.89s)