### PR TITLE
Update Eviction Policy due to service update

### DIFF
--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -271,10 +271,6 @@ func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta inter
 		return fmt.Errorf("setting module error: %+v", err)
 	}
 
-	if isGeoEnabled && module != nil && evictionPolicy != databases.EvictionPolicyNoEviction {
-		return fmt.Errorf("evictionPolicy must be set to NoEviction when using RediSearch module")
-	}
-
 	parameters := databases.Database{
 		Properties: &databases.DatabaseProperties{
 			ClientProtocol:   &protocol,
@@ -431,10 +427,6 @@ func resourceRedisEnterpriseDatabaseUpdate(d *pluginsdk.ResourceData, meta inter
 	module, err := expandArmDatabaseModuleArray(d.Get("module").([]interface{}), isGeoEnabled)
 	if err != nil {
 		return fmt.Errorf("setting module error: %+v", err)
-	}
-
-	if isGeoEnabled && module != nil && evictionPolicy != databases.EvictionPolicyNoEviction {
-		return fmt.Errorf("evictionPolicy must be set to NoEviction when using RediSearch module")
 	}
 
 	parameters := databases.Database{

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -67,9 +67,7 @@ The following arguments are supported:
 
 * `clustering_policy` - (Optional) Clustering policy - default is OSSCluster. Specified at create time. Possible values are `EnterpriseCluster` and `OSSCluster`. Defaults to `OSSCluster`. Changing this forces a new Redis Enterprise Database to be created.
 
-* `eviction_policy` - (Optional) Redis eviction policy - default is VolatileLRU. Possible values are `AllKeysLFU`, `AllKeysLRU`, `AllKeysRandom`, `VolatileLRU`, `VolatileLFU`, `VolatileTTL`, `VolatileRandom` and `NoEviction`. Defaults to `VolatileLRU`. Changing this forces a new Redis Enterprise Database to be created.
-
--> **NOTE:** Eviction Policy must be set to NoEviction when using RediSearch module
+* `eviction_policy` - (Optional) Redis eviction policy - default is `VolatileLRU`. Possible values are `AllKeysLFU`, `AllKeysLRU`, `AllKeysRandom`, `VolatileLRU`, `VolatileLFU`, `VolatileTTL`, `VolatileRandom` and `NoEviction`. Changing this forces a new Redis Enterprise Database to be created.
 
 * `module` - (Optional)  A `module` block as defined below.
 


### PR DESCRIPTION
The previous behavior is the eviction policy must be set to NoEviction when rediSerach module is enabled. Now, service team updated the feature to support all the supported values.

acc tests:
```
--- PASS: TestRedisEnterpriseDatabase_requiresImport (1538.36s)
--- PASS: TestRedisEnterpriseDatabase_complete (1649.01s)
--- PASS: TestRedisEnterpriseDatabase_geoDatabaseOtherEvictionPolicy (1649.59s)
--- PASS: TestRedisEnterpriseDatabase_geoDatabaseModule (1775.76s)
--- PASS: TestRedisEnterpriseDatabase_basic (1800.99s)
--- PASS: TestRedisEnterpriseDatabase_geoDatabase (1865.83s)
--- PASS: TestRedisEnterpriseDatabase_geoDatabaseUnlinkDatabase (1887.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise       1887.770s

```