### PR TITLE
Fix the issue of upgrading Network API Version

### DIFF
--- a/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network/_meta.json
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network/_meta.json
@@ -1,5 +1,5 @@
 {
-  "commit": "fc9d4d2798f755bea848ac1c29b2730d31002cb8",
+  "commit": "50ed15bd61ac79f2368d769df0c207a00b9e099f",
   "readme": "/_/azure-rest-api-specs/specification/network/resource-manager/readme.md",
   "tag": "package-2021-08",
   "use": "@microsoft.azure/autorest.go@2.1.187",


### PR DESCRIPTION
Seems this [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/16631) blocks the PR's dependency check. So raised this PR to fix it.

![image](https://user-images.githubusercontent.com/19754191/168207686-fccb2a51-d282-4cb7-a8f8-2d60e2755ceb.png)
