### PR TITLE
`azurerm_storage_account` - Allow omitting optional blocks under`queue_properties`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,4 +91,6 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 )
 
+replace github.com/tombuildsstuff/giovanni => ../giovanni
+
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9
 	github.com/sergi/go-diff v1.2.0
 	github.com/shopspring/decimal v1.2.0
-	github.com/tombuildsstuff/giovanni v0.19.0
+	github.com/tombuildsstuff/giovanni v0.20.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	gopkg.in/yaml.v2 v2.3.0
@@ -90,7 +90,5 @@ require (
 	google.golang.org/grpc v1.39.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
-
-replace github.com/tombuildsstuff/giovanni => ../giovanni
 
 go 1.18

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tombuildsstuff/giovanni v0.19.0 h1:iUn8m5ee4nKQ0t0kr/opgtXGMAtYAUgV+7bHVbHC8/I=
-github.com/tombuildsstuff/giovanni v0.19.0/go.mod h1:66KVLYma2whJhEdxPSPL3GQHkulhK+C5CluKfHGfPF4=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tombuildsstuff/giovanni v0.20.0 h1:IM/I/iNWMXnPYwcSq8uxV7TKDlv7Nejq0bRK9i6O/C0=
+github.com/tombuildsstuff/giovanni v0.20.0/go.mod h1:66KVLYma2whJhEdxPSPL3GQHkulhK+C5CluKfHGfPF4=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -469,6 +469,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 						"logging": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
@@ -500,6 +501,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 						"hour_metrics": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
@@ -527,6 +529,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 						"minute_metrics": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
@@ -2461,10 +2464,27 @@ func expandQueueProperties(input []interface{}) (queues.StorageServiceProperties
 			CorsRule: []queues.CorsRule{},
 		},
 		HourMetrics: &queues.MetricsConfig{
+			Version: "1.0",
 			Enabled: false,
+			RetentionPolicy: queues.RetentionPolicy{
+				Enabled: false,
+			},
 		},
 		MinuteMetrics: &queues.MetricsConfig{
+			Version: "1.0",
 			Enabled: false,
+			RetentionPolicy: queues.RetentionPolicy{
+				Enabled: false,
+			},
+		},
+		Logging: &queues.LoggingConfig{
+			Version: "1.0",
+			Delete:  false,
+			Read:    false,
+			Write:   false,
+			RetentionPolicy: queues.RetentionPolicy{
+				Enabled: false,
+			},
 		},
 	}
 	if len(input) == 0 {
@@ -2489,7 +2509,13 @@ func expandQueueProperties(input []interface{}) (queues.StorageServiceProperties
 
 func expandQueuePropertiesMetrics(input []interface{}) (*queues.MetricsConfig, error) {
 	if len(input) == 0 {
-		return &queues.MetricsConfig{}, nil
+		return &queues.MetricsConfig{
+			Version: "1.0",
+			Enabled: false,
+			RetentionPolicy: queues.RetentionPolicy{
+				Enabled: false,
+			},
+		}, nil
 	}
 
 	metricsAttr := input[0].(map[string]interface{})
@@ -2522,7 +2548,15 @@ func expandQueuePropertiesMetrics(input []interface{}) (*queues.MetricsConfig, e
 
 func expandQueuePropertiesLogging(input []interface{}) *queues.LoggingConfig {
 	if len(input) == 0 {
-		return &queues.LoggingConfig{}
+		return &queues.LoggingConfig{
+			Version: "1.0",
+			Delete:  false,
+			Read:    false,
+			Write:   false,
+			RetentionPolicy: queues.RetentionPolicy{
+				Enabled: false,
+			},
+		}
 	}
 
 	loggingAttr := input[0].(map[string]interface{})

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -510,6 +510,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 										Required:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
+									// TODO 4.0: Remove this property and determine whether to enable based on existance of the out side block.
 									"enabled": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,
@@ -538,6 +539,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 										Required:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
+									// TODO 4.0: Remove this property and determine whether to enable based on existance of the out side block.
 									"enabled": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -510,7 +510,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 										Required:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
-									// TODO 4.0: Remove this property and determine whether to enable based on existance of the out side block.
+									// TODO 4.0: Remove this property and determine whether to enable based on existence of the out side block.
 									"enabled": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,
@@ -539,7 +539,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 										Required:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
-									// TODO 4.0: Remove this property and determine whether to enable based on existance of the out side block.
+									// TODO 4.0: Remove this property and determine whether to enable based on existence of the out side block.
 									"enabled": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -705,6 +705,20 @@ func TestAccStorageAccount_queueProperties(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.queuePropertiesLoggingOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.queuePropertiesMinuteMetricsOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.queueProperties(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -2611,6 +2625,68 @@ resource "azurerm_storage_account" "test" {
       version               = "1.0"
       enabled               = true
       include_apis          = false
+      retention_policy_days = 7
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) queuePropertiesLoggingOnly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  queue_properties {
+    logging {
+      version               = "1.0"
+      delete                = true
+      read                  = true
+      write                 = true
+      retention_policy_days = 7
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) queuePropertiesMinuteMetricsOnly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  queue_properties {
+    minute_metrics {
+      version               = "1.0"
+      enabled               = false
       retention_policy_days = 7
     }
   }

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2019-12-12/queue/queues/models.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2019-12-12/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -389,7 +389,7 @@ github.com/sergi/go-diff/diffmatchpatch
 # github.com/shopspring/decimal v1.2.0
 ## explicit; go 1.13
 github.com/shopspring/decimal
-# github.com/tombuildsstuff/giovanni v0.19.0
+# github.com/tombuildsstuff/giovanni v0.19.0 => ../giovanni
 ## explicit; go 1.13
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/accounts
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/blobs
@@ -600,3 +600,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/yaml.v2 v2.3.0
 ## explicit
 gopkg.in/yaml.v2
+# github.com/tombuildsstuff/giovanni => ../giovanni

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -389,7 +389,7 @@ github.com/sergi/go-diff/diffmatchpatch
 # github.com/shopspring/decimal v1.2.0
 ## explicit; go 1.13
 github.com/shopspring/decimal
-# github.com/tombuildsstuff/giovanni v0.19.0 => ../giovanni
+# github.com/tombuildsstuff/giovanni v0.20.0
 ## explicit; go 1.13
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/accounts
 github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/blobs
@@ -600,4 +600,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/yaml.v2 v2.3.0
 ## explicit
 gopkg.in/yaml.v2
-# github.com/tombuildsstuff/giovanni => ../giovanni


### PR DESCRIPTION
This PR is using a local replace for the giovanni, once https://github.com/tombuildsstuff/giovanni/pull/60 is merged and a new version released, we can use the official dependency instead.

This PR makes users to optionally omitting blocks under `queue_properties`. Previously, it will cause API issue when setting properties due to the default setting for the `queue_properties` failed to pass validation on service side (as is reported in #15525). This PR makes sure when certain block is not set, their default values can pass the validation, meanwhile keeping the same semantic as before (i.e. disabled). Furthermore, we also need to set these optional blocks as `O+C`, just as was done for the containing `queue_properties` block.

Fixes #15525.

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_queueProperties'
=== RUN   TestAccStorageAccount_queueProperties
=== PAUSE TestAccStorageAccount_queueProperties
=== CONT  TestAccStorageAccount_queueProperties
--- PASS: TestAccStorageAccount_queueProperties (387.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       387.566s
```
