### PR TITLE
Add ability to use dashes in administrator login

### DIFF
--- a/internal/services/synapse/validate/sql_administrator_login_name.go
+++ b/internal/services/synapse/validate/sql_administrator_login_name.go
@@ -16,7 +16,6 @@ func SqlAdministratorLoginName(i interface{}, k string) (warnings []string, erro
 	// 1. can contain only letters, numbers, or dashes.
 	// 2. must start with letter
 	// 3. The value must be between 1 and 128 characters long
-	
 
 	if !regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d-]{0,127}$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%s can contain only letters, numbers, or dashes, must start with a letter, The value must be between 1 and 128 characters long", k))

--- a/internal/services/synapse/validate/sql_administrator_login_name.go
+++ b/internal/services/synapse/validate/sql_administrator_login_name.go
@@ -13,12 +13,13 @@ func SqlAdministratorLoginName(i interface{}, k string) (warnings []string, erro
 	}
 
 	// The name attribute rules are :
-	// 1. can contain only letters or numbers.
+	// 1. can contain only letters, numbers, or dashes.
 	// 2. must start with letter
 	// 3. The value must be between 1 and 128 characters long
+	
 
-	if !regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d]{0,127}$`).MatchString(v) {
-		errors = append(errors, fmt.Errorf("%s can contain only letters or numbers, must start with a letter, The value must be between 1 and 128 characters long", k))
+	if !regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d-]{0,127}$`).MatchString(v) {
+		errors = append(errors, fmt.Errorf("%s can contain only letters, numbers, or dashes, must start with a letter, The value must be between 1 and 128 characters long", k))
 		return
 	}
 


### PR DESCRIPTION
Attempt to solve #12355.

The proposed error text could be improved, though I'm not quite sure how at this moment.

(fies #12355)