### PR TITLE
`azurerm_storage_share` - Add new enum `Premium` for `access_tier`

### DIFF
--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -125,9 +125,12 @@ func resourceStorageShare() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{string(shares.HotAccessTier),
+					[]string{
+						string(shares.PremiumAccessTier),
+						string(shares.HotAccessTier),
 						string(shares.CoolAccessTier),
-						string(shares.TransactionOptimizedAccessTier)}, false),
+						string(shares.TransactionOptimizedAccessTier),
+					}, false),
 			},
 		},
 	}

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -123,6 +123,7 @@ func resourceStorageShare() *pluginsdk.Resource {
 
 			"access_tier": {
 				Type:     pluginsdk.TypeString,
+				Computed: true,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -191,6 +191,13 @@ func TestAccStorageShare_accessTier(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.accessTier(data, "Premium"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.accessTier(data, "Cool"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -185,34 +185,42 @@ func TestAccStorageShare_largeQuota(t *testing.T) {
 	})
 }
 
-func TestAccStorageShare_accessTier(t *testing.T) {
+func TestAccStorageShare_accessTierStandard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
 	r := StorageShareResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.accessTier(data, "Premium"),
+			Config: r.accessTierStandard(data, "Cool"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.accessTier(data, "Cool"),
+			Config: r.accessTierStandard(data, "Hot"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.accessTier(data, "Hot"),
+			Config: r.accessTierStandard(data, "TransactionOptimized"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccStorageShare_accessTierPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
+	r := StorageShareResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.accessTier(data, "TransactionOptimized"),
+			Config: r.accessTierPremium(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -522,7 +530,7 @@ resource "azurerm_storage_share" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
-func (r StorageShareResource) accessTier(data acceptance.TestData, tier string) string {
+func (r StorageShareResource) accessTierStandard(data acceptance.TestData, tier string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -550,6 +558,36 @@ resource "azurerm_storage_share" "test" {
   access_tier          = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, tier)
+}
+
+func (r StorageShareResource) accessTierPremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+  account_kind             = "FileStorage"
+}
+
+resource "azurerm_storage_share" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 100
+  enabled_protocol     = "SMB"
+  access_tier          = "Premium"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
 func (r StorageShareResource) protocol(data acceptance.TestData, protocol string) string {

--- a/website/docs/d/storage_share.html.markdown
+++ b/website/docs/d/storage_share.html.markdown
@@ -37,8 +37,6 @@ The following arguments are supported:
 
 * `quota` - The quota of the File Share in GB.
 
-* `access_tier` - The tier of the File Share. Can be one of `Hot`, `Cool`, `TransactionOptimized`.
-
 * `metadata` - A map of custom file share metadata.
 
 * `acl` - One or more acl blocks as defined below.

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -64,6 +64,8 @@ The following arguments are supported:
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
 
+* `access_tier` - (Optional) The tier of the File Share. Can be one of `Hot`, `Cool`, `TransactionOptimized`, `Premium`.
+
 ---
 
 A `acl` block supports the following:


### PR DESCRIPTION
Fixes #16834.

Besides, making the `access_tier` computed so that it doesn't fail the existing tests (otherwise, should we change it to required instead?).

## Test

```shell
❯ TF_ACC=1 go test -timeout=60m -v -run='TestAccStorageShare_accessTier|TestAccStorageShare_basic' ./internal/services/storage
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== RUN   TestAccStorageShare_accessTierStandard
=== PAUSE TestAccStorageShare_accessTierStandard
=== RUN   TestAccStorageShare_accessTierPremium
=== PAUSE TestAccStorageShare_accessTierPremium
=== CONT  TestAccStorageShare_basic
=== CONT  TestAccStorageShare_accessTierPremium
=== CONT  TestAccStorageShare_accessTierStandard
--- PASS: TestAccStorageShare_basic (148.42s)
--- PASS: TestAccStorageShare_accessTierPremium (154.99s)
--- PASS: TestAccStorageShare_accessTierStandard (194.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       194.770s
```