### PR TITLE
`azurerm_resource_policy_remediation` - Fix deletion failure due to canceling a completed remediation task

### DIFF
--- a/internal/services/policy/remediation_resource.go
+++ b/internal/services/policy/remediation_resource.go
@@ -196,24 +196,27 @@ func resourceArmResourcePolicyRemediationDelete(d *pluginsdk.ResourceData, meta 
 	}
 
 	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-		if _, err := client.CancelAtResource(ctx, id.ResourceId, id.Name); err != nil {
-			return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-		}
+		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
+			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+			if _, err := client.CancelAtResource(ctx, id.ResourceId, id.Name); err != nil {
+				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+			}
 
-		log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-		stateConf := &pluginsdk.StateChangeConf{
-			Pending: []string{"Cancelling"},
-			Target: []string{
-				"Succeeded", "Canceled", "Failed",
-			},
-			Refresh:    resourcePolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-			MinTimeout: 10 * time.Second,
-			Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-		}
+			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Cancelling"},
+				Target: []string{
+					"Succeeded", "Canceled", "Failed",
+				},
+				Refresh:    resourcePolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+				MinTimeout: 10 * time.Second,
+				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+			}
 
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			}
 		}
 	}
 

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -201,24 +201,27 @@ func resourceArmResourceGroupPolicyRemediationDelete(d *pluginsdk.ResourceData, 
 	}
 
 	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-		if _, err := client.CancelAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName); err != nil {
-			return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-		}
+		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
+			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+			if _, err := client.CancelAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName); err != nil {
+				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+			}
 
-		log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-		stateConf := &pluginsdk.StateChangeConf{
-			Pending: []string{"Cancelling"},
-			Target: []string{
-				"Succeeded", "Canceled", "Failed",
-			},
-			Refresh:    resourceGroupPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-			MinTimeout: 10 * time.Second,
-			Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-		}
+			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Cancelling"},
+				Target: []string{
+					"Succeeded", "Canceled", "Failed",
+				},
+				Refresh:    resourceGroupPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+				MinTimeout: 10 * time.Second,
+				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+			}
 
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			}
 		}
 	}
 

--- a/internal/services/policy/remediation_subscription.go
+++ b/internal/services/policy/remediation_subscription.go
@@ -201,24 +201,27 @@ func resourceArmSubscriptionPolicyRemediationDelete(d *pluginsdk.ResourceData, m
 	}
 
 	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-		if _, err := client.CancelAtSubscription(ctx, id.SubscriptionId, id.RemediationName); err != nil {
-			return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-		}
+		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
+			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+			if _, err := client.CancelAtSubscription(ctx, id.SubscriptionId, id.RemediationName); err != nil {
+				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+			}
 
-		log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-		stateConf := &pluginsdk.StateChangeConf{
-			Pending: []string{"Cancelling"},
-			Target: []string{
-				"Succeeded", "Canceled", "Failed",
-			},
-			Refresh:    subscriptionPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-			MinTimeout: 10 * time.Second,
-			Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-		}
+			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Cancelling"},
+				Target: []string{
+					"Succeeded", "Canceled", "Failed",
+				},
+				Refresh:    subscriptionPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+				MinTimeout: 10 * time.Second,
+				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+			}
 
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Remediation task can only be canceled when it is in "Evaluating" status; Canceling a completed remediation task will cause 400 bad request.

I've tested locally by using the config from `TestAccAzureRMResourcePolicyRemediation_basic`. After provisioning, the remediation is in "Evaluating" state. Wait for a couple of minutes till its state changes to `Completed`, then sending the cancel request will raise 400 bad request, complaining that a completed remediation task can't be canceled.

Fix #16456