### PR TITLE
Remove unneeded storage account from example

### DIFF
--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -22,14 +22,6 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_storage_account" "example" {
-  name                     = "examplesa"
-  resource_group_name      = azurerm_resource_group.example.name
-  location                 = azurerm_resource_group.example.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_mssql_server" "example" {
   name                         = "mssqlserver"
   resource_group_name          = azurerm_resource_group.example.name


### PR DESCRIPTION
The `azurerm_storage_account` is setup but nowhere referenced. This result into confusion, what a storage account has to do with a sql server.