### PR TITLE
Add tip to prevent gotcha around `MicrosoftWindowsServer` Publisher and using `plan` block

### DIFF
--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -279,7 +279,7 @@ A `plan` block supports the following:
 
 * `publisher` - (Required) Specifies the Publisher of the Marketplace Image this Virtual Machine should be created from. Changing this forces a new resource to be created.
 
--> **NOTE:** If you use the `plan` block with Microsoft's standard image (e.g. `publisher = "MicrosoftWindowsServer"`). This may prevent the purchase of the offer. An example Azure API error: `The Offer: 'WindowsServer' cannot be purchased by subscription: '12345678-12234-5678-9012-123456789012' as it is not to be sold in market: 'US'. Please choose a subscription which is associated with a different market.`
+-> **NOTE:** If you use the `plan` block with one of Microsoft's marketplace images (e.g. `publisher = "MicrosoftWindowsServer"`). This may prevent the purchase of the offer. An example Azure API error: `The Offer: 'WindowsServer' cannot be purchased by subscription: '12345678-12234-5678-9012-123456789012' as it is not to be sold in market: 'US'. Please choose a subscription which is associated with a different market.`
  
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -279,7 +279,8 @@ A `plan` block supports the following:
 
 * `publisher` - (Required) Specifies the Publisher of the Marketplace Image this Virtual Machine should be created from. Changing this forces a new resource to be created.
 
--> **NOTE:** Do not use the `plan` block with Microsoft's standard image (e.g. when `publisher = "MicrosoftWindowsServer"`). This will prevent the purchase of the offer. 
+-> **NOTE:** If you use the `plan` block with Microsoft's standard image (e.g. `publisher = "MicrosoftWindowsServer"`). This may prevent the purchase of the offer. An example Azure API error: `The Offer: 'WindowsServer' cannot be purchased by subscription: '12345678-12234-5678-9012-123456789012' as it is not to be sold in market: 'US'. Please choose a subscription which is associated with a different market.`
+ 
 ---
 
 A `secret` block supports the following:


### PR DESCRIPTION
Specifying the `plan` block with `MicrosoftWindowsServer` offers causes a nasty error message:

`The Offer: 'WindowsServer' cannot be purchased by subscription: 'aaaaa-1111-2222-cccc-adf23ad' as it is not to be sold in market: 'US'. Please choose a subscription which is associated with a different market.`

https://stackoverflow.com/questions/72076412/unable-to-deploy-windows-vm-not-to-be-sold-in-market-us/72100206#72100206

This addition will hopefully help others avoid this pitfall.

https://stackoverflow.com/questions/72076412/unable-to-deploy-windows-vm-not-to-be-sold-in-market-us/72100206#72100206