### PR TITLE
Set gateway connection back on update

### DIFF
--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -92,6 +92,13 @@ func resourceExpressRouteGatewayCreateUpdate(d *pluginsdk.ResourceData, meta int
 	t := d.Get("tags").(map[string]interface{})
 
 	minScaleUnits := int32(d.Get("scale_units").(int))
+
+	erConnectionsClient := meta.(*clients.Client).Network.ExpressRouteConnectionsClient
+	erConnections, err := erConnectionsClient.List(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf(" get Gateway Connections error %s: %+v", id, err)
+	}
+
 	parameters := network.ExpressRouteGateway{
 		Location: utils.String(location),
 		ExpressRouteGatewayProperties: &network.ExpressRouteGatewayProperties{
@@ -103,6 +110,7 @@ func resourceExpressRouteGatewayCreateUpdate(d *pluginsdk.ResourceData, meta int
 			VirtualHub: &network.VirtualHubID{
 				ID: &virtualHubId,
 			},
+			ExpressRouteConnections: erConnections.Value,
 		},
 		Tags: tags.Expand(t),
 	}


### PR DESCRIPTION
Fix #13368  ,  set connections back on update. The ER-connections needs ER-circuits provisioned which is not available in AccTest(Need ER provider support),  manually check this patch to make sure the ER-connections are not ignored when updating.