### PR TITLE
sentinel - removing setting `etag` before updating it

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
@@ -102,7 +102,6 @@ func resourceSentinelAlertRuleFusionCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	// Service avoid concurrent update of this resource via checking the "etag" to guarantee it is the same value as last Read.
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name)
 		if err != nil {
@@ -112,7 +111,6 @@ func resourceSentinelAlertRuleFusionCreateUpdate(d *pluginsdk.ResourceData, meta
 		if err := assertAlertRuleKind(resp.Value, securityinsight.AlertRuleKindFusion); err != nil {
 			return fmt.Errorf("asserting alert rule of %q: %+v", id, err)
 		}
-		params.Etag = resp.Value.(securityinsight.FusionAlertRule).Etag
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name, params); err != nil {

--- a/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics.go
+++ b/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics.go
@@ -102,7 +102,6 @@ func resourceSentinelAlertRuleMLBehaviorAnalyticsCreateUpdate(d *pluginsdk.Resou
 		},
 	}
 
-	// Service avoid concurrent update of this resource via checking the "etag" to guarantee it is the same value as last Read.
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name)
 		if err != nil {
@@ -112,7 +111,6 @@ func resourceSentinelAlertRuleMLBehaviorAnalyticsCreateUpdate(d *pluginsdk.Resou
 		if err := assertAlertRuleKind(resp.Value, securityinsight.AlertRuleKindMLBehaviorAnalytics); err != nil {
 			return fmt.Errorf("asserting alert rule of %q: %+v", id, err)
 		}
-		params.Etag = resp.Value.(securityinsight.MLBehaviorAnalyticsAlertRule).Etag
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name, params); err != nil {

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
@@ -178,7 +178,6 @@ func resourceSentinelAlertRuleMsSecurityIncidentCreateUpdate(d *pluginsdk.Resour
 		param.DisplayNamesExcludeFilter = utils.ExpandStringSlice(v.(*pluginsdk.Set).List())
 	}
 
-	// Service avoid concurrent update of this resource via checking the "etag" to guarantee it is the same value as last Read.
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name)
 		if err != nil {
@@ -188,7 +187,6 @@ func resourceSentinelAlertRuleMsSecurityIncidentCreateUpdate(d *pluginsdk.Resour
 		if err := assertAlertRuleKind(resp.Value, securityinsight.AlertRuleKindMicrosoftSecurityIncidentCreation); err != nil {
 			return fmt.Errorf("asserting alert rule of %q: %+v", id, err)
 		}
-		param.Etag = resp.Value.(securityinsight.MicrosoftSecurityIncidentCreationAlertRule).Etag
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name, param); err != nil {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -445,7 +445,6 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 		param.ScheduledAlertRuleProperties.EntityMappings = expandAlertRuleScheduledEntityMapping(v.([]interface{}))
 	}
 
-	// Service avoid concurrent update of this resource via checking the "etag" to guarantee it is the same value as last Read.
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name)
 		if err != nil {
@@ -455,7 +454,6 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 		if err := assertAlertRuleKind(resp.Value, securityinsight.AlertRuleKindScheduled); err != nil {
 			return fmt.Errorf("asserting alert rule of %q: %+v", id, err)
 		}
-		param.Etag = resp.Value.(securityinsight.ScheduledAlertRule).Etag
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, workspaceID.ResourceGroup, workspaceID.WorkspaceName, name, param); err != nil {

--- a/internal/services/sentinel/sentinel_data_connector_aws_cloud_trail.go
+++ b/internal/services/sentinel/sentinel_data_connector_aws_cloud_trail.go
@@ -98,20 +98,15 @@ func resourceSentinelDataConnectorAwsCloudTrailCreateUpdate(d *pluginsdk.Resourc
 		Kind: securityinsight.KindBasicDataConnectorKindAmazonWebServicesCloudTrail,
 	}
 
-	// Service avoid concurrent updates of this resource via checking the "etag" to guarantee it is the same value as last Read.
-	// TODO: following code can be removed once the issue below is fixed:
-	// https://github.com/Azure/azure-rest-api-specs/issues/13203
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, name)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		dc, ok := resp.Value.(securityinsight.AwsCloudTrailDataConnector)
-		if !ok {
+		if _, ok := resp.Value.(securityinsight.AwsCloudTrailDataConnector); !ok {
 			return fmt.Errorf("%s was not an AWS Cloud Trail Data Connector", id)
 		}
-		param.Etag = dc.Etag
 	}
 
 	if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, param); err != nil {

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security.go
@@ -138,20 +138,15 @@ func resourceSentinelDataConnectorMicrosoftCloudAppSecurityCreateUpdate(d *plugi
 		Kind: securityinsight.KindBasicDataConnectorKindMicrosoftCloudAppSecurity,
 	}
 
-	// Service avoid concurrent updates of this resource via checking the "etag" to guarantee it is the same value as last Read.
-	// TODO: following code can be removed once the issue below is fixed:
-	// https://github.com/Azure/azure-rest-api-specs/issues/13203
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, name)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		dc, ok := resp.Value.(securityinsight.MCASDataConnector)
-		if !ok {
+		if _, ok := resp.Value.(securityinsight.MCASDataConnector); !ok {
 			return fmt.Errorf("%s was not a Microsoft Cloud App Security Data Connector", id)
 		}
-		param.Etag = dc.Etag
 	}
 
 	if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, param); err != nil {

--- a/internal/services/sentinel/sentinel_data_connector_office_365.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365.go
@@ -154,21 +154,15 @@ func resourceSentinelDataConnectorOffice365CreateUpdate(d *pluginsdk.ResourceDat
 		Kind: securityinsight.KindBasicDataConnectorKindOffice365,
 	}
 
-	// Service avoid concurrent updates of this resource via checking the "etag" to guarantee it is the same value as last Read.
-	// TODO: following code can be removed once the issue below is fixed:
-	// https://github.com/Azure/azure-rest-api-specs/issues/13203
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, name)
 		if err != nil {
 			return fmt.Errorf("retrieving Sentinel Data Connector Office 365 %q: %+v", id, err)
 		}
 
-		dc, ok := resp.Value.(securityinsight.OfficeDataConnector)
-		if !ok {
+		if _, ok := resp.Value.(securityinsight.OfficeDataConnector); !ok {
 			return fmt.Errorf("%s was not an Office 365 Data Connector", id)
 		}
-
-		param.Etag = dc.Etag
 	}
 
 	if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, param); err != nil {


### PR DESCRIPTION
Previously, sentinel API requires an `etag` is set in the update request (`PUT`), which is trakced in https://github.com/Azure/azure-rest-api-specs/issues/13203. While it appears this is not a must now, which aligns with ARM's expectation that `etag` should be optional.