### PR TITLE
windows_function_app_slot fix slot name formatting #16305

### DIFF
--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -344,7 +344,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			availabilityRequest := web.ResourceNameAvailabilityRequest{
-				Name: utils.String(fmt.Sprintf("%s-%s", functionAppId.SiteName, functionAppSlot.Name)),
+				Name: utils.String(fmt.Sprintf("%s-%s", id.SiteName, id.SlotName)),
 				Type: web.CheckNameResourceTypesMicrosoftWebsites,
 			}
 

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -344,7 +344,7 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			availabilityRequest := web.ResourceNameAvailabilityRequest{
-				Name: utils.String(functionAppSlot.Name),
+				Name: utils.String(fmt.Sprintf("%s-%s", functionAppId.SiteName, functionAppSlot.Name)),
 				Type: web.CheckNameResourceTypesMicrosoftWebsites,
 			}
 

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -350,7 +350,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			availabilityRequest := web.ResourceNameAvailabilityRequest{
-				Name: utils.String(functionAppSlot.Name),
+				Name: utils.String(fmt.Sprintf("%s-%s", functionAppId.SiteName, functionAppSlot.Name)),
 				Type: web.CheckNameResourceTypesMicrosoftWebsites,
 			}
 

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -350,7 +350,7 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			availabilityRequest := web.ResourceNameAvailabilityRequest{
-				Name: utils.String(fmt.Sprintf("%s-%s", functionAppId.SiteName, functionAppSlot.Name)),
+				Name: utils.String(fmt.Sprintf("%s-%s", id.SiteName, id.SlotName)),
 				Type: web.CheckNameResourceTypesMicrosoftWebsites,
 			}
 


### PR DESCRIPTION
The current check for slot names in windows_function_app_slot and linux_function_app_slot is wrong.
It does not check for the full slot name but only for the extension part. 

This means it stops the deployment for names that don't necessarily exist but just happen to be common. And it will pass the check for names that do already exist.

Fixes #16305 
FIxes #15784