### PR TITLE
azurerm_mssql_managed_instance_failover_group ：fix update error "Only one managed instance pair is supported"

### DIFF
--- a/internal/services/mssql/mssql_managed_instance_failover_group_resource_test.go
+++ b/internal/services/mssql/mssql_managed_instance_failover_group_resource_test.go
@@ -3,12 +3,12 @@ package mssql_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -72,7 +72,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) basic(data acceptance.TestDat
 
 resource "azurerm_mssql_managed_instance_failover_group" "test" {
   name                        = "acctest-fog-%[2]d"
-  resource_group_name         = azurerm_resource_group.test.name
   location                    = "%[3]s"
   managed_instance_id         = azurerm_mssql_managed_instance.test.id
   partner_managed_instance_id = azurerm_mssql_managed_instance.secondary.id
@@ -95,7 +94,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) update(data acceptance.TestDa
 
 resource "azurerm_mssql_managed_instance_failover_group" "test" {
   name                        = "acctest-fog-%[2]d"
-  resource_group_name         = azurerm_resource_group.test.name
   location                    = "%[3]s"
   managed_instance_id         = azurerm_mssql_managed_instance.test.id
   partner_managed_instance_id = azurerm_mssql_managed_instance.secondary.id

--- a/internal/services/mssql/mssql_managed_instance_failover_group_resource_test.go
+++ b/internal/services/mssql/mssql_managed_instance_failover_group_resource_test.go
@@ -3,12 +3,12 @@ package mssql_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/mssql/mssql_managed_instance_resource.go
+++ b/internal/services/mssql/mssql_managed_instance_resource.go
@@ -411,6 +411,8 @@ func (r MsSqlManagedInstanceResource) Read() sdk.ResourceFunc {
 
 				// This value is not returned, so we'll just set whatever is in the state/config
 				AdministratorLoginPassword: state.AdministratorLoginPassword,
+				// This value is not returned, so we'll just set whatever is in the state/config
+				DnsZonePartnerId: state.DnsZonePartnerId,
 			}
 
 			if sku := existing.Sku; sku != nil && sku.Name != nil {

--- a/website/docs/r/mssql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/mssql_managed_instance_failover_group.html.markdown
@@ -61,7 +61,6 @@ resource "azurerm_mssql_managed_instance" "secondary" {
 
 resource "azurerm_mssql_managed_instance_failover_group" "example" {
   name                        = "example-failover-group"
-  resource_group_name         = azurerm_resource_group.primary.name
   location                    = azurerm_mssql_managed_instance.primary.location
   managed_instance_id         = azurerm_mssql_managed_instance.primary.id
   partner_managed_instance_id = azurerm_mssql_managed_instance.secondary.id
@@ -78,8 +77,6 @@ resource "azurerm_mssql_managed_instance_failover_group" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Managed Instance Failover Group. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Managed Instance Failover Group should exist. Changing this forces a new resource to be created.
 
 * `location` - The Azure Region where the Managed Instance Failover Group should exist. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
The purpose of this PR:

> 1. Fix update error "Only one managed instance pair is supported" as missing some parameters when updating resource `TestAccMsSqlManagedInstanceFailoverGroup_update`.
> 2. Remove `resource_group_name` in tf doc and test file as it doesn't exist in the latest TF code.
> 3. Fix the "the plan was not empty" issue for `dns_zone_partner_id` property when running test case `TestAccMsSqlManagedInstanceFailoverGroup_update`

Follow-up fix based on PR [#16705](https://github.com/hashicorp/terraform-provider-azurerm/pull/16705)