### PR TITLE
Fix dangling OS disk in `TestAccMsSqlVirtualMachine_*`

### DIFF
--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -270,6 +270,8 @@ resource "azurerm_virtual_machine" "test" {
   network_interface_ids = [azurerm_network_interface.test.id]
   vm_size               = "Standard_F2s"
 
+  delete_os_disk_on_termination = true
+
   storage_image_reference {
     publisher = "MicrosoftSQLServer"
     offer     = "SQL2017-WS2016"


### PR DESCRIPTION
these tests `TestAccMsSqlVirtualMachine_*` are failing on main due to the dangling os disk on created by `azurerm_virtual_machine`. Fixing it by adding `delete_os_disk_on_termination`.