### PR TITLE
Fix `TestAccCognitiveAccountCustomerManagedKey_complete`

### DIFF
--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
@@ -171,8 +171,8 @@ resource "azurerm_cognitive_account" "test" {
   name                  = "acctest-cogacc-%d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
-  kind                  = "Face"
-  sku_name              = "E0"
+  kind                  = "SpeechServices"
+  sku_name              = "S0"
   custom_subdomain_name = "acctest-cogacc-%d"
   identity {
     type         = "SystemAssigned, UserAssigned"


### PR DESCRIPTION
The kind `Face` seems to have an issue of using User-Assigned Managed Identity for CMK, which breaks this acc test. I've opened an issue https://github.com/Azure/azure-rest-api-specs/issues/18726 to track this. Meanwhile, changing the kind to `SpeechServices` with its proper`S0` `sku_name` to fix the test