### PR TITLE
`azurerm_linux_web_app` Add length check to fix #16400

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -2927,7 +2927,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 		expanded.AppCommandLine = utils.String(linuxSiteConfig.AppCommandLine)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.application_stack") {
+	if metadata.ResourceData.HasChange("site_config.0.application_stack") && len(linuxSiteConfig.ApplicationStack) > 0 {
 		linuxAppStack := linuxSiteConfig.ApplicationStack[0]
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = utils.String(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))

--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -880,6 +880,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"dotnet_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"v3.0",
 						"v4.0",
@@ -891,6 +899,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"php_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"7.4",
 					}, false),
@@ -899,6 +915,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"python_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"3.4.0", // Note: The portal only lists `3.6`, however, the service only uses the value `3.4.0`. Anything else is silently discarded
 					}, false),
@@ -907,6 +931,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"node_version": { // Discarded by service if JavaVersion is specified
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"12-LTS",
 						"14-LTS",
@@ -920,6 +952,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"java_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"1.8",
 						"11",
@@ -948,8 +988,16 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				},
 
 				"docker_container_name": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_container_name",
+					},
 					ValidateFunc: validation.StringIsNotEmpty,
 					RequiredWith: []string{
 						"site_config.0.application_stack.0.docker_container_tag",
@@ -1078,6 +1126,15 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				"dotnet_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"3.1",
 						"5.0",
@@ -1095,6 +1152,15 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				"php_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"7.4",
 						"8.0",
@@ -1111,6 +1177,15 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				"python_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"3.7",
 						"3.8",
@@ -1128,6 +1203,15 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				"node_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"12-lts",
 						"14-lts",
@@ -1145,6 +1229,15 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				"ruby_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringInSlice([]string{
 						"2.6",
 						"2.7",
@@ -1159,8 +1252,17 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				},
 
 				"java_version": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringIsNotEmpty, // There a significant number of variables here, and the versions are not uniformly formatted.
 					// TODO - Needs notes in the docs for this to help users navigate the inconsistencies in the service. e.g. jre8 va java8 etc
 					ConflictsWith: []string{
@@ -1188,8 +1290,17 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 				},
 
 				"docker_image": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					AtLeastOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.php_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.ruby_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.docker_image",
+					},
 					ValidateFunc: validation.StringIsNotEmpty,
 					RequiredWith: []string{
 						"site_config.0.application_stack.0.docker_image_tag",
@@ -2778,7 +2889,7 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded.AppCommandLine = utils.String(winSiteConfig.AppCommandLine)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.application_stack") {
+	if metadata.ResourceData.HasChange("site_config.0.application_stack") && len(winSiteConfig.ApplicationStack) > 0 {
 		winAppStack := winSiteConfig.ApplicationStack[0]
 		expanded.NetFrameworkVersion = utils.String(winAppStack.NetFrameworkVersion)
 		expanded.PhpVersion = utils.String(winAppStack.PhpVersion)


### PR DESCRIPTION
Add length check to fix #16400
Acc tests:

=== RUN   TestAccLinuxWebApp_basic
=== PAUSE TestAccLinuxWebApp_basic
=== CONT  TestAccLinuxWebApp_basic
--- PASS: TestAccLinuxWebApp_basic (335.96s)
=== RUN   TestAccLinuxWebApp_complete
=== PAUSE TestAccLinuxWebApp_complete


=== CONT  TestAccLinuxWebApp_complete
--- PASS: TestAccLinuxWebApp_complete (352.22s)
=== RUN   TestAccLinuxWebApp_completeUpdated
=== PAUSE TestAccLinuxWebApp_completeUpdated
=== CONT  TestAccLinuxWebApp_completeUpdated
--- PASS: TestAccLinuxWebApp_completeUpdated (934.05s)
=== RUN   TestAccLinuxWebApp_backup
=== PAUSE TestAccLinuxWebApp_backup
=== CONT  TestAccLinuxWebApp_backup
--- PASS: TestAccLinuxWebApp_backup (348.21s)
=== RUN   TestAccLinuxWebApp_backupUpdate
=== PAUSE TestAccLinuxWebApp_backupUpdate
=== CONT  TestAccLinuxWebApp_backupUpdate
--- PASS: TestAccLinuxWebApp_backupUpdate (630.28s)
=== RUN   TestAccLinuxWebApp_withConnectionStrings
=== PAUSE TestAccLinuxWebApp_withConnectionStrings
=== CONT  TestAccLinuxWebApp_withConnectionStrings
--- PASS: TestAccLinuxWebApp_withConnectionStrings (319.15s)
=== RUN   TestAccLinuxWebApp_withConnectionStringsUpdate
=== PAUSE TestAccLinuxWebApp_withConnectionStringsUpdate
=== CONT  TestAccLinuxWebApp_withConnectionStringsUpdate
--- PASS: TestAccLinuxWebApp_withConnectionStringsUpdate (953.52s)
=== RUN   TestAccLinuxWebApp_withLogging
=== PAUSE TestAccLinuxWebApp_withLogging
=== CONT  TestAccLinuxWebApp_withLogging
--- PASS: TestAccLinuxWebApp_withLogging (273.87s)
=== RUN   TestAccLinuxWebApp_removeLogging
=== PAUSE TestAccLinuxWebApp_removeLogging
=== CONT  TestAccLinuxWebApp_removeLogging
--- PASS: TestAccLinuxWebApp_removeLogging (443.23s)
=== RUN   TestAccLinuxWebApp_withLoggingUpdate
=== PAUSE TestAccLinuxWebApp_withLoggingUpdate
=== CONT  TestAccLinuxWebApp_withLoggingUpdate
--- PASS: TestAccLinuxWebApp_withLoggingUpdate (1078.41s)
=== RUN   TestAccLinuxWebApp_requiresImport
=== PAUSE TestAccLinuxWebApp_requiresImport


=== CONT  TestAccLinuxWebApp_requiresImport
--- PASS: TestAccLinuxWebApp_requiresImport (351.63s)
=== RUN   TestAccLinuxWebApp_updateServicePlan
=== PAUSE TestAccLinuxWebApp_updateServicePlan
=== CONT  TestAccLinuxWebApp_updateServicePlan
--- PASS: TestAccLinuxWebApp_updateServicePlan (511.72s)
=== RUN   TestAccLinuxWebApp_loadBalancing
=== PAUSE TestAccLinuxWebApp_loadBalancing
=== CONT  TestAccLinuxWebApp_loadBalancing
--- PASS: TestAccLinuxWebApp_loadBalancing (253.58s)
=== RUN   TestAccLinuxWebApp_withIPRestrictions
=== PAUSE TestAccLinuxWebApp_withIPRestrictions
=== CONT  TestAccLinuxWebApp_withIPRestrictions
--- PASS: TestAccLinuxWebApp_withIPRestrictions (262.49s)
=== RUN   TestAccLinuxWebApp_withIPRestrictionsUpdate
=== PAUSE TestAccLinuxWebApp_withIPRestrictionsUpdate
=== CONT  TestAccLinuxWebApp_withIPRestrictionsUpdate
--- PASS: TestAccLinuxWebApp_withIPRestrictionsUpdate (653.90s)
=== RUN   TestAccLinuxWebApp_withAuthSettings
=== PAUSE TestAccLinuxWebApp_withAuthSettings


=== CONT  TestAccLinuxWebApp_withAuthSettings

--- PASS: TestAccLinuxWebApp_withAuthSettings (346.20s)
=== RUN   TestAccLinuxWebApp_withAuthSettingsUpdate
=== PAUSE TestAccLinuxWebApp_withAuthSettingsUpdate
=== CONT  TestAccLinuxWebApp_withAuthSettingsUpdate
--- PASS: TestAccLinuxWebApp_withAuthSettingsUpdate (974.89s)
=== RUN   TestAccLinuxWebApp_withStorageAccount
=== PAUSE TestAccLinuxWebApp_withStorageAccount
=== CONT  TestAccLinuxWebApp_withStorageAccount
--- PASS: TestAccLinuxWebApp_withStorageAccount (366.27s)
=== RUN   TestAccLinuxWebApp_withStorageAccountUpdate
=== PAUSE TestAccLinuxWebApp_withStorageAccountUpdate
=== CONT  TestAccLinuxWebApp_withStorageAccountUpdate
--- PASS: TestAccLinuxWebApp_withStorageAccountUpdate (926.85s)
=== RUN   TestAccLinuxWebApp_identity
=== PAUSE TestAccLinuxWebApp_identity
=== CONT  TestAccLinuxWebApp_identity
--- PASS: TestAccLinuxWebApp_identity (873.74s)
=== RUN   TestAccLinuxWebApp_identityKeyVaultIdentity
=== PAUSE TestAccLinuxWebApp_identityKeyVaultIdentity
=== CONT  TestAccLinuxWebApp_identityKeyVaultIdentity
--- PASS: TestAccLinuxWebApp_identityKeyVaultIdentity (265.85s)
=== RUN   TestAccLinuxWebApp_withDotNet31
=== PAUSE TestAccLinuxWebApp_withDotNet31
=== CONT  TestAccLinuxWebApp_withDotNet31
--- PASS: TestAccLinuxWebApp_withDotNet31 (359.93s)
=== RUN   TestAccLinuxWebApp_withDotNet50
=== PAUSE TestAccLinuxWebApp_withDotNet50
=== CONT  TestAccLinuxWebApp_withDotNet50
--- PASS: TestAccLinuxWebApp_withDotNet50 (338.59s)
=== RUN   TestAccLinuxWebApp_withDotNet60
=== PAUSE TestAccLinuxWebApp_withDotNet60







=== CONT  TestAccLinuxWebApp_withDotNet60
--- PASS: TestAccLinuxWebApp_withDotNet60 (309.71s)
=== RUN   TestAccLinuxWebApp_withPhp74
=== PAUSE TestAccLinuxWebApp_withPhp74
=== CONT  TestAccLinuxWebApp_withPhp74
--- PASS: TestAccLinuxWebApp_withPhp74 (389.48s)
=== RUN   TestAccLinuxWebApp_withPhp80
=== PAUSE TestAccLinuxWebApp_withPhp80
=== CONT  TestAccLinuxWebApp_withPhp80
--- PASS: TestAccLinuxWebApp_withPhp80 (347.66s)
=== RUN   TestAccLinuxWebApp_withPython37
=== PAUSE TestAccLinuxWebApp_withPython37
=== CONT  TestAccLinuxWebApp_withPython37
--- PASS: TestAccLinuxWebApp_withPython37 (273.09s)
=== RUN   TestAccLinuxWebApp_withPython38
=== PAUSE TestAccLinuxWebApp_withPython38
=== CONT  TestAccLinuxWebApp_withPython38
--- PASS: TestAccLinuxWebApp_withPython38 (325.17s)
=== RUN   TestAccLinuxWebApp_withPython39
=== PAUSE TestAccLinuxWebApp_withPython39
=== CONT  TestAccLinuxWebApp_withPython39
--- PASS: TestAccLinuxWebApp_withPython39 (260.95s)
=== RUN   TestAccLinuxWebApp_withRuby26
=== PAUSE TestAccLinuxWebApp_withRuby26
=== CONT  TestAccLinuxWebApp_withRuby26
--- PASS: TestAccLinuxWebApp_withRuby26 (330.53s)
=== RUN   TestAccLinuxWebApp_withRuby27
=== PAUSE TestAccLinuxWebApp_withRuby27
=== CONT  TestAccLinuxWebApp_withRuby27
--- PASS: TestAccLinuxWebApp_withRuby27 (358.73s)
=== RUN   TestAccLinuxWebApp_withNode12LTS
=== PAUSE TestAccLinuxWebApp_withNode12LTS




=== CONT  TestAccLinuxWebApp_withNode12LTS

--- PASS: TestAccLinuxWebApp_withNode12LTS (332.24s)
=== RUN   TestAccLinuxWebApp_withNode14LTS
=== PAUSE TestAccLinuxWebApp_withNode14LTS
=== CONT  TestAccLinuxWebApp_withNode14LTS
--- PASS: TestAccLinuxWebApp_withNode14LTS (321.18s)
=== RUN   TestAccLinuxWebApp_withJre8Java
=== PAUSE TestAccLinuxWebApp_withJre8Java
=== CONT  TestAccLinuxWebApp_withJre8Java
--- PASS: TestAccLinuxWebApp_withJre8Java (282.14s)
=== RUN   TestAccLinuxWebApp_withJre11Java
=== PAUSE TestAccLinuxWebApp_withJre11Java
=== CONT  TestAccLinuxWebApp_withJre11Java
--- PASS: TestAccLinuxWebApp_withJre11Java (328.60s)
=== RUN   TestAccLinuxWebApp_withJava1109
=== PAUSE TestAccLinuxWebApp_withJava1109
=== CONT  TestAccLinuxWebApp_withJava1109
--- PASS: TestAccLinuxWebApp_withJava1109 (339.79s)
=== RUN   TestAccLinuxWebApp_withJava8u242
=== PAUSE TestAccLinuxWebApp_withJava8u242
=== CONT  TestAccLinuxWebApp_withJava8u242
--- PASS: TestAccLinuxWebApp_withJava8u242 (326.94s)
=== RUN   TestAccLinuxWebApp_withJava11Tomcat9
=== PAUSE TestAccLinuxWebApp_withJava11Tomcat9
=== CONT  TestAccLinuxWebApp_withJava11Tomcat9
--- PASS: TestAccLinuxWebApp_withJava11Tomcat9 (266.64s)
=== RUN   TestAccLinuxWebApp_withJava11Tomcat9041
=== PAUSE TestAccLinuxWebApp_withJava11Tomcat9041
=== CONT  TestAccLinuxWebApp_withJava11Tomcat9041
--- PASS: TestAccLinuxWebApp_withJava11Tomcat9041 (329.28s)
=== RUN   TestAccLinuxWebApp_withJava11Tomcat85
=== PAUSE TestAccLinuxWebApp_withJava11Tomcat85
=== CONT  TestAccLinuxWebApp_withJava11Tomcat85
--- PASS: TestAccLinuxWebApp_withJava11Tomcat85 (312.04s)
=== RUN   TestAccLinuxWebApp_withJava11Tomcat8561
=== PAUSE TestAccLinuxWebApp_withJava11Tomcat8561
=== CONT  TestAccLinuxWebApp_withJava11Tomcat8561
--- PASS: TestAccLinuxWebApp_withJava11Tomcat8561 (258.94s)
=== RUN   TestAccLinuxWebApp_withJava8JBOSSEAP73
=== PAUSE TestAccLinuxWebApp_withJava8JBOSSEAP73
=== CONT  TestAccLinuxWebApp_withJava8JBOSSEAP73
--- PASS: TestAccLinuxWebApp_withJava8JBOSSEAP73 (321.54s)
=== RUN   TestAccLinuxWebApp_withDocker
=== PAUSE TestAccLinuxWebApp_withDocker
=== CONT  TestAccLinuxWebApp_withDocker
--- PASS: TestAccLinuxWebApp_withDocker (328.34s)
=== RUN   TestAccLinuxWebApp_updateAppStack
=== PAUSE TestAccLinuxWebApp_updateAppStack
=== CONT  TestAccLinuxWebApp_updateAppStack
--- PASS: TestAccLinuxWebApp_updateAppStack (451.55s)
=== RUN   TestAccLinuxWebApp_withAutoHealRules
=== PAUSE TestAccLinuxWebApp_withAutoHealRules
=== CONT  TestAccLinuxWebApp_withAutoHealRules
--- PASS: TestAccLinuxWebApp_withAutoHealRules (320.63s)
=== RUN   TestAccLinuxWebApp_withAutoHealRulesUpdate
=== PAUSE TestAccLinuxWebApp_withAutoHealRulesUpdate
=== CONT  TestAccLinuxWebApp_withAutoHealRulesUpdate
--- PASS: TestAccLinuxWebApp_withAutoHealRulesUpdate (786.55s)
=== RUN   TestAccLinuxWebApp_withAutoHealRulesStatusCodeRange
=== PAUSE TestAccLinuxWebApp_withAutoHealRulesStatusCodeRange
=== CONT  TestAccLinuxWebApp_withAutoHealRulesStatusCodeRange
--- PASS: TestAccLinuxWebApp_withAutoHealRulesStatusCodeRange (335.48s)
=== RUN   TestAccLinuxWebApp_appSettings
=== PAUSE TestAccLinuxWebApp_appSettings
=== CONT  TestAccLinuxWebApp_appSettings
--- PASS: TestAccLinuxWebApp_appSettings (278.60s)
PASS
