### PR TITLE
azurerm_postgresql_server - add validation for public_network_access_enabled

### DIFF
--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -468,6 +468,11 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 		time, _ := time.Parse(time.RFC3339, v.(string)) // should be validated by the schema
 
+		// d.GetOk cannot identify whether user sets the property that is bool type and has default value. So it has to identify it using `d.GetRawConfig()`
+		if v := d.GetRawConfig().AsValueMap()["public_network_access_enabled"]; !v.IsNull() {
+			return fmt.Errorf("`public_network_access_enabled` doesn't support PointInTimeRestore mode")
+		}
+
 		props = &postgresql.ServerPropertiesForRestore{
 			CreateMode:     mode,
 			SourceServerID: &source,
@@ -475,7 +480,6 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 				Time: time,
 			},
 			InfrastructureEncryption: infraEncrypt,
-			PublicNetworkAccess:      publicAccess,
 			MinimalTLSVersion:        tlsMin,
 			SslEnforcement:           ssl,
 			StorageProfile:           storage,
@@ -649,11 +653,6 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	publicAccess := postgresql.PublicNetworkAccessEnumEnabled
-	if v := d.Get("public_network_access_enabled"); !v.(bool) {
-		publicAccess = postgresql.PublicNetworkAccessEnumDisabled
-	}
-
 	ssl := postgresql.SslEnforcementEnumEnabled
 	if v := d.Get("ssl_enforcement_enabled"); !v.(bool) {
 		ssl = postgresql.SslEnforcementEnumDisabled
@@ -673,14 +672,26 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	properties := postgresql.ServerUpdateParameters{
 		Identity: expandedIdentity,
 		ServerUpdateParametersProperties: &postgresql.ServerUpdateParametersProperties{
-			PublicNetworkAccess: publicAccess,
-			SslEnforcement:      ssl,
-			MinimalTLSVersion:   tlsMin,
-			StorageProfile:      expandPostgreSQLStorageProfile(d),
-			Version:             postgresql.ServerVersion(d.Get("version").(string)),
+			SslEnforcement:    ssl,
+			MinimalTLSVersion: tlsMin,
+			StorageProfile:    expandPostgreSQLStorageProfile(d),
+			Version:           postgresql.ServerVersion(d.Get("version").(string)),
 		},
 		Sku:  sku,
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if mode == postgresql.CreateModePointInTimeRestore {
+		// d.GetOk cannot identify whether user sets the property that is bool type and has default value. So it has to identify it using `d.GetRawConfig()`
+		if v := d.GetRawConfig().AsValueMap()["public_network_access_enabled"]; !v.IsNull() {
+			return fmt.Errorf("`public_network_access_enabled` doesn't support the PointInTimeRestore mode")
+		}
+	} else {
+		publicAccess := postgresql.PublicNetworkAccessEnumEnabled
+		if v := d.Get("public_network_access_enabled"); !v.(bool) {
+			publicAccess = postgresql.PublicNetworkAccessEnumDisabled
+		}
+		properties.ServerUpdateParametersProperties.PublicNetworkAccess = publicAccess
 	}
 
 	oldCreateMode, newCreateMode := d.GetChange("create_mode")

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -684,7 +684,7 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	if mode == postgresql.CreateModePointInTimeRestore {
 		// d.GetOk cannot identify whether user sets the property that is bool type and has default value. So it has to identify it using `d.GetRawConfig()`
 		if v := d.GetRawConfig().AsValueMap()["public_network_access_enabled"]; !v.IsNull() {
-			return fmt.Errorf("`public_network_access_enabled` doesn't support the PointInTimeRestore mode")
+			return fmt.Errorf("`public_network_access_enabled` doesn't support PointInTimeRestore mode")
 		}
 	} else {
 		publicAccess := postgresql.PublicNetworkAccessEnumEnabled

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this server. Defaults to `true`.
 
--> **NOTE:** `public_network_access_enabled` doesn't support the PointInTimeRestore mode.
+-> **NOTE:** `public_network_access_enabled` doesn't support PointInTimeRestore mode.
 
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore` the point in time to restore from `creation_source_server_id`. 
 

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this server. Defaults to `true`.
 
+-> **NOTE:** `public_network_access_enabled` doesn't support the PointInTimeRestore mode.
+
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore` the point in time to restore from `creation_source_server_id`. 
 
 * `ssl_enforcement_enabled` - (Optional) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.


### PR DESCRIPTION
Service team confirmed API doesn't support `public_network_access_enabled` when `create_mode` is `PointInTimeRestore`. So it's better to add a validation for it.

--- PASS: TestAccPostgreSQLServer_threatDetectionEmptyAttrs (421.22s)
--- PASS: TestAccPostgreSQLServer_complete (428.06s)
--- PASS: TestAccPostgreSQLServer_basicNinePointFive (442.13s)
--- PASS: TestAccPostgreSQLServer_basicEleven (464.25s)
--- PASS: TestAccPostgreSQLServer_requiresImport (482.34s)
--- PASS: TestAccPostgreSQLServer_autogrowOnly (556.57s)
--- PASS: TestAccPostgreSQLServer_gpTenPointZero (386.15s)
--- PASS: TestAccPostgreSQLServer_moTenPointZero (387.97s)
--- PASS: TestAccPostgreSQLServer_basicTenPointZero (441.76s)
--- PASS: TestAccPostgreSQLServer_basicWithIdentity (509.79s)
--- PASS: TestAccPostgreSQLServer_updated (1088.72s)
--- PASS: TestAccPostgreSQLServer_updateSKU (1151.99s)
--- PASS: TestAccPostgreSQLServer_basicNinePointSix (439.34s)
--- PASS: TestAccPostgreSQLServer_createReplica
--- PASS: TestAccPostgreSQLServer_updateReplicaToDefaultAndSetPassword
--- PASS: TestAccPostgreSQLServer_updateReplicaToDefault
--- PASS: TestAccPostgreSQLServer_scaleReplicas
--- PASS: TestAccPostgreSQLServer_createPointInTimeRestore