### PR TITLE
Function apps, note about not using FUNCTIONS_WORKER_RUNTIME

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -387,7 +387,9 @@ A `site_config` block supports the following:
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Linux Function App to Application Insights.
 
-* `application_stack` - (Optional) An `application_stack` block as defined above. **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
+* `application_stack` - (Optional) An `application_stack` block as defined above.
+
+~> **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
 
 * `app_service_logs` - (Optional) An `app_service_logs` block as defined above.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -387,7 +387,7 @@ A `site_config` block supports the following:
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Linux Function App to Application Insights.
 
-* `application_stack` - (Optional) An `application_stack` block as defined above.
+* `application_stack` - (Optional) An `application_stack` block as defined above. **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
 
 * `app_service_logs` - (Optional) An `app_service_logs` block as defined above.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -365,7 +365,9 @@ A `site_config` block supports the following:
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights.
 
-* `application_stack` - (Optional) An `application_stack` block as defined above. **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
+* `application_stack` - (Optional) An `application_stack` block as defined above.
+
+~> **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
 
 * `app_service_logs` - (Optional) An `app_service_logs` block as defined above.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -365,7 +365,7 @@ A `site_config` block supports the following:
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights.
 
-* `application_stack` - (Optional) An `application_stack` block as defined above.
+* `application_stack` - (Optional) An `application_stack` block as defined above. **Note:** If this is set, there must not be an application setting `FUNCTIONS_WORKER_RUNTIME`.
 
 * `app_service_logs` - (Optional) An `app_service_logs` block as defined above.
 


### PR DESCRIPTION
I recently ran into this one when migrating my function apps to 3.0. And the error message on deployment is not helpful at all (error=nil), so it took me a while to figure out what caused the error.