### PR TITLE
azurerm_batch_account ：fix storage account id is invalid error

### DIFF
--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -297,8 +297,6 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-
-	storageAccountId := d.Get("storage_account_id").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	identity, err := expandBatchAccountIdentity(d.Get("identity").([]interface{}))
@@ -311,13 +309,16 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	parameters := batch.AccountUpdateParameters{
 		AccountUpdateProperties: &batch.AccountUpdateProperties{
-			AutoStorage: &batch.AutoStorageBaseProperties{
-				StorageAccountID: &storageAccountId,
-			},
 			Encryption: encryption,
 		},
 		Identity: identity,
 		Tags:     tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("storage_account_id"); ok && v.(string) != "" {
+		parameters.AccountUpdateProperties.AutoStorage = &batch.AutoStorageBaseProperties{
+			StorageAccountID: utils.String(v.(string)),
+		}
 	}
 
 	if _, err = client.Update(ctx, id.ResourceGroup, id.BatchAccountName, parameters); err != nil {

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -55,6 +55,22 @@ func TestAccBatchAccount_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("BatchService"),
 			),
 		},
+		data.ImportStep(),
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("BatchService"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("BatchService"),
+			),
+		},
 	})
 }
 
@@ -187,6 +203,30 @@ resource "azurerm_batch_account" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   location             = azurerm_resource_group.test.location
   pool_allocation_mode = "BatchService"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (BatchAccountResource) basicUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_batch_account" "test" {
+  name                 = "testaccbatch%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  pool_allocation_mode = "BatchService"
+
+  tags = {
+    env = "test"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
The error "properties.autoStorage.storageAccountId' is invalid" occurred while updating the `azurerm_batch_account` resource, even though the value of the  `storage_account_id`  is not set on both creation and update. It is caused by `properties.autoStorage.storageAccountId` is set to empty. After checking the older[ v2017-05-01](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/batch/resource-manager/Microsoft.Batch/stable/2017-05-01/BatchManagement.json#L44) and the latest [v2022-01-01](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json#L42) API, neither of them supports setting the `storageAccountId` to empty. So, submitted this PR to fix issue #16660.

Test Results:

> PASS: TestAccBatchAccount_basic (470.22s)
> PASS: TestAccBatchAccount_complete (451.43s)
> PASS: TestAccBatchAccount_removeStorageAccount (538.09s)
> PASS: TestAccBatchAccount_cmk (485.20s)
> PASS: TestAccBatchAccount_identity (394.48s)
> PASS: TestAccBatchAccount_requiresImport (286.28s)