### PR TITLE
Added `triggers` attribute to `azurerm_virtual_network_peering` to allow `address_space` synchronisation

### DIFF
--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -83,6 +83,14 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"triggers": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
 		},
 	}
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -223,9 +223,9 @@ resource "azurerm_virtual_network_peering" "test1" {
   virtual_network_name         = azurerm_virtual_network.test1.name
   remote_virtual_network_id    = azurerm_virtual_network.test2.id
   allow_virtual_network_access = true
-	triggers = {
-		remote_address_space = join(",", azurerm_virtual_network.test2.address_space)
-	}
+  triggers = {
+    remote_address_space = join(",", azurerm_virtual_network.test2.address_space)
+  }
 }
 
 resource "azurerm_virtual_network_peering" "test2" {
@@ -234,9 +234,9 @@ resource "azurerm_virtual_network_peering" "test2" {
   virtual_network_name         = azurerm_virtual_network.test2.name
   remote_virtual_network_id    = azurerm_virtual_network.test1.id
   allow_virtual_network_access = true
-	triggers = {
-		remote_address_space = join(",", azurerm_virtual_network.test1.address_space)
-	}
+  triggers = {
+    remote_address_space = join(",", azurerm_virtual_network.test1.address_space)
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -34,6 +34,29 @@ func TestAccVirtualNetworkPeering_basic(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkPeering_withTriggers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+	secondResourceName := "azurerm_virtual_network_peering.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withTriggers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("allow_virtual_network_access").HasValue("true"),
+				check.That(data.ResourceName).Key("triggers.remote_address_space").Exists(),
+				check.That(data.ResourceName).Key("triggers.remote_address_space").HasValue("10.0.2.0/24"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_virtual_network_access", "true"),
+			),
+		},
+		// triggers is an arbitrary list(string) which
+		// is not known at the backend API
+		data.ImportStep("triggers"),
+	})
+}
+
 func TestAccVirtualNetworkPeering_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_peering", "test1")
 	r := VirtualNetworkPeeringResource{}
@@ -165,6 +188,55 @@ resource "azurerm_virtual_network_peering" "test2" {
   virtual_network_name         = azurerm_virtual_network.test2.name
   remote_virtual_network_id    = azurerm_virtual_network.test1.id
   allow_virtual_network_access = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkPeeringResource) withTriggers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test1" {
+  name                = "acctestvirtnet-1-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.1.0/24"]
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_network" "test2" {
+  name                = "acctestvirtnet-2-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.2.0/24"]
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_network_peering" "test1" {
+  name                         = "acctestpeer-1-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test1.name
+  remote_virtual_network_id    = azurerm_virtual_network.test2.id
+  allow_virtual_network_access = true
+	triggers = {
+		remote_address_space = join(",", azurerm_virtual_network.test2.address_space)
+	}
+}
+
+resource "azurerm_virtual_network_peering" "test2" {
+  name                         = "acctestpeer-2-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test2.name
+  remote_virtual_network_id    = azurerm_virtual_network.test1.id
+  allow_virtual_network_access = true
+	triggers = {
+		remote_address_space = join(",", azurerm_virtual_network.test1.address_space)
+	}
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
This is a continuation of the abandoned PR #14067

# Problem

Azure Virtual network peerings require a "resync" after the address space of one
of the connected Virtual network changes. This effectively syncs the network routes
from the remote vnet to the local vnet.

Right now its not possible to trigger a resync without tainting/recreating the
peering resource.

**The resync has to be initiated on the remote peering, which further complicates things**

The API for triggering a sync is currently the same as creating/updating the
peering, with an additional URI parameter:
https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtual-network-peerings/create-or-update#uri-parameters

# Possible solutions

We discussed and I've tried a few implementations

#### Solution 1: Added a `triggers` property to the `azurerm_virtual_network_peering` resource, which for example can be used together with the `address_space` property of the peered remote vnet (resource or data source)

- Good, easy to implement, flexible to use
- Good, no dependency or cycle issues
- Good, final state can be reached in one `plan/apply`
- Bad, `triggers` is not intuitive

Example:

```terraform
resource "azurerm_resource_group" "example" {
  name     = "peeredvnets-rg"
  location = "West Europe"
}

resource "azurerm_virtual_network" "peer1" {
  name                = "peer1"
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.0.1.0/24"]
  location            = "West US"
}

resource "azurerm_virtual_network" "peer2" {
  name                = "peer2"
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.0.2.0/24", "10.0.3.0/24"]
  location            = "West US"
}

resource "azurerm_virtual_network_peering" "peer1to2" {
  name                      = "peer1to2"
  resource_group_name       = azurerm_resource_group.example.name
  virtual_network_name      = azurerm_virtual_network.example-1.name
  remote_virtual_network_id = azurerm_virtual_network.example-2.id
  triggers = {
    remote_address_space = join(",", azurerm_virtual_network.peer2.address_space)
  }
}

resource "azurerm_virtual_network_peering" "peer2to1" {
  name                      = "peer2to1"
  resource_group_name       = azurerm_resource_group.example.name
  virtual_network_name      = azurerm_virtual_network.peer2.name
  remote_virtual_network_id = azurerm_virtual_network.peer1.id
  triggers = {
    remote_address_space = join(",", azurerm_virtual_network.peer1.address_space)
  }
}
```

#### Solution 2: I've updated the `azurerm_virtual_network` resource to automatically update all remote peerings if the local `address_space` list changed.

- Good, this just works out of the box, without user interaction 
- Good, no dependency or cycle issues
- Neutral, can be implemented as opt-in feature (that's what I did)
- Really bad, this only works if the remote peering is in the same subscription, which may not always be the case

If interested, working implementation is here: https://github.com/tiwood/terraform-provider-azurerm/commit/b7f09b2aaf3884d35f4508bf3af54ebf84c984c8

#### Solution 3: Create a dedicated `azure_virtual_network_peering_sync`

- Good, makes more sense to the users than a `triggers` property
- Bad, this is basically code dup of the actual peering resource, as a resync is just a `create/update` operations which requires all properties from the peering resource (these can be discovered automatically)
- Bad, if the address space changes happen in the same configuration where this resource is located, you need more than one `plan/apply` to trigger the sync
- Neutral, would need a `triggers` property to allow for "one step" plan/apply.

Example:

```terraform
resource "azurerm_virtual_network_peering_sync" "peer1to2" {
  virtual_network_peering_id = azurerm_virtual_network_peering.peer1to2.id

  # Optional triggers
  triggers = {}
}
```

This PR implements `Solution 1`. Let me know what you guys think.