### PR TITLE
Fix `TestAccBackupProtectedVm_*` `TestAccSiteRecoveryReplicatedVm_*`

### DIFF
--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -234,6 +234,9 @@ resource "azurerm_virtual_machine" "test" {
   vm_size               = "Standard_D1_v2"
   network_interface_ids = [azurerm_network_interface.test.id]
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -197,6 +197,8 @@ resource "azurerm_virtual_machine" "test" {
 
   vm_size = "Standard_B1s"
 
+  delete_os_disk_on_termination    = true
+
   storage_image_reference {
     publisher = "OpenLogic"
     offer     = "CentOS"
@@ -434,6 +436,9 @@ resource "azurerm_virtual_machine" "test" {
   resource_group_name   = azurerm_resource_group.test.name
   network_interface_ids = [azurerm_network_interface.test.id]
   vm_size               = "Standard_D1_v2"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = "Canonical"
@@ -804,6 +809,8 @@ resource "azurerm_virtual_machine" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   vm_size = "Standard_B1s"
+
+  delete_os_disk_on_termination    = true
 
   storage_image_reference {
     publisher = "OpenLogic"

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -197,7 +197,7 @@ resource "azurerm_virtual_machine" "test" {
 
   vm_size = "Standard_B1s"
 
-  delete_os_disk_on_termination    = true
+  delete_os_disk_on_termination = true
 
   storage_image_reference {
     publisher = "OpenLogic"
@@ -810,7 +810,7 @@ resource "azurerm_virtual_machine" "test" {
 
   vm_size = "Standard_B1s"
 
-  delete_os_disk_on_termination    = true
+  delete_os_disk_on_termination = true
 
   storage_image_reference {
     publisher = "OpenLogic"


### PR DESCRIPTION
similar to #16519. these tests are failing on main due to the dangling os/data disk created by `azurerm_virtual_machine`. Fixing it by adding `delete_os_disk_on_termination` and `delete_data_disks_on_termination`.