### PR TITLE
Add `dynamic_container_enabled` field to the schemas. Fix #16525

### DIFF
--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -465,7 +465,7 @@ func flattenDataFactoryDatasetAzureBlobStorageLocation(input *datafactory.AzureB
 	result := make(map[string]interface{})
 
 	if input.Container != nil {
-		container, dynamicContainerEnabled := flattenDataFactoryExpressionResultType(input.FolderPath)
+		container, dynamicContainerEnabled := flattenDataFactoryExpressionResultType(input.Container)
 		result["container"] = container
 		result["dynamic_container_enabled"] = dynamicContainerEnabled
 	}

--- a/internal/services/datafactory/data_factory_dataset_binary_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_binary_resource.go
@@ -154,6 +154,11 @@ func resourceDataFactoryDatasetBinary() *pluginsdk.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"dynamic_container_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},

--- a/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
@@ -125,6 +125,11 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"dynamic_container_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},

--- a/internal/services/datafactory/data_factory_dataset_json_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_json_resource.go
@@ -128,6 +128,11 @@ func resourceDataFactoryDatasetJSON() *pluginsdk.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"dynamic_container_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},

--- a/internal/services/datafactory/data_factory_dataset_parquet_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_parquet_resource.go
@@ -105,6 +105,11 @@ func resourceDataFactoryDatasetParquet() *pluginsdk.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"dynamic_container_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},

--- a/website/docs/r/data_factory_dataset_binary.html.markdown
+++ b/website/docs/r/data_factory_dataset_binary.html.markdown
@@ -110,6 +110,8 @@ A `azure_blob_storage_location` block supports the following:
 
 * `filename` - (Optional) The filename of the file in the blob container.
 
+* `dynamic_container_enabled` - (Optional) Is the `container` using dynamic expression, function or system variables? Defaults to `false`.
+
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
 * `dynamic_filename_enabled` - (Optional) Is the `filename` using dynamic expression, function or system variables? Defaults to `false`.

--- a/website/docs/r/data_factory_dataset_delimited_text.html.markdown
+++ b/website/docs/r/data_factory_dataset_delimited_text.html.markdown
@@ -132,6 +132,8 @@ An `azure_blob_storage_location` block supports the following:
 
 * `filename` - (Optional) The filename of the file.
 
+* `dynamic_container_enabled` - (Optional) Is the `container` using dynamic expression, function or system variables? Defaults to `false`.
+
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
 * `dynamic_filename_enabled` - (Optional) Is the `filename` using dynamic expression, function or system variables? Defaults to `false`.

--- a/website/docs/r/data_factory_dataset_json.html.markdown
+++ b/website/docs/r/data_factory_dataset_json.html.markdown
@@ -113,6 +113,8 @@ A `azure_blob_storage_location` block supports the following:
 
 * `filename` - (Required) The filename of the file on the web server.
 
+* `dynamic_container_enabled` - (Optional) Is the `container` using dynamic expression, function or system variables? Defaults to `false`.
+
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
 * `dynamic_filename_enabled` - (Optional) Is the `filename` using dynamic expression, function or system variables? Defaults to `false`.

--- a/website/docs/r/data_factory_dataset_parquet.html.markdown
+++ b/website/docs/r/data_factory_dataset_parquet.html.markdown
@@ -110,6 +110,8 @@ A `azure_blob_storage_location` block supports the following:
 
 * `filename` - (Required) The filename of the file on the web server.
 
+* `dynamic_container_enabled` - (Optional) Is the `container` using dynamic expression, function or system variables? Defaults to `false`.
+
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
 * `dynamic_filename_enabled` - (Optional) Is the `filename` using dynamic expression, function or system variables? Defaults to `false`.


### PR DESCRIPTION
Fix #16525

Four resources are affected:
* `azurerm_data_factory_dataset_binary`
*  `azurerm_data_factory_dataset_delimited_text`
*  `azurerm_data_factory_dataset_json`
*  `azurerm_data_factory_dataset_parquet`

Acc tests:

=== RUN   TestAccDataFactoryDatasetDelimitedText_http
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http
=== CONT  TestAccDataFactoryDatasetDelimitedText_http
--- PASS: TestAccDataFactoryDatasetDelimitedText_http (242.30s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_http_update
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http_update
=== CONT  TestAccDataFactoryDatasetDelimitedText_http_update
--- PASS: TestAccDataFactoryDatasetDelimitedText_http_update (353.12s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob_basic
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob_basic
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob_basic
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob_basic (263.16s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob (265.85s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob_empty_path
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob_empty_path
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob_empty_path
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob_empty_path (263.97s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blobFS
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blobFS
=== CONT  TestAccDataFactoryDatasetDelimitedText_blobFS
--- PASS: TestAccDataFactoryDatasetDelimitedText_blobFS (245.35s)
PASS

=== RUN   TestAccDataFactoryDatasetBinary_blob
=== PAUSE TestAccDataFactoryDatasetBinary_blob
=== CONT  TestAccDataFactoryDatasetBinary_blob
--- PASS: TestAccDataFactoryDatasetBinary_blob (192.96s)
=== RUN   TestAccDataFactoryDatasetBinary_blob_with_filepath
=== PAUSE TestAccDataFactoryDatasetBinary_blob_with_filepath
=== CONT  TestAccDataFactoryDatasetBinary_blob_with_filepath
--- PASS: TestAccDataFactoryDatasetBinary_blob_with_filepath (256.06s)
=== RUN   TestAccDataFactoryDatasetBinary_http
=== PAUSE TestAccDataFactoryDatasetBinary_http
=== CONT  TestAccDataFactoryDatasetBinary_http
--- PASS: TestAccDataFactoryDatasetBinary_http (175.27s)
=== RUN   TestAccDataFactoryDatasetBinary_sftp
=== PAUSE TestAccDataFactoryDatasetBinary_sftp
=== CONT  TestAccDataFactoryDatasetBinary_sftp
--- PASS: TestAccDataFactoryDatasetBinary_sftp (237.02s)
=== RUN   TestAccDataFactoryDatasetBinary_sftpComplete
=== PAUSE TestAccDataFactoryDatasetBinary_sftpComplete
=== CONT  TestAccDataFactoryDatasetBinary_sftpComplete
--- PASS: TestAccDataFactoryDatasetBinary_sftpComplete (239.05s)
PASS

=== RUN   TestAccDataFactoryDatasetJSON_basic
=== PAUSE TestAccDataFactoryDatasetJSON_basic
=== CONT  TestAccDataFactoryDatasetJSON_basic
--- PASS: TestAccDataFactoryDatasetJSON_basic (176.10s)
=== RUN   TestAccDataFactoryDatasetJSON_update
=== PAUSE TestAccDataFactoryDatasetJSON_update
=== CONT  TestAccDataFactoryDatasetJSON_update
--- PASS: TestAccDataFactoryDatasetJSON_update (278.44s)
=== RUN   TestAccDataFactoryDatasetJSON_blob
=== PAUSE TestAccDataFactoryDatasetJSON_blob
=== CONT  TestAccDataFactoryDatasetJSON_blob
--- PASS: TestAccDataFactoryDatasetJSON_blob (256.97s)
PASS

=== RUN   TestAccDataFactoryDatasetParquet_http
=== PAUSE TestAccDataFactoryDatasetParquet_http
=== CONT  TestAccDataFactoryDatasetParquet_http
--- PASS: TestAccDataFactoryDatasetParquet_http (239.87s)
=== RUN   TestAccDataFactoryDatasetParquet_http_update
=== PAUSE TestAccDataFactoryDatasetParquet_http_update
=== CONT  TestAccDataFactoryDatasetParquet_http_update
--- PASS: TestAccDataFactoryDatasetParquet_http_update (351.81s)
=== RUN   TestAccDataFactoryDatasetParquet_blob
=== PAUSE TestAccDataFactoryDatasetParquet_blob
=== CONT  TestAccDataFactoryDatasetParquet_blob
--- PASS: TestAccDataFactoryDatasetParquet_blob (260.20s)
PASS
