### PR TITLE
`document`: Fix `iothub` `network_rule_set.default_action` values

### DIFF
--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -226,7 +226,7 @@ An `identity` block supports the following:
 
 A `network_rule_set` block supports the following:
 
-* `default_action` - (Optional) Default Action for Network Rule Set. Possible values are `DefaultActionDeny`, `DefaultActionAllow`. Defaults to `DefaultActionDeny`.
+* `default_action` - (Optional) Default Action for Network Rule Set. Possible values are `Deny`, `Allow`. Defaults to `Deny`.
 
 * `apply_to_builtin_eventhub_endpoint` - (Optional) Determines if Network Rule Set is also applied to the BuiltIn EventHub EndPoint of the IotHub. Defaults to `false`.
 


### PR DESCRIPTION
Fixing #16568
https://github.com/hashicorp/terraform-provider-azurerm/blob/bc9712156fcbb1ed354d6d2f9340d4b63dd394f3/internal/services/iothub/iothub_resource.go#L489-L496

https://github.com/hashicorp/terraform-provider-azurerm/blob/bc9712156fcbb1ed354d6d2f9340d4b63dd394f3/vendor/github.com/Azure/azure-sdk-for-go/services/iothub/mgmt/2021-07-02/devices/enums.go#L102-L107