### PR TITLE
data.azurerm_service_plan: fix missing setting values of “kind” and “os_type” properties issue

### DIFF
--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -131,7 +131,7 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 			}
 
 			servicePlan.Location = location.NormalizeNilable(existing.Location)
-			servicePlan.Kind = *existing.Kind
+			servicePlan.Kind = utils.NormalizeNilableString(existing.Kind)
 
 			if sku := existing.Sku; sku != nil {
 				if sku.Name != nil {

--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -131,6 +131,7 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 			}
 
 			servicePlan.Location = location.NormalizeNilable(existing.Location)
+			servicePlan.Kind = *existing.Kind
 
 			if sku := existing.Sku; sku != nil {
 				if sku.Name != nil {
@@ -142,6 +143,7 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 			}
 
 			if props := existing.AppServicePlanProperties; props != nil {
+				servicePlan.OSType = OSTypeWindows
 				if props.HyperV != nil && *props.HyperV {
 					servicePlan.OSType = OSTypeWindowsContainer
 				}


### PR DESCRIPTION
The purpose of this PR:

> 1. Setting the value of the `kind` property in `func (r ServicePlanDataSource) Read() sdk.ResourceFunc`.
> 2. When the `os_type` is "Windows", it should be set value in `func (r ServicePlanDataSource) Read() sdk.ResourceFunc` .

Fix issue #16401.