### PR TITLE
Doc Update: `azurerm_route*` - Update `address_prefix` to reflect service tags can be set

### DIFF
--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -47,9 +47,9 @@ The following arguments are supported:
 
 * `route_table_name` - (Required) The name of the route table within which create the route. Changing this forces a new resource to be created.
 
-* `address_prefix` - (Required) The destination CIDR to which the route applies, such as `10.1.0.0/16`
+* `address_prefix` - (Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/en-us/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
 
-* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`
+* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 
 * `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -62,9 +62,9 @@ The following arguments are supported:
 
 Elements of `route` support:
 
-* `name` - (Required) The name of the route.
+* `name` - (Required) The name of the route.(Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/en-us/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
 
-* `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16. Tags such as `VirtualNetwork`, `AzureLoadBalancer` or `Internet` can also be used.
+* `address_prefix` - (Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/en-us/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
 
 * `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 


### PR DESCRIPTION
Capability is now GA from Microsoft as per https://azure.microsoft.com/en-us/updates/generally-available-service-tags-support-for-user-defined-routing/