### PR TITLE
azurerm_stream_analytics_function_javascript_uda - support new property is_configuration_parameter

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
@@ -70,6 +70,12 @@ func resourceStreamAnalyticsFunctionUDA() *pluginsdk.Resource {
 								"record",
 							}, false),
 						},
+
+						"is_configuration_parameter": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -267,7 +273,8 @@ func expandStreamAnalyticsFunctionUDAInputs(input []interface{}) *[]streamanalyt
 		v := raw.(map[string]interface{})
 		variableType := v["type"].(string)
 		outputs = append(outputs, streamanalytics.FunctionInput{
-			DataType: utils.String(variableType),
+			DataType:                 utils.String(variableType),
+			IsConfigurationParameter: utils.Bool(v["is_configuration_parameter"].(bool)),
 		})
 	}
 
@@ -287,8 +294,14 @@ func flattenStreamAnalyticsFunctionUDAInputs(input *[]streamanalytics.FunctionIn
 			variableType = *v.DataType
 		}
 
+		var isConfigurationParameter bool
+		if v.IsConfigurationParameter != nil {
+			isConfigurationParameter = *v.IsConfigurationParameter
+		}
+
 		outputs = append(outputs, map[string]interface{}{
-			"type": variableType,
+			"type":                       variableType,
+			"is_configuration_parameter": isConfigurationParameter,
 		})
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
@@ -71,7 +71,7 @@ func resourceStreamAnalyticsFunctionUDA() *pluginsdk.Resource {
 							}, false),
 						},
 
-						"is_configuration_parameter": {
+						"configuration_parameter": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
@@ -274,7 +274,7 @@ func expandStreamAnalyticsFunctionUDAInputs(input []interface{}) *[]streamanalyt
 		variableType := v["type"].(string)
 		outputs = append(outputs, streamanalytics.FunctionInput{
 			DataType:                 utils.String(variableType),
-			IsConfigurationParameter: utils.Bool(v["is_configuration_parameter"].(bool)),
+			IsConfigurationParameter: utils.Bool(v["configuration_parameter"].(bool)),
 		})
 	}
 
@@ -300,8 +300,8 @@ func flattenStreamAnalyticsFunctionUDAInputs(input *[]streamanalytics.FunctionIn
 		}
 
 		outputs = append(outputs, map[string]interface{}{
-			"type":                       variableType,
-			"is_configuration_parameter": isConfigurationParameter,
+			"type":                    variableType,
+			"configuration_parameter": isConfigurationParameter,
 		})
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
@@ -96,6 +96,28 @@ func TestAccStreamAnalyticsFunctionJavaScriptUDA_update(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsFunctionJavaScriptUDA_isConfigurationParameter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_function_javascript_uda", "test")
+	r := StreamAnalyticsFunctionJavaScriptUDAResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.isConfigurationParameter(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.isConfigurationParameter(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StreamAnalyticsFunctionJavaScriptUDAResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FunctionID(state.ID)
 	if err != nil {
@@ -243,6 +265,43 @@ SCRIPT
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r StreamAnalyticsFunctionJavaScriptUDAResource) isConfigurationParameter(data acceptance.TestData, isConfigurationParameter bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_function_javascript_uda" "test" {
+  name                    = "acctestinput-%d"
+  stream_analytics_job_id = azurerm_stream_analytics_job.test.id
+
+  script = <<SCRIPT
+function main() {
+    this.init = function () {
+        this.state = 0;
+    }
+
+    this.accumulate = function (value, timestamp) {
+        this.state += value;
+    }
+
+    this.computeResult = function () {
+        return this.state;
+    }
+}
+SCRIPT
+
+
+  input {
+    type                       = "bigint"
+    is_configuration_parameter = %t
+  }
+
+  output {
+    type = "bigint"
+  }
+}
+`, r.template(data), data.RandomInteger, isConfigurationParameter)
 }
 
 func (r StreamAnalyticsFunctionJavaScriptUDAResource) template(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
@@ -293,8 +293,8 @@ SCRIPT
 
 
   input {
-    type                       = "bigint"
-    is_configuration_parameter = %t
+    type                    = "bigint"
+    configuration_parameter = %t
   }
 
   output {

--- a/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
@@ -72,6 +72,8 @@ An `input` block supports the following:
 
 * `type` - The input data type of this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
+* `is_configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
+
 ---
 
 An `output` block supports the following:

--- a/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
@@ -72,7 +72,7 @@ An `input` block supports the following:
 
 * `type` - The input data type of this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
-* `is_configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
+* `configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
This PR is to support new property is_configuration_parameter.

--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDA_basic (260.69s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDA_requiresImport (280.73s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDA_update (347.83s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDA_isConfigurationParameter (348.76s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDA_inputs (452.18s)