### PR TITLE
Documentation Improvements - General streamlining in code blocks.

### DIFF
--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_storage_account" "example" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
-  location                 = "westus"
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
 

--- a/website/docs/guides/migrating-from-deprecated-resources.html.markdown
+++ b/website/docs/guides/migrating-from-deprecated-resources.html.markdown
@@ -57,7 +57,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "Example App Service Plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "B1"
 }

--- a/website/docs/r/advanced_threat_protection.html.markdown
+++ b/website/docs/r/advanced_threat_protection.html.markdown
@@ -13,7 +13,7 @@ Manages a resources Advanced Threat Protection setting.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "atp-example"
   location = "West Europe"
 }

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -13,7 +13,7 @@ Manages an Analysis Services Server.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "analysis-services-server-test"
   location = "West Europe"
 }
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "rg" {
 resource "azurerm_analysis_services_server" "server" {
   name                    = "analysisservicesserver"
   location                = "northeurope"
-  resource_group_name     = azurerm_resource_group.rg.name
+  resource_group_name     = azurerm_resource_group.example.name
   sku                     = "S0"
   admin_users             = ["myuser@domain.tld"]
   enable_power_bi_service = true

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_analysis_services_server" "server" {
   name                    = "analysisservicesserver"
-  location                = "northeurope"
+  location                = azurerm_resource_group.example.location
   resource_group_name     = azurerm_resource_group.example.name
   sku                     = "S0"
   admin_users             = ["myuser@domain.tld"]

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -14,15 +14,15 @@ Manages an Azure App Configuration.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_app_configuration" "appconf" {
   name                = "appConf1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 ```
 

--- a/website/docs/r/app_configuration_feature.html.markdown
+++ b/website/docs/r/app_configuration_feature.html.markdown
@@ -14,15 +14,15 @@ Manages an Azure App Configuration Feature.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_app_configuration" "appconf" {
   name                = "appConf1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_app_configuration_feature" "test" {

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -16,15 +16,15 @@ Manages an Azure App Configuration Key.
 ## Example Usage of `kv` type
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_app_configuration" "appconf" {
   name                = "appConf1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 data "azurerm_client_config" "current" {}
@@ -49,15 +49,15 @@ resource "azurerm_app_configuration_key" "test" {
 
 ## Example Usage of `vault` type
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_app_configuration" "appconf" {
   name                = "appConf1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 data "azurerm_client_config" "current" {}

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/app_service_source_control_slot.html.markdown
+++ b/website/docs/r/app_service_source_control_slot.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example-plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_application_insights" "example" {
   name                = "tf-test-appinsights"
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   application_type    = "web"
 }

--- a/website/docs/r/application_insights_api_key.html.markdown
+++ b/website/docs/r/application_insights_api_key.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_application_insights" "example" {
   name                = "tf-test-appinsights"
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   application_type    = "web"
 }

--- a/website/docs/r/application_insights_smart_detection_rule.html.markdown
+++ b/website/docs/r/application_insights_smart_detection_rule.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_application_insights" "example" {
   name                = "tf-test-appinsights"
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   application_type    = "web"
 }

--- a/website/docs/r/application_insights_web_test.html.markdown
+++ b/website/docs/r/application_insights_web_test.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_application_insights" "example" {
   name                = "tf-test-appinsights"
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   application_type    = "web"
 }

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -14,28 +14,28 @@ Manages registration of a storage account with Azure Backup. Storage accounts mu
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "tfex-network-mapping-primary"
   location = "West Europe"
 }
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "example-recovery-vault"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_storage_account" "sa" {
   name                     = "examplesa"
-  location                 = azurerm_resource_group.rg.location
-  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_backup_container_storage_account" "container" {
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   recovery_vault_name = azurerm_recovery_services_vault.vault.name
   storage_account_id  = azurerm_storage_account.sa.id
 }

--- a/website/docs/r/backup_protected_file_share.html.markdown
+++ b/website/docs/r/backup_protected_file_share.html.markdown
@@ -13,22 +13,22 @@ Manages an Azure Backup Protected File Share to enable backups for file shares w
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "tfex-recovery_vault"
   location = "West Europe"
 }
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "tfex-recovery-vault"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_storage_account" "sa" {
   name                     = "examplesa"
-  location                 = azurerm_resource_group.rg.location
-  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
@@ -39,14 +39,14 @@ resource "azurerm_storage_share" "example" {
 }
 
 resource "azurerm_backup_container_storage_account" "protection-container" {
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   recovery_vault_name = azurerm_recovery_services_vault.vault.name
   storage_account_id  = azurerm_storage_account.sa.id
 }
 
 resource "azurerm_backup_policy_file_share" "example" {
   name                = "tfex-recovery-vault-policy"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   recovery_vault_name = azurerm_recovery_services_vault.vault.name
 
   backup {
@@ -60,7 +60,7 @@ resource "azurerm_backup_policy_file_share" "example" {
 }
 
 resource "azurerm_backup_protected_file_share" "share1" {
-  resource_group_name       = azurerm_resource_group.rg.name
+  resource_group_name       = azurerm_resource_group.example.name
   recovery_vault_name       = azurerm_recovery_services_vault.vault.name
   source_storage_account_id = azurerm_backup_container_storage_account.protection-container.storage_account_id
   source_file_share_name    = azurerm_storage_share.example.name

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_cdn_profile" "example" {
   name                = "exampleCdnProfile"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard_Verizon"
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -17,15 +17,15 @@ Manages an Azure Container Registry.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_container_registry" "acr" {
   name                = "containerRegistry1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sku                 = "Premium"
   admin_enabled       = false
   georeplications {
@@ -44,15 +44,15 @@ resource "azurerm_container_registry" "acr" {
 ## Example Usage (Encryption)
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_container_registry" "acr" {
   name                = "containerRegistry1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sku                 = "Premium"
 
   identity {

--- a/website/docs/r/container_registry_scope_map.html.markdown
+++ b/website/docs/r/container_registry_scope_map.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_container_registry" "example" {
 resource "azurerm_container_registry_scope_map" "example" {
   name                    = "example-scope-map"
   container_registry_name = azurerm_container_registry.acr.name
-  resource_group_name     = azurerm_resource_group.rg.name
+  resource_group_name     = azurerm_resource_group.example.name
   actions = [
     "repositories/repo1/content/read",
     "repositories/repo1/content/write"

--- a/website/docs/r/container_registry_token.html.markdown
+++ b/website/docs/r/container_registry_token.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_container_registry" "example" {
 resource "azurerm_container_registry_scope_map" "example" {
   name                    = "example-scope-map"
   container_registry_name = azurerm_container_registry.acr.name
-  resource_group_name     = azurerm_resource_group.rg.name
+  resource_group_name     = azurerm_resource_group.example.name
   actions = [
     "repositories/repo1/content/read",
     "repositories/repo1/content/write"
@@ -39,7 +39,7 @@ resource "azurerm_container_registry_scope_map" "example" {
 resource "azurerm_container_registry_token" "example" {
   name                    = "exampletoken"
   container_registry_name = azurerm_container_registry.acr.name
-  resource_group_name     = azurerm_resource_group.rg.name
+  resource_group_name     = azurerm_resource_group.example.name
   scope_map_id            = azurerm_container_registry_scope_map.map.id
 }
 ```

--- a/website/docs/r/container_registry_webhook.html.markdown
+++ b/website/docs/r/container_registry_webhook.html.markdown
@@ -14,24 +14,24 @@ Manages an Azure Container Registry Webhook.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_container_registry" "acr" {
   name                = "containerRegistry1"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sku                 = "Standard"
   admin_enabled       = false
 }
 
 resource "azurerm_container_registry_webhook" "webhook" {
   name                = "mywebhook"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   registry_name       = azurerm_container_registry.acr.name
-  location            = azurerm_resource_group.rg.location
+  location            = azurerm_resource_group.example.location
 
   service_uri = "https://mywebhookreceiver.example/mytag"
   status      = "enabled"

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -13,7 +13,7 @@ Manages a CosmosDB (formally DocumentDB) Account.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = var.resource_group_name
   location = var.resource_group_location
 }
@@ -25,8 +25,8 @@ resource "random_integer" "ri" {
 
 resource "azurerm_cosmosdb_account" "db" {
   name                = "tfex-cosmos-db-${random_integer.ri.result}"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   offer_type          = "Standard"
   kind                = "MongoDB"
 
@@ -60,7 +60,7 @@ resource "azurerm_cosmosdb_account" "db" {
   }
 
   geo_location {
-    location          = azurerm_resource_group.rg.location
+    location          = azurerm_resource_group.example.location
     failover_priority = 0
   }
 }

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -13,14 +13,15 @@ Manages a Cassandra KeySpace within a Cosmos DB Account.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "tflex-cosmosdb-account-rg"
+resource "azurerm_resource_group" "example" {
+  name     = "tflex-cosmosdb-account-rg"
+  location = "West Europe"
 }
 
 resource "azurerm_cosmosdb_account" "example" {
   name                = "tfex-cosmosdb-account"
-  resource_group_name = data.azurerm_resource_group.example.name
-  location            = data.azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   offer_type          = "Standard"
 
   capabilities {

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_cosmosdb_account" "example" {
   }
 
   geo_location {
-    location          = "West US"
+    location          = azurerm_resource_group.example.location
     failover_priority = 0
   }
 }

--- a/website/docs/r/cosmosdb_cassandra_table.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_table.html.markdown
@@ -13,14 +13,15 @@ Manages a Cassandra Table within a Cosmos DB Cassandra Keyspace.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "tflex-cosmosdb-account-rg"
+resource "azurerm_resource_group" "example" {
+  name     = "tflex-cosmosdb-account-rg"
+  location = "West Europe"
 }
 
 resource "azurerm_cosmosdb_account" "example" {
   name                = "tfex-cosmosdb-account"
-  resource_group_name = data.azurerm_resource_group.example.name
-  location            = data.azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   offer_type          = "Standard"
 
   capabilities {

--- a/website/docs/r/cosmosdb_cassandra_table.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_table.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_cosmosdb_account" "example" {
   }
 
   geo_location {
-    location          = "West US"
+    location          = azurerm_resource_group.example.location
     failover_priority = 0
   }
 }

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -27,15 +27,15 @@ variable "video_link" {
 
 data "azurerm_subscription" "current" {}
 
-resource "azurerm_resource_group" "my-group" {
+resource "azurerm_resource_group" "example" {
   name     = "mygroup"
   location = "West Europe"
 }
 
 resource "azurerm_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }
@@ -210,8 +210,8 @@ data "template_file" "dash-template" {
 
 resource "azurerm_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }
@@ -225,8 +225,8 @@ resource "azurerm_dashboard" "my-board" {
 ```hcl
 resource "azurerm_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }

--- a/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_data_factory_linked_service_azure_blob_storage" "example" {
 ## Example Usage with SAS URI and SAS Token.
 
 ```hcl
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
@@ -51,14 +51,14 @@ data "azurerm_client_config" "current" {
 
 resource "azurerm_data_factory" "test" {
   name                = "example"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_key_vault" "test" {
   name                = "example"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
 }

--- a/website/docs/r/data_protection_backup_instance_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_disk.html.markdown
@@ -13,15 +13,15 @@ Manages a Backup Instance to back up Disk.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_managed_disk" "example" {
   name                 = "example-disk"
-  location             = azurerm_resource_group.rg.location
-  resource_group_name  = azurerm_resource_group.rg.name
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = "1"
@@ -29,8 +29,8 @@ resource "azurerm_managed_disk" "example" {
 
 resource "azurerm_data_protection_backup_vault" "example" {
   name                = "example-backup-vault"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
   identity {
@@ -39,7 +39,7 @@ resource "azurerm_data_protection_backup_vault" "example" {
 }
 
 resource "azurerm_role_assignment" "example1" {
-  scope                = azurerm_resource_group.rg.id
+  scope                = azurerm_resource_group.example.id
   role_definition_name = "Disk Snapshot Contributor"
   principal_id         = azurerm_data_protection_backup_vault.example.identity[0].principal_id
 }
@@ -64,7 +64,7 @@ resource "azurerm_data_protection_backup_instance_disk" "example" {
   location                     = azurerm_data_protection_backup_vault.example.location
   vault_id                     = azurerm_data_protection_backup_vault.example.id
   disk_id                      = azurerm_managed_disk.example.id
-  snapshot_resource_group_name = azurerm_resource_group.rg.name
+  snapshot_resource_group_name = azurerm_resource_group.example.name
   backup_policy_id             = azurerm_data_protection_backup_policy_disk.example.id
 }
 ```

--- a/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
@@ -13,15 +13,15 @@ Manages a Backup Policy Blob Storage.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_data_protection_backup_vault" "example" {
   name                = "example-backup-vault"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
 }

--- a/website/docs/r/data_protection_backup_policy_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_disk.html.markdown
@@ -13,15 +13,15 @@ Manages a Backup Policy Disk.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_data_protection_backup_vault" "example" {
   name                = "example-backup-vault"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
 }

--- a/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_postgresql.html.markdown
@@ -13,22 +13,22 @@ Manages a Backup Policy to back up PostgreSQL.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_data_protection_backup_vault" "example" {
   name                = "example-backup-vault"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
 }
 
 resource "azurerm_data_protection_backup_policy_postgresql" "example" {
   name                = "example-backup-policy"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   vault_name          = azurerm_data_protection_backup_vault.example.name
 
   backup_repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]

--- a/website/docs/r/data_protection_backup_vault.html.markdown
+++ b/website/docs/r/data_protection_backup_vault.html.markdown
@@ -13,15 +13,15 @@ Manages a Backup Vault.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_data_protection_backup_vault" "example" {
   name                = "example-backup-vault"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   datastore_type      = "VaultStore"
   redundancy          = "LocallyRedundant"
 }

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -14,15 +14,15 @@ Manages an EventGrid Event Subscription
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "default" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_storage_account" "default" {
   name                     = "defaultStorageAccount"
-  resource_group_name      = azurerm_resource_group.default.name
-  location                 = azurerm_resource_group.default.location
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -38,7 +38,7 @@ resource "azurerm_storage_queue" "default" {
 
 resource "azurerm_eventgrid_event_subscription" "default" {
   name  = "defaultEventSubscription"
-  scope = azurerm_resource_group.default.id
+  scope = azurerm_resource_group.example.id
 
   storage_queue_endpoint {
     storage_account_id = azurerm_storage_account.default.id

--- a/website/docs/r/eventhub_authorization_rule.html.markdown
+++ b/website/docs/r/eventhub_authorization_rule.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_eventhub_namespace" "example" {
   name                = "acceptanceTestEventHubNamespace"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Basic"
   capacity            = 2

--- a/website/docs/r/eventhub_consumer_group.html.markdown
+++ b/website/docs/r/eventhub_consumer_group.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_eventhub_namespace" "example" {
   name                = "acceptanceTestEventHubNamespace"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Basic"
   capacity            = 2

--- a/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_eventhub_namespace" "primary" {
 
 resource "azurerm_eventhub_namespace" "secondary" {
   name                = "eventhub-secondary"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_image" "example" {
   name                = "acctest"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
   os_disk {
@@ -42,7 +42,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_image" "example" {
   name                      = "acctest"
-  location                  = "West US"
+  location                  = azurerm_resource_group.example.location
   resource_group_name       = azurerm_resource_group.example.name
   source_virtual_machine_id = "{vm_id}"
 }

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -13,15 +13,15 @@ Manages a Kusto (also known as Azure Data Explorer) Attached Database Configurat
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "my-kusto-rg"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "follower_cluster" {
   name                = "cluster1"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Dev(No SLA)_Standard_D11_v2"
@@ -31,8 +31,8 @@ resource "azurerm_kusto_cluster" "follower_cluster" {
 
 resource "azurerm_kusto_cluster" "followed_cluster" {
   name                = "cluster2"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Dev(No SLA)_Standard_D11_v2"
@@ -42,22 +42,22 @@ resource "azurerm_kusto_cluster" "followed_cluster" {
 
 resource "azurerm_kusto_database" "followed_database" {
   name                = "my-followed-database"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.cluster2.name
 }
 
 resource "azurerm_kusto_database" "example" {
   name                = "example"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.cluster2.name
 }
 
 resource "azurerm_kusto_attached_database_configuration" "example" {
   name                                 = "configuration1"
-  resource_group_name                  = azurerm_resource_group.rg.name
-  location                             = azurerm_resource_group.rg.location
+  resource_group_name                  = azurerm_resource_group.example.name
+  location                             = azurerm_resource_group.example.location
   cluster_name                         = azurerm_kusto_cluster.follower_cluster.name
   cluster_resource_id                  = azurerm_kusto_cluster.followed_cluster.id
   database_name                        = azurerm_kusto_database.example.name

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -13,15 +13,15 @@ Manages a Kusto (also known as Azure Data Explorer) Cluster
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "my-kusto-cluster-rg"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "example" {
   name                = "kustocluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -61,8 +61,8 @@ resource "azurerm_key_vault_key" "example" {
 
 resource "azurerm_kusto_cluster" "example" {
   name                = "kustocluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"

--- a/website/docs/r/kusto_cluster_principal_assignment.html.markdown
+++ b/website/docs/r/kusto_cluster_principal_assignment.html.markdown
@@ -15,15 +15,15 @@ Manages a Kusto Cluster Principal Assignment.
 ```hcl
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "KustoRG"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "example" {
   name                = "KustoCluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"
@@ -33,7 +33,7 @@ resource "azurerm_kusto_cluster" "example" {
 
 resource "azurerm_kusto_cluster_principal_assignment" "example" {
   name                = "KustoPrincipalAssignment"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   cluster_name        = azurerm_kusto_cluster.example.name
 
   tenant_id      = data.azurerm_client_config.current.tenant_id

--- a/website/docs/r/kusto_database.html.markdown
+++ b/website/docs/r/kusto_database.html.markdown
@@ -13,15 +13,15 @@ Manages a Kusto (also known as Azure Data Explorer) Database
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "my-kusto-rg"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "cluster" {
   name                = "kustocluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"
@@ -31,8 +31,8 @@ resource "azurerm_kusto_cluster" "cluster" {
 
 resource "azurerm_kusto_database" "database" {
   name                = "my-kusto-database"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.cluster.name
 
   hot_cache_period   = "P7D"

--- a/website/docs/r/kusto_database_principal_assignment.html.markdown
+++ b/website/docs/r/kusto_database_principal_assignment.html.markdown
@@ -15,15 +15,15 @@ Manages a Kusto (also known as Azure Data Explorer) Database Principal Assignmen
 ```hcl
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "KustoRG"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "example" {
   name                = "KustoCluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"
@@ -33,8 +33,8 @@ resource "azurerm_kusto_cluster" "example" {
 
 resource "azurerm_kusto_database" "example" {
   name                = "KustoDatabase"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.example.name
 
   hot_cache_period   = "P7D"
@@ -43,7 +43,7 @@ resource "azurerm_kusto_database" "example" {
 
 resource "azurerm_kusto_database_principal_assignment" "example" {
   name                = "KustoPrincipalAssignment"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   cluster_name        = azurerm_kusto_cluster.example.name
   database_name       = azurerm_kusto_database.example.name
 

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -13,15 +13,15 @@ Manages a Kusto (also known as Azure Data Explorer) EventHub Data Connection
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "my-kusto-rg"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "cluster" {
   name                = "kustocluster"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   sku {
     name     = "Standard_D13_v2"
@@ -31,8 +31,8 @@ resource "azurerm_kusto_cluster" "cluster" {
 
 resource "azurerm_kusto_database" "database" {
   name                = "my-kusto-database"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.cluster.name
   hot_cache_period    = "P7D"
   soft_delete_period  = "P31D"
@@ -40,15 +40,15 @@ resource "azurerm_kusto_database" "database" {
 
 resource "azurerm_eventhub_namespace" "eventhub_ns" {
   name                = "my-eventhub-ns"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_eventhub" "eventhub" {
   name                = "my-eventhub"
   namespace_name      = azurerm_eventhub_namespace.eventhub_ns.name
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
   partition_count     = 1
   message_retention   = 1
 }
@@ -57,13 +57,13 @@ resource "azurerm_eventhub_consumer_group" "consumer_group" {
   name                = "my-eventhub-consumergroup"
   namespace_name      = azurerm_eventhub_namespace.eventhub_ns.name
   eventhub_name       = azurerm_eventhub.eventhub.name
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_kusto_eventhub_data_connection" "eventhub_connection" {
   name                = "my-kusto-eventhub-data-connection"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.cluster.name
   database_name       = azurerm_kusto_database.database.name
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -20,14 +20,14 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_public_ip" "example" {
   name                = "PublicIPForLB"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
 }
 
 resource "azurerm_lb" "example" {
   name                = "TestLoadBalancer"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
   frontend_ip_configuration {

--- a/website/docs/r/lb_nat_pool.html.markdown
+++ b/website/docs/r/lb_nat_pool.html.markdown
@@ -24,14 +24,14 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_public_ip" "example" {
   name                = "PublicIPForLB"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
 }
 
 resource "azurerm_lb" "example" {
   name                = "TestLoadBalancer"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
   frontend_ip_configuration {

--- a/website/docs/r/lb_outbound_rule.html.markdown
+++ b/website/docs/r/lb_outbound_rule.html.markdown
@@ -22,14 +22,14 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_public_ip" "example" {
   name                = "PublicIPForLB"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
 }
 
 resource "azurerm_lb" "example" {
   name                = "TestLoadBalancer"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
   frontend_ip_configuration {

--- a/website/docs/r/lb_probe.html.markdown
+++ b/website/docs/r/lb_probe.html.markdown
@@ -22,14 +22,14 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_public_ip" "example" {
   name                = "PublicIPForLB"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
 }
 
 resource "azurerm_lb" "example" {
   name                = "TestLoadBalancer"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
   frontend_ip_configuration {

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example-plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/load_test.html.markdown
+++ b/website/docs/r/load_test.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_load_test" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
 }
 ```
 

--- a/website/docs/r/logic_app_integration_account_agreement.html.markdown
+++ b/website/docs/r/logic_app_integration_account_agreement.html.markdown
@@ -13,21 +13,21 @@ Manages a Logic App Integration Account Agreement.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_logic_app_integration_account" "test" {
   name                = "example-ia"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku_name            = "Standard"
 }
 
 resource "azurerm_logic_app_integration_account_partner" "host" {
   name                     = "example-hostpartner"
-  resource_group_name      = azurerm_resource_group.test.name
+  resource_group_name      = azurerm_resource_group.example.name
   integration_account_name = azurerm_logic_app_integration_account.test.name
 
   business_identity {
@@ -38,7 +38,7 @@ resource "azurerm_logic_app_integration_account_partner" "host" {
 
 resource "azurerm_logic_app_integration_account_partner" "guest" {
   name                     = "example-guestpartner"
-  resource_group_name      = azurerm_resource_group.test.name
+  resource_group_name      = azurerm_resource_group.example.name
   integration_account_name = azurerm_logic_app_integration_account.test.name
 
   business_identity {
@@ -49,7 +49,7 @@ resource "azurerm_logic_app_integration_account_partner" "guest" {
 
 resource "azurerm_logic_app_integration_account_agreement" "test" {
   name                     = "example-agreement"
-  resource_group_name      = azurerm_resource_group.test.name
+  resource_group_name      = azurerm_resource_group.example.name
   integration_account_name = azurerm_logic_app_integration_account.test.name
   agreement_type           = "AS2"
   host_partner_name        = azurerm_logic_app_integration_account_partner.host.name

--- a/website/docs/r/machine_learning_compute_cluster.html.markdown
+++ b/website/docs/r/machine_learning_compute_cluster.html.markdown
@@ -79,7 +79,7 @@ resource "azurerm_subnet" "example" {
 
 resource "azurerm_machine_learning_compute_cluster" "test" {
   name                          = "example"
-  location                      = "West Europe"
+  location                      = azurerm_resource_group.example.location
   vm_priority                   = "LowPriority"
   vm_size                       = "Standard_DS2_v2"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_managed_disk" "example" {
   name                 = "acctestmd"
-  location             = "West US 2"
+  location             = azurerm_resource_group.example.location
   resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
@@ -42,7 +42,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_managed_disk" "source" {
   name                 = "acctestmd1"
-  location             = "West US 2"
+  location             = azurerm_resource_group.example.location
   resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
@@ -55,7 +55,7 @@ resource "azurerm_managed_disk" "source" {
 
 resource "azurerm_managed_disk" "copy" {
   name                 = "acctestmd2"
-  location             = "West US 2"
+  location             = azurerm_resource_group.example.location
   resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Copy"

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -13,14 +13,14 @@ Manages an Activity Log Alert within Azure Monitor.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "main" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_monitor_action_group" "main" {
   name                = "example-actiongroup"
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = azurerm_resource_group.example.name
   short_name          = "p0action"
 
   webhook_receiver {
@@ -31,16 +31,16 @@ resource "azurerm_monitor_action_group" "main" {
 
 resource "azurerm_storage_account" "to_monitor" {
   name                     = "examplesa"
-  resource_group_name      = azurerm_resource_group.main.name
-  location                 = azurerm_resource_group.main.location
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
 }
 
 resource "azurerm_monitor_activity_log_alert" "main" {
   name                = "example-activitylogalert"
-  resource_group_name = azurerm_resource_group.main.name
-  scopes              = [azurerm_resource_group.main.id]
+  resource_group_name = azurerm_resource_group.example.name
+  scopes              = [azurerm_resource_group.example.id]
   description         = "This alert will monitor a specific storage account updates."
 
   criteria {

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -13,22 +13,22 @@ Manages a Metric Alert within Azure Monitor.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "main" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_storage_account" "to_monitor" {
   name                     = "examplestorageaccount"
-  resource_group_name      = azurerm_resource_group.main.name
-  location                 = azurerm_resource_group.main.location
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_monitor_action_group" "main" {
   name                = "example-actiongroup"
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = azurerm_resource_group.example.name
   short_name          = "exampleact"
 
   webhook_receiver {
@@ -39,7 +39,7 @@ resource "azurerm_monitor_action_group" "main" {
 
 resource "azurerm_monitor_metric_alert" "example" {
   name                = "example-metricalert"
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = azurerm_resource_group.example.name
   scopes              = [azurerm_storage_account.to_monitor.id]
   description         = "Action will be triggered when Transactions count is greater than 50."
 

--- a/website/docs/r/mssql_firewall_rule.html.markdown
+++ b/website/docs/r/mssql_firewall_rule.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_mssql_server" "example" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = "West US"
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"

--- a/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
+++ b/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
@@ -13,6 +13,11 @@ Allows you to set a user, group or service principal as the AAD Administrator fo
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
 resource "azurerm_mssql_managed_instance" "example" {
   name                = "managedsqlinstance"
   resource_group_name = azurerm_resource_group.example.name

--- a/website/docs/r/mssql_outbound_firewall_rule.html.markdown
+++ b/website/docs/r/mssql_outbound_firewall_rule.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_mssql_server" "example" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = "West US"
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -14,27 +14,27 @@ Manages a Network Watcher Flow Log.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_network_security_group" "test" {
   name                = "acctestnsg"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_network_watcher" "test" {
   name                = "acctestnw"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_storage_account" "test" {
   name                = "acctestsa"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 
   account_tier              = "Standard"
   account_kind              = "StorageV2"
@@ -44,14 +44,14 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_log_analytics_workspace" "test" {
   name                = "acctestlaw"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "PerGB2018"
 }
 
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
+  resource_group_name  = azurerm_resource_group.example.name
   name                 = "example-log"
 
   network_security_group_id = azurerm_network_security_group.test.id

--- a/website/docs/r/portal_dashboard.html.markdown
+++ b/website/docs/r/portal_dashboard.html.markdown
@@ -25,15 +25,15 @@ variable "video_link" {
 
 data "azurerm_subscription" "current" {}
 
-resource "azurerm_resource_group" "my-group" {
+resource "azurerm_resource_group" "example" {
   name     = "mygroup"
   location = "West Europe"
 }
 
 resource "azurerm_portal_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }
@@ -208,8 +208,8 @@ data "template_file" "dash-template" {
 
 resource "azurerm_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }
@@ -223,8 +223,8 @@ resource "azurerm_dashboard" "my-board" {
 ```hcl
 resource "azurerm_dashboard" "my-board" {
   name                = "my-cool-dashboard"
-  resource_group_name = azurerm_resource_group.my-group.name
-  location            = azurerm_resource_group.my-group.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   tags = {
     source = "terraform"
   }

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -13,20 +13,20 @@ Enables you to manage DNS AAAA Records within Azure Private DNS.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_private_dns_zone" "test" {
   name                = "mydomain.com"
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "test"
   zone_name           = azurerm_private_dns_zone.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.example.name
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 }

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -98,25 +98,25 @@ resource "azurerm_private_endpoint" "example" {
 Using a Private Link Service Alias with existing resources:
 
 ```hcl
-data "azurerm_resource_group" "rg" {
+data "azurerm_resource_group" "example" {
   name = "example-resources"
 }
 
 data "azurerm_virtual_network" "vnet" {
   name                = "example-network"
-  resource_group_name = data.azurerm_resource_group.rg.name
+  resource_group_name = data.azurerm_resource_group.example.name
 }
 
 data "azurerm_subnet" "subnet" {
   name                 = "default"
   virtual_network_name = data.azurerm_virtual_network.vnet.name
-  resource_group_name  = data.azurerm_resource_group.rg.name
+  resource_group_name  = data.azurerm_resource_group.example.name
 }
 
 resource "azurerm_private_endpoint" "example" {
   name                = "example-endpoint"
-  location            = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.example.location
+  resource_group_name = data.azurerm_resource_group.example.name
   subnet_id           = data.azurerm_subnet.subnet.id
 
   private_service_connection {

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -13,15 +13,15 @@ Manages a Recovery Services Vault.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "example" {
   name     = "tfex-recovery_vault"
   location = "West Europe"
 }
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "example-recovery-vault"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 
   soft_delete_enabled = true

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_servicebus_namespace" "primary" {
 
 resource "azurerm_servicebus_namespace" "secondary" {
   name                = "servicebus-secondary"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Premium"
   capacity            = "1"

--- a/website/docs/r/site_recovery_replication_policy.html.markdown
+++ b/website/docs/r/site_recovery_replication_policy.html.markdown
@@ -13,21 +13,21 @@ Manages a Azure Site Recovery replication policy within a recovery vault. Replic
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "secondary" {
+resource "azurerm_resource_group" "example" {
   name     = "tfex-network-mapping-secondary"
   location = "East US"
 }
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "example-recovery-vault"
-  location            = azurerm_resource_group.secondary.location
-  resource_group_name = azurerm_resource_group.secondary.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_site_recovery_replication_policy" "policy" {
   name                                                 = "policy"
-  resource_group_name                                  = azurerm_resource_group.secondary.name
+  resource_group_name                                  = azurerm_resource_group.example.name
   recovery_vault_name                                  = azurerm_recovery_services_vault.vault.name
   recovery_point_retention_in_minutes                  = 24 * 60
   application_consistent_snapshot_frequency_in_minutes = 4 * 60

--- a/website/docs/r/spring_cloud_custom_domain.html.markdown
+++ b/website/docs/r/spring_cloud_custom_domain.html.markdown
@@ -17,13 +17,14 @@ provider "azurerm" {
   features {}
 }
 
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_dns_zone" "example" {
   name                = "mydomain.com"
-  resource_group_name = data.azurerm_resource_group.example.name
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_spring_cloud_service" "example" {

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_sql_server" "example" {
   name                         = "myexamplesqlserver"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = "West US"
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -46,7 +46,7 @@ resource "azurerm_storage_account" "example" {
 resource "azurerm_sql_database" "example" {
   name                = "myexamplesqldatabase"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   server_name         = azurerm_sql_server.example.name
 
   extended_auditing_policy {

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_sql_server" "primary" {
 resource "azurerm_sql_server" "secondary" {
   name                         = "sql-secondary"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = "northeurope"
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "sqladmin"
   administrator_login_password = "pa$$w0rd"

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_sql_server" "example" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.example.name
-  location                     = "West US"
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"

--- a/website/docs/r/sql_managed_database.html.markdown
+++ b/website/docs/r/sql_managed_database.html.markdown
@@ -15,6 +15,11 @@ Manages a SQL Azure Managed Database.
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
 resource "azurerm_sql_managed_database" "example" {
   name                    = "exampledatabase"
   sql_managed_instance_id = azurerm_sql_managed_instance.example.id

--- a/website/docs/r/sql_managed_instance_active_directory_administrator.html.markdown
+++ b/website/docs/r/sql_managed_instance_active_directory_administrator.html.markdown
@@ -15,6 +15,11 @@ Allows you to set a user or group as the AD administrator for an Azure SQL Manag
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
 resource "azurerm_sql_managed_instance" "example" {
   name                         = "managedsqlinstance"
   resource_group_name          = azurerm_resource_group.example.name

--- a/website/docs/r/sql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/sql_managed_instance_failover_group.html.markdown
@@ -17,6 +17,11 @@ Manages a SQL Instance Failover Group.
 ~> **Note:** For a more complete example, see the [the `examples/sql-azure/managed_instance_failover_group` directory](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/managed_instance_failover_group) within the GitHub Repository.
 
 ```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
 resource "azurerm_sql_managed_instance" "primary" {
   name                         = "example-primary"
   resource_group_name          = azurerm_resource_group.primary.name

--- a/website/docs/r/stream_analytics_output_blob.html.markdown
+++ b/website/docs/r/stream_analytics_output_blob.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to Blob Storage.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_storage_account" "example" {
   name                     = "examplesa"
-  resource_group_name      = data.azurerm_resource_group.example.name
-  location                 = data.azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }

--- a/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
+++ b/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to CosmosDB.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_cosmosdb_account" "example" {
   name                = "exampledb"
-  resource_group_name = data.azurerm_resource_group.example.name
-  location            = data.azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to an EventHub.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_eventhub_namespace" "example" {
   name                = "example-ehnamespace"
-  location            = data.azurerm_resource_group.example.location
-  resource_group_name = data.azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
   capacity            = 1
 }
@@ -33,7 +34,7 @@ resource "azurerm_eventhub_namespace" "example" {
 resource "azurerm_eventhub" "example" {
   name                = "example-eventhub"
   namespace_name      = azurerm_eventhub_namespace.example.name
-  resource_group_name = data.azurerm_resource_group.example.name
+  resource_group_name = azurerm_resource_group.example.name
   partition_count     = 2
   message_retention   = 1
 }

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to Microsoft SQL Server Database.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to a ServiceBus Queue.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_servicebus_namespace" "example" {
   name                = "example-namespace"
-  location            = data.azurerm_resource_group.example.location
-  resource_group_name = data.azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to a ServiceBus Topic.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_servicebus_namespace" "example" {
   name                = "example-namespace"
-  location            = data.azurerm_resource_group.example.location
-  resource_group_name = data.azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 

--- a/website/docs/r/stream_analytics_output_synapse.html.markdown
+++ b/website/docs/r/stream_analytics_output_synapse.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output to an Azure Synapse Analytics Workspace.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/stream_analytics_output_table.html.markdown
+++ b/website/docs/r/stream_analytics_output_table.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Output Table.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_storage_account" "example" {
   name                     = "examplesa"
-  resource_group_name      = data.azurerm_resource_group.example.name
-  location                 = data.azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Reference Input Blob. Reference data (also known as a
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Reference Input from MS SQL. Reference data (also kno
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/stream_analytics_stream_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_blob.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Stream Input Blob.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Stream Input EventHub.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {
@@ -24,8 +25,8 @@ data "azurerm_stream_analytics_job" "example" {
 
 resource "azurerm_eventhub_namespace" "example" {
   name                = "example-namespace"
-  location            = data.azurerm_resource_group.example.location
-  resource_group_name = data.azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
   capacity            = 1
 }
@@ -33,7 +34,7 @@ resource "azurerm_eventhub_namespace" "example" {
 resource "azurerm_eventhub" "example" {
   name                = "example-eventhub"
   namespace_name      = azurerm_eventhub_namespace.example.name
-  resource_group_name = data.azurerm_resource_group.example.name
+  resource_group_name = azurerm_resource_group.example.name
   partition_count     = 2
   message_retention   = 1
 }
@@ -42,7 +43,7 @@ resource "azurerm_eventhub_consumer_group" "example" {
   name                = "example-consumergroup"
   namespace_name      = azurerm_eventhub_namespace.example.name
   eventhub_name       = azurerm_eventhub.example.name
-  resource_group_name = data.azurerm_resource_group.example.name
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_stream_analytics_stream_input_eventhub" "example" {

--- a/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
@@ -13,8 +13,9 @@ Manages a Stream Analytics Stream Input IoTHub.
 ## Example Usage
 
 ```hcl
-data "azurerm_resource_group" "example" {
-  name = "example-resources"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 data "azurerm_stream_analytics_job" "example" {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -25,7 +25,7 @@ variable "prefix" {
   default = "tfvmex"
 }
 
-resource "azurerm_resource_group" "main" {
+resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
   location = "West Europe"
 }
@@ -33,21 +33,21 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = azurerm_resource_group.main.name
-  virtual_network_name = azurerm_virtual_network.main.name
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "main" {
   name                = "${var.prefix}-nic"
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "testconfiguration1"
@@ -58,8 +58,8 @@ resource "azurerm_network_interface" "main" {
 
 resource "azurerm_virtual_machine" "main" {
   name                  = "${var.prefix}-vm"
-  location              = azurerm_resource_group.main.location
-  resource_group_name   = azurerm_resource_group.main.name
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = [azurerm_network_interface.main.id]
   vm_size               = "Standard_DS1_v2"
 

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -25,7 +25,7 @@ locals {
   vm_name = "${var.prefix}-vm"
 }
 
-resource "azurerm_resource_group" "main" {
+resource "azurerm_resource_group" "example" {
   name     = "${var.prefix}-resources"
   location = "West Europe"
 }
@@ -33,21 +33,21 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = azurerm_resource_group.main.name
+  resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "main" {
   name                = "${var.prefix}-nic"
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
     name                          = "internal"
@@ -58,8 +58,8 @@ resource "azurerm_network_interface" "main" {
 
 resource "azurerm_virtual_machine" "example" {
   name                  = local.vm_name
-  location              = azurerm_resource_group.main.location
-  resource_group_name   = azurerm_resource_group.main.name
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = [azurerm_network_interface.main.id]
   vm_size               = "Standard_F2"
 
@@ -90,8 +90,8 @@ resource "azurerm_virtual_machine" "example" {
 
 resource "azurerm_managed_disk" "example" {
   name                 = "${local.vm_name}-disk1"
-  location             = azurerm_resource_group.main.location
-  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = 10

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -177,7 +177,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_virtual_network" "example" {
   name                = "acctvn"
   address_space       = ["10.0.0.0/16"]
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 }
 
@@ -191,7 +191,7 @@ resource "azurerm_subnet" "example" {
 resource "azurerm_storage_account" "example" {
   name                     = "accsa"
   resource_group_name      = azurerm_resource_group.example.name
-  location                 = "westus"
+  location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -208,7 +208,7 @@ resource "azurerm_storage_container" "example" {
 
 resource "azurerm_virtual_machine_scale_set" "example" {
   name                = "mytestscaleset-1"
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   upgrade_policy_mode = "Manual"
 

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -66,7 +66,7 @@ variable "vnet_address_space" {
   ]
 }
 
-resource "azurerm_resource_group" "vnet" {
+resource "azurerm_resource_group" "example" {
   count    = length(var.location)
   name     = "rg-global-vnet-peering-${count.index}"
   location = element(var.location, count.index)
@@ -75,15 +75,15 @@ resource "azurerm_resource_group" "vnet" {
 resource "azurerm_virtual_network" "vnet" {
   count               = length(var.location)
   name                = "vnet-${count.index}"
-  resource_group_name = element(azurerm_resource_group.vnet.*.name, count.index)
+  resource_group_name = element(azurerm_resource_group.example.*.name, count.index)
   address_space       = [element(var.vnet_address_space, count.index)]
-  location            = element(azurerm_resource_group.vnet.*.location, count.index)
+  location            = element(azurerm_resource_group.example.*.location, count.index)
 }
 
 resource "azurerm_subnet" "nva" {
   count                = length(var.location)
   name                 = "nva"
-  resource_group_name  = element(azurerm_resource_group.vnet.*.name, count.index)
+  resource_group_name  = element(azurerm_resource_group.example.*.name, count.index)
   virtual_network_name = element(azurerm_virtual_network.vnet.*.name, count.index)
   address_prefix = cidrsubnet(
     element(
@@ -99,7 +99,7 @@ resource "azurerm_subnet" "nva" {
 resource "azurerm_virtual_network_peering" "peering" {
   count                        = length(var.location)
   name                         = "peering-to-${element(azurerm_virtual_network.vnet.*.name, 1 - count.index)}"
-  resource_group_name          = element(azurerm_resource_group.vnet.*.name, count.index)
+  resource_group_name          = element(azurerm_resource_group.example.*.name, count.index)
   virtual_network_name         = element(azurerm_virtual_network.vnet.*.name, count.index)
   remote_virtual_network_id    = element(azurerm_virtual_network.vnet.*.id, 1 - count.index)
   allow_virtual_network_access = true

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -24,14 +24,14 @@ resource "azurerm_virtual_network" "example-1" {
   name                = "peternetwork1"
   resource_group_name = azurerm_resource_group.example.name
   address_space       = ["10.0.1.0/24"]
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_virtual_network" "example-2" {
   name                = "peternetwork2"
   resource_group_name = azurerm_resource_group.example.name
   address_space       = ["10.0.2.0/24"]
-  location            = "West US"
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_virtual_network_peering" "example-1" {

--- a/website/docs/r/web_app_active_slot.html.markdown
+++ b/website/docs/r/web_app_active_slot.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example-plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Windows"
   sku_name            = "P1v2"
 }
@@ -69,7 +69,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example-plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Linux"
   sku_name            = "P1v2"
 }

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   sku_name            = "P1v2"
 }
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_service_plan" "example" {
   name                = "example-plan"
   resource_group_name = azurerm_resource_group.example.name
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   os_type             = "Windows"
   sku_name            = "P1v2"
 }


### PR DESCRIPTION
**Change 1:**

In a lot of the examples, a resource group is created in a region (e.g. west europe), and the subsequent resource, for which the document is about, references the resource group for its name, but then proceeds to manually enter a location for the resource. In many of these places the second resource, in a different region.

In these examples, where the resource is referring to a resource group, the location have been updated to a reference, and now uses the resource groups location, such that they are actually placed in the same region. This does not apply to resources, where a secondary region makes sense. And I am aware, that you are not required to use the same location between the resource group and the resource, but if there is no particular reason not to, then doing so, is just odd.

```
resource "azurerm_resource_group" "example" {
  name     = "example-resources"
  location = "West Europe"
}

resource "azurerm_virtual_network" "example" {
  name                = "acctvn"
  address_space       = ["10.0.0.0/16"]
  location            = "West US"
  resource_group_name = azurerm_resource_group.example.name
}
```


**Change 2:**

In a lot of examples, a data reference was created to a resource group:
```
data "azurerm_resource_group" "example" {
  name = "example-resources"
}
```

Then in subsequent resources, the references was made to a resource, and not the data, e.g.:
```
resource "azurerm_storage_account" "example" {
  name                     = "examplestoracc"
  resource_group_name      = azurerm_resource_group.example.name
  location                 = azurerm_resource_group.example.location
  account_tier             = "Standard"
  account_replication_type = "LRS"
}
```

This lead to un-runnable examples, throwing an obvious "Error: Reference to undeclared resource". Now there's two ways this solution could go, either I could have updated the references to use data.* or I could change the data declaration, into an actual resource group - resource. I went with the ladder, as this leaves more out-the-box examples, that can be copied in, without having to create the resource groups in advance. There are a few places that I've not made this change, which is in examples that by nature, require multiple RG. These examples are more complex, and adding multiple RG to the creation would clutter.


**Change 3:**

Resource Group resources have been streamlined, so the naming is consistent across all examples. Instead of being called (internal reference, in Terraform) "rg", "main", "example" and other odd names such as "my-group", they are now all named "example". References has also been updated. This change has not been done to examples, which requires more than one resource group, such as the nature of primary/secondary, source/destination, failover etc.


