### PR TITLE
`azurerm_subnet` - add up the missing part for deprecating `address_prefix`

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -59,8 +59,7 @@ func resourceSubnet() *pluginsdk.Resource {
 
 			"address_prefixes": {
 				Type:     pluginsdk.TypeList,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -57,11 +57,7 @@ The following arguments are supported:
 
 * `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created.
 
-* `address_prefix` - (Optional / **Deprecated in favour of `address_prefixes`**) The address prefix to use for the subnet.
-
-* `address_prefixes` - (Optional) The address prefixes to use for the subnet.
-
--> **NOTE:** One of `address_prefix` or `address_prefixes` is required.
+* `address_prefixes` - (Required) The address prefixes to use for the subnet.
 
 ---
 


### PR DESCRIPTION
This PR adds up the missing part for deprecating `address_prefix` in https://github.com/hashicorp/terraform-provider-azurerm/commit/91fe6291fb62b100d0faa61ac87d426873158436.