### PR TITLE
`azurerm_batch_pool` add test for start_task.user_identity.user_name  

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -459,11 +459,10 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 				Scope:          batch.AutoUserScope(autoUserMap["scope"].(string)),
 			}
 		}
-	} else if userNameValue, ok := userIdentityValue["username"]; ok {
+	}
+	if userNameValue, ok := userIdentityValue["user_name"]; ok {
 		userName := userNameValue.(string)
 		userIdentity.UserName = &userName
-	} else {
-		return nil, fmt.Errorf("either auto_user or user_name should be specified for Batch pool start task")
 	}
 
 	resourceFileList := startTaskValue["resource_file"].([]interface{})


### PR DESCRIPTION
test result:
<img width="730" alt="batch-pool1" src="https://user-images.githubusercontent.com/96756505/165914880-6e687198-8120-4045-af98-ef91b90bd31c.png">
  
Defining both the user_name and auto_user blocks in the user_identity block gives the following error：

 Error: creating Pool: (Name "testaccpool72ying" / Batch Account Name "testaccbatch72ying" / Resource Group "testaccRG-batch-72ying"): auto_user and user_name cannot be specified in the user_identity at the same time.

When neither the user_name nor the auto_user block is defined in the user_identity block, the following error occurs：

Error: Missing required argument
"start_task.0.user_identity.0.auto_user": one of `start_task.0.user_identity.0.auto_user,start_task.0.user_identity.0.user_name` must be  specified.

 