### PR TITLE
`azurerm_storage_management_policy` - Mark `rule.filters.blob_type` as required

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -61,22 +61,15 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Required: true,
 						},
-						//lintignore:XS003
 						"filters": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"prefix_match": {
-										Type:     pluginsdk.TypeSet,
-										Optional: true,
-										Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-										Set:      pluginsdk.HashString,
-									},
 									"blob_types": {
 										Type:     pluginsdk.TypeSet,
-										Optional: true,
+										Required: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{
@@ -86,7 +79,12 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 										},
 										Set: pluginsdk.HashString,
 									},
-
+									"prefix_match": {
+										Type:     pluginsdk.TypeSet,
+										Optional: true,
+										Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+										Set:      pluginsdk.HashString,
+									},
 									"match_blob_index_tag": {
 										Type:     pluginsdk.TypeSet,
 										Optional: true,

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -103,9 +103,9 @@ The following arguments are supported:
 
 `filters` supports the following:
 
-* `prefix_match` - An array of strings for prefixes to be matched.
-* `blob_types` - An array of predefined values. Valid options are `blockBlob` and `appendBlob`.
-* `match_blob_index_tag` - A `match_blob_index_tag` block as defined below. The block defines the blob index tag based filtering for blob objects.
+* `blob_types` - (Required) An array of predefined values. Valid options are `blockBlob` and `appendBlob`.
+* `prefix_match` - (Optional) An array of strings for prefixes to be matched.
+* `match_blob_index_tag` - (Optional) A `match_blob_index_tag` block as defined below. The block defines the blob index tag based filtering for blob objects.
 
 ~> **NOTE:** The `match_blob_index_tag` property requires enabling the `blobIndex` feature with [PSH or CLI commands](https://azure.microsoft.com/en-us/blog/manage-and-find-data-with-blob-index-for-azure-storage-now-in-preview/). 
 ---


### PR DESCRIPTION
The `blobType` of the storage management policy's rule filters are required, see: https://github.com/Azure/azure-rest-api-specs/blob/62631144da413d71bf332bd0104bbcbffe55d642/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json#L3890-L3892.

Fixes: #16686