### PR TITLE
videoanalyzer: deprecating since this is scheduled for removal on 2022-11-30

### DIFF
--- a/internal/services/videoanalyzer/video_analyzer_edge_module_resource.go
+++ b/internal/services/videoanalyzer/video_analyzer_edge_module_resource.go
@@ -34,6 +34,8 @@ func resourceVideoAnalyzerEdgeModule() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: `Video Analyzer (Preview) is now Deprecated and will be Retired on 2022-11-30 - as such the 'azurerm_video_analyzer_edge_module' resource is deprecated and will be removed in v4.0 of the AzureRM Provider`,
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/videoanalyzer/video_analyzer_resource.go
+++ b/internal/services/videoanalyzer/video_analyzer_resource.go
@@ -40,6 +40,8 @@ func resourceVideoAnalyzer() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: `Video Analyzer (Preview) is now Deprecated and will be Retired on 2022-11-30 - as such the 'azurerm_video_analyzer' resource is deprecated and will be removed in v4.0 of the AzureRM Provider`,
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:         pluginsdk.TypeString,

--- a/website/docs/r/video_analyzer.html.markdown
+++ b/website/docs/r/video_analyzer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Video Analyzer.
 
+!> Video Analyzer (Preview) is now Deprecated and will be Retired on 2022-11-30 - as such the `azurerm_video_analyzer` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/video_analyzer_edge_module.html.markdown
+++ b/website/docs/r/video_analyzer_edge_module.html.markdown
@@ -6,9 +6,11 @@ description: |-
   Manages a Video Analyzer Edge Module.
 ---
 
-# azurerm_video_analyzer
+# azurerm_video_analyzer_edge_module
 
 Manages a Video Analyzer Edge Module.
+
+!> Video Analyzer (Preview) is now Deprecated and will be Retired on 2022-11-30 - as such the `azurerm_video_analyzer_edge_module` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.
 
 ## Example Usage
 


### PR DESCRIPTION
See: https://github.com/azure-deprecation/dashboard/issues/238