### PR TITLE
Add information to documentation that changing vm_size of default node pool will recreate the whole cluster

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -310,7 +310,7 @@ A `default_node_pool` block supports the following:
 
 * `name` - (Required) The name which should be used for the default Kubernetes Node Pool. Changing this forces a new resource to be created.
 
-* `vm_size` - (Required) The size of the Virtual Machine, such as `Standard_DS2_v2`.
+* `vm_size` - (Required) The size of the Virtual Machine, such as `Standard_DS2_v2`. Changing this forces a new resource to be created.
 
 * `enable_auto_scaling` - (Optional) Should [the Kubernetes Auto Scaler](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler) be enabled for this Node Pool? Defaults to `false`.
 


### PR DESCRIPTION
This came as a surprise to me today as the field is not documented as such but the code has been this way since 2019 https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/containers/kubernetes_nodepool.go#L53
