### PR TITLE
`azurerm_servicebus_namespace` - `sku` can be updated to `Basic`/`Standard` without recreating the resource

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -78,7 +78,6 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(servicebus.SkuNameBasic),
 					string(servicebus.SkuNameStandard),
@@ -164,6 +163,14 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 			oldCustomerManagedKey, newCustomerManagedKey := diff.GetChange("customer_managed_key")
 			if len(oldCustomerManagedKey.([]interface{})) != 0 && len(newCustomerManagedKey.([]interface{})) == 0 {
 				diff.ForceNew("customer_managed_key")
+			}
+
+			oldSku, newSku := diff.GetChange("sku")
+			if diff.HasChange("sku") {
+				if strings.EqualFold(newSku.(string), string(servicebus.SkuNamePremium)) || strings.EqualFold(oldSku.(string), string(servicebus.SkuNamePremium)) {
+					log.Printf("[DEBUG] cannot migrate a namespace from or to Premium SKU")
+					diff.ForceNew("sku")
+				}
 			}
 			return nil
 		}),

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -281,9 +281,6 @@ resource "azurerm_servicebus_namespace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
   local_auth_enabled  = false
-  tags = {
-    ENV = "Test"
-  }
 }`, data.RandomInteger, data.Locations.Primary)
 }
 

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -44,6 +44,26 @@ func TestAccAzureRMServiceBusNamespace_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusNamespace_updateSku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace", "test")
+	r := ServiceBusNamespaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r)),
+		},
+		data.ImportStep(),
+		{
+			Config: r.standardSku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r)),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAzureRMServiceBusNamespace_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace", "test")
 	r := ServiceBusNamespaceResource{}
@@ -242,6 +262,29 @@ resource "azurerm_servicebus_namespace" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (ServiceBusNamespaceResource) standardSku(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestservicebusnamespace-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  local_auth_enabled  = false
+  tags = {
+    ENV = "Test"
+  }
+}`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r ServiceBusNamespaceResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Defines which tier to use. Valid options are `Basic`, `Standard`, and `Premium`. Please not that setting this field to `Premium` will force the creation of a new resource and also requires setting `zone_redundant` to true.
+* `sku` - (Required) Defines which tier to use. Valid options are `Basic`, `Standard`, and `Premium`. Please note that setting this field to `Premium` will force the creation of a new resource and also requires setting `zone_redundant` to true.
 
 * `capacity` - (Optional) Specifies the Capacity / Throughput Units for a `Standard` SKU namespace. Default capacity has a maximum of `2`, but can be increased in blocks of 2 on a committed purchase basis.
 

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Defines which tier to use. Options are basic, standard or premium. Changing this forces a new resource to be created.
+* `sku` - (Required) Defines which tier to use. Options are `Basic`, `Standard` or `Premium`. Please note that setting this field to `Premium` will force the creation of a new resource.
 
 * `identity` - (Optional) An `identity` block as defined below.
 


### PR DESCRIPTION
The `sku` property shouldn't be defined as `forcenew` since the service supports sku update from `basic` to `standard`.

acc tests:
```
--- PASS: TestAccAzureRMServiceBusNamespace_updateSku (610.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    611.142s
```
Fix GH issue:
https://github.com/hashicorp/terraform-provider-azurerm/issues/16463