### PR TITLE
`azurerm_source_control_token` Fix #16693 by correcting `IDValidationFunc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ ENHANCEMENTS:
 * `azurerm_snapshot` - support for the `trusted_launch_enabled` propertyu [GH-16679]
 * `azurerm_stream_analytics_function_javascript_udf` - support for the `input.configuration_parameter` property [GH-16579]
 
+BUG FIXES:
+
+* `azurerm_source_control_token` - fix incorrect id validator [GH-16693]
+
 ## 3.5.0 (May 05, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ ENHANCEMENTS:
 * `azurerm_snapshot` - support for the `trusted_launch_enabled` propertyu [GH-16679]
 * `azurerm_stream_analytics_function_javascript_udf` - support for the `input.configuration_parameter` property [GH-16579]
 
-BUG FIXES:
-
-* `azurerm_source_control_token` - fix incorrect id validator [GH-16693]
-
 ## 3.5.0 (May 05, 2022)
 
 FEATURES:

--- a/internal/services/appservice/validate/source_control_token.go
+++ b/internal/services/appservice/validate/source_control_token.go
@@ -2,7 +2,7 @@ package validate
 
 import "fmt"
 
-const expectedID = "/providers/Microsoft.Web/sourcecontrols/GitHub"
+const expectedID = "/providers/Microsoft.Web/sourceControls/GitHub"
 
 func AppServiceSourceControlTokenID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)

--- a/website/docs/r/source_control_token.html.markdown
+++ b/website/docs/r/source_control_token.html.markdown
@@ -51,5 +51,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 App Service Source GitHub Tokens can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_service_github_token.example /providers/Microsoft.Web/sourcecontrols/GitHub
+terraform import azurerm_source_control_token.example /providers/Microsoft.Web/sourceControls/GitHub
 ```


### PR DESCRIPTION
This patch will fix #16693 .
The original id validator function used an incorrect id prefix. This patch fixed the prefix so we can import the existing token.
The document's import statement had an incorrect resource type and id sample. This patch also fixed the document.

Acc tests:

=== RUN   TestAccSourceControlGitHubToken_basic
=== PAUSE TestAccSourceControlGitHubToken_basic
=== CONT  TestAccSourceControlGitHubToken_basic
--- PASS: TestAccSourceControlGitHubToken_basic (127.23s)
=== RUN   TestAccSourceControlGitHubToken_requiresImport
=== PAUSE TestAccSourceControlGitHubToken_requiresImport
=== CONT  TestAccSourceControlGitHubToken_requiresImport
--- PASS: TestAccSourceControlGitHubToken_requiresImport (151.37s)
