### PR TITLE
`azurerm_api_management` - Default hostname proxy configuration is no longer ignored

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -1301,11 +1301,6 @@ func flattenApiManagementHostnameConfigurations(input *[]apimanagement.HostnameC
 			output["host_name"] = *config.HostName
 		}
 
-		// There'll always be a default custom domain with hostName "apim_name.azure-api.net" and Type "Proxy", which should be ignored
-		if *config.HostName == strings.ToLower(name)+"."+apimHostNameSuffix && config.Type == apimanagement.HostnameTypeProxy {
-			continue
-		}
-
 		if config.NegotiateClientCertificate != nil {
 			output["negotiate_client_certificate"] = *config.NegotiateClientCertificate
 		}


### PR DESCRIPTION
#16065  Default hostname proxy configuration should not be ignored. 

AccTests:
```
=== RUN   TestAccApiManagement_basic
=== PAUSE TestAccApiManagement_basic
=== CONT  TestAccApiManagement_basic
--- PASS: TestAccApiManagement_basic (5167.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement (4241.322s)
=== RUN   TestAccApiManagement_requiresImport
=== PAUSE TestAccApiManagement_requiresImport
=== CONT  TestAccApiManagement_requiresImport
--- PASS: TestAccApiManagement_requiresImport (8485.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 8488.355s

```

