### PR TITLE
Doc Fix: `linux_web_app` and `windows_web_app` - make file_system_level argument required

### DIFF
--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -115,7 +115,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Optional) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -118,7 +118,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Optional) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -113,7 +113,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Optional) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -120,7 +120,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Optional) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-azurerm/issues/16321 
In docs `file_system_level` is listed as optional, but argument is required for application_logs in the code. This PR makes this argument required in documentation 