### PR TITLE
Fix the document issue related with #12456 

### DIFF
--- a/website/docs/r/automation_certificate.html.markdown
+++ b/website/docs/r/automation_certificate.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `automation_account_name` - (Required) The name of the automation account in which the Certificate is created. Changing this forces a new resource to be created.
 
-* `base64` - (Required) Base64 encoded value of the certificate.
+* `base64` - (Required) Base64 encoded value of the certificate. Changing this forces a new resource to be created.
 
 * `description` -  (Optional) The description of this Automation Certificate.
 


### PR DESCRIPTION
According to the [code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/automation/automation_certificate_resource.go#L63), the `base64` property is a ForceNew argument.