### PR TITLE
azurerm_app_configuration_feature : fix test cases failures and ClientFilters uninitialized issue

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -388,6 +388,7 @@ func createOrUpdateFeature(ctx context.Context, client *appconfiguration.BaseCli
 		Enabled:     model.Enabled,
 	}
 
+	value.Conditions.ClientFilters.Filters = make([]interface{}, 0)
 	if model.PercentageFilter > 0 {
 		value.Conditions.ClientFilters.Filters = append(value.Conditions.ClientFilters.Filters, PercentageFeatureFilter{
 			Name:       PercentageFilterName,

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -164,11 +164,24 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+
 resource "azurerm_app_configuration" "test" {
   name                = "testacc-appconf%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 
 resource "azurerm_app_configuration_feature" "test" {
@@ -216,11 +229,24 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+
 resource "azurerm_app_configuration" "test" {
   name                = "testacc-appconf%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 
 resource "azurerm_app_configuration_feature" "test" {
@@ -279,11 +305,24 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+
 resource "azurerm_app_configuration" "test" {
   name                = "testacc-appconf%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 
 resource "azurerm_app_configuration_feature" "test" {
@@ -308,11 +347,24 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+
 resource "azurerm_app_configuration" "test" {
   name                = "testacc-appconf%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 
 resource "azurerm_app_configuration_feature" "test" {
@@ -336,11 +388,24 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+
 resource "azurerm_app_configuration" "test" {
   name                = "testacc-appconf%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 
 resource "azurerm_app_configuration_feature" "test" {


### PR DESCRIPTION
The purpose of this PR:

- Fix the test case failures - The "App Configuration Data Owner" role" is required to access  azurerm_app_configuration when adding features to app configuration.
- Fix issue #[16329 ](https://github.com/hashicorp/terraform-provider-azurerm/issues/16329)- Initliazes the ClientFilters when no filters are set.

Test results:
```
PASS: TestAccAppConfigurationFeature_basicNoFilters (279.14s)
PASS: TestAccAppConfigurationFeature_basic (279.82s)
PASS: TestAccAppConfigurationFeature_basicNoLabel (283.67s)
PASS: TestAccAppConfigurationFeature_requiresImport (311.20s)
PASS: TestAccAppConfigurationFeature_enabledUpdate (350.18s)
PASS: TestAccAppConfigurationFeature_lockUpdate (356.08s)
```