### PR TITLE
`r\iothub` Add validation for `ip_rules.name`

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -508,7 +508,7 @@ func resourceIotHub() *pluginsdk.Resource {
 										"name": {
 											Type:         pluginsdk.TypeString,
 											Required:     true,
-											ValidateFunc: validation.StringIsNotEmpty,
+											ValidateFunc: iothubValidate.IoTHubIpRuleName,
 										},
 										"ip_mask": {
 											Type:         pluginsdk.TypeString,

--- a/internal/services/iothub/validate/iothub_ip_rule_name.go
+++ b/internal/services/iothub/validate/iothub_ip_rule_name.go
@@ -1,0 +1,16 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func IoTHubIpRuleName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z-:.+%_#*?!(),=@;']{1,128}$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("`ip_rule_name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus {'-', ':', '.', '+', '%%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '''} are accepted"))
+	}
+
+	return
+}

--- a/internal/services/iothub/validate/iothub_ip_rule_name.go
+++ b/internal/services/iothub/validate/iothub_ip_rule_name.go
@@ -9,7 +9,7 @@ func IoTHubIpRuleName(v interface{}, k string) (warnings []string, errors []erro
 	value := v.(string)
 
 	if matched := regexp.MustCompile(`^[0-9a-zA-Z-:.+%_#*?!(),=@;']{1,128}$`).Match([]byte(value)); !matched {
-		errors = append(errors, fmt.Errorf("`ip_rule_name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus {'-', ':', '.', '+', '%%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '''} are accepted"))
+		errors = append(errors, fmt.Errorf("`ip_rule_name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus the following special characters are accepted: - : . + %% _ # * ? ! ( ) , = @ ; '"))
 	}
 
 	return

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -238,7 +238,7 @@ A `ip_rule` block supports the following:
 
 * `name` - (Required) The name of the IP rule.
 
-~> **NOTE:** `name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '''} are accepted.
+~> **NOTE:** `name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus the following special characters are accepted: `- : . + % _ # * ? ! ( ) , = @ ; '`.
 
 * `ip_mask` - (Required) The IP address range in CIDR notation for the IP rule.
 

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -238,8 +238,6 @@ A `ip_rule` block supports the following:
 
 * `name` - (Required) The name of the IP rule.
 
-~> **NOTE:** `name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus the following special characters are accepted: `- : . + % _ # * ? ! ( ) , = @ ; '`.
-
 * `ip_mask` - (Required) The IP address range in CIDR notation for the IP rule.
 
 * `action` - (Optional) The desired action for requests captured by this rule. Possible values are `Allow`. Defaults to `Allow`.

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -238,6 +238,8 @@ A `ip_rule` block supports the following:
 
 * `name` - (Required) The name of the IP rule.
 
+~> **NOTE:** `name` can only be alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '''} are accepted.
+
 * `ip_mask` - (Required) The IP address range in CIDR notation for the IP rule.
 
 * `action` - (Optional) The desired action for requests captured by this rule. Possible values are `Allow`. Defaults to `Allow`.


### PR DESCRIPTION
Fixing #16568, according to the issue, error message from Azure is unclear, so adding the validation.
Referencing doc: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-ip-filtering#add-or-edit-an-ip-filter-rule
```
Provide a name for the IP Filter rule. This name must be a unique, case-insensitive, alphanumeric string up to 128 characters long. Only the ASCII 7-bit alphanumeric characters plus {'-', ':', '/', '\', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '''} are accepted.
``` 
And during my test, `/` and `\` is actually not allowed, have excluded these two characters in the validation and opened an issue https://github.com/MicrosoftDocs/azure-docs/issues/92219 for Azure