### PR TITLE
New resources `capacity_reservation_group` and `capacity_reservation`

### DIFF
--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -1,0 +1,163 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceCapacityReservationGroup() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceCapacityReservationGroupCreate,
+		Read:   resourceCapacityReservationGroupRead,
+		Update: resourceCapacityReservationGroupUpdate,
+		Delete: resourceCapacityReservationGroupDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.CapacityReservationGroupID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			"zones": commonschema.ZonesMultipleOptionalForceNew(),
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceCapacityReservationGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationGroupsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	id := parse.NewCapacityReservationGroupID(subscriptionId, resourceGroup, name)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for existing %s: %+v", id, err)
+		}
+	}
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_capacity_reservation_group", id.ID())
+	}
+
+	parameters := compute.CapacityReservationGroup{
+		Name:     utils.String(name),
+		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	if len(zones) > 0 {
+		parameters.Zones = &zones
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceCapacityReservationGroupRead(d, meta)
+}
+
+func resourceCapacityReservationGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationGroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Capacity Reservation Group %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceCapacityReservationGroupUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationGroupsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	parameters := compute.CapacityReservationGroupUpdate{}
+
+	if d.HasChange("tags") {
+		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if _, err := client.Update(ctx, id.ResourceGroup, id.Name, parameters); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+	return resourceCapacityReservationGroupRead(d, meta)
+}
+
+func resourceCapacityReservationGroupDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationGroupsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.Name); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+	return nil
+}

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -45,7 +45,7 @@ func resourceCapacityReservationGroup() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validate.CapacityReservationGroupName(),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -110,7 +110,7 @@ func resourceCapacityReservationGroupRead(d *pluginsdk.ResourceData, meta interf
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Capacity Reservation Group %q does not exist - removing from state", d.Id())
+			log.Printf("[INFO] %s was not found - removing from state", *id)
 			d.SetId("")
 			return nil
 		}

--- a/internal/services/compute/capacity_reservation_group_resource_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_test.go
@@ -1,0 +1,182 @@
+package compute_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type CapacityReservationGroupResource struct{}
+
+func TestAccCapacityReservationGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCapacityReservationGroup_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCapacityReservationGroup_zones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.zones(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCapacityReservationGroup_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.tags(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tagsUpdated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r CapacityReservationGroupResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.CapacityReservationGroupID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Compute.CapacityReservationGroupsClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r CapacityReservationGroupResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-compute-%d"
+  location = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r CapacityReservationGroupResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-crg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationGroupResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "import" {
+  name                = azurerm_capacity_reservation_group.test.name
+  resource_group_name = azurerm_capacity_reservation_group.test.resource_group_name
+  location            = azurerm_capacity_reservation_group.test.location
+}
+`, config)
+}
+
+func (r CapacityReservationGroupResource) zones(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["1", "2"]
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationGroupResource) tags(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  tags = {
+    ENV = "Test"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationGroupResource) tagsUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  tags = {
+    ENV2 = "Test2"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/compute/capacity_reservation_resource.go
+++ b/internal/services/compute/capacity_reservation_resource.go
@@ -1,0 +1,282 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceCapacityReservation() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceCapacityReservationCreate,
+		Read:   resourceCapacityReservationRead,
+		Update: resourceCapacityReservationUpdate,
+		Delete: resourceCapacityReservationDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.CapacityReservationID(id)
+			return err
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			"capacity_reservation_group_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"zone": commonschema.ZoneSingleOptionalForceNew(),
+
+			"sku": {
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"capacity": {
+							Type:         pluginsdk.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceCapacityReservationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	capacityReservationGroupName := d.Get("capacity_reservation_group_name").(string)
+	id := parse.NewCapacityReservationID(subscriptionId, resourceGroup, capacityReservationGroupName, name)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, "")
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for existing %s: %+v", id, err)
+		}
+	}
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_capacity_reservation", id.ID())
+	}
+
+	parameters := compute.CapacityReservation{
+		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Sku:      expandCapacityReservationSku(d.Get("sku").([]interface{})),
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("zone"); ok {
+		zones := []string{v.(string)}
+		parameters.Zones = &zones
+	}
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, parameters)
+	if err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceCapacityReservationRead(d, meta)
+}
+
+func resourceCapacityReservationRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Capacity Reservation %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("capacity_reservation_group_name", id.CapacityReservationGroupName)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+	if err := d.Set("sku", flattenCapacityReservationSku(resp.Sku)); err != nil {
+		return fmt.Errorf("setting `sku`: %+v", err)
+	}
+
+	if zones := resp.Zones; zones != nil && len(*zones) > 0 {
+		d.Set("zone", (*zones)[0])
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceCapacityReservationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	parameters := compute.CapacityReservationUpdate{}
+	if d.HasChange("sku") {
+		parameters.Sku = expandCapacityReservationSku(d.Get("sku").([]interface{}))
+	}
+
+	if d.HasChange("tags") {
+		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	future, err := client.Update(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, parameters)
+	if err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update of %s: %+v", id, err)
+	}
+	return resourceCapacityReservationRead(d, meta)
+}
+
+func resourceCapacityReservationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.CapacityReservationsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.CapacityReservationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of %s: %+v", id, err)
+	}
+
+	// API has bug, which appears to be eventually consistent.
+	log.Printf("[DEBUG] Waiting for %s to be fully deleted..", *id)
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{"Exists"},
+		Target:                    []string{"NotFound"},
+		Refresh:                   capacityReservationDeleteRefreshFunc(ctx, client, *id),
+		MinTimeout:                15 * time.Second,
+		ContinuousTargetOccurence: 5,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutDelete),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to be fully deleted: %+v", *id, err)
+	}
+
+	return nil
+}
+
+func expandCapacityReservationSku(input []interface{}) *compute.Sku {
+	if len(input) == 0 {
+		return &compute.Sku{}
+	}
+
+	v := input[0].(map[string]interface{})
+	return &compute.Sku{
+		Name:     utils.String(v["name"].(string)),
+		Capacity: utils.Int64(int64(v["capacity"].(int))),
+	}
+}
+
+func flattenCapacityReservationSku(input *compute.Sku) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	var name string
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	var capacity int64
+	if input.Capacity != nil {
+		capacity = *input.Capacity
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":     name,
+			"capacity": capacity,
+		},
+	}
+}
+
+func capacityReservationDeleteRefreshFunc(ctx context.Context, client *compute.CapacityReservationsClient, id parse.CapacityReservationId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(res.Response) {
+				return "NotFound", "NotFound", nil
+			}
+
+			return nil, "", fmt.Errorf("checking if %s has been deleted: %+v", id, err)
+		}
+
+		return res, "Exists", nil
+	}
+}

--- a/internal/services/compute/capacity_reservation_resource_test.go
+++ b/internal/services/compute/capacity_reservation_resource_test.go
@@ -1,0 +1,282 @@
+package compute_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type CapacityReservationResource struct{}
+
+func TestAccCapacityReservation_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCapacityReservation_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCapacityReservation_zone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.zone(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCapacityReservation_skuCapacity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.skuCapacity(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuCapacityUpdated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCapacityReservation_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.tags(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tagsUpdated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r CapacityReservationResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.CapacityReservationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Compute.CapacityReservationsClient.Get(ctx, id.ResourceGroup, id.CapacityReservationGroupName, id.Name, compute.CapacityReservationInstanceViewTypesInstanceView)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r CapacityReservationResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-compute-%d"
+  location = "%s"
+}
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "import" {
+  name                            = azurerm_capacity_reservation.test.name
+  resource_group_name             = azurerm_capacity_reservation.test.resource_group_name
+  location                        = azurerm_capacity_reservation.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation.test.capacity_reservation_group_name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+}
+`, config)
+}
+
+func (r CapacityReservationResource) zone(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-compute-%d"
+  location = "%s"
+}
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["1", "2"]
+}
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  zone                            = "2"
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) skuCapacity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) skuCapacityUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) tags(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+  tags = {
+    ENV = "Test"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CapacityReservationResource) tagsUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation" "test" {
+  name                            = "acctest-ccr-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 2
+  }
+  tags = {
+    ENV2 = "Test2"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/compute/capacity_reservation_resource_test.go
+++ b/internal/services/compute/capacity_reservation_resource_test.go
@@ -141,10 +141,8 @@ func (r CapacityReservationResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2
@@ -159,10 +157,8 @@ func (r CapacityReservationResource) requiresImport(data acceptance.TestData) st
 %s
 
 resource "azurerm_capacity_reservation" "import" {
-  name                            = azurerm_capacity_reservation.test.name
-  resource_group_name             = azurerm_capacity_reservation.test.resource_group_name
-  location                        = azurerm_capacity_reservation.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation.test.capacity_reservation_group_name
+  name                          = azurerm_capacity_reservation.test.name
+  capacity_reservation_group_id = azurerm_capacity_reservation.test.capacity_reservation_group_id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2
@@ -190,11 +186,9 @@ resource "azurerm_capacity_reservation_group" "test" {
 }
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
-  zone                            = "2"
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  zone                          = "2"
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2
@@ -209,10 +203,8 @@ func (r CapacityReservationResource) skuCapacity(data acceptance.TestData) strin
 %s
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2
@@ -227,10 +219,8 @@ func (r CapacityReservationResource) skuCapacityUpdated(data acceptance.TestData
 %s
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 1
@@ -245,10 +235,8 @@ func (r CapacityReservationResource) tags(data acceptance.TestData) string {
 %s
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2
@@ -266,10 +254,8 @@ func (r CapacityReservationResource) tagsUpdated(data acceptance.TestData) strin
 %s
 
 resource "azurerm_capacity_reservation" "test" {
-  name                            = "acctest-ccr-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.test.name
+  name                          = "acctest-ccr-%d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 2

--- a/internal/services/compute/capacity_reservation_resource_test.go
+++ b/internal/services/compute/capacity_reservation_resource_test.go
@@ -144,7 +144,7 @@ resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
 }
@@ -160,7 +160,7 @@ resource "azurerm_capacity_reservation" "import" {
   name                          = azurerm_capacity_reservation.test.name
   capacity_reservation_group_id = azurerm_capacity_reservation.test.capacity_reservation_group_id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
 }
@@ -190,7 +190,7 @@ resource "azurerm_capacity_reservation" "test" {
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   zone                          = "2"
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
 }
@@ -206,7 +206,7 @@ resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
 }
@@ -222,7 +222,7 @@ resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 1
   }
 }
@@ -238,7 +238,7 @@ resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
   tags = {
@@ -257,7 +257,7 @@ resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_D2s_v3"
+    name     = "Standard_F2"
     capacity = 2
   }
   tags = {

--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -8,6 +8,8 @@ import (
 
 type Client struct {
 	AvailabilitySetsClient          *compute.AvailabilitySetsClient
+	CapacityReservationsClient      *compute.CapacityReservationsClient
+	CapacityReservationGroupsClient *compute.CapacityReservationGroupsClient
 	DedicatedHostsClient            *compute.DedicatedHostsClient
 	DedicatedHostGroupsClient       *compute.DedicatedHostGroupsClient
 	DisksClient                     *compute.DisksClient
@@ -35,6 +37,12 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	availabilitySetsClient := compute.NewAvailabilitySetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&availabilitySetsClient.Client, o.ResourceManagerAuthorizer)
+
+	capacityReservationsClient := compute.NewCapacityReservationsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&capacityReservationsClient.Client, o.ResourceManagerAuthorizer)
+
+	capacityReservationGroupsClient := compute.NewCapacityReservationGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&capacityReservationGroupsClient.Client, o.ResourceManagerAuthorizer)
 
 	dedicatedHostsClient := compute.NewDedicatedHostsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&dedicatedHostsClient.Client, o.ResourceManagerAuthorizer)
@@ -104,6 +112,8 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		AvailabilitySetsClient:          &availabilitySetsClient,
+		CapacityReservationsClient:      &capacityReservationsClient,
+		CapacityReservationGroupsClient: &capacityReservationGroupsClient,
 		DedicatedHostsClient:            &dedicatedHostsClient,
 		DedicatedHostGroupsClient:       &dedicatedHostGroupsClient,
 		DisksClient:                     &disksClient,

--- a/internal/services/compute/parse/capacity_reservation.go
+++ b/internal/services/compute/parse/capacity_reservation.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type CapacityReservationId struct {
+	SubscriptionId               string
+	ResourceGroup                string
+	CapacityReservationGroupName string
+	Name                         string
+}
+
+func NewCapacityReservationID(subscriptionId, resourceGroup, capacityReservationGroupName, name string) CapacityReservationId {
+	return CapacityReservationId{
+		SubscriptionId:               subscriptionId,
+		ResourceGroup:                resourceGroup,
+		CapacityReservationGroupName: capacityReservationGroupName,
+		Name:                         name,
+	}
+}
+
+func (id CapacityReservationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Capacity Reservation Group Name %q", id.CapacityReservationGroupName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Capacity Reservation", segmentsStr)
+}
+
+func (id CapacityReservationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/capacityReservationGroups/%s/capacityReservations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CapacityReservationGroupName, id.Name)
+}
+
+// CapacityReservationID parses a CapacityReservation ID into an CapacityReservationId struct
+func CapacityReservationID(input string) (*CapacityReservationId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := CapacityReservationId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.CapacityReservationGroupName, err = id.PopSegment("capacityReservationGroups"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("capacityReservations"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/compute/parse/capacity_reservation_group.go
+++ b/internal/services/compute/parse/capacity_reservation_group.go
@@ -1,0 +1,69 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type CapacityReservationGroupId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewCapacityReservationGroupID(subscriptionId, resourceGroup, name string) CapacityReservationGroupId {
+	return CapacityReservationGroupId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id CapacityReservationGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Capacity Reservation Group", segmentsStr)
+}
+
+func (id CapacityReservationGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/capacityReservationGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// CapacityReservationGroupID parses a CapacityReservationGroup ID into an CapacityReservationGroupId struct
+func CapacityReservationGroupID(input string) (*CapacityReservationGroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := CapacityReservationGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("capacityReservationGroups"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/compute/parse/capacity_reservation_group_test.go
+++ b/internal/services/compute/parse/capacity_reservation_group_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = CapacityReservationGroupId{}
+
+func TestCapacityReservationGroupIDFormatter(t *testing.T) {
+	actual := NewCapacityReservationGroupID("12345678-1234-9876-4563-123456789012", "resGroup1", "capacityReservationGroup1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestCapacityReservationGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CapacityReservationGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1",
+			Expected: &CapacityReservationGroupId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "capacityReservationGroup1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/CAPACITYRESERVATIONGROUPS/CAPACITYRESERVATIONGROUP1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := CapacityReservationGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/internal/services/compute/parse/capacity_reservation_test.go
+++ b/internal/services/compute/parse/capacity_reservation_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = CapacityReservationId{}
+
+func TestCapacityReservationIDFormatter(t *testing.T) {
+	actual := NewCapacityReservationID("12345678-1234-9876-4563-123456789012", "resGroup1", "capacityReservationGroup1", "capacityReservation1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/capacityReservation1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestCapacityReservationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CapacityReservationId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing CapacityReservationGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
+			Error: true,
+		},
+
+		{
+			// missing value for CapacityReservationGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/capacityReservation1",
+			Expected: &CapacityReservationId{
+				SubscriptionId:               "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:                "resGroup1",
+				CapacityReservationGroupName: "capacityReservationGroup1",
+				Name:                         "capacityReservation1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/CAPACITYRESERVATIONGROUPS/CAPACITYRESERVATIONGROUP1/CAPACITYRESERVATIONS/CAPACITYRESERVATION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := CapacityReservationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.CapacityReservationGroupName != v.Expected.CapacityReservationGroupName {
+			t.Fatalf("Expected %q but got %q for CapacityReservationGroupName", v.Expected.CapacityReservationGroupName, actual.CapacityReservationGroupName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -46,6 +46,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	resources := map[string]*pluginsdk.Resource{
 		"azurerm_availability_set":                       resourceAvailabilitySet(),
+		"azurerm_capacity_reservation":                   resourceCapacityReservation(),
+		"azurerm_capacity_reservation_group":             resourceCapacityReservationGroup(),
 		"azurerm_dedicated_host":                         resourceDedicatedHost(),
 		"azurerm_dedicated_host_group":                   resourceDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":                    resourceDiskEncryptionSet(),

--- a/internal/services/compute/resourceids.go
+++ b/internal/services/compute/resourceids.go
@@ -1,6 +1,8 @@
 package compute
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AvailabilitySet -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/availabilitySets/set1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=CapacityReservationGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=CapacityReservation -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/capacityReservation1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DedicatedHostGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/hostGroup1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DedicatedHost -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/hostGroup1/hosts/host1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DiskEncryptionSet -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/diskEncryptionSets/set1

--- a/internal/services/compute/validate/capacity_reservation_group_id.go
+++ b/internal/services/compute/validate/capacity_reservation_group_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+)
+
+func CapacityReservationGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.CapacityReservationGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/compute/validate/capacity_reservation_group_id_test.go
+++ b/internal/services/compute/validate/capacity_reservation_group_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCapacityReservationGroupID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/CAPACITYRESERVATIONGROUPS/CAPACITYRESERVATIONGROUP1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CapacityReservationGroupID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/compute/validate/capacity_reservation_group_name.go
+++ b/internal/services/compute/validate/capacity_reservation_group_name.go
@@ -1,0 +1,11 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func CapacityReservationGroupName() func(i interface{}, k string) (warnings []string, errors []error) {
+	return validation.StringMatch(regexp.MustCompile(`^[^_\W]([\w-._]{0,62}[\w_])?$`), `The Capacity Reservation Group Name must be between 1 and 64 characters long. It cannot contain special characters \/"[]:|<>+=;,?*@&, whitespace, or begin with '_' or end with '.' or '-'`)
+}

--- a/internal/services/compute/validate/capacity_reservation_id.go
+++ b/internal/services/compute/validate/capacity_reservation_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+)
+
+func CapacityReservationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.CapacityReservationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/compute/validate/capacity_reservation_id_test.go
+++ b/internal/services/compute/validate/capacity_reservation_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCapacityReservationID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing CapacityReservationGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CapacityReservationGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/capacityReservation1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.COMPUTE/CAPACITYRESERVATIONGROUPS/CAPACITYRESERVATIONGROUP1/CAPACITYRESERVATIONS/CAPACITYRESERVATION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CapacityReservationID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/compute/validate/capacity_reservation_name.go
+++ b/internal/services/compute/validate/capacity_reservation_name.go
@@ -1,0 +1,11 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func CapacityReservationName() func(i interface{}, k string) (warnings []string, errors []error) {
+	return validation.StringMatch(regexp.MustCompile(`^[^_\W]([\w-._]{0,78}[\w_])?$`), `The Capacity Reservation Name must be between 1 and 80 characters long. It cannot contain special characters \/"[]:|<>+=;,?*@&, whitespace, or begin with '_' or end with '.' or '-'`)
+}

--- a/website/docs/r/capacity_reservation.html.markdown
+++ b/website/docs/r/capacity_reservation.html.markdown
@@ -25,10 +25,8 @@ resource "azurerm_capacity_reservation_group" "example" {
 }
 
 resource "azurerm_capacity_reservation" "example" {
-  name                            = "example-capacity-reservation"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  capacity_reservation_group_name = azurerm_capacity_reservation_group.example.name
+  name                          = "example-capacity-reservation"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.example.id
   sku {
     name     = "Standard_D2s_v3"
     capacity = 1
@@ -42,15 +40,11 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of this Capacity Reservation. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the Capacity Reservation is located in. Changing this forces a new resource to be created.
-
-* `location` - (Required) The Azure location where the Capacity Reservation exists. Changing this forces a new resource to be created.
-
-* `capacity_reservation_group_name` - (Required) The name of the Capacity Reservation Group where the Capacity Reservation exists. Changing this forces a new resource to be created.
+* `capacity_reservation_group_id` - (Required) The ID of the Capacity Reservation Group where the Capacity Reservation exists. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as defined below.
 
-* `zone` - (Optional) Specifies a list of Availability Zone which this Capacity Reservation reserves. Changing this forces a new resource to be created.
+* `zone` - (Optional) Specifies the Availability Zone for this Capacity Reservation. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/capacity_reservation.html.markdown
+++ b/website/docs/r/capacity_reservation.html.markdown
@@ -1,0 +1,86 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_capacity_reservation"
+description: |-
+  Manages a Capacity Reservation within a Capacity Reservation Group.
+---
+
+# azurerm_capacity_reservation
+
+Manages a Capacity Reservation within a Capacity Reservation Group.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_capacity_reservation_group" "example" {
+  name                = "example-capacity-reservation-group"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_capacity_reservation" "example" {
+  name                            = "example-capacity-reservation"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.example.location
+  capacity_reservation_group_name = azurerm_capacity_reservation_group.example.name
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of this Capacity Reservation. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Capacity Reservation is located in. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure location where the Capacity Reservation exists. Changing this forces a new resource to be created.
+
+* `capacity_reservation_group_name` - (Required) The name of the Capacity Reservation Group where the Capacity Reservation exists. Changing this forces a new resource to be created.
+
+* `sku` - (Required) A `sku` block as defined below.
+
+* `zone` - (Optional) Specifies a list of Availability Zone which this Capacity Reservation reserves. Changing this forces a new resource to be created.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+An `sku` block exports the following:
+
+* `name` - (Required) Name of the sku.Changing this forces a new resource to be created.
+
+* `capacity` - (Required) Specifies the number of instances to be reserved.
+
+## Attributes Reference
+
+The following Attributes are exported:
+
+* `id` - The ID of the Capacity Reservation.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Capacity Reservation.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Capacity Reservation.
+* `update` - (Defaults to 30 minutes) Used when updating the Capacity Reservation.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Capacity Reservation.
+
+## Import
+
+Capacity Reservations can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_capacity_reservation.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1/capacityReservations/capacityReservation1
+```

--- a/website/docs/r/capacity_reservation.html.markdown
+++ b/website/docs/r/capacity_reservation.html.markdown
@@ -52,9 +52,9 @@ The following arguments are supported:
 
 An `sku` block exports the following:
 
-* `name` - (Required) Name of the sku.Changing this forces a new resource to be created.
+* `name` - (Required) Name of the sku, such as `Standard_F2`. Changing this forces a new resource to be created.
 
-* `capacity` - (Required) Specifies the number of instances to be reserved.
+* `capacity` - (Required) Specifies the number of instances to be reserved. It must be a positive `integer` and not exceed the quota in the subscription.
 
 ## Attributes Reference
 

--- a/website/docs/r/capacity_reservation_group.html.markdown
+++ b/website/docs/r/capacity_reservation_group.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_capacity_reservation_group"
+description: |-
+  Manages a Capacity Reservation Group.
+---
+
+# azurerm_capacity_reservation_group
+
+Manages a Capacity Reservation Group.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_capacity_reservation_group" "example" {
+  name                = "example-capacity-reservation-group"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of this Capacity Reservation Group. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Capacity Reservation Group is located in. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure location where the Capacity Reservation Group exists. Changing this forces a new resource to be created.
+
+* `zones` - (Optional) Specifies a list of Availability Zones which this Capacity Reservation Group can reserve. Changing this forces a new resource to be created.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following Attributes are exported:
+
+* `id` - The ID of the Capacity Reservation Group.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Capacity Reservation Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Capacity Reservation Group.
+* `update` - (Defaults to 30 minutes) Used when updating the Capacity Reservation Group.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Capacity Reservation Group.
+
+## Import
+
+Capacity Reservation Groups can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_capacity_reservation_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/capacityReservationGroups/capacityReservationGroup1
+```

--- a/website/docs/r/capacity_reservation_group.html.markdown
+++ b/website/docs/r/capacity_reservation_group.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure location where the Capacity Reservation Group exists. Changing this forces a new resource to be created.
 
-* `zones` - (Optional) Specifies a list of Availability Zones which this Capacity Reservation Group can reserve. Changing this forces a new resource to be created.
+* `zones` - (Optional) Specifies a list of Availability Zones for this Capacity Reservation Group. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
- Implementing [On-demand Capacity Reservation](https://docs.microsoft.com/azure/virtual-machines/capacity-reservation-overview)
- VM resources also need an additional property [capacityReservationGroup Id](https://docs.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update#create-or-update-a-vm-with-capacity-reservation) to specify the CapacityReserviceGroup to put the VM, I'll add it in a separate pr