### PR TITLE
azurerm_cosmosdb_cassandra_cluster - support new property tags

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -20,9 +20,9 @@ func TestAccCassandraCluster(t *testing.T) {
 	// Azure only being able provision against one app id at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			//"basic":          testAccCassandraCluster_basic,
-			//"requiresImport": testAccCassandraCluster_requiresImport,
-			"tags": testAccCassandraCluster_tags,
+			"basic":          testAccCassandraCluster_basic,
+			"requiresImport": testAccCassandraCluster_requiresImport,
+			"tags":           testAccCassandraCluster_tags,
 		},
 	})
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -20,9 +20,9 @@ func TestAccCassandraCluster(t *testing.T) {
 	// Azure only being able provision against one app id at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			"basic":          testAccCassandraCluster_basic,
-			"requiresImport": testAccCassandraCluster_requiresImport,
-			"tags":           testAccCassandraCluster_tags,
+			//"basic":          testAccCassandraCluster_basic,
+			//"requiresImport": testAccCassandraCluster_requiresImport,
+			"tags": testAccCassandraCluster_tags,
 		},
 	})
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -15,11 +15,23 @@ import (
 
 type CassandraClusterResource struct{}
 
-func TestAccCassandraCluster_basic(t *testing.T) {
+func TestAccCassandraCluster(t *testing.T) {
+	// NOTE: this is a combined test rather than separate split out tests due to
+	// Azure only being able provision against one app id at a time
+	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"basic": {
+			"basic":          testAccCassandraCluster_basic,
+			"requiresImport": testAccCassandraCluster_requiresImport,
+			"tags":           testAccCassandraCluster_tags,
+		},
+	})
+}
+
+func testAccCassandraCluster_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_cluster", "test")
 	r := CassandraClusterResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
@@ -30,11 +42,11 @@ func TestAccCassandraCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccCassandraCluster_requiresImport(t *testing.T) {
+func testAccCassandraCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_cluster", "test")
 	r := CassandraClusterResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -46,6 +58,28 @@ func TestAccCassandraCluster_requiresImport(t *testing.T) {
 			Config:      r.requiresImport(data),
 			ExpectError: acceptance.RequiresImportError("azurerm_cosmosdb_cassandra_cluster"),
 		},
+	})
+}
+
+func testAccCassandraCluster_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_cluster", "test")
+	r := CassandraClusterResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.tags(data, "Test"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_admin_password"),
+		{
+			Config: r.tags(data, "Test2"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_admin_password"),
 	})
 }
 
@@ -63,50 +97,23 @@ func (t CassandraClusterResource) Exists(ctx context.Context, clients *clients.C
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func (CassandraClusterResource) basic(data acceptance.TestData) string {
+func (r CassandraClusterResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-ca-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctvn-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "acctsub-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_virtual_network.test.id
-  role_definition_name = "Network Contributor"
-  principal_id         = "255f3c8e-0c3d-4f06-ba9d-2fb68af0faed"
-}
+%s
 
 resource "azurerm_cosmosdb_cassandra_cluster" "test" {
-  name                           = "acctca-mi-cluster-%[1]d"
+  name                           = "acctca-mi-cluster-%d"
   resource_group_name            = azurerm_resource_group.test.name
   location                       = azurerm_resource_group.test.location
   delegated_management_subnet_id = azurerm_subnet.test.id
   default_admin_password         = "Password1234"
+
+  depends_on = [azurerm_role_assignment.test]
 }
-`, data.RandomInteger, data.Locations.Secondary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (CassandraClusterResource) requiresImport(data acceptance.TestData) string {
-	template := CassandraClusterResource{}.basic(data)
+func (r CassandraClusterResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -117,5 +124,62 @@ resource "azurerm_cosmosdb_cassandra_cluster" "import" {
   delegated_management_subnet_id = azurerm_subnet.test.id
   default_admin_password         = "Password1234"
 }
-`, template)
+`, r.basic(data))
+}
+
+func (r CassandraClusterResource) tags(data acceptance.TestData, tag string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cosmosdb_cassandra_cluster" "test" {
+  name                           = "acctca-mi-cluster-%d"
+  resource_group_name            = azurerm_resource_group.test.name
+  location                       = azurerm_resource_group.test.location
+  delegated_management_subnet_id = azurerm_subnet.test.id
+  default_admin_password         = "Password1234"
+
+  tags = {
+    Env = "%s"
+  }
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, r.template(data), data.RandomInteger, tag)
+}
+
+func (r CassandraClusterResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-ca-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+data "azuread_service_principal" "test" {
+  display_name = "Azure Cosmos DB"
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_virtual_network.test.id
+  role_definition_name = "Network Contributor"
+  principal_id         = data.azuread_service_principal.test.object_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -16,8 +16,7 @@ import (
 type CassandraClusterResource struct{}
 
 func TestAccCassandraCluster(t *testing.T) {
-	// NOTE: this is a combined test rather than separate split out tests due to
-	// Azure only being able provision against one app id at a time
+	// NOTE: this is a combined test rather than separate split out tests due to all below TCs sharing same sp
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
 			"basic":          testAccCassandraCluster_basic,

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -58,6 +58,8 @@ resource "azurerm_cosmosdb_cassandra_cluster" "example" {
   location                       = azurerm_resource_group.example.location
   delegated_management_subnet_id = azurerm_subnet.example.id
   default_admin_password         = "Password1234"
+
+  depends_on = [azurerm_role_assignment.example]
 }
 ```
 

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -10,6 +10,12 @@ description: |-
 
 Manages a Cassandra Cluster.
 
+~> ** NOTE: ** In order for the `Azure Managed Instances for Apache Cassandra` to work properly the product requires the `Azure Cosmos DB` Application ID to be present and working in your tenant. If the `Azure Cosmos DB` Application ID is missing in your environment you will need to have an administrator of your tenant run the following command to add the `Azure Cosmos DB` Application ID to your tenant:
+
+```powershell
+New-AzADServicePrincipal -ApplicationId a232010e-820c-4083-83bb-3ace5fc29d0b
+```
+
 ## Example Usage
 
 ```hcl
@@ -69,7 +75,7 @@ The following arguments are supported:
 
 * `default_admin_password` - (Required) The initial admin password for this Cassandra Cluster.
 
-* `tags` - A mapping of tags assigned to the resource.
+* `tags` - (Optional) A mapping of tags assigned to the resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -36,10 +36,14 @@ resource "azurerm_subnet" "example" {
   address_prefixes     = ["10.0.1.0/24"]
 }
 
+data "azuread_service_principal" "example" {
+  display_name = "Azure Cosmos DB"
+}
+
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_virtual_network.example.id
   role_definition_name = "Network Contributor"
-  principal_id         = "e5007d2c-4b13-4a74-9b6a-605d99f03501"
+  principal_id         = data.azuread_service_principal.example.object_id
 }
 
 resource "azurerm_cosmosdb_cassandra_cluster" "example" {
@@ -65,6 +69,8 @@ The following arguments are supported:
 
 * `default_admin_password` - (Required) The initial admin password for this Cassandra Cluster.
 
+* `tags` - A mapping of tags assigned to the resource.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 
@@ -77,6 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Cassandra Cluster.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Cassandra Cluster.
+* `update` - (Defaults to 30 minutes) Used when updating the Cassandra Cluster.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Cassandra Cluster.
 
 ## Import


### PR DESCRIPTION
This PR is to support new property tags for azurerm_cosmosdb_cassandra_cluster.

--- PASS: TestAccCassandraCluster/basic/basic (847.38s)
--- PASS: TestAccCassandraCluster/basic/requiresImport (916.02s)
--- PASS: TestAccCassandraCluster/basic/tags (1042.72s)

![image](https://user-images.githubusercontent.com/19754191/167827165-634acdd4-67ff-4066-a2c4-068f6c0fa5e5.png)

Note: This PR depends on https://github.com/hashicorp/terraform-provider-azurerm/pull/16752. Once PR 16752 is merged, I will refine TC in this PR.