### PR TITLE
`azurerm_linux_function_app` and `azurerm_linux_function_app_slot` fix WEBSITE_RUN_FROM_PACKAGE handling from external sources

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema_test.go
+++ b/internal/services/appservice/helpers/function_app_schema_test.go
@@ -2,6 +2,7 @@ package helpers_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
@@ -57,16 +58,16 @@ func TestMergeUserAppSettings(t *testing.T) {
 			},
 			expected: []web.NameValuePair{
 				{
+					Name:  utils.String("test"),
+					Value: utils.String("UserValue"),
+				},
+				{
 					Name:  utils.String("test2"),
 					Value: utils.String("ServiceValue2"),
 				},
 				{
 					Name:  utils.String("test3"),
 					Value: utils.String("ServiceValue3"),
-				},
-				{
-					Name:  utils.String("test"),
-					Value: utils.String("UserValue"),
 				},
 				{
 					Name:  utils.String("test4"),
@@ -77,9 +78,13 @@ func TestMergeUserAppSettings(t *testing.T) {
 	}
 
 	for _, v := range cases {
-		actual := helpers.MergeUserAppSettings(&v.service, v.user)
-		if !reflect.DeepEqual(*actual, v.expected) {
-			t.Fatalf("expected %+v, got %+v", v.expected, *actual)
+		actualRaw := helpers.MergeUserAppSettings(&v.service, v.user)
+		actual := *actualRaw
+		sort.Slice(actual, func(i, j int) bool {
+			return *actual[i].Name < *actual[j].Name
+		})
+		if !reflect.DeepEqual(actual, v.expected) {
+			t.Fatalf("expected %+v, got %+v", v.expected, actual)
 		}
 	}
 }

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1022,6 +1022,12 @@ func (m *LinuxFunctionAppModel) unpackLinuxFunctionAppSettings(input web.StringD
 		case "AzureWebJobsDashboard__accountName":
 			m.BuiltinLogging = true
 
+		case "WEBSITE_RUN_FROM_PACKAGE":
+			// Keep if user explicitly set, otherwise filter out as will have been added by ADO et al
+			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_RUN_FROM_PACKAGE"); ok {
+				appSettings[k] = utils.NormalizeNilableString(v)
+			}
+
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -868,6 +868,11 @@ func (m *LinuxFunctionAppSlotModel) unpackLinuxFunctionAppSettings(input web.Str
 		case "AzureWebJobsDashboard__accountName":
 			m.BuiltinLogging = true
 
+		case "WEBSITE_RUN_FROM_PACKAGE":
+			if _, ok := metadata.ResourceData.GetOk("app_settings.WEBSITE_RUN_FROM_PACKAGE"); ok {
+				appSettings[k] = utils.NormalizeNilableString(v)
+			}
+
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}


### PR DESCRIPTION
* `azurerm_linux_function_app` -  fix `app_settings.WEBSITE_RUN_FROM_PACKAGE` handling from external sources
* `azurerm_linux_function_app_slot` - fix `app_settings.WEBSITE_RUN_FROM_PACKAGE` handling from external sources

Also related to #16396
