### PR TITLE
azurerm_vpn_site - support new property o365_policy

### DIFF
--- a/internal/services/network/vpn_site_resource.go
+++ b/internal/services/network/vpn_site_resource.go
@@ -151,19 +151,19 @@ func resourceVpnSite() *pluginsdk.Resource {
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"allow_controlled": {
+									"allow_endpoint_enabled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
 									},
 
-									"default_controlled": {
+									"default_endpoint_enabled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
 									},
 
-									"optimize_controlled": {
+									"optimize_endpoint_enabled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
@@ -510,9 +510,9 @@ func expandVpnSiteO365TrafficCategoryPolicy(input []interface{}) *network.O365Br
 	trafficCategory := input[0].(map[string]interface{})
 
 	return &network.O365BreakOutCategoryPolicies{
-		Allow:    utils.Bool(trafficCategory["allow_controlled"].(bool)),
-		Default:  utils.Bool(trafficCategory["default_controlled"].(bool)),
-		Optimize: utils.Bool(trafficCategory["optimize_controlled"].(bool)),
+		Allow:    utils.Bool(trafficCategory["allow_endpoint_enabled"].(bool)),
+		Default:  utils.Bool(trafficCategory["default_endpoint_enabled"].(bool)),
+		Optimize: utils.Bool(trafficCategory["optimize_endpoint_enabled"].(bool)),
 	}
 }
 
@@ -555,9 +555,9 @@ func flattenVpnSiteO365TrafficCategoryPolicy(input *network.O365BreakOutCategory
 
 	return []interface{}{
 		map[string]interface{}{
-			"allow_controlled":    isAllowed,
-			"default_controlled":  isDefault,
-			"optimize_controlled": isOptimized,
+			"allow_endpoint_enabled":    isAllowed,
+			"default_endpoint_enabled":  isDefault,
+			"optimize_endpoint_enabled": isOptimized,
 		},
 	}
 }

--- a/internal/services/network/vpn_site_resource.go
+++ b/internal/services/network/vpn_site_resource.go
@@ -144,26 +144,26 @@ func resourceVpnSite() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"breakout_category": {
+						"traffic_category": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"allow_category_enabled": {
+									"allow_controlled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
 									},
 
-									"default_category_enabled": {
+									"default_controlled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
 									},
 
-									"optimize_category_enabled": {
+									"optimize_controlled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
 										Default:  false,
@@ -498,21 +498,21 @@ func expandVpnSiteO365Policy(input []interface{}) *network.O365PolicyProperties 
 	o365Policy := input[0].(map[string]interface{})
 
 	return &network.O365PolicyProperties{
-		BreakOutCategories: expandVpnSiteO365BreakOutCategoryPolicy(o365Policy["breakout_category"].([]interface{})),
+		BreakOutCategories: expandVpnSiteO365TrafficCategoryPolicy(o365Policy["traffic_category"].([]interface{})),
 	}
 }
 
-func expandVpnSiteO365BreakOutCategoryPolicy(input []interface{}) *network.O365BreakOutCategoryPolicies {
+func expandVpnSiteO365TrafficCategoryPolicy(input []interface{}) *network.O365BreakOutCategoryPolicies {
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
-	breakoutCategory := input[0].(map[string]interface{})
+	trafficCategory := input[0].(map[string]interface{})
 
 	return &network.O365BreakOutCategoryPolicies{
-		Allow:    utils.Bool(breakoutCategory["allow_category_enabled"].(bool)),
-		Default:  utils.Bool(breakoutCategory["default_category_enabled"].(bool)),
-		Optimize: utils.Bool(breakoutCategory["optimize_category_enabled"].(bool)),
+		Allow:    utils.Bool(trafficCategory["allow_controlled"].(bool)),
+		Default:  utils.Bool(trafficCategory["default_controlled"].(bool)),
+		Optimize: utils.Bool(trafficCategory["optimize_controlled"].(bool)),
 	}
 }
 
@@ -521,19 +521,19 @@ func flattenVpnSiteO365Policy(input *network.O365PolicyProperties) []interface{}
 		return []interface{}{}
 	}
 
-	var breakoutCategory []interface{}
+	var trafficCategory []interface{}
 	if input.BreakOutCategories != nil {
-		breakoutCategory = flattenVpnSiteO365BreakOutCategoryPolicy(input.BreakOutCategories)
+		trafficCategory = flattenVpnSiteO365TrafficCategoryPolicy(input.BreakOutCategories)
 	}
 
 	return []interface{}{
 		map[string]interface{}{
-			"breakout_category": breakoutCategory,
+			"traffic_category": trafficCategory,
 		},
 	}
 }
 
-func flattenVpnSiteO365BreakOutCategoryPolicy(input *network.O365BreakOutCategoryPolicies) []interface{} {
+func flattenVpnSiteO365TrafficCategoryPolicy(input *network.O365BreakOutCategoryPolicies) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
@@ -555,9 +555,9 @@ func flattenVpnSiteO365BreakOutCategoryPolicy(input *network.O365BreakOutCategor
 
 	return []interface{}{
 		map[string]interface{}{
-			"allow_category_enabled":    isAllowed,
-			"default_category_enabled":  isDefault,
-			"optimize_category_enabled": isOptimized,
+			"allow_controlled":    isAllowed,
+			"default_controlled":  isDefault,
+			"optimize_controlled": isOptimized,
 		},
 	}
 }

--- a/internal/services/network/vpn_site_resource_test.go
+++ b/internal/services/network/vpn_site_resource_test.go
@@ -89,6 +89,28 @@ func TestAccVpnSite_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccVpnSite_o365Policy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_site", "test")
+	r := VPNSiteResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.o365Policy(data, true, true, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.o365Policy(data, false, false, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VPNSiteResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnSiteID(state.ID)
 	if err != nil {
@@ -150,15 +172,6 @@ resource "azurerm_vpn_site" "test" {
     name = "link2"
     fqdn = "foo.com"
   }
-
-  o365_policy {
-    breakout_category {
-      allow_category_enabled    = true
-      default_category_enabled  = true
-      optimize_category_enabled = true
-    }
-  }
-
   tags = {
     ENV = "Test"
   }
@@ -181,6 +194,33 @@ resource "azurerm_vpn_site" "import" {
   }
 }
 `, r.basic(data), data.RandomInteger)
+}
+
+func (r VPNSiteResource) o365Policy(data acceptance.TestData, allowCategoryEnabled, defaultCategoryEnabled, optimizeCategoryEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_site" "test" {
+  name                = "acctest-VpnSite-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  virtual_wan_id      = azurerm_virtual_wan.test.id
+  address_cidrs       = ["10.0.0.0/24"]
+
+  o365_policy {
+    breakout_category {
+      allow_category_enabled    = %t
+      default_category_enabled  = %t
+      optimize_category_enabled = %t
+    }
+  }
+
+  link {
+    name       = "link1"
+    ip_address = "10.0.0.1"
+  }
+}
+`, r.template(data), data.RandomInteger, allowCategoryEnabled, defaultCategoryEnabled, optimizeCategoryEnabled)
 }
 
 func (VPNSiteResource) template(data acceptance.TestData) string {

--- a/internal/services/network/vpn_site_resource_test.go
+++ b/internal/services/network/vpn_site_resource_test.go
@@ -209,9 +209,9 @@ resource "azurerm_vpn_site" "test" {
 
   o365_policy {
     traffic_category {
-      allow_controlled    = %t
-      default_controlled  = %t
-      optimize_controlled = %t
+      allow_endpoint_enabled    = %t
+      default_endpoint_enabled  = %t
+      optimize_endpoint_enabled = %t
     }
   }
 

--- a/internal/services/network/vpn_site_resource_test.go
+++ b/internal/services/network/vpn_site_resource_test.go
@@ -208,10 +208,10 @@ resource "azurerm_vpn_site" "test" {
   address_cidrs       = ["10.0.0.0/24"]
 
   o365_policy {
-    breakout_category {
-      allow_category_enabled    = %t
-      default_category_enabled  = %t
-      optimize_category_enabled = %t
+    traffic_category {
+      allow_controlled    = %t
+      default_controlled  = %t
+      optimize_controlled = %t
     }
   }
 

--- a/internal/services/network/vpn_site_resource_test.go
+++ b/internal/services/network/vpn_site_resource_test.go
@@ -150,6 +150,15 @@ resource "azurerm_vpn_site" "test" {
     name = "link2"
     fqdn = "foo.com"
   }
+
+  o365_policy {
+    breakout_category {
+      allow_category_enabled    = true
+      default_category_enabled  = true
+      optimize_category_enabled = true
+    }
+  }
+
   tags = {
     ENV = "Test"
   }

--- a/website/docs/r/vpn_site.html.markdown
+++ b/website/docs/r/vpn_site.html.markdown
@@ -102,17 +102,17 @@ A `link` block supports the following:
 
 A `o365_policy` block supports the following:
 
-* `breakout_category` - (Optional) A `breakout_category` block as defined above.
+* `traffic_category` - (Optional) A `traffic_category` block as defined above.
 
 ---
 
-A `breakout_category` block supports the following:
+A `traffic_category` block supports the following:
 
-* `allow_category_enabled` - (Optional) Is allow category controlled? Defaults to `false`.
+* `allow_controlled` - (Optional) Is allow category controlled? Defaults to `false`.
 
-* `default_category_enabled` - (Optional) Is default category controlled? Defaults to `false`.
+* `default_controlled` - (Optional) Is default category controlled? Defaults to `false`.
 
-* `optimize_category_enabled` - (Optional) Is optimize category controlled? Defaults to `false`.
+* `optimize_controlled` - (Optional) Is optimize category controlled? Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/vpn_site.html.markdown
+++ b/website/docs/r/vpn_site.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `device_vendor` - (Optional) The name of the VPN device vendor.
 
+* `o365_policy` - (Optional) An `o365_policy` block as defined below.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the VPN Site.
 
 ---
@@ -95,6 +97,22 @@ A `link` block supports the following:
 * `provider_name` - (Optional) The name of the physical link at the VPN Site. Example: `ATT`, `Verizon`.
 
 * `speed_in_mbps` - (Optional) The speed of the VPN device at the branch location in unit of mbps.
+
+---
+
+A `o365_policy` block supports the following:
+
+* `breakout_category` - (Optional) A `breakout_category` block as defined above.
+
+---
+
+A `breakout_category` block supports the following:
+
+* `allow_category_enabled` - (Optional) Is allow category controlled? Defaults to `false`.
+
+* `default_category_enabled` - (Optional) Is default category controlled? Defaults to `false`.
+
+* `optimize_category_enabled` - (Optional) Is optimize category controlled? Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/vpn_site.html.markdown
+++ b/website/docs/r/vpn_site.html.markdown
@@ -108,11 +108,11 @@ A `o365_policy` block supports the following:
 
 A `traffic_category` block supports the following:
 
-* `allow_controlled` - (Optional) Is allow category controlled? Defaults to `false`.
+* `allow_endpoint_enabled` - (Optional) Is allow endpoint enabled? The `Allow` endpoint is required for connectivity to specific O365 services and features, but are not as sensitive to network performance and latency as other endpoint types. Defaults to `false`.
 
-* `default_controlled` - (Optional) Is default category controlled? Defaults to `false`.
+* `default_endpoint_enabled` - (Optional) Is default endpoint enabled? The `Default` endpoint represents O365 services and dependencies that do not require any optimization, and can be treated by customer networks as normal Internet bound traffic. Defaults to `false`.
 
-* `optimize_controlled` - (Optional) Is optimize category controlled? Defaults to `false`.
+* `optimize_endpoint_enabled` - (Optional) Is optimize endpoint enabled? The `Optimize` endpoint is required for connectivity to every O365 service and represents the O365 scenario that is the most sensitive to network performance, latency, and availability. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is to support new property `o365_policy`.

--- PASS: TestAccVpnSite_basic (301.95s)
--- PASS: TestAccVpnSite_complete (303.11s)
--- PASS: TestAccVpnSite_requiresImport (338.98s)
--- PASS: TestAccVpnSite_o365Policy (423.74s)
--- PASS: TestAccVpnSite_update (578.85s)

![image](https://user-images.githubusercontent.com/19754191/172994455-019af464-b603-4205-b4b2-230e6724e69a.png)
