### PR TITLE
Added client certificate exclusion paths app service setting

### DIFF
--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -38,6 +38,7 @@ type LinuxFunctionAppDataSourceModel struct {
 	BuiltinLogging            bool                                 `tfschema:"builtin_logging_enabled"`
 	ClientCertEnabled         bool                                 `tfschema:"client_certificate_enabled"`
 	ClientCertMode            string                               `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths  string                               `tfschema:"client_certificate_exclusion_paths"`
 	ConnectionStrings         []helpers.ConnectionString           `tfschema:"connection_string"`
 	DailyMemoryTimeQuota      int                                  `tfschema:"daily_memory_time_quota"`
 	Enabled                   bool                                 `tfschema:"enabled"`
@@ -140,6 +141,12 @@ func (d LinuxFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchemaComputed(),
@@ -307,6 +314,7 @@ func (d LinuxFunctionAppDataSource) Read() sdk.ResourceFunc {
 				Location:                   location.NormalizeNilable(functionApp.Location),
 				Enabled:                    utils.NormaliseNilableBool(functionApp.Enabled),
 				ClientCertMode:             string(functionApp.ClientCertMode),
+				ClientCertExclusionPaths:   utils.NormalizeNilableString(functionApp.ClientCertExclusionPaths),
 				DailyMemoryTimeQuota:       int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
 				StickySettings:             helpers.FlattenStickySettings(stickySettings.SlotConfigNames),
 				Tags:                       tags.ToTypedObject(functionApp.Tags),

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -465,6 +465,10 @@ func (r LinuxFunctionAppResource) Create() sdk.ResourceFunc {
 				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(functionApp.VirtualNetworkSubnetID)
 			}
 
+			if functionApp.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(functionApp.ClientCertExclusionPaths)
+			}
+
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
 			if err != nil {
 				return fmt.Errorf("creating Linux %s: %+v", id, err)
@@ -601,6 +605,7 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 				Location:                    location.NormalizeNilable(functionApp.Location),
 				Enabled:                     utils.NormaliseNilableBool(functionApp.Enabled),
 				ClientCertMode:              string(functionApp.ClientCertMode),
+				ClientCertExclusionPaths:    utils.NormalizeNilableString(functionApp.ClientCertExclusionPaths),
 				DailyMemoryTimeQuota:        int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
 				StickySettings:              helpers.FlattenStickySettings(stickySettings.SlotConfigNames),
 				Tags:                        tags.ToTypedObject(functionApp.Tags),

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -46,6 +46,7 @@ type LinuxFunctionAppModel struct {
 	BuiltinLogging              bool                                 `tfschema:"builtin_logging_enabled"`
 	ClientCertEnabled           bool                                 `tfschema:"client_certificate_enabled"`
 	ClientCertMode              string                               `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths    string                               `tfschema:"client_certificate_exclusion_paths"`
 	ConnectionStrings           []helpers.ConnectionString           `tfschema:"connection_string"`
 	DailyMemoryTimeQuota        int                                  `tfschema:"daily_memory_time_quota"` // TODO - Value ignored in for linux apps, even in Consumption plans?
 	Enabled                     bool                                 `tfschema:"enabled"`
@@ -190,6 +191,12 @@ func (r LinuxFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 				string(web.ClientCertModeOptionalInteractiveUser),
 			}, false),
 			Description: "The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser` ",
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchema(),
@@ -743,6 +750,10 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
+			}
+
+			if metadata.ResourceData.HasChange("client_certificate_exclusion_paths") {
+				existing.SiteProperties.ClientCertExclusionPaths = utils.String(state.ClientCertExclusionPaths)
 			}
 
 			if metadata.ResourceData.HasChange("identity") {

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -2377,9 +2377,10 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "Required"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Required"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "Second"
@@ -2558,9 +2559,10 @@ resource "azurerm_linux_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "OptionalInteractiveUser"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "OptionalInteractiveUser"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -442,14 +442,13 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp,linux"),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             utils.String(servicePlanId.ID()),
-					Enabled:                  utils.Bool(functionAppSlot.Enabled),
-					HTTPSOnly:                utils.Bool(functionAppSlot.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientCertEnabled:        utils.Bool(functionAppSlot.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(functionAppSlot.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(functionAppSlot.ClientCertExclusionPaths),
-					DailyMemoryTimeQuota:     utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)), // TODO - Investigate, setting appears silently ignored on Linux Function Apps?
+					ServerFarmID:         utils.String(servicePlanId.ID()),
+					Enabled:              utils.Bool(functionAppSlot.Enabled),
+					HTTPSOnly:            utils.Bool(functionAppSlot.HttpsOnly),
+					SiteConfig:           siteConfig,
+					ClientCertEnabled:    utils.Bool(functionAppSlot.ClientCertEnabled),
+					ClientCertMode:       web.ClientCertMode(functionAppSlot.ClientCertMode),
+					DailyMemoryTimeQuota: utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)), // TODO - Investigate, setting appears silently ignored on Linux Function Apps?
 				},
 			}
 
@@ -459,6 +458,10 @@ func (r LinuxFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 			if functionAppSlot.VirtualNetworkSubnetID != "" {
 				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(functionAppSlot.VirtualNetworkSubnetID)
+			}
+
+			if functionAppSlot.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(functionAppSlot.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -1733,9 +1733,10 @@ resource "azurerm_linux_function_app_slot" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "Required"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Required"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "Second"
@@ -1912,9 +1913,10 @@ resource "azurerm_linux_function_app_slot" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "OptionalInteractiveUser"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "OptionalInteractiveUser"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -30,6 +30,7 @@ type LinuxWebAppDataSourceModel struct {
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
 	ClientCertMode                string                     `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths      string                     `tfschema:"client_certificate_exclusion_paths"`
 	Enabled                       bool                       `tfschema:"enabled"`
 	HttpsOnly                     bool                       `tfschema:"https_only"`
 	KeyVaultReferenceIdentityID   string                     `tfschema:"key_vault_reference_identity_id"`
@@ -110,6 +111,12 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchemaComputed(),
@@ -287,6 +294,7 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 					webApp.ClientCertEnabled = *props.ClientCertEnabled
 				}
 				webApp.ClientCertMode = string(props.ClientCertMode)
+				webApp.ClientCertExclusionPaths = utils.NormalizeNilableString(props.ClientCertExclusionPaths)
 				webApp.CustomDomainVerificationId = utils.NormalizeNilableString(props.CustomDomainVerificationID)
 				webApp.DefaultHostname = utils.NormalizeNilableString(props.DefaultHostName)
 				if props.Enabled != nil {

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -317,14 +317,13 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 				Identity: expandedIdentity,
 				Tags:     tags.FromTypedObject(webApp.Tags),
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             utils.String(webApp.ServicePlanId),
-					Enabled:                  utils.Bool(webApp.Enabled),
-					HTTPSOnly:                utils.Bool(webApp.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientAffinityEnabled:    utils.Bool(webApp.ClientAffinityEnabled),
-					ClientCertEnabled:        utils.Bool(webApp.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(webApp.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(webApp.ClientCertExclusionPaths),
+					ServerFarmID:          utils.String(webApp.ServicePlanId),
+					Enabled:               utils.Bool(webApp.Enabled),
+					HTTPSOnly:             utils.Bool(webApp.HttpsOnly),
+					SiteConfig:            siteConfig,
+					ClientAffinityEnabled: utils.Bool(webApp.ClientAffinityEnabled),
+					ClientCertEnabled:     utils.Bool(webApp.ClientCertEnabled),
+					ClientCertMode:        web.ClientCertMode(webApp.ClientCertMode),
 				},
 			}
 
@@ -334,6 +333,10 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 
 			if webApp.KeyVaultReferenceIdentityID != "" {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(webApp.KeyVaultReferenceIdentityID)
+			}
+
+			if webApp.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(webApp.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -1328,9 +1328,10 @@ resource "azurerm_linux_web_app" "test" {
     }
   }
 
-  client_affinity_enabled    = true
-  client_certificate_enabled = true
-  client_certificate_mode    = "Optional"
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"
@@ -1502,9 +1503,10 @@ resource "azurerm_linux_web_app" "test" {
     }
   }
 
-  client_affinity_enabled    = true
-  client_certificate_enabled = true
-  client_certificate_mode    = "Optional"
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -284,14 +284,13 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 				Identity: expandedIdentity,
 				Tags:     tags.FromTypedObject(webAppSlot.Tags),
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             siteProps.ServerFarmID,
-					Enabled:                  utils.Bool(webAppSlot.Enabled),
-					HTTPSOnly:                utils.Bool(webAppSlot.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientAffinityEnabled:    utils.Bool(webAppSlot.ClientAffinityEnabled),
-					ClientCertEnabled:        utils.Bool(webAppSlot.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(webAppSlot.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(webAppSlot.ClientCertExclusionPaths),
+					ServerFarmID:          siteProps.ServerFarmID,
+					Enabled:               utils.Bool(webAppSlot.Enabled),
+					HTTPSOnly:             utils.Bool(webAppSlot.HttpsOnly),
+					SiteConfig:            siteConfig,
+					ClientAffinityEnabled: utils.Bool(webAppSlot.ClientAffinityEnabled),
+					ClientCertEnabled:     utils.Bool(webAppSlot.ClientCertEnabled),
+					ClientCertMode:        web.ClientCertMode(webAppSlot.ClientCertMode),
 				},
 			}
 
@@ -301,6 +300,10 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 
 			if webAppSlot.KeyVaultReferenceIdentityID != "" {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(webAppSlot.KeyVaultReferenceIdentityID)
+			}
+
+			if webAppSlot.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(webAppSlot.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -1224,9 +1224,10 @@ resource "azurerm_linux_web_app_slot" "test" {
     }
   }
 
-  client_affinity_enabled    = true
-  client_certificate_enabled = true
-  client_certificate_mode    = "Optional"
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -38,6 +38,7 @@ type WindowsFunctionAppDataSourceModel struct {
 	BuiltinLogging            bool                                   `tfschema:"builtin_logging_enabled"`
 	ClientCertEnabled         bool                                   `tfschema:"client_certificate_enabled"`
 	ClientCertMode            string                                 `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths  string                                 `tfschema:"client_certificate_exclusion_paths"`
 	ConnectionStrings         []helpers.ConnectionString             `tfschema:"connection_string"`
 	DailyMemoryTimeQuota      int                                    `tfschema:"daily_memory_time_quota"`
 	Enabled                   bool                                   `tfschema:"enabled"`
@@ -137,6 +138,12 @@ func (d WindowsFunctionAppDataSource) Attributes() map[string]*pluginsdk.Schema 
 		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchemaComputed(),
@@ -258,6 +265,7 @@ func (d WindowsFunctionAppDataSource) Read() sdk.ResourceFunc {
 			functionApp.Location = location.NormalizeNilable(existing.Location)
 			functionApp.Enabled = utils.NormaliseNilableBool(existing.Enabled)
 			functionApp.ClientCertMode = string(existing.ClientCertMode)
+			functionApp.ClientCertExclusionPaths = utils.NormalizeNilableString(existing.ClientCertExclusionPaths)
 			functionApp.DailyMemoryTimeQuota = int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota))
 			functionApp.Tags = tags.ToTypedObject(existing.Tags)
 			functionApp.Kind = utils.NormalizeNilableString(existing.Kind)

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -46,6 +46,7 @@ type WindowsFunctionAppModel struct {
 	BuiltinLogging              bool                                   `tfschema:"builtin_logging_enabled"`
 	ClientCertEnabled           bool                                   `tfschema:"client_certificate_enabled"`
 	ClientCertMode              string                                 `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths    string                                 `tfschema:"client_certificate_exclusion_paths"`
 	ConnectionStrings           []helpers.ConnectionString             `tfschema:"connection_string"`
 	DailyMemoryTimeQuota        int                                    `tfschema:"daily_memory_time_quota"`
 	Enabled                     bool                                   `tfschema:"enabled"`
@@ -190,6 +191,12 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 				string(web.ClientCertModeOptionalInteractiveUser),
 			}, false),
 			Description: "The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser` ",
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchema(),
@@ -439,13 +446,14 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp"),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:         utils.String(functionApp.ServicePlanId),
-					Enabled:              utils.Bool(functionApp.Enabled),
-					HTTPSOnly:            utils.Bool(functionApp.HttpsOnly),
-					SiteConfig:           siteConfig,
-					ClientCertEnabled:    utils.Bool(functionApp.ClientCertEnabled),
-					ClientCertMode:       web.ClientCertMode(functionApp.ClientCertMode),
-					DailyMemoryTimeQuota: utils.Int32(int32(functionApp.DailyMemoryTimeQuota)),
+					ServerFarmID:             utils.String(functionApp.ServicePlanId),
+					Enabled:                  utils.Bool(functionApp.Enabled),
+					HTTPSOnly:                utils.Bool(functionApp.HttpsOnly),
+					SiteConfig:               siteConfig,
+					ClientCertEnabled:        utils.Bool(functionApp.ClientCertEnabled),
+					ClientCertMode:           web.ClientCertMode(functionApp.ClientCertMode),
+					ClientCertExclusionPaths: utils.String(functionApp.ClientCertExclusionPaths),
+					DailyMemoryTimeQuota:     utils.Int32(int32(functionApp.DailyMemoryTimeQuota)),
 				},
 			}
 
@@ -593,6 +601,7 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 				Location:                    location.NormalizeNilable(functionApp.Location),
 				Enabled:                     utils.NormaliseNilableBool(functionApp.Enabled),
 				ClientCertMode:              string(functionApp.ClientCertMode),
+				ClientCertExclusionPaths:    utils.NormalizeNilableString(functionApp.ClientCertExclusionPaths),
 				DailyMemoryTimeQuota:        int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
 				StickySettings:              helpers.FlattenStickySettings(stickySettings.SlotConfigNames),
 				Tags:                        tags.ToTypedObject(functionApp.Tags),
@@ -729,6 +738,10 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
+			}
+
+			if metadata.ResourceData.HasChange("client_certificate_exclusion_paths") {
+				existing.SiteProperties.ClientCertExclusionPaths = utils.String(state.ClientCertExclusionPaths)
 			}
 
 			if metadata.ResourceData.HasChange("identity") {

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -446,14 +446,13 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp"),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             utils.String(functionApp.ServicePlanId),
-					Enabled:                  utils.Bool(functionApp.Enabled),
-					HTTPSOnly:                utils.Bool(functionApp.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientCertEnabled:        utils.Bool(functionApp.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(functionApp.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(functionApp.ClientCertExclusionPaths),
-					DailyMemoryTimeQuota:     utils.Int32(int32(functionApp.DailyMemoryTimeQuota)),
+					ServerFarmID:         utils.String(functionApp.ServicePlanId),
+					Enabled:              utils.Bool(functionApp.Enabled),
+					HTTPSOnly:            utils.Bool(functionApp.HttpsOnly),
+					SiteConfig:           siteConfig,
+					ClientCertEnabled:    utils.Bool(functionApp.ClientCertEnabled),
+					ClientCertMode:       web.ClientCertMode(functionApp.ClientCertMode),
+					DailyMemoryTimeQuota: utils.Int32(int32(functionApp.DailyMemoryTimeQuota)),
 				},
 			}
 
@@ -463,6 +462,10 @@ func (r WindowsFunctionAppResource) Create() sdk.ResourceFunc {
 
 			if functionApp.KeyVaultReferenceIdentityID != "" {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(functionApp.KeyVaultReferenceIdentityID)
+			}
+
+			if functionApp.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(functionApp.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -1686,9 +1686,10 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "Required"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Required"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "Second"
@@ -1874,9 +1875,10 @@ resource "azurerm_windows_function_app" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "OptionalInteractiveUser"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "OptionalInteractiveUser"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -451,14 +451,13 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp"),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             utils.String(servicePlanId.ID()),
-					Enabled:                  utils.Bool(functionAppSlot.Enabled),
-					HTTPSOnly:                utils.Bool(functionAppSlot.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientCertEnabled:        utils.Bool(functionAppSlot.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(functionAppSlot.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(functionAppSlot.ClientCertExclusionPaths),
-					DailyMemoryTimeQuota:     utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)),
+					ServerFarmID:         utils.String(servicePlanId.ID()),
+					Enabled:              utils.Bool(functionAppSlot.Enabled),
+					HTTPSOnly:            utils.Bool(functionAppSlot.HttpsOnly),
+					SiteConfig:           siteConfig,
+					ClientCertEnabled:    utils.Bool(functionAppSlot.ClientCertEnabled),
+					ClientCertMode:       web.ClientCertMode(functionAppSlot.ClientCertMode),
+					DailyMemoryTimeQuota: utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)),
 				},
 			}
 
@@ -468,6 +467,10 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 
 			if functionAppSlot.KeyVaultReferenceIdentityID != "" {
 				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(functionAppSlot.KeyVaultReferenceIdentityID)
+			}
+
+			if functionAppSlot.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(functionAppSlot.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -39,6 +39,7 @@ type WindowsFunctionAppSlotModel struct {
 	BuiltinLogging                bool                                       `tfschema:"builtin_logging_enabled"`
 	ClientCertEnabled             bool                                       `tfschema:"client_certificate_enabled"`
 	ClientCertMode                string                                     `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths      string                                     `tfschema:"client_certificate_exclusion_paths"`
 	ConnectionStrings             []helpers.ConnectionString                 `tfschema:"connection_string"`
 	DailyMemoryTimeQuota          int                                        `tfschema:"daily_memory_time_quota"`
 	Enabled                       bool                                       `tfschema:"enabled"`
@@ -173,6 +174,12 @@ func (r WindowsFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema
 				string(web.ClientCertModeOptionalInteractiveUser),
 			}, false),
 			Description: "The mode of the Function App Slot's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.",
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchema(),
@@ -444,13 +451,14 @@ func (r WindowsFunctionAppSlotResource) Create() sdk.ResourceFunc {
 				Kind:     utils.String("functionapp"),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:         utils.String(servicePlanId.ID()),
-					Enabled:              utils.Bool(functionAppSlot.Enabled),
-					HTTPSOnly:            utils.Bool(functionAppSlot.HttpsOnly),
-					SiteConfig:           siteConfig,
-					ClientCertEnabled:    utils.Bool(functionAppSlot.ClientCertEnabled),
-					ClientCertMode:       web.ClientCertMode(functionAppSlot.ClientCertMode),
-					DailyMemoryTimeQuota: utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)),
+					ServerFarmID:             utils.String(servicePlanId.ID()),
+					Enabled:                  utils.Bool(functionAppSlot.Enabled),
+					HTTPSOnly:                utils.Bool(functionAppSlot.HttpsOnly),
+					SiteConfig:               siteConfig,
+					ClientCertEnabled:        utils.Bool(functionAppSlot.ClientCertEnabled),
+					ClientCertMode:           web.ClientCertMode(functionAppSlot.ClientCertMode),
+					ClientCertExclusionPaths: utils.String(functionAppSlot.ClientCertExclusionPaths),
+					DailyMemoryTimeQuota:     utils.Int32(int32(functionAppSlot.DailyMemoryTimeQuota)),
 				},
 			}
 
@@ -580,6 +588,7 @@ func (r WindowsFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				FunctionAppID:               parse.NewFunctionAppID(id.SubscriptionId, id.ResourceGroup, id.SiteName).ID(),
 				Enabled:                     utils.NormaliseNilableBool(functionApp.Enabled),
 				ClientCertMode:              string(functionApp.ClientCertMode),
+				ClientCertExclusionPaths:    utils.NormalizeNilableString(functionApp.ClientCertExclusionPaths),
 				DailyMemoryTimeQuota:        int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
 				Tags:                        tags.ToTypedObject(functionApp.Tags),
 				Kind:                        utils.NormalizeNilableString(functionApp.Kind),
@@ -701,6 +710,10 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
+			}
+
+			if metadata.ResourceData.HasChange("client_certificate_exclusion_paths") {
+				existing.SiteProperties.ClientCertExclusionPaths = utils.String(state.ClientCertExclusionPaths)
 			}
 
 			if metadata.ResourceData.HasChange("identity") {

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -1242,9 +1242,10 @@ resource "azurerm_windows_function_app_slot" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "Required"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Required"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "Second"
@@ -1418,9 +1419,10 @@ resource "azurerm_windows_function_app_slot" "test" {
     }
   }
 
-  builtin_logging_enabled    = false
-  client_certificate_enabled = true
-  client_certificate_mode    = "OptionalInteractiveUser"
+  builtin_logging_enabled            = false
+  client_certificate_enabled         = true
+  client_certificate_mode            = "OptionalInteractiveUser"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -30,6 +30,7 @@ type WindowsWebAppDataSourceModel struct {
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
 	ClientCertMode                string                      `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths      string                      `tfschema:"client_certificate_exclusion_paths"`
 	Enabled                       bool                        `tfschema:"enabled"`
 	HttpsOnly                     bool                        `tfschema:"https_only"`
 	LogsConfig                    []helpers.LogsConfig        `tfschema:"logs"`
@@ -105,6 +106,12 @@ func (d WindowsWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		"client_certificate_mode": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchemaComputed(),
@@ -277,6 +284,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 					webApp.ClientCertEnabled = *props.ClientCertEnabled
 				}
 				webApp.ClientCertMode = string(props.ClientCertMode)
+				webApp.ClientCertExclusionPaths = utils.NormalizeNilableString(props.ClientCertExclusionPaths)
 				webApp.CustomDomainVerificationId = utils.NormalizeNilableString(props.CustomDomainVerificationID)
 				webApp.DefaultHostname = utils.NormalizeNilableString(props.DefaultHostName)
 				if props.Enabled != nil {

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -315,14 +315,13 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 				Tags:     tags.FromTypedObject(webApp.Tags),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:             utils.String(webApp.ServicePlanId),
-					Enabled:                  utils.Bool(webApp.Enabled),
-					HTTPSOnly:                utils.Bool(webApp.HttpsOnly),
-					SiteConfig:               siteConfig,
-					ClientAffinityEnabled:    utils.Bool(webApp.ClientAffinityEnabled),
-					ClientCertEnabled:        utils.Bool(webApp.ClientCertEnabled),
-					ClientCertMode:           web.ClientCertMode(webApp.ClientCertMode),
-					ClientCertExclusionPaths: utils.String(webApp.ClientCertExclusionPaths),
+					ServerFarmID:          utils.String(webApp.ServicePlanId),
+					Enabled:               utils.Bool(webApp.Enabled),
+					HTTPSOnly:             utils.Bool(webApp.HttpsOnly),
+					SiteConfig:            siteConfig,
+					ClientAffinityEnabled: utils.Bool(webApp.ClientAffinityEnabled),
+					ClientCertEnabled:     utils.Bool(webApp.ClientCertEnabled),
+					ClientCertMode:        web.ClientCertMode(webApp.ClientCertMode),
 				},
 			}
 
@@ -332,6 +331,10 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 
 			if webApp.VirtualNetworkSubnetID != "" {
 				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(webApp.VirtualNetworkSubnetID)
+			}
+
+			if webApp.ClientCertExclusionPaths != "" {
+				siteEnvelope.ClientCertExclusionPaths = utils.String(webApp.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1751,6 +1751,7 @@ resource "azurerm_windows_web_app" "test" {
   client_affinity_enabled    = true
   client_certificate_enabled = true
   //client_certificate_mode    = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"
@@ -1933,9 +1934,11 @@ resource "azurerm_windows_web_app" "test" {
     }
   }
 
-  client_affinity_enabled    = true
-  client_certificate_enabled = true
-  client_certificate_mode    = "Optional"
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
+
 
   connection_string {
     name  = "First"

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -31,6 +31,7 @@ type WindowsWebAppSlotModel struct {
 	ClientAffinityEnabled         bool                                  `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                                  `tfschema:"client_certificate_enabled"`
 	ClientCertMode                string                                `tfschema:"client_certificate_mode"`
+	ClientCertExclusionPaths      string                                `tfschema:"client_certificate_exclusion_paths"`
 	Enabled                       bool                                  `tfschema:"enabled"`
 	HttpsOnly                     bool                                  `tfschema:"https_only"`
 	KeyVaultReferenceIdentityID   string                                `tfschema:"key_vault_reference_identity_id"`
@@ -116,6 +117,12 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 				string(web.ClientCertModeRequired),
 				string(web.ClientCertModeOptionalInteractiveUser),
 			}, false),
+		},
+
+		"client_certificate_exclusion_paths": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Paths to exclude when using client certificates, separated by ;",
 		},
 
 		"connection_string": helpers.ConnectionStringSchema(),
@@ -267,13 +274,14 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 				Tags:     tags.FromTypedObject(webAppSlot.Tags),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:          siteProps.ServerFarmID,
-					Enabled:               utils.Bool(webAppSlot.Enabled),
-					HTTPSOnly:             utils.Bool(webAppSlot.HttpsOnly),
-					SiteConfig:            siteConfig,
-					ClientAffinityEnabled: utils.Bool(webAppSlot.ClientAffinityEnabled),
-					ClientCertEnabled:     utils.Bool(webAppSlot.ClientCertEnabled),
-					ClientCertMode:        web.ClientCertMode(webAppSlot.ClientCertMode),
+					ServerFarmID:             siteProps.ServerFarmID,
+					Enabled:                  utils.Bool(webAppSlot.Enabled),
+					HTTPSOnly:                utils.Bool(webAppSlot.HttpsOnly),
+					SiteConfig:               siteConfig,
+					ClientAffinityEnabled:    utils.Bool(webAppSlot.ClientAffinityEnabled),
+					ClientCertEnabled:        utils.Bool(webAppSlot.ClientCertEnabled),
+					ClientCertMode:           web.ClientCertMode(webAppSlot.ClientCertMode),
+					ClientCertExclusionPaths: utils.String(webAppSlot.ClientCertExclusionPaths),
 				},
 			}
 
@@ -450,6 +458,7 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 				ClientAffinityEnabled:       utils.NormaliseNilableBool(props.ClientAffinityEnabled),
 				ClientCertEnabled:           utils.NormaliseNilableBool(props.ClientCertEnabled),
 				ClientCertMode:              string(props.ClientCertMode),
+				ClientCertExclusionPaths:    utils.NormalizeNilableString(props.ClientCertExclusionPaths),
 				ConnectionStrings:           helpers.FlattenConnectionStrings(connectionStrings),
 				CustomDomainVerificationId:  utils.NormalizeNilableString(props.CustomDomainVerificationID),
 				DefaultHostname:             utils.NormalizeNilableString(props.DefaultHostName),
@@ -569,6 +578,9 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			}
 			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
+			}
+			if metadata.ResourceData.HasChange("client_certificate_exclusion_paths") {
+				existing.SiteProperties.ClientCertExclusionPaths = utils.String(state.ClientCertExclusionPaths)
 			}
 
 			if metadata.ResourceData.HasChange("identity") {

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1028,9 +1028,10 @@ resource "azurerm_windows_web_app_slot" "test" {
     }
   }
 
-  client_affinity_enabled    = true
-  client_certificate_enabled = true
-  client_certificate_mode    = "Optional"
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
     name  = "First"

--- a/website/docs/d/linux_function_app.html.markdown
+++ b/website/docs/d/linux_function_app.html.markdown
@@ -51,6 +51,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_certificate_mode` -  The mode of the Function App's client certificates requirement for incoming requests.
 
+* `client_certificate_exclusion_paths` - Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` -  A `connection_string` blocks as defined below.
 
 * `content_share_force_disabled` - Are the settings for linking the Function App to storage suppressed?

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -51,6 +51,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_certificate_mode` - The Client Certificate mode.
 
+* `client_certificate_exclusion_paths` - Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - A `connection_string` block as defined below.
 
 * `custom_domain_verification_id` - The identifier used by App Service to perform domain ownership verification via DNS TXT record.

--- a/website/docs/d/windows_function_app.html.markdown
+++ b/website/docs/d/windows_function_app.html.markdown
@@ -49,6 +49,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_certificate_mode` - The mode of the Function App's client certificates requirement for incoming requests.
 
+* `client_certificate_exclusion_paths` - Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - One or more `connection_string` blocks as defined below.
 
 * `content_share_force_disabled` - Are Content Share Settings disabled?

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -49,6 +49,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `client_certificate_mode` - The Client Certificate mode.
 
+* `client_certificate_exclusion_paths` - Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - A `connection_string` block as defined below.
 
 * `custom_domain_verification_id` - The identifier used by App Service to perform domain ownership verification via DNS TXT record.

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `daily_memory_time_quota` - (Optional) The amount of memory in gigabyte-seconds that your application is allowed to consume per day. Setting this value only affects function apps under the consumption plan. Defaults to `0`.

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The mode of the Function App Slot's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) a `connection_string` block as detailed below.
 
 * `content_share_force_disabled` - (Optional) Force disable the content share settings.

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`. This property has no effect when `client_certificate_enabled` is `false`
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ; 
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `enabled` - (Optional) Should the Linux Web App be enabled? Defaults to `true`.

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`. This property has no effect when `client_cert_enabled` is `false`
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `enabled` - (Optional) Should the Linux Web App be enabled? Defaults to `true`.

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `content_share_force_disabled` - (Optional) Should Content Share Settings be disabled. Defaults to `false`.

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -81,6 +81,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The mode of the Function App Slot's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) a `connection_string` block as detailed below.
 
 * `content_share_force_disabled` - (Optional) Force disable the content share settings.

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`. This property has no effect when `client_cert_enabled` is `false`
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `enabled` - (Optional) Should the Windows Web App be enabled? Defaults to `true`.

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `client_certificate_mode` - (Optional) The Client Certificate mode. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`. This property has no effect when `client_cert_enabled` is `false`
 
+* `client_certificate_exclusion_paths` - (Optional) Paths to exclude when using client certificates, separated by ;
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `enabled` - (Optional) Should the Windows Web App Slot be enabled? Defaults to `true`.


### PR DESCRIPTION
Allows setting the "client_cert_exclusion_paths" on app service web and function apps as suggested in:
https://github.com/hashicorp/terraform-provider-azurerm/issues/8876
