### PR TITLE
`azurerm_{\w+_}?policy_assignment` - ensure `name` not contains `/`

### DIFF
--- a/internal/services/policy/assignment_management_group_resource.go
+++ b/internal/services/policy/assignment_management_group_resource.go
@@ -28,8 +28,9 @@ func (r ManagementGroupAssignmentResource) Arguments() map[string]*pluginsdk.Sch
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				validation.StringLenBetween(3, 24),
 				// The policy assignment name length must not exceed '24' characters.
+				validation.StringLenBetween(3, 24),
+				validation.StringDoesNotContainAny("/"),
 			),
 		},
 	}

--- a/internal/services/policy/assignment_resource.go
+++ b/internal/services/policy/assignment_resource.go
@@ -16,10 +16,13 @@ type ResourceAssignmentResource struct {
 func (r ResourceAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
 	schema := map[string]*pluginsdk.Schema{
 		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.StringIsNotWhiteSpace,
+				validation.StringDoesNotContainAny("/"),
+			),
 		},
 		"resource_id": {
 			// TODO: tests for this

--- a/internal/services/policy/assignment_resource_group_resource.go
+++ b/internal/services/policy/assignment_resource_group_resource.go
@@ -17,10 +17,13 @@ type ResourceGroupAssignmentResource struct {
 func (r ResourceGroupAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
 	schema := map[string]*pluginsdk.Schema{
 		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.StringIsNotWhiteSpace,
+				validation.StringDoesNotContainAny("/"),
+			),
 		},
 		"resource_group_id": {
 			Type:         pluginsdk.TypeString,

--- a/internal/services/policy/assignment_subscription_resource.go
+++ b/internal/services/policy/assignment_subscription_resource.go
@@ -17,10 +17,13 @@ type SubscriptionAssignmentResource struct {
 func (r SubscriptionAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
 	schema := map[string]*pluginsdk.Schema{
 		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.StringIsNotWhiteSpace,
+				validation.StringDoesNotContainAny("/"),
+			),
 		},
 		"subscription_id": {
 			Type:         pluginsdk.TypeString,


### PR DESCRIPTION
Fix #16449. Arguably, this validation should be added to almost all resources?