### PR TITLE
Doc Fix: azurerm_linux_function_app - [force_disable_content_share] property should match windows property [content_share_force_disabled]

### DIFF
--- a/website/docs/d/linux_function_app.html.markdown
+++ b/website/docs/d/linux_function_app.html.markdown
@@ -63,7 +63,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `enabled` - Is the Function App enabled?
 
-* `force_disable_content_share` - Are the settings for linking the Function App to storage suppressed?
+* `content_share_force_disabled` - Are the settings for linking the Function App to storage suppressed?
 
 * `functions_extension_version` - The runtime version associated with the Function App.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Function App enabled?
 
-* `force_disable_content_share` - (Optional) Should the settings for linking the Function App to storage be suppressed. 
+* `content_share_force_disabled` - (Optional) Should the settings for linking the Function App to storage be suppressed. 
 
 * `functions_extension_version` - (Optional) The runtime version associated with the Function App. Defaults to `~4`.
 


### PR DESCRIPTION
 Fix issue [#16789](https://github.com/hashicorp/terraform-provider-azurerm/issues/16789).