### PR TITLE
`azurerm_data_factory_dataset_delimited_text` Add missing default values to fix #13545

### DIFF
--- a/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
@@ -164,6 +164,7 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 			"column_delimiter": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  ",",
 			},
 
 			// Delimited Text Specific Field
@@ -176,12 +177,14 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 			"quote_character": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  `"`,
 			},
 
 			// Delimited Text Specific Field
 			"escape_character": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  `\`,
 			},
 
 			// Delimited Text Specific Field
@@ -195,12 +198,14 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 			"first_row_as_header": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 
 			// Delimited Text Specific Field
 			"null_value": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 
 			"parameters": {
@@ -362,12 +367,12 @@ func resourceDataFactoryDatasetDelimitedTextCreateUpdate(d *pluginsdk.ResourceDa
 		delimited_textDatasetProperties.EncodingName = v.(string)
 	}
 
-	if v, ok := d.GetOk("first_row_as_header"); ok {
-		delimited_textDatasetProperties.FirstRowAsHeader = v.(bool)
+	if v, ok := d.Get("first_row_as_header").(bool); ok {
+		delimited_textDatasetProperties.FirstRowAsHeader = v
 	}
 
-	if v, ok := d.GetOk("null_value"); ok {
-		delimited_textDatasetProperties.NullValue = v.(string)
+	if v, ok := d.Get("null_value").(string); ok {
+		delimited_textDatasetProperties.NullValue = v
 	}
 
 	if v, ok := d.GetOk("compression_level"); ok {


### PR DESCRIPTION
This pr fix #13545 by adding the missing default values.

Acc tests:

=== RUN   TestAccDataFactoryDatasetDelimitedText_http
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http
=== CONT  TestAccDataFactoryDatasetDelimitedText_http
--- PASS: TestAccDataFactoryDatasetDelimitedText_http (244.74s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_http_update
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http_update
=== CONT  TestAccDataFactoryDatasetDelimitedText_http_update
--- PASS: TestAccDataFactoryDatasetDelimitedText_http_update (358.27s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob_basic
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob_basic
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob_basic
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob_basic (269.31s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob (259.26s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob_empty_path
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob_empty_path
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob_empty_path
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob_empty_path (269.73s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blobFS
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blobFS
=== CONT  TestAccDataFactoryDatasetDelimitedText_blobFS
--- PASS: TestAccDataFactoryDatasetDelimitedText_blobFS (284.44s)
=== RUN   TestAccDataFactoryDatasetDelimitedText_blobDynamicContainer
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blobDynamicContainer
=== CONT  TestAccDataFactoryDatasetDelimitedText_blobDynamicContainer
--- PASS: TestAccDataFactoryDatasetDelimitedText_blobDynamicContainer (495.68s)
PASS