### PR TITLE
azurerm_stream_analytics_function_javascript_udf - support new property is_configuration_parameter

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
@@ -71,6 +71,12 @@ func resourceStreamAnalyticsFunctionUDF() *pluginsdk.Resource {
 								"record",
 							}, false),
 						},
+
+						"is_configuration_parameter": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -242,7 +248,8 @@ func expandStreamAnalyticsFunctionInputs(input []interface{}) *[]streamanalytics
 		v := raw.(map[string]interface{})
 		variableType := v["type"].(string)
 		outputs = append(outputs, streamanalytics.FunctionInput{
-			DataType: utils.String(variableType),
+			DataType:                 utils.String(variableType),
+			IsConfigurationParameter: utils.Bool(v["is_configuration_parameter"].(bool)),
 		})
 	}
 
@@ -262,8 +269,14 @@ func flattenStreamAnalyticsFunctionInputs(input *[]streamanalytics.FunctionInput
 			variableType = *v.DataType
 		}
 
+		var isConfigurationParameter bool
+		if v.IsConfigurationParameter != nil {
+			isConfigurationParameter = *v.IsConfigurationParameter
+		}
+
 		outputs = append(outputs, map[string]interface{}{
-			"type": variableType,
+			"type":                       variableType,
+			"is_configuration_parameter": isConfigurationParameter,
 		})
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
@@ -72,7 +72,7 @@ func resourceStreamAnalyticsFunctionUDF() *pluginsdk.Resource {
 							}, false),
 						},
 
-						"is_configuration_parameter": {
+						"configuration_parameter": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
@@ -249,7 +249,7 @@ func expandStreamAnalyticsFunctionInputs(input []interface{}) *[]streamanalytics
 		variableType := v["type"].(string)
 		outputs = append(outputs, streamanalytics.FunctionInput{
 			DataType:                 utils.String(variableType),
-			IsConfigurationParameter: utils.Bool(v["is_configuration_parameter"].(bool)),
+			IsConfigurationParameter: utils.Bool(v["configuration_parameter"].(bool)),
 		})
 	}
 
@@ -275,8 +275,8 @@ func flattenStreamAnalyticsFunctionInputs(input *[]streamanalytics.FunctionInput
 		}
 
 		outputs = append(outputs, map[string]interface{}{
-			"type":                       variableType,
-			"is_configuration_parameter": isConfigurationParameter,
+			"type":                    variableType,
+			"configuration_parameter": isConfigurationParameter,
 		})
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
@@ -67,6 +67,28 @@ func TestAccStreamAnalyticsFunctionJavaScriptUDF_inputs(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsFunctionJavaScriptUDF_isConfigurationParameter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_function_javascript_udf", "test")
+	r := StreamAnalyticsFunctionJavaScriptUDFResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.isConfigurationParameter(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.isConfigurationParameter(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StreamAnalyticsFunctionJavaScriptUDFResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FunctionID(state.ID)
 	if err != nil {
@@ -164,6 +186,35 @@ SCRIPT
   }
 }
 `, template, data.RandomInteger)
+}
+
+func (r StreamAnalyticsFunctionJavaScriptUDFResource) isConfigurationParameter(data acceptance.TestData, isConfigurationParameter bool) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_function_javascript_udf" "test" {
+  name                      = "acctestinput-%d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+
+  script = <<SCRIPT
+function getRandomNumber(in) {
+  return in;
+}
+SCRIPT
+
+
+  input {
+    type                       = "bigint"
+    is_configuration_parameter = %t
+  }
+
+  output {
+    type = "bigint"
+  }
+}
+`, template, data.RandomInteger, isConfigurationParameter)
 }
 
 func (r StreamAnalyticsFunctionJavaScriptUDFResource) template(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
@@ -206,8 +206,8 @@ SCRIPT
 
 
   input {
-    type                       = "bigint"
-    is_configuration_parameter = %t
+    type                    = "bigint"
+    configuration_parameter = %t
   }
 
   output {

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -66,7 +66,7 @@ A `input` block supports the following:
 
 * `type` - The Data Type for the Input Argument of this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
-* `is_configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
+* `configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -66,6 +66,8 @@ A `input` block supports the following:
 
 * `type` - The Data Type for the Input Argument of this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
+* `is_configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
+
 ---
 
 A `output` block supports the following:


### PR DESCRIPTION
This PR is to support new property is_configuration_parameter.

--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDF_basic (239.56s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDF_requiresImport (274.65s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDF_isConfigurationParameter (354.59s)
--- PASS: TestAccStreamAnalyticsFunctionJavaScriptUDF_inputs (364.07s)