### PR TITLE
Fix the issue of Network API version of Virtual Network Gateway Nat Rule

### DIFF
--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"


### PR DESCRIPTION
This PR is to upgrade Network API version for Virtual Network Gateway Nat Rule.

![image](https://user-images.githubusercontent.com/19754191/168966884-a1f3fed6-6c33-4960-a545-ed5b37528919.png)
