### PR TITLE
`azurerm_service_fabric_managed_cluster` - Fix argument (networkSecurityRules.priority and networkSecurityRules.direction) contains duplicate items: 1000 and inbound issue

### DIFF
--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -922,7 +922,7 @@ func expandClusterProperties(model *ClusterResourceModel) *managedcluster.Manage
 				DestinationAddressPrefixes: &[]string{"0.0.0.0/0"},
 				Direction:                  managedcluster.DirectionInbound,
 				Name:                       fmt.Sprintf("rule%d-allow-fe", rule.FrontendPort),
-				Priority:                   1000,
+				Priority:                   1000 + int64(idx),
 				Protocol:                   sgProto,
 			}
 		}

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
@@ -48,6 +48,22 @@ func TestAccServiceFabricManagedCluster_withCustomSettings(t *testing.T) {
 	})
 }
 
+func TestAccServiceFabricManagedCluster_multipleLBRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_fabric_managed_cluster", "test")
+	r := ClusterResource{}
+	nodeTypeData1 := r.nodeType("test1", true, 130)
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleLBRules(data, nodeTypeData1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.Test").HasValue("value")),
+		},
+		data.ImportStep("password"),
+	})
+}
+
 func TestAccServiceFabricManagedCluster_importError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_service_fabric_managed_cluster", "test")
 
@@ -140,6 +156,54 @@ func (r ClusterResource) Exists(ctx context.Context, clients *clients.Client, st
 		return nil, fmt.Errorf("while checking for cluster's %q existence: %+v", resourceID.String(), err)
 	}
 	return utils.Bool(resp.HttpResponse.StatusCode == 200), nil
+}
+
+func (r ClusterResource) multipleLBRules(data acceptance.TestData, nodeTypeData string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sfmc-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_service_fabric_managed_cluster" "test" {
+  name                = "testacc-sfmc-%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+  username            = "testUser"
+  password            = "NotV3ryS3cur3P@$$w0rd"
+  dns_service_enabled = true
+
+  client_connection_port = 12345
+  http_gateway_port      = 23456
+
+  lb_rule {
+    backend_port       = 8000
+    frontend_port      = 443
+    probe_protocol     = "http"
+    protocol           = "tcp"
+    probe_request_path = "/"
+  }
+
+  lb_rule {
+    backend_port       = 8001
+    frontend_port      = 1443
+    probe_protocol     = "http"
+    protocol           = "tcp"
+    probe_request_path = "/"
+  }
+
+  %[4]s
+
+  tags = {
+    Test = "value"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, nodeTypeData)
 }
 
 func (r ClusterResource) basic(data acceptance.TestData, nodeTypeData string) string {

--- a/website/docs/r/service_fabric_managed_cluster.html.markdown
+++ b/website/docs/r/service_fabric_managed_cluster.html.markdown
@@ -26,6 +26,19 @@ resource "azurerm_service_fabric_managed_cluster" "example" {
     probe_request_path = "/test"
     protocol           = "tcp"
   }
+
+  network_security_rules {
+    access                       = "allow"
+    protocol                     = "tcp"
+    destination_address_prefixes = ["172.16.0.0/20", "8.8.8.8"]
+    destination_port_ranges      = ["80", "443", "8080", "8190"]
+    direction                    = "outbound"
+    name                         = "test1"
+    priority                     = 1000
+    source_address_prefixes      = ["10.0.0.0/8", "192.168.0.0/16"]
+    source_port_ranges           = ["10000-40000"]
+  }
+
   client_connection_port = 12345
 
   node_type {
@@ -72,6 +85,8 @@ The following arguments are supported:
 * `dns_name` - (Optional) Hostname for the cluster. If unset the cluster's name will be used..
 
 * `dns_service_enabled` - (Optional) If true, DNS service is enabled.
+
+* `network_security_rules` - (Optional) One or more `network_security_rules` blocks as defined below.
 
 * `node_type` - (Optional) One or more `node_type` blocks as defined below.
 
@@ -182,6 +197,30 @@ A `node_type` block supports the following:
 * `stateless` - (Optional) If set to true, only stateless workloads can run on this node type.
 
 * `vm_secrets` - (Optional) One or more `vm_secrets` blocks as defined below.
+
+---
+
+A `network_security_rules` block supports the following:
+
+* `access` - (Required) Specifies whether network traffic is allowed or denied. Possible values are `allow` and `deny`.
+
+* `destination_address_prefixes` - (Required) List of destination address prefixes.
+
+* `destination_port_ranges` - (Required) List of destination ports or port ranges.
+
+* `direction` - (Required) The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are `inbound` and `outbound`.
+
+* `name` - (Required) The name of the security rule.
+
+* `priority` - (Required) Specifies the priority of the rule. The value can be between 1000 and 3000. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule.
+
+* `protocol` - (Required) Network protocol this rule applies to. Possible values include `ah`, `esp`, `http`, `https`, `icmp` ,`tcp` or `udp`.
+
+* `source_address_prefixes` - (Required) List of source address prefixes.
+
+* `source_port_ranges` - (Required) List of source ports or port ranges.
+
+* `description` - (Optional) A description for this rule.
 
 ---
 


### PR DESCRIPTION
The purpose of this PR:

- Fix issue [#16206](https://github.com/hashicorp/terraform-provider-azurerm/issues/16206) - Per the [Doc](https://docs.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview#security-rules), _You may not create two security rules with the same priority and direction._ So, currently when multiple lb rules are set, hardcoding the priority to 1000 is not feasible. Go through the [NSG rules guidance](https://docs.microsoft.com/en-us/azure/service-fabric/how-to-managed-cluster-networking#nsg-rules-guidance)  and [NetworkSecurityRule  ](https://docs.microsoft.com/en-us/azure/templates/microsoft.servicefabric/managedclusters?tabs=bicep#networksecurityrule),  expose the Network Security Rules to support user to set value for it.
- Add multiple `lb_rule` test case.

Test Results:

> PASS: TestAccServiceFabricManagedCluster_basic (2869.35s)
> PASS: TestAccServiceFabricManagedCluster_nsRules (2152.67s)
> PASS: TestAccServiceFabricManagedCluster_multipleLBRules (2093.14s)
> PASS: TestAccServiceFabricManagedCluster_importError (2316.34s)
> PASS: TestAccServiceFabricManagedCluster_full (7106.22s)