### PR TITLE
Changed the database SKU from BC_Gen5_2 to S0.

### DIFF
--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -48,7 +48,7 @@ resource "azurerm_mssql_database" "test" {
   license_type   = "LicenseIncluded"
   max_size_gb    = 4
   read_scale     = true
-  sku_name       = "BC_Gen5_2"
+  sku_name       = "S0"
   zone_redundant = true
 
   extended_auditing_policy {


### PR DESCRIPTION
The example of Azurerm mssql database has a default SKU of BC_Gen5_2, this is a business-critical SKU, so anyone who copies the example code will end up with a database, that is fairly expensive in consumption. I suggest changing this into a standard tier S0. The demonstration purposes of the code remain the same, but you avoid a run-amock cost.