### PR TITLE
azurerm_vpn_gateway - support new property bgp_route_translation_for_nat_enabled

### DIFF
--- a/internal/services/network/vpn_gateway_resource.go
+++ b/internal/services/network/vpn_gateway_resource.go
@@ -72,6 +72,12 @@ func resourceVPNGateway() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"bgp_route_translation_for_nat_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"bgp_settings": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -221,7 +227,8 @@ func resourceVPNGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	parameters := network.VpnGateway{
 		Location: utils.String(location),
 		VpnGatewayProperties: &network.VpnGatewayProperties{
-			BgpSettings: bgpSettings,
+			EnableBgpRouteTranslationForNat: utils.Bool(d.Get("bgp_route_translation_for_nat_enabled").(bool)),
+			BgpSettings:                     bgpSettings,
 			VirtualHub: &network.SubResource{
 				ID: utils.String(virtualHubId),
 			},
@@ -307,6 +314,9 @@ func resourceVPNGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	if d.HasChange("tags") {
 		existing.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
+	if d.HasChange("bgp_route_translation_for_nat_enabled") {
+		existing.EnableBgpRouteTranslationForNat = utils.Bool(d.Get("bgp_route_translation_for_nat_enabled").(bool))
+	}
 
 	bgpSettingsRaw := d.Get("bgp_settings").([]interface{})
 	if len(bgpSettingsRaw) > 0 {
@@ -372,6 +382,12 @@ func resourceVPNGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		if err := d.Set("bgp_settings", flattenVPNGatewayBGPSettings(props.BgpSettings)); err != nil {
 			return fmt.Errorf("setting `bgp_settings`: %+v", err)
 		}
+
+		bgpRouteTranslationForNatEnabled := false
+		if props.EnableBgpRouteTranslationForNat != nil {
+			bgpRouteTranslationForNatEnabled = *props.EnableBgpRouteTranslationForNat
+		}
+		d.Set("bgp_route_translation_for_nat_enabled", bgpRouteTranslationForNatEnabled)
 
 		scaleUnit := 0
 		if props.VpnGatewayScaleUnit != nil {

--- a/internal/services/network/vpn_gateway_resource_test.go
+++ b/internal/services/network/vpn_gateway_resource_test.go
@@ -144,6 +144,28 @@ func TestAccVPNGateway_routingPreferenceInternet(t *testing.T) {
 	})
 }
 
+func TestAccVPNGateway_bgpRouteTranslationForNatEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_gateway", "test")
+	r := VPNGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.bgpRouteTranslationForNatEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.bgpRouteTranslationForNatEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VPNGatewayResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnGatewayID(state.ID)
 	if err != nil {
@@ -271,6 +293,20 @@ resource "azurerm_vpn_gateway" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r VPNGatewayResource) bgpRouteTranslationForNatEnabled(data acceptance.TestData, bgpRouteTranslationForNatEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway" "test" {
+  name                                  = "acctestVPNG-%d"
+  location                              = azurerm_resource_group.test.location
+  resource_group_name                   = azurerm_resource_group.test.name
+  virtual_hub_id                        = azurerm_virtual_hub.test.id
+  bgp_route_translation_for_nat_enabled = %t
+}
+`, r.template(data), data.RandomInteger, bgpRouteTranslationForNatEnabled)
 }
 
 func (VPNGatewayResource) template(data acceptance.TestData) string {

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -61,6 +61,8 @@ The following arguments are supported:
 
 ---
 
+* `bgp_route_translation_for_nat_enabled` - (Optional) Is BGP route translation for NAT on this VPN Gateway enabled? Defaults to `false`.
+
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below.
 
 * `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the


### PR DESCRIPTION
This PR is to support new property `bgp_route_translation_for_nat_enabled`.

--- PASS: TestAccVPNGateway_routingPreferenceMicrosoftNetwork (4459.47s)
--- PASS: TestAccVPNGateway_basic (4553.52s)
--- PASS: TestAccVPNGateway_routingPreferenceInternet (4616.52s)
--- PASS: TestAccVPNGateway_bgpRouteTranslationForNatEnabled (4762.22s)
--- PASS: TestAccVPNGateway_requiresImport (4775.15s)
--- PASS: TestAccVPNGateway_bgpSettings (5026.92s)
--- PASS: TestAccVPNGateway_tags (5872.58s)
--- PASS: TestAccVPNGateway_scaleUnit (6827.67s)
