### PR TITLE
Doc Fix: azurerm_public_ip_prefix - remove availability_zone for public ip prefix in tf doc as it is not supported after v3.0

### DIFF
--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,21 +45,17 @@ The following arguments are supported:
 
 -> **Note:** Public IP Prefix can only be created with Standard SKUs at this time.
 
-* `availability_zone` - (Optional) The availability zone to allocate the Public IP in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`. 
-
--> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time.
-
 * `ip_version` - (Optional) The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.
 
 * `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 31 (2 addresses). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.
 
--> **Please Note**: There may be Public IP address limits on the subscription . [More information available here](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits?toc=%2fazure%2fvirtual-network%2ftoc.json#publicip-address)
+-> **Please Note:** There may be Public IP address limits on the subscription . [More information available here](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits?toc=%2fazure%2fvirtual-network%2ftoc.json#publicip-address)
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Public IP Prefix should be located. Changing this forces a new Public IP Prefix to be created.
 
--> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
+-> **Please Note:** Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
 
 ## Attributes Reference
 


### PR DESCRIPTION
 1. Remove `availability_zone` propterty for public ip prefix in tf doc as it is not supported after v3.0. 
 2. Change the position of the colons to at least ensure their consistency in the same file. Currently as follows:
 ![image](https://user-images.githubusercontent.com/39109137/165468066-4a18dfe7-2ec0-47af-8b1e-2a3f0d84a6b1.png)
