### PR TITLE
Document on which day a week starts for postgresql_flexible_server

### DIFF
--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -132,7 +132,7 @@ A `maintenance_window` block supports the following:
 
 * `day_of_week` - (Optional) The day of week for maintenance window, where the week starts on a Sunday, i.e. Sunday = `0`, Monday = `1`. Defaults to `0`.
 
-* `start_hour` - (Optional) The day of week for maintenance window. Defaults to `0`.
+* `start_hour` - (Optional) The start hour for maintenance window. Defaults to `0`.
 
 * `start_minute` - (Optional) The start minute for maintenance window. Defaults to `0`.
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -130,7 +130,7 @@ The following arguments are supported:
 
 A `maintenance_window` block supports the following:
 
-* `day_of_week` - (Optional) The day of week for maintenance window. Defaults to `0`.
+* `day_of_week` - (Optional) The day of week for maintenance window, where the week starts on a Sunday, i.e. Sunday = `0`, Monday = `1`. Defaults to `0`.
 
 * `start_hour` - (Optional) The day of week for maintenance window. Defaults to `0`.
 


### PR DESCRIPTION
It is not obvious from the current provider documentation (nor Azure API documentation) which day of the week is `0`. After testing the behaviour in practice I have identified that the day names start on Sunday rather than following ISO 8601. This PR updates the documentation to reflect this discovery so that others do not need to wonder.

## Changes 

- Expand sentence documenting day_of_week to clarify that a week starts on Sunday, not Monday
- Correct typo in documentation `start_hour` refers to the hour, not the day of week
