### PR TITLE
`azurerm_container_registry_task` - Fix document about `registry_credential.custom.identity`

### DIFF
--- a/website/docs/r/container_registry_task.html.markdown
+++ b/website/docs/r/container_registry_task.html.markdown
@@ -129,7 +129,7 @@ A `custom` block supports the following:
 
 * `login_server` - (Required) The login server of the custom Container Registry.
 
-* `identity` - (Optional) The managed identity assigned to this custom credential. For user assigned identity, the value is the client ID of the identity. For system assigned identity, the value is `system`.
+* `identity` - (Optional) The managed identity assigned to this custom credential. For user assigned identity, the value is the client ID of the identity. For system assigned identity, the value is `[system]`.
 
 * `password` - (Optional) The password for logging into the custom Container Registry. It can be either a plain text of password, or a Keyvault Secret ID.
 


### PR DESCRIPTION
Fix #16725

```shell
❯ TF_ACC=1 go test -v -run=TestAccContainerRegistryTask_fileTaskStepRegistryCredential ./internal/services/containers
=== RUN   TestAccContainerRegistryTask_fileTaskStepRegistryCredential
=== PAUSE TestAccContainerRegistryTask_fileTaskStepRegistryCredential
=== CONT  TestAccContainerRegistryTask_fileTaskStepRegistryCredential
--- PASS: TestAccContainerRegistryTask_fileTaskStepRegistryCredential (267.17s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    267.178s
```