### PR TITLE
`azurerm_mysql_server` Add update in create function to update `public_network_access_enabled`

### DIFF
--- a/internal/services/mysql/mysql_server_resource_test.go
+++ b/internal/services/mysql/mysql_server_resource_test.go
@@ -516,6 +516,7 @@ resource "azurerm_mysql_server" "replica" {
 
   create_mode                      = "Replica"
   creation_source_server_id        = azurerm_mysql_server.test.id
+  public_network_access_enabled	   = false
   ssl_enforcement_enabled          = true
   ssl_minimal_tls_version_enforced = "TLS1_1"
 }

--- a/internal/services/mysql/mysql_server_resource_test.go
+++ b/internal/services/mysql/mysql_server_resource_test.go
@@ -356,19 +356,20 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_mysql_server" "test" {
-  name                         = "acctestmysqlsvr-%[1]d"
-  location                     = azurerm_resource_group.test.location
-  resource_group_name          = azurerm_resource_group.test.name
-  sku_name                     = "GP_Gen5_2"
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!updated"
-  auto_grow_enabled            = true
-  backup_retention_days        = 7
-  create_mode                  = "Default"
-  geo_redundant_backup_enabled = false
-  ssl_enforcement_enabled      = false
-  storage_mb                   = 51200
-  version                      = "%[3]s"
+  name                             = "acctestmysqlsvr-%[1]d"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  sku_name                         = "GP_Gen5_2"
+  administrator_login              = "acctestun"
+  administrator_login_password     = "H@Sh1CoR3!updated"
+  auto_grow_enabled                = true
+  backup_retention_days            = 7
+  create_mode                      = "Default"
+  geo_redundant_backup_enabled     = false
+  ssl_enforcement_enabled          = false
+  ssl_minimal_tls_version_enforced = "TLSEnforcementDisabled"
+  storage_mb                       = 51200
+  version                          = "%[3]s"
   threat_detection_policy {
     enabled                    = true
     disabled_alerts            = ["Sql_Injection"]
@@ -402,19 +403,20 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_mysql_server" "test" {
-  name                         = "acctestmysqlsvr-%[1]d"
-  location                     = azurerm_resource_group.test.location
-  resource_group_name          = azurerm_resource_group.test.name
-  sku_name                     = "GP_Gen5_2"
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!updated"
-  auto_grow_enabled            = true
-  backup_retention_days        = 7
-  create_mode                  = "Default"
-  geo_redundant_backup_enabled = false
-  ssl_enforcement_enabled      = false
-  storage_mb                   = 51200
-  version                      = "%[3]s"
+  name                             = "acctestmysqlsvr-%[1]d"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  sku_name                         = "GP_Gen5_2"
+  administrator_login              = "acctestun"
+  administrator_login_password     = "H@Sh1CoR3!updated"
+  auto_grow_enabled                = true
+  backup_retention_days            = 7
+  create_mode                      = "Default"
+  geo_redundant_backup_enabled     = false
+  ssl_enforcement_enabled          = false
+  ssl_minimal_tls_version_enforced = "TLSEnforcementDisabled"
+  storage_mb                       = 51200
+  version                          = "%[3]s"
   threat_detection_policy {
     enabled                    = true
     email_account_admins       = true

--- a/internal/services/mysql/mysql_server_resource_test.go
+++ b/internal/services/mysql/mysql_server_resource_test.go
@@ -516,7 +516,7 @@ resource "azurerm_mysql_server" "replica" {
 
   create_mode                      = "Replica"
   creation_source_server_id        = azurerm_mysql_server.test.id
-  public_network_access_enabled	   = false
+  public_network_access_enabled    = false
   ssl_enforcement_enabled          = true
   ssl_minimal_tls_version_enforced = "TLS1_1"
 }

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `ssl_enforcement_enabled` - (Required) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.
 
-* `ssl_minimal_tls_version_enforced` - (Optional) The minimum TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLSEnforcementDisabled`.
+* `ssl_minimal_tls_version_enforced` - (Optional) The minimum TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_2`.
 
 * `storage_mb` - (Required) Max storage allowed for a server. Possible values are between `5120` MB(5GB) and `1048576` MB(1TB) for the Basic SKU and between `5120` MB(5GB) and `16777216` MB(16TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/azure/mysql/concepts-pricing-tiers).
 


### PR DESCRIPTION
Add update in create function to update `public_network_access_enabled` when create mode is replica.
This pr will fix #13302, basically it copied the code from #11465 .

One acc test failed:

=== RUN   TestAccMySQLServer_update
=== PAUSE TestAccMySQLServer_update
=== CONT  TestAccMySQLServer_update
    testcase.go:110: Step 5/10 error: Error running apply: exit status 1
        
        Error: creating Server: (Name "acctestmysqlsvr-220422192116295294" / Resource Group "acctestRG-mysql-220422192116295294"): mysql.ServersClient#Create: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameterValue" Message="Invalid value given for parameter 'MinimalTlsVersion'. Specify a valid parameter value."
        
          with azurerm_mysql_server.test,
          on terraform_plugin_test.tf line 19, in resource "azurerm_mysql_server" "test":
          19: resource "azurerm_mysql_server" "test" {
        
--- FAIL: TestAccMySQLServer_update (782.84s)

But this test also failed in main branch, so I guess it's irrelevant to this pr.