### PR TITLE
Documentation note to match examples

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -129,7 +129,7 @@ resource "azurerm_function_app" "example" {
   version                    = "~3"
 }
 ```
-~> **Note:** Version `~3` is required for Linux Function Apps.
+~> **Note:** Version `~3` or `~4` is required for Linux Function Apps.
 
 ## Example Usage (Python in a Consumption Plan)
 


### PR DESCRIPTION
Note says version ~3 is required for Linux.  Examples show either ~3 or ~4 is acceptable for Linux