### PR TITLE
`azurerm_virtual_hub_connection` - Remove ForceNew for `internet_security_enabled`

### DIFF
--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -68,7 +68,6 @@ func resourceVirtualHubConnectionSchema() map[string]*pluginsdk.Schema {
 		"internet_security_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
-			ForceNew: true,
 			Default:  false,
 		},
 

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -105,7 +105,14 @@ func TestAccVirtualHubConnection_enableInternetSecurity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.enableInternetSecurity(data),
+			Config: r.enableInternetSecurity(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.enableInternetSecurity(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -343,7 +350,7 @@ resource "azurerm_virtual_hub_connection" "test2" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r VirtualHubConnectionResource) enableInternetSecurity(data acceptance.TestData) string {
+func (r VirtualHubConnectionResource) enableInternetSecurity(data acceptance.TestData, internetSecurityEnabled bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -351,9 +358,9 @@ resource "azurerm_virtual_hub_connection" "test" {
   name                      = "acctestbasicvhubconn-%[2]d"
   virtual_hub_id            = azurerm_virtual_hub.test.id
   remote_virtual_network_id = azurerm_virtual_network.test.id
-  internet_security_enabled = true
+  internet_security_enabled = %t
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, internetSecurityEnabled)
 }
 
 func (VirtualHubConnectionResource) template(data acceptance.TestData) string {

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub_connection"
 description: |-
-Manages a Connection for a Virtual Hub.
+  Manages a Connection for a Virtual Hub.
 ---
 
 # azurerm_virtual_hub_connection

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub_connection"
 description: |-
-  Manages a Connection for a Virtual Hub.
+Manages a Connection for a Virtual Hub.
 ---
 
 # azurerm_virtual_hub_connection
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 ---
 
-* `internet_security_enabled` - (Optional) Should Internet Security be enabled to secure internet traffic? Changing this forces a new resource to be created. Defaults to `false`.
+* `internet_security_enabled` - (Optional) Should Internet Security be enabled to secure internet traffic? Defaults to `false`.
 
 * `routing` - (Optional)  A `routing` block as defined below.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16424

--- PASS: TestAccVirtualHubConnection_basic (2232.31s)
--- PASS: TestAccVirtualHubConnection_requiresImport (2282.81s)
--- PASS: TestAccVirtualHubConnection_removeVnetStaticRoute (2354.05s)
--- PASS: TestAccVirtualHubConnection_complete (2504.42s)
--- PASS: TestAccVirtualHubConnection_removePropagatedRouteTable (2506.37s)
--- PASS: TestAccVirtualHubConnection_removeRoutingConfiguration (2531.10s)
--- PASS: TestAccVirtualHubConnection_updateRoutingConfiguration (2556.71s)
--- PASS: TestAccVirtualHubConnection_requiresLocking (2669.12s)
--- PASS: TestAccVirtualHubConnection_recreateWithSameConnectionName (2692.63s)
--- PASS: TestAccVirtualHubConnection_enableInternetSecurity (2716.55s)
--- PASS: TestAccVirtualHubConnection_update (3357.75s)