### PR TITLE
Bump azure-go-sdk to v63.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/hashicorp/terraform-provider-azurerm
 
 require (
-	github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
+	github.com/Azure/azure-sdk-for-go v63.4.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.26
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ cloud.google.com/go/storage v1.16.0/go.mod h1:ieKBmUyzcftN5tbxwnXClMKH00CfcQ+xL6
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v45.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v56.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v63.1.0+incompatible h1:yNC7qlSUWVF8p0TzxdmWW1FJ3DdIA+0Pge41IU/2+9U=
-github.com/Azure/azure-sdk-for-go v63.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v63.4.0+incompatible h1:fle3M5Q7vr8auaiPffKyUQmLbvYeqpw30bKU6PrWJFo=
+github.com/Azure/azure-sdk-for-go v63.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.3/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network/_meta.json
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network/_meta.json
@@ -1,5 +1,5 @@
 {
-  "commit": "ad6f098218e4f5eab87e784f1b6fc8a713147cab",
+  "commit": "fc9d4d2798f755bea848ac1c29b2730d31002cb8",
   "readme": "/_/azure-rest-api-specs/specification/network/resource-manager/readme.md",
   "tag": "package-2021-05",
   "use": "@microsoft.azure/autorest.go@2.1.187",

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network/models.go
@@ -15653,7 +15653,7 @@ type ExpressRouteGatewayList struct {
 type ExpressRouteGatewayProperties struct {
 	// AutoScaleConfiguration - Configuration for auto scaling.
 	AutoScaleConfiguration *ExpressRouteGatewayPropertiesAutoScaleConfiguration `json:"autoScaleConfiguration,omitempty"`
-	// ExpressRouteConnections - READ-ONLY; List of ExpressRoute connections to the ExpressRoute gateway.
+	// ExpressRouteConnections - List of ExpressRoute connections to the ExpressRoute gateway.
 	ExpressRouteConnections *[]ExpressRouteConnection `json:"expressRouteConnections,omitempty"`
 	// ProvisioningState - READ-ONLY; The provisioning state of the express route gateway resource. Possible values include: 'ProvisioningStateSucceeded', 'ProvisioningStateUpdating', 'ProvisioningStateDeleting', 'ProvisioningStateFailed'
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
@@ -15666,6 +15666,9 @@ func (ergp ExpressRouteGatewayProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	if ergp.AutoScaleConfiguration != nil {
 		objectMap["autoScaleConfiguration"] = ergp.AutoScaleConfiguration
+	}
+	if ergp.ExpressRouteConnections != nil {
+		objectMap["expressRouteConnections"] = ergp.ExpressRouteConnections
 	}
 	if ergp.VirtualHub != nil {
 		objectMap["virtualHub"] = ergp.VirtualHub

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -4,4 +4,4 @@ package version
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 // Number contains the semantic version of this SDK.
-const Number = "v63.1.0"
+const Number = "v63.4.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # cloud.google.com/go/storage v1.16.0
 ## explicit; go 1.11
-# github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
+# github.com/Azure/azure-sdk-for-go v63.4.0+incompatible
 ## explicit
 github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
 github.com/Azure/azure-sdk-for-go/services/aad/mgmt/2017-04-01/aad


### PR DESCRIPTION
Bump azure-go-sdk to v63.4. v63.4 include two swagger bug fix:
https://github.com/Azure/azure-rest-api-specs/pull/18417
https://github.com/Azure/azure-rest-api-specs/pull/18416
which will help fix issue : #13368 
