### PR TITLE
`azurerm_storage_account` - Fix error when enabling identity and cmk

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1185,6 +1185,28 @@ func TestAccStorageAccount_customerManagedKeyRemoteKeyVault(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withoutCustomerManagedKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.customerManagedKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccount_edgeZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -3452,6 +3474,21 @@ resource "azurerm_key_vault_key" "test" {
   ]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (r StorageAccountResource) withoutCustomerManagedKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+}
+`, r.cmkTemplate(data), data.RandomString)
 }
 
 func (r StorageAccountResource) customerManagedKey(data acceptance.TestData) string {


### PR DESCRIPTION
Fix #16374

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey'
=== RUN   TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
=== PAUSE TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
=== CONT  TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
--- PASS: TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey (994.86s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       994.876s
```