### PR TITLE
docs(kubernetes_cluster): Fix failing output

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -48,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 }
 
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
+  value     = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
   sensitive = true
 }
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -49,7 +49,6 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 output "client_certificate" {
   value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
-  
   sensitive = true
 }
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -49,6 +49,8 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 output "client_certificate" {
   value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
+  
+  sensitive = true
 }
 
 output "kube_config" {


### PR DESCRIPTION
Currently this code sample fails after apply due to not having `sensitive = true`
```
│ Error: Output refers to sensitive values
│ 
│   on main.tf line 32:
│   32: output "client_certificate" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true
```

Adding this section fixes error 