### PR TITLE
azurerm_stream_analytics_output_servicebus_topic - add support for new property system_property_columns

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
@@ -86,6 +86,27 @@ func resourceStreamAnalyticsOutputServiceBusTopic() *pluginsdk.Resource {
 				},
 			},
 
+			"system_property_columns": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"ContentType",
+						"CorrelationId",
+						"Label",
+						"MessageId",
+						"PartitionKey",
+						"ReplyTo",
+						"ReplyToSessionId",
+						"ScheduledEnqueueTimeUtc",
+						"SessionId",
+						"TimeToLive",
+						"To",
+					}, false),
+				},
+			},
+
 			"serialization": schemaStreamAnalyticsOutputSerialization(),
 		},
 	}
@@ -130,6 +151,7 @@ func resourceStreamAnalyticsOutputServiceBusTopicCreateUpdate(d *pluginsdk.Resou
 					SharedAccessPolicyKey:  utils.String(d.Get("shared_access_policy_key").(string)),
 					SharedAccessPolicyName: utils.String(d.Get("shared_access_policy_name").(string)),
 					PropertyColumns:        utils.ExpandStringSlice(d.Get("property_columns").([]interface{})),
+					SystemPropertyColumns:  utils.ExpandMapStringPtrString(d.Get("system_property_columns").(map[string]interface{})),
 				},
 			},
 			Serialization: serialization,
@@ -184,6 +206,10 @@ func resourceStreamAnalyticsOutputServiceBusTopicRead(d *pluginsdk.ResourceData,
 		d.Set("servicebus_namespace", v.ServiceBusNamespace)
 		d.Set("shared_access_policy_name", v.SharedAccessPolicyName)
 		d.Set("property_columns", v.PropertyColumns)
+
+		if err = d.Set("system_property_columns", utils.FlattenMapStringPtrString(v.SystemPropertyColumns)); err != nil {
+			return err
+		}
 
 		if err := d.Set("serialization", flattenStreamAnalyticsOutputSerialization(props.Serialization)); err != nil {
 			return fmt.Errorf("setting `serialization`: %+v", err)

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
@@ -90,20 +90,8 @@ func resourceStreamAnalyticsOutputServiceBusTopic() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeMap,
 				Optional: true,
 				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"ContentType",
-						"CorrelationId",
-						"Label",
-						"MessageId",
-						"PartitionKey",
-						"ReplyTo",
-						"ReplyToSessionId",
-						"ScheduledEnqueueTimeUtc",
-						"SessionId",
-						"TimeToLive",
-						"To",
-					}, false),
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `property_columns` - (Optional) A list of property columns to add to the Service Bus Topic output.
 
-* `system_property_columns` - (Optional) A key-value pair of system property columns for the Service Bus Topic Output.
+* `system_property_columns` - (Optional) A key-value pair of system property columns that will be attached to the outgoing messages for the Service Bus Topic Output.
 
 -> **NOTE:** The acceptable keys are `ContentType`, `CorrelationId`, `Label`, `MessageId`, `PartitionKey`, `ReplyTo`, `ReplyToSessionId`, `ScheduledEnqueueTimeUtc`, `SessionId`, `TimeToLive` and `To`.
 

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -73,7 +73,9 @@ The following arguments are supported:
 
 * `property_columns` - (Optional) A list of property columns to add to the Service Bus Topic output.
 
-* `system_property_columns` - (Optional) A key-value pair of system property columns for the Service Bus Topic Output. Possible values are `ContentType`, `CorrelationId`, `Label`, `MessageId`, `PartitionKey`, `ReplyTo`, `ReplyToSessionId`, `ScheduledEnqueueTimeUtc`, `SessionId`, `TimeToLive` and `To`.
+* `system_property_columns` - (Optional) A key-value pair of system property columns for the Service Bus Topic Output.
+
+-> **NOTE:** The acceptable keys are `ContentType`, `CorrelationId`, `Label`, `MessageId`, `PartitionKey`, `ReplyTo`, `ReplyToSessionId`, `ScheduledEnqueueTimeUtc`, `SessionId`, `TimeToLive` and `To`.
 
 ---
 

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `property_columns` - (Optional) A list of property columns to add to the Service Bus Topic output.
 
+* `system_property_columns` - (Optional) A key-value pair of system property columns for the Service Bus Topic Output. Possible values are `ContentType`, `CorrelationId`, `Label`, `MessageId`, `PartitionKey`, `ReplyTo`, `ReplyToSessionId`, `ScheduledEnqueueTimeUtc`, `SessionId`, `TimeToLive` and `To`.
+
 ---
 
 A `serialization` block supports the following:


### PR DESCRIPTION
This PR is to support new property system_property_columns.

--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_avro (394.98s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_json (399.42s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_csv (411.32s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_propertyColumns (423.36s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport (443.03s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_update (608.75s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_systemPropertyColumns (746.85s)
