### PR TITLE
Update version number azurerm_postgresql_server

### DIFF
--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_postgresql_server" "example" {
   administrator_login_password = "H@Sh1CoR3!"
 
   sku_name   = "GP_Gen5_4"
-  version    = "9.6"
+  version    = "11"
   storage_mb = 640000
 
   backup_retention_days        = 7


### PR DESCRIPTION
Version 9.6 is retired, so it's not possible to create postgres instances with that version anymore. Version 11 is advised as a replacement.