### PR TITLE
`azurerm_data_factory_linked_service_azure_blob_storage`: Support SP key KV reference

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -65,6 +65,7 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"connection_string", "sas_uri", "service_endpoint"},
 			},
 
+			// TODO for @favoretti: rename this to 'sas_token_linked_key_vault_key' for 3.4.0
 			"key_vault_sas_token": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -86,6 +87,7 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *pluginsdk.Resource {
 				},
 			},
 
+			// TODO for @favoretti: rename this to 'service_principal_linked_key_vault_key' for 3.4.0
 			"key_vault_service_principal_key": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,

--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -87,8 +87,7 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *pluginsdk.Resource {
 				},
 			},
 
-			// TODO for @favoretti: rename this to 'service_principal_linked_key_vault_key' for 3.4.0
-			"key_vault_service_principal_key": {
+			"service_principal_linked_key_vault_key": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -241,7 +240,7 @@ func resourceDataFactoryLinkedServiceBlobStorageCreateUpdate(d *pluginsdk.Resour
 		if v, ok := d.GetOk("service_endpoint"); ok {
 			blobStorageProperties.ServiceEndpoint = utils.String(v.(string))
 		}
-		if kvsp, ok := d.GetOk("key_vault_service_principal_key"); ok {
+		if kvsp, ok := d.GetOk("service_principal_linked_key_vault_key"); ok {
 			blobStorageProperties.ServicePrincipalKey = expandAzureKeyVaultSecretReference(kvsp.([]interface{}))
 		} else {
 			secureString := datafactory.SecureString{
@@ -347,8 +346,8 @@ func resourceDataFactoryLinkedServiceBlobStorageRead(d *pluginsdk.ResourceData, 
 
 		if spKey := properties.ServicePrincipalKey; spKey != nil {
 			if kvSPkey, ok := spKey.AsAzureKeyVaultSecretReference(); ok {
-				if err := d.Set("key_vault_service_principal_key", flattenAzureKeyVaultSecretReference(kvSPkey)); err != nil {
-					return fmt.Errorf("Error setting `key_vault_service_principal_key`: %+v", err)
+				if err := d.Set("service_principal_linked_key_vault_key", flattenAzureKeyVaultSecretReference(kvSPkey)); err != nil {
+					return fmt.Errorf("Error setting `service_principal_linked_key_vault_key`: %+v", err)
 				}
 			}
 		}

--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
@@ -3,6 +3,7 @@ package datafactory_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -75,6 +76,27 @@ func TestAccDataFactoryLinkedServiceAzureBlobStorage_sas_uri_with_key_vault_sas_
 			),
 		},
 		data.ImportStep("sas_uri"),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_blob_storage", "test")
+	r := LinkedServiceAzureBlobStorageResource{}
+
+	tenantID := os.Getenv("ARM_TENANT_ID")
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.service_endpoint_with_key_vault_service_principal_key(data, tenantID),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_principal_id").Exists(),
+				check.That(data.ResourceName).Key("tenant_id").Exists(),
+				check.That(data.ResourceName).Key("key_vault_service_principal_key.0.linked_service_name").HasValue("linkkv"),
+				check.That(data.ResourceName).Key("key_vault_service_principal_key.0.secret_name").HasValue("secret"),
+			),
+		},
+		data.ImportStep("service_endpoint"),
 	})
 }
 
@@ -348,4 +370,55 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceAzureBlobStorageResource) service_endpoint_with_key_vault_service_principal_key(data acceptance.TestData, tenantID string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctkv%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+  name            = "linkkv"
+  data_factory_id = azurerm_data_factory.test.id
+  key_vault_id    = azurerm_key_vault.test.id
+}
+
+resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
+  name                 = "acctestBlobStorage"
+  data_factory_id      = azurerm_data_factory.test.id
+  service_endpoint     = "https://storageaccountname.blob.core.windows.net"
+  service_principal_id = data.azurerm_client_config.current.client_id
+  tenant_id            = "%s"
+  key_vault_service_principal_key {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, tenantID)
 }

--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
@@ -79,7 +79,7 @@ func TestAccDataFactoryLinkedServiceAzureBlobStorage_sas_uri_with_key_vault_sas_
 	})
 }
 
-func TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key(t *testing.T) {
+func TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_service_principal_linked_key_vault_key(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_blob_storage", "test")
 	r := LinkedServiceAzureBlobStorageResource{}
 
@@ -87,13 +87,13 @@ func TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_v
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.service_endpoint_with_key_vault_service_principal_key(data, tenantID),
+			Config: r.service_endpoint_with_service_principal_linked_key_vault_key(data, tenantID),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_principal_id").Exists(),
 				check.That(data.ResourceName).Key("tenant_id").Exists(),
-				check.That(data.ResourceName).Key("key_vault_service_principal_key.0.linked_service_name").HasValue("linkkv"),
-				check.That(data.ResourceName).Key("key_vault_service_principal_key.0.secret_name").HasValue("secret"),
+				check.That(data.ResourceName).Key("service_principal_linked_key_vault_key.0.linked_service_name").HasValue("linkkv"),
+				check.That(data.ResourceName).Key("service_principal_linked_key_vault_key.0.secret_name").HasValue("secret"),
 			),
 		},
 		data.ImportStep("service_endpoint"),
@@ -372,7 +372,7 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (LinkedServiceAzureBlobStorageResource) service_endpoint_with_key_vault_service_principal_key(data acceptance.TestData, tenantID string) string {
+func (LinkedServiceAzureBlobStorageResource) service_endpoint_with_service_principal_linked_key_vault_key(data acceptance.TestData, tenantID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -415,7 +415,7 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
   service_endpoint     = "https://storageaccountname.blob.core.windows.net"
   service_principal_id = data.azurerm_client_config.current.client_id
   tenant_id            = "%s"
-  key_vault_service_principal_key {
+  service_principal_linked_key_vault_key {
     linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
     secret_name         = "secret"
   }

--- a/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
@@ -87,7 +87,7 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
   service_endpoint     = "https://storageaccountname.blob.core.windows.net"
   service_principal_id = "00000000-0000-0000-0000-000000000000"
   tenant_id            = "00000000-0000-0000-0000-000000000000"
-  key_vault_service_principal_key {
+  service_principal_linked_key_vault_key {
     linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
     secret_name         = "secret"
   }
@@ -130,11 +130,11 @@ A `key_vault_sas_token` block supports the following:
 
 ---
 
-* `key_vault_service_principal_key` - (Optional) A `key_vault_service_principal_key` block as defined below. Use this argument to store Service Principal key in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
+* `service_principal_linked_key_vault_key` - (Optional) A `service_principal_linked_key_vault_key` block as defined below. Use this argument to store Service Principal key in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
 
 ---
 
-A `key_vault_service_principal_key` block supports the following:
+A `service_principal_linked_key_vault_key` block supports the following:
 
 * `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
 

--- a/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
@@ -84,9 +84,9 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
   name            = "example"
   data_factory_id = azurerm_data_factory.test.id
 
-  service_endpoint = "https://storageaccountname.blob.core.windows.net"
+  service_endpoint     = "https://storageaccountname.blob.core.windows.net"
   service_principal_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id            = "00000000-0000-0000-0000-000000000000"
   key_vault_service_principal_key {
     linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
     secret_name         = "secret"

--- a/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
@@ -79,6 +79,19 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
     secret_name         = "secret"
   }
 }
+
+resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
+  name            = "example"
+  data_factory_id = azurerm_data_factory.test.id
+
+  service_endpoint = "https://storageaccountname.blob.core.windows.net"
+  service_principal_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id = "00000000-0000-0000-0000-000000000000"
+  key_vault_service_principal_key {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
+  }
+}
 ```
 
 ## Argument Reference
@@ -117,13 +130,25 @@ A `key_vault_sas_token` block supports the following:
 
 ---
 
-* `service_endpoint` - (Optional) The Service Endpoint. Conflicts with `connection_string` and `sas_uri`. Required with `use_managed_identity`.
+* `key_vault_service_principal_key` - (Optional) A `key_vault_service_principal_key` block as defined below. Use this argument to store Service Principal key in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
+
+---
+
+A `key_vault_service_principal_key` block supports the following:
+
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores the Service Principal key.
+
+---
+
+* `service_endpoint` - (Optional) The Service Endpoint. Conflicts with `connection_string` and `sas_uri`.
 
 * `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Blob Storage account. Incompatible with `service_principal_id` and `service_principal_key`.
 
-* `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure Blob Storage account. Required if `service_principal_key` is set.
+* `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure Blob Storage account.
 
-* `service_principal_key` - (Optional) The service principal key in which to authenticate against the AAzure Blob Storage account.  Required if `service_principal_id` is set.
+* `service_principal_key` - (Optional) The service principal key in which to authenticate against the AAzure Blob Storage account.
 
 * `tenant_id` - (Optional) The tenant id or name in which to authenticate against the Azure Blob Storage account.
 


### PR DESCRIPTION
Adds support for passing SP key as a linked KV reference for ADF blob
storage linked service.

```
$ TF_ACC=1 go test -v ./internal/services/datafactory -timeout=1000m -run='TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key'
=== RUN   TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key
=== PAUSE TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key
=== CONT  TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key
--- PASS: TestAccDataFactoryLinkedServiceAzureBlobStorage_service_endpoint_with_key_vault_service_principal_key (360.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory	361.646s
```