### PR TITLE
`recovery_services_vault`: Split create and update

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -27,9 +27,9 @@ import (
 
 func resourceRecoveryServicesVault() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceRecoveryServicesVaultCreateUpdate,
+		Create: resourceRecoveryServicesVaultCreate,
 		Read:   resourceRecoveryServicesVaultRead,
-		Update: resourceRecoveryServicesVaultCreateUpdate,
+		Update: resourceRecoveryServicesVaultUpdate,
 		Delete: resourceRecoveryServicesVaultDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -99,6 +99,7 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 			"sku": {
 				Type:             pluginsdk.TypeString,
 				Required:         true,
+				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifferenceV2Only,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(recoveryservices.SkuNameRS0),
@@ -132,12 +133,12 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 	}
 }
 
-func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).RecoveryServices.VaultsClient
 	cfgsClient := meta.(*clients.Client).RecoveryServices.VaultsConfigsClient
 	storageCfgsClient := meta.(*clients.Client).RecoveryServices.StorageConfigsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := parse.NewVaultID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
@@ -152,32 +153,16 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 	location := d.Get("location").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	log.Printf("[DEBUG] Creating/updating Recovery Service %s", id.String())
+	log.Printf("[DEBUG] Creating Recovery Service %s", id.String())
 
-	encryption := expandEncryption(d)
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id.String(), err)
-			}
-		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_recovery_services_vault", *existing.ID)
-		}
-	} else {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
-		if err != nil {
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id.String(), err)
 		}
-		if existing.Properties != nil && existing.Properties.Encryption != nil {
-			if encryption == nil {
-				return fmt.Errorf("once encryption with your own key has been enabled it's not possible to disable it")
-			}
-			if encryption.InfrastructureEncryption != existing.Properties.Encryption.InfrastructureEncryption {
-				return fmt.Errorf("once `infrastructure_encryption_enabled` has been set it's not possible to change it")
-			}
-		}
+	}
+	if existing.ID != nil && *existing.ID != "" {
+		return tf.ImportAsExistsError("azurerm_recovery_services_vault", *existing.ID)
 	}
 
 	expandedIdentity, err := expandVaultIdentity(d.Get("identity").([]interface{}))
@@ -196,10 +181,10 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, vault)
 	if err != nil {
-		return fmt.Errorf("creating/updating Recovery Service %s: %+v", id.String(), err)
+		return fmt.Errorf("creating Recovery Service %s: %+v", id.String(), err)
 	}
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of %q: %+v", id, err)
+		return fmt.Errorf("waiting for creation of %q: %+v", id, err)
 	}
 	cfg := backup.ResourceVaultConfigResource{
 		Properties: &backup.ResourceVaultConfig{
@@ -230,11 +215,7 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		},
 	}
 
-	if d.IsNewResource() {
-		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
-	} else {
-		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
-	}
+	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
@@ -261,7 +242,7 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	// storage type is not updated instantaneously, so we wait until storage type is correct
@@ -283,14 +264,14 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	// recovery vault's encryption config cannot be set while creation, so a standalone update is required.
 	if _, ok := d.GetOk("encryption"); ok {
 		updateFuture, err := client.Update(ctx, id.ResourceGroup, id.Name, recoveryservices.PatchVault{
 			Properties: &recoveryservices.VaultProperties{
-				Encryption: encryption,
+				Encryption: expandEncryption(d),
 			},
 		})
 		if err != nil {
@@ -299,6 +280,157 @@ func resourceRecoveryServicesVaultCreateUpdate(d *pluginsdk.ResourceData, meta i
 		if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for update encryption of %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
 		}
+	}
+
+	d.SetId(id.ID())
+	return resourceRecoveryServicesVaultRead(d, meta)
+}
+
+func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).RecoveryServices.VaultsClient
+	cfgsClient := meta.(*clients.Client).RecoveryServices.VaultsConfigsClient
+	storageCfgsClient := meta.(*clients.Client).RecoveryServices.StorageConfigsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewVaultID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	encryption := expandEncryption(d)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id.String(), err)
+	}
+	if existing.Properties != nil && existing.Properties.Encryption != nil {
+		if encryption == nil {
+			return fmt.Errorf("once encryption with your own key has been enabled it's not possible to disable it")
+		}
+		if encryption.InfrastructureEncryption != existing.Properties.Encryption.InfrastructureEncryption {
+			return fmt.Errorf("once `infrastructure_encryption_enabled` has been set it's not possible to change it")
+		}
+	}
+
+	storageMode := d.Get("storage_mode_type").(string)
+	crossRegionRestore := d.Get("cross_region_restore_enabled").(bool)
+
+	if crossRegionRestore && storageMode != string(backup.StorageTypeGeoRedundant) {
+		return fmt.Errorf("cannot enable cross region restore when storage mode type is not %s. %s", string(backup.StorageTypeGeoRedundant), id.String())
+	}
+
+	expandedIdentity, err := expandVaultIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
+
+	cfg := backup.ResourceVaultConfigResource{
+		Properties: &backup.ResourceVaultConfig{
+			EnhancedSecurityState: backup.EnhancedSecurityStateEnabled, // always enabled
+		},
+	}
+
+	if d.HasChange("soft_delete_enabled") {
+		if sd := d.Get("soft_delete_enabled").(bool); sd {
+			cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateEnabled
+		} else {
+			cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateDisabled
+		}
+
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending:    []string{"syncing"},
+			Target:     []string{"success"},
+			MinTimeout: 30 * time.Second,
+			Refresh: func() (interface{}, string, error) {
+				resp, err := cfgsClient.Update(ctx, id.Name, id.ResourceGroup, cfg)
+				if err != nil {
+					if strings.Contains(err.Error(), "ResourceNotYetSynced") {
+						return resp, "syncing", nil
+					}
+					return resp, "error", fmt.Errorf("updating Recovery Service Vault Cfg %s: %+v", id.String(), err)
+				}
+
+				return resp, "success", nil
+			},
+		}
+
+		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
+
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
+		}
+	}
+
+	if d.HasChanges("storage_mode_type", "cross_region_restore_enabled") {
+		storageCfg := backup.ResourceConfigResource{
+			Properties: &backup.ResourceConfig{
+				StorageModelType:       backup.StorageType(storageMode),
+				CrossRegionRestoreFlag: utils.Bool(crossRegionRestore),
+			},
+		}
+
+		err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutUpdate), func() *pluginsdk.RetryError {
+			if resp, err := storageCfgsClient.Update(ctx, id.Name, id.ResourceGroup, storageCfg); err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					return pluginsdk.RetryableError(fmt.Errorf("updating Recovery Service Storage Cfg %s: %+v", id.String(), err))
+				}
+				if utils.ResponseWasBadRequest(resp.Response) {
+					return pluginsdk.RetryableError(fmt.Errorf("updating Recovery Service Storage Cfg %s: %+v", id.String(), err))
+				}
+
+				return pluginsdk.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
+
+		// storage type is not updated instantaneously, so we wait until storage type is correct
+		err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutUpdate), func() *pluginsdk.RetryError {
+			if resp, err := storageCfgsClient.Get(ctx, id.Name, id.ResourceGroup); err == nil {
+				if resp.Properties == nil {
+					return pluginsdk.NonRetryableError(fmt.Errorf("updating %s Storage Config: `properties` was nil", id))
+				}
+				if resp.Properties.StorageType != storageCfg.Properties.StorageModelType {
+					return pluginsdk.RetryableError(fmt.Errorf("updating Storage Config: %+v", err))
+				}
+				if *resp.Properties.CrossRegionRestoreFlag != *storageCfg.Properties.CrossRegionRestoreFlag {
+					return pluginsdk.RetryableError(fmt.Errorf("updating Storage Config: %+v", err))
+				}
+			} else {
+				return pluginsdk.NonRetryableError(err)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
+	}
+
+	vault := recoveryservices.PatchVault{}
+
+	if d.HasChange("identity") {
+		vault.Identity = expandedIdentity
+	}
+
+	if d.HasChange("encryption") {
+		if vault.Properties == nil {
+			vault.Properties = &recoveryservices.VaultProperties{}
+		}
+
+		vault.Properties.Encryption = encryption
+	}
+
+	if d.HasChange("tags") {
+		vault.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	updateFuture, err := client.Update(ctx, id.ResourceGroup, id.Name, vault)
+	if err != nil {
+		return fmt.Errorf("updating Recovery Service Encryption %s: %+v", id, err)
+	}
+	if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update encryption of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -139,13 +139,93 @@ func TestAccRecoveryServicesVault_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccRecoveryServicesVault_basicWithIdentity(t *testing.T) {
+func TestAccRecoveryServicesVault_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
 	r := RecoveryServicesVaultResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicWithIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRecoveryServicesVault_softDelete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.softDeleteDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.softDeleteDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRecoveryServicesVault_storageModeType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageModeTypeDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageModeTypeUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRecoveryServicesVault_crossRegionRestore(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossRegionRestoreDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.crossRegionRestoreEnabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -507,6 +587,132 @@ resource "azurerm_recovery_services_vault" "test" {
 
   soft_delete_enabled = false
   storage_mode_type   = "ZoneRedundant"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) softDeleteDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) softDeleteDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  soft_delete_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) crossRegionRestoreDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) crossRegionRestoreEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  cross_region_restore_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) storageModeTypeDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) storageModeTypeUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  storage_mode_type = "ZoneRedundant"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -234,6 +234,55 @@ func TestAccRecoveryServicesVault_crossRegionRestore(t *testing.T) {
 	})
 }
 
+func TestAccRecoveryServicesVault_sku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.skuStandard(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuRS0(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// This step is to ensure `sku` and `encryption` can be updated together when `encryption` was not specified in the existing resource
+			Config: r.skuWithEncryption(data, "Standard"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRecoveryServicesVault_updateSkuWithExistingEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.skuWithEncryption(data, "Standard"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:      r.skuWithEncryption(data, "RS0"),
+			ExpectError: regexp.MustCompile("`sku` cannot be changed when encryption with your own key has been enabled"),
+		},
+	})
+}
+
 func (t RecoveryServicesVaultResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VaultID(state.ID)
 	if err != nil {
@@ -715,4 +764,129 @@ resource "azurerm_recovery_services_vault" "test" {
   storage_mode_type = "ZoneRedundant"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) skuStandard(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) skuRS0(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "RS0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) skuWithEncryption(data acceptance.TestData, sku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctest-key-vault-%[3]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctest-key-vault-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "%[4]s"
+
+  encryption {
+    key_id                            = azurerm_key_vault_key.test.id
+    infrastructure_encryption_enabled = false
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, sku)
 }


### PR DESCRIPTION
Fix #16116
Below code is invoked in the common `CreateUpdate`. A vault without Encryption is created first, and then encryption is added by update API. This causes the `update` to fail when encryption is specified because once it's specified, it cannot be removed, and this below PUT call will fail. This change is to split the `create` and `update` so that a default vault is not needed to be created first in the update
https://github.com/hashicorp/terraform-provider-azurerm/blob/cdd2a577a0ed4717318d575d2b03330ca68a07a8/internal/services/recoveryservices/recovery_services_vault_resource.go#L187-L197