### PR TITLE
azurerm_mssql_managed_instance_failover_group :  Fix "The given primary field in create or update instance failover group request body is empty or invalid" error

### DIFF
--- a/internal/services/mssql/mssql_managed_instance_failover_group_resource.go
+++ b/internal/services/mssql/mssql_managed_instance_failover_group_resource.go
@@ -195,7 +195,7 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Create() sdk.ResourceFunc {
 					},
 					ManagedInstancePairs: &[]sql.ManagedInstancePairInfo{
 						{
-							PrimaryManagedInstanceID: utils.String(id.ID()),
+							PrimaryManagedInstanceID: utils.String(managedInstanceId.ID()),
 							PartnerManagedInstanceID: utils.String(partnerId.ID()),
 						},
 					},


### PR DESCRIPTION
The customer is encountering "The given primary field in create or update instance failover group request body is empty or invalid" error when creating `azurerm_mssql_managed_instance_failover_group` resource. After investigation, it was found that the parameter `PrimaryManagedInstanceID` was set to the ID of failover group instead of the primary managed instance ID. So, I submitted this PR to fix the error.

It's worth mentioning that when the env variable ARM_TEST_LOCATION is set to `eastus` and the ARM_TEST_LOCATION_ALT is set to `westus3`, the test case `TestAccMsSqlManagedInstanceFailoverGroup_update` fails with error "The async operation failed" while creating  `azurerm_mssql_managed_instance` resource on my local(There is this error both before and after this fix. And it seems that team city has the same error). After replacing the `westcentralus` and `westus2` with the `eastus` and `westus3` for AzureCloud, Storage, EventHub, Sql route  in [const managedInstanceStaticRoutes ](https://github.com/hashicorp/terraform-provider-azurerm/blob/5ec191b8bbc5824fdf4cb3f71884ea0aad62bbb0/internal/services/mssql/mssql_managed_instance_resource_test.go#L902), this error went away. Since our test subscription does not support creating `azurerm_mssql_managed_instance` resource under `westcentralus` and `westus2` region, I could not test on these regions. 

Given that the resource `azurerm_mssql_managed_instance` was contributed in [PR #15203 ](https://github.com/hashicorp/terraform-provider-azurerm/pull/15203) by manicminer. @manicminer, do you have any suggesstions on how to resolve the test case failure? May I ask you help to review this PR to fix the invalid request body error to unblock the customer first?

Related issue:  [#16566](https://github.com/hashicorp/terraform-provider-azurerm/issues/16566).

