### PR TITLE
Fix `TestAccSiteRecoveryReplicatedVm_*`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -901,7 +901,6 @@ func (t SiteRecoveryReplicatedVmResource) Exists(ctx context.Context, clients *c
 	return utils.Bool(resp.ID != nil), nil
 }
 
-
 // A temporary disk with name `ms-asr-*` is created and deleted automatically by recovery service when creating the replication.
 // After this temporary disk is deleted, its entry still remains in the resource list of the resource group for some time, causing the deletion of the resource group to fail.
 // Delete the temporary disk explicitly as a workaround, this can be removed after https://github.com/Azure/azure-rest-api-specs/issues/18993 is fixed.


### PR DESCRIPTION
These tests fail after 3.0 due to the dangling disk `ms-asr-*` created during the replication.
Error is like below:
```
Terraform has detected that the following Resources still exist within the Resource Group:
* `/subscriptions/*******/resourceGroups/ACCTESTRG-RECOVERY-220429025552402809-1/providers/Microsoft.Compute/disks/ms-asr-ee1904e0-938e-56fb-910b-033874e002c6`
```

This dangling disk is actually a temporary disk, after the replication is created, it is deleted automatically (Have verified by looking at the resource detail and using GET api). However, due to some cache sync latency, its entry still remains in the resource list of that resource group for a while (longer than couple of minutes). Since this temporary disk is already considered as deleted, I'm considering calling the Delete API to explicitly delete it, this can remove its entry in the resource list and fix the deletion issue of the resource group.