### PR TITLE
Fix docs example error in `azurerm_data_protection_backup_instance_blob_storage`

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource_test.go
@@ -133,7 +133,7 @@ resource "azurerm_data_protection_backup_vault" "test" {
 
 resource "azurerm_role_assignment" "test" {
   scope                = azurerm_storage_account.test.id
-  role_definition_name = "Storage Account Backup Contributor Role"
+  role_definition_name = "Storage Account Backup Contributor"
   principal_id         = azurerm_data_protection_backup_vault.test.identity[0].principal_id
 }
 

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -39,7 +39,7 @@ resource "azurerm_data_protection_backup_vault" "example" {
 
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_storage_account.example.id
-  role_definition_name = "Storage Account Backup Contributor Role"
+  role_definition_name = "Storage Account Backup Contributor"
   principal_id         = azurerm_data_protection_backup_vault.example.identity[0].principal_id
 }
 


### PR DESCRIPTION
The proper role name is `Storage Account Backup Contributor`.

![image](https://user-images.githubusercontent.com/3743342/164874537-7033db6e-d00c-41ea-94d5-fe2e341813a2.png)