### PR TITLE
Correct documentation of boundary conditions for azurerm_storage_share.quota property

### DIFF
--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 ~>**NOTE:** The `Premium` SKU of the `azurerm_storage_account` is required for the `NFS` protocol.
 
-* `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1`GB (or higher) and less than `5120` GB (`5` TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and less than `102400` GB (`100` TB).
+* `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1`GB (or higher) and at most `5120` GB (`5` TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and at most `102400` GB (`100` TB).
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
 


### PR DESCRIPTION
The previous phrasing 'less than' implies to me that the upper bound is exclusive. From experience with my own resources `5120` is an acceptable value for standard storage accounts and checking the validation code in the resource the `102400` limit also appears to be inclusive. Therefore I've tweaked the phrasing to correctly indicate that the boundary conditions are inclusive.
