### PR TITLE
azurerm_vpn_gateway_nat_rule - support new property port_range

### DIFF
--- a/internal/services/network/vpn_gateway_nat_rule_resource.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource.go
@@ -55,7 +55,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"external_mapping": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Computed: !features.FourPointOhBeta(),
 				AtLeastOneOf: func() []string {
@@ -85,7 +85,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"internal_mapping": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Computed: !features.FourPointOhBeta(),
 				AtLeastOneOf: func() []string {
@@ -149,7 +149,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		resource.Schema["external_address_space_mappings"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeSet,
+			Type:       pluginsdk.TypeList,
 			Optional:   true,
 			Computed:   true,
 			Deprecated: "`external_address_space_mappings` will be removed in favour of the property `external_mapping` in version 4.0 of the AzureRM Provider.",
@@ -169,7 +169,7 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 		}
 
 		resource.Schema["internal_address_space_mappings"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeSet,
+			Type:       pluginsdk.TypeList,
 			Optional:   true,
 			Computed:   true,
 			Deprecated: "`internal_address_space_mappings` will be removed in favour of the property `internal_mapping` in version 4.0 of the AzureRM Provider.",
@@ -225,20 +225,20 @@ func resourceVPNGatewayNatRuleCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	if !features.FourPointOhBeta() {
 		if v, ok := d.GetOk("external_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.(*pluginsdk.Set).List())
+			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("internal_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.(*pluginsdk.Set).List())
+			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(v.([]interface{}))
 		}
 	}
 
 	if v, ok := d.GetOk("external_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(v.(*pluginsdk.Set).List())
+		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("internal_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(v.(*pluginsdk.Set).List())
+		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("ip_configuration_id"); ok {
@@ -342,20 +342,20 @@ func resourceVPNGatewayNatRuleUpdate(d *pluginsdk.ResourceData, meta interface{}
 	// d.GetOk always returns true and the value that is set in the previous apply when the property has the attribute `Computed: true`. Hence, at this time d.GetOk cannot identify whether user sets the property in tf config so that it has to identify it via splitting create and update method and using d.HasChange
 	if !features.FourPointOhBeta() {
 		if ok := d.HasChange("external_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("external_address_space_mappings").(*pluginsdk.Set).List())
+			props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("external_address_space_mappings").([]interface{}))
 		}
 
 		if ok := d.HasChange("internal_address_space_mappings"); ok {
-			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("internal_address_space_mappings").(*pluginsdk.Set).List())
+			props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleAddressSpaceMappings(d.Get("internal_address_space_mappings").([]interface{}))
 		}
 	}
 
 	if ok := d.HasChange("external_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(d.Get("external_mapping").(*pluginsdk.Set).List())
+		props.VpnGatewayNatRuleProperties.ExternalMappings = expandVpnGatewayNatRuleMappings(d.Get("external_mapping").([]interface{}))
 	}
 
 	if ok := d.HasChange("internal_mapping"); ok {
-		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(d.Get("internal_mapping").(*pluginsdk.Set).List())
+		props.VpnGatewayNatRuleProperties.InternalMappings = expandVpnGatewayNatRuleMappings(d.Get("internal_mapping").([]interface{}))
 	}
 
 	if v, ok := d.GetOk("ip_configuration_id"); ok {

--- a/internal/services/network/vpn_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource_test.go
@@ -3,6 +3,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -82,6 +83,28 @@ func TestAccVpnGatewayNatRule_update(t *testing.T) {
 	})
 }
 
+func TestAccVpnGatewayNatRule_externalMappingAndInternalMapping(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_gateway_nat_rule", "test")
+	r := VPNGatewayNatRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.externalMappingAndInternalMapping(data, "10.2.0.0/26", "200", "10.4.0.0/26", "400"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.externalMappingAndInternalMapping(data, "10.3.0.0/26", "300", "10.5.0.0/26", "500"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r VPNGatewayNatRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnGatewayNatRuleID(state.ID)
 	if err != nil {
@@ -97,7 +120,8 @@ func (r VPNGatewayNatRuleResource) Exists(ctx context.Context, clients *clients.
 }
 
 func (r VPNGatewayNatRuleResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_vpn_gateway_nat_rule" "test" {
@@ -108,10 +132,30 @@ resource "azurerm_vpn_gateway_nat_rule" "test" {
   internal_address_space_mappings = ["10.4.0.0/26"]
 }
 `, r.template(data), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway_nat_rule" "test" {
+  name                = "acctest-vpnnatrule-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vpn_gateway_id      = azurerm_vpn_gateway.test.id
+
+  external_mapping {
+    address_space = "192.168.21.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r VPNGatewayNatRuleResource) complete(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_vpn_gateway_nat_rule" "test" {
@@ -125,10 +169,33 @@ resource "azurerm_vpn_gateway_nat_rule" "test" {
   ip_configuration_id             = "Instance0"
 }
 `, r.template(data), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway_nat_rule" "test" {
+  name                = "acctest-vpnnatrule-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vpn_gateway_id      = azurerm_vpn_gateway.test.id
+  mode                = "EgressSnat"
+  type                = "Dynamic"
+  ip_configuration_id = "Instance0"
+
+  external_mapping {
+    address_space = "192.168.21.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r VPNGatewayNatRuleResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_vpn_gateway_nat_rule" "test" {
@@ -142,10 +209,33 @@ resource "azurerm_vpn_gateway_nat_rule" "test" {
   ip_configuration_id             = "Instance1"
 }
 `, r.template(data), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway_nat_rule" "test" {
+  name                = "acctest-vpnnatrule-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vpn_gateway_id      = azurerm_vpn_gateway.test.id
+  mode                = "EgressSnat"
+  type                = "Dynamic"
+  ip_configuration_id = "Instance1"
+
+  external_mapping {
+    address_space = "192.168.22.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.5.0.0/26"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r VPNGatewayNatRuleResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_vpn_gateway_nat_rule" "import" {
@@ -158,6 +248,49 @@ resource "azurerm_vpn_gateway_nat_rule" "import" {
   type                            = azurerm_vpn_gateway_nat_rule.test.type
 }
 `, r.basic(data))
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway_nat_rule" "import" {
+  name                = azurerm_vpn_gateway_nat_rule.test.name
+  resource_group_name = azurerm_vpn_gateway_nat_rule.test.resource_group_name
+  vpn_gateway_id      = azurerm_vpn_gateway_nat_rule.test.vpn_gateway_id
+  mode                = azurerm_vpn_gateway_nat_rule.test.mode
+  type                = azurerm_vpn_gateway_nat_rule.test.type
+
+  external_mapping {
+    address_space = "192.168.21.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
+}
+`, r.basic(data))
+}
+
+func (r VPNGatewayNatRuleResource) externalMappingAndInternalMapping(data acceptance.TestData, externalAddressSpace, externalPortRange, internalAddressSpace, internalPortRange string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway_nat_rule" "test" {
+  name                = "acctest-vpnnatrule-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vpn_gateway_id      = azurerm_vpn_gateway.test.id
+
+  external_mapping {
+    address_space = "%s"
+    port_range    = "%s"
+  }
+
+  internal_mapping {
+    address_space = "%s"
+    port_range    = "%s"
+  }
+}
+`, r.template(data), data.RandomInteger, externalAddressSpace, externalPortRange, internalAddressSpace, internalPortRange)
 }
 
 func (VPNGatewayNatRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/network/vpn_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource_test.go
@@ -3,12 +3,12 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/website/docs/r/vpn_gateway_nat_rule.html.markdown
+++ b/website/docs/r/vpn_gateway_nat_rule.html.markdown
@@ -40,11 +40,17 @@ resource "azurerm_vpn_gateway" "example" {
 }
 
 resource "azurerm_vpn_gateway_nat_rule" "example" {
-  name                            = "example-vpngatewaynatrule"
-  resource_group_name             = azurerm_resource_group.example.name
-  vpn_gateway_id                  = azurerm_vpn_gateway.example.id
-  external_address_space_mappings = ["192.168.21.0/26"]
-  internal_address_space_mappings = ["10.4.0.0/26"]
+  name                = "example-vpngatewaynatrule"
+  resource_group_name = azurerm_resource_group.example.name
+  vpn_gateway_id      = azurerm_vpn_gateway.example.id
+
+  external_mapping {
+    address_space = "192.168.21.0/26"
+  }
+
+  internal_mapping {
+    address_space = "10.4.0.0/26"
+  }
 }
 ```
 
@@ -58,15 +64,39 @@ The following arguments are supported:
 
 * `vpn_gateway_id` - (Required) The ID of the VPN Gateway that this VPN Gateway NAT Rule belongs to. Changing this forces a new resource to be created.
 
-* `external_address_space_mappings` - (Required) A list of CIDR Ranges which are used for external mapping of the VPN Gateway NAT Rule.
+* `external_address_space_mappings` - (Optional) A list of CIDR Ranges which are used for external mapping of the VPN Gateway NAT Rule.
 
-* `internal_address_space_mappings` - (Required) A list of CIDR Ranges which are used for internal mapping of the VPN Gateway NAT Rule.
+~> **NOTE:** `external_address_space_mappings` is deprecated and will be removed in favour of the property `external_mapping` in version 4.0 of the AzureRM Provider.
+
+* `external_mapping` - (Optional) One or more `external_mapping` blocks as documented below.
+
+* `internal_address_space_mappings` - (Optional) A list of CIDR Ranges which are used for internal mapping of the VPN Gateway NAT Rule.
+
+~> **NOTE:** `internal_address_space_mappings` is deprecated and will be removed in favour of the property `internal_mapping` in version 4.0 of the AzureRM Provider.
+
+* `internal_mapping` - (Optional) One or more `internal_mapping` blocks as documented below.
 
 * `ip_configuration_id` - (Optional) The ID of the IP Configuration this VPN Gateway NAT Rule applies to. Possible values are `Instance0` and `Instance1`.
 
 * `mode` - (Optional) The source NAT direction of the VPN NAT. Possible values are `EgressSnat` and `IngressSnat`. Defaults to `EgressSnat`. Changing this forces a new resource to be created.
 
 * `type` - (Optional) The type of the VPN Gateway NAT Rule. Possible values are `Dynamic` and `Static`. Defaults to `Static`. Changing this forces a new resource to be created.
+
+---
+
+A `external_mapping` block exports the following:
+
+* `address_space` - (Required) The string CIDR representing the address space for the VPN Gateway Nat Rule external mapping.
+
+* `port_range` - (Optional) The single port range for the VPN Gateway Nat Rule external mapping.
+
+---
+
+A `internal_mapping` block exports the following:
+
+* `address_space` - (Required) The string CIDR representing the address space for the VPN Gateway Nat Rule internal mapping.
+
+* `port_range` - (Optional) The single port range for the VPN Gateway Nat Rule internal mapping.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is to support new property `port_range` for azurerm_vpn_gateway_nat_rule.

--- PASS: TestAccVpnGatewayNatRule_basic (4465.47s)
--- PASS: TestAccVpnGatewayNatRule_complete (4610.49s)
--- PASS: TestAccVpnGatewayNatRule_update (4727.26s)
--- PASS: TestAccVpnGatewayNatRule_externalMappingAndInternalMapping (4739.50s)
--- PASS: TestAccVpnGatewayNatRule_requiresImport (4805.02s)