### PR TITLE
`r\snapshot` `d\snapshot`: Add support for `trusted_launch_enabled`

### DIFF
--- a/internal/services/compute/snapshot_data_source.go
+++ b/internal/services/compute/snapshot_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
@@ -104,6 +105,11 @@ func dataSourceSnapshot() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"trusted_launch_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -137,6 +143,14 @@ func dataSourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		if err := d.Set("encryption_settings", flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)); err != nil {
 			return fmt.Errorf("setting `encryption_settings`: %+v", err)
 		}
+
+		trustedLaunchEnabled := false
+		if securityProfile := props.SecurityProfile; securityProfile != nil {
+			if securityProfile.SecurityType == compute.DiskSecurityTypesTrustedLaunch {
+				trustedLaunchEnabled = true
+			}
+		}
+		d.Set("trusted_launch_enabled", trustedLaunchEnabled)
 	}
 
 	if data := resp.CreationData; data != nil {

--- a/internal/services/compute/snapshot_data_source_test.go
+++ b/internal/services/compute/snapshot_data_source_test.go
@@ -43,17 +43,15 @@ func TestAccDataSourceSnapshot_encryption(t *testing.T) {
 
 func TestAccDataSourceSnapshot_trustedLaunch(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_snapshot", "snapshot")
-	r := SnapshotResource{}
+	r := SnapshotDataSource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: r.trustedLaunch(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("trusted_launch_enabled").HasValue("true"),
 			),
 		},
-		data.ImportStep("source_uri"),
 	})
 }
 

--- a/internal/services/compute/snapshot_data_source_test.go
+++ b/internal/services/compute/snapshot_data_source_test.go
@@ -41,6 +41,22 @@ func TestAccDataSourceSnapshot_encryption(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceSnapshot_trustedLaunch(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_snapshot", "snapshot")
+	r := SnapshotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.trustedLaunch(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("trusted_launch_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep("source_uri"),
+	})
+}
+
 func (SnapshotDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -178,4 +194,49 @@ data "azurerm_snapshot" "snapshot" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
+}
+
+func (SnapshotDataSource) trustedLaunch(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_platform_image" "test" {
+  location  = "%[2]s"
+  publisher = "Canonical"
+  offer     = "UbuntuServer"
+  sku       = "18_04-LTS-gen2"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                   = "acctestd-%[1]d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  os_type                = "Linux"
+  create_option          = "FromImage"
+  image_reference_id     = data.azurerm_platform_image.test.id
+  storage_account_type   = "Standard_LRS"
+  hyper_v_generation     = "V2"
+  trusted_launch_enabled = true
+}
+
+resource "azurerm_snapshot" "test" {
+  name                = "acctestss_%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  create_option       = "Copy"
+  source_uri          = azurerm_managed_disk.test.id
+}
+
+data "azurerm_snapshot" "snapshot" {
+  name                = azurerm_snapshot.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -87,6 +87,11 @@ func resourceSnapshot() *pluginsdk.Resource {
 
 			"encryption_settings": encryptionSettingsSchema(),
 
+			"trusted_launch_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -206,6 +211,14 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		if err := d.Set("encryption_settings", flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)); err != nil {
 			return fmt.Errorf("setting `encryption_settings`: %+v", err)
 		}
+
+		trustedLaunchEnabled := false
+		if securityProfile := props.SecurityProfile; securityProfile != nil {
+			if securityProfile.SecurityType == compute.DiskSecurityTypesTrustedLaunch {
+				trustedLaunchEnabled = true
+			}
+		}
+		d.Set("trusted_launch_enabled", trustedLaunchEnabled)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -39,6 +39,8 @@ data "azurerm_snapshot" "example" {
 
 * `disk_size_gb` - The size of the Snapshotted Disk in GB.
 
+* `trusted_launch_enabled` - Whether Trusted Launch is enabled for the Snapshot.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -69,6 +69,8 @@ The following attributes are exported:
 
 * `disk_size_gb` - The Size of the Snapshotted Disk in GB.
 
+* `trusted_launch_enabled` - Whether Trusted Launch is enabled for the Snapshot.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
The `trusted_launch_enabled` property is populated from the source disk/snapshot, marking it as `Computed`