### PR TITLE
azurerm_app_configuration_key : fix "cannot use a / (slash) in the name of a label" issue

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -132,7 +132,7 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 			appCfgKeyResourceID := parse.AppConfigurationKeyId{
 				ConfigurationStoreId: model.ConfigurationStoreId,
 				Key:                  url.QueryEscape(model.Key),
-				Label:                model.Label,
+				Label:                url.QueryEscape(model.Label),
 			}
 
 			kv, err := client.GetKeyValue(ctx, model.Key, model.Label, "", "", "", []string{})
@@ -218,7 +218,12 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("while decoding key of resource ID: %+v", err)
 			}
 
-			kv, err := client.GetKeyValue(ctx, decodedKey, resourceID.Label, "", "", "", []string{})
+			decodedLabel, err := url.QueryUnescape(resourceID.Label)
+			if err != nil {
+				return fmt.Errorf("while decoding label of resource ID: %+v", err)
+			}
+
+			kv, err := client.GetKeyValue(ctx, decodedKey, decodedLabel, "", "", "", []string{})
 			if err != nil {
 				if v, ok := err.(autorest.DetailedError); ok {
 					if utils.ResponseWasNotFound(autorest.Response{Response: v.Response}) {
@@ -348,7 +353,12 @@ func (k KeyResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("while decoding key of resource ID: %+v", err)
 			}
 
-			if _, err = client.DeleteLock(ctx, decodedKey, resourceID.Label, "", ""); err != nil {
+			decodedLabel, err := url.QueryUnescape(resourceID.Label)
+			if err != nil {
+				return fmt.Errorf("while decoding label of resource ID: %+v", err)
+			}
+
+			if _, err = client.DeleteLock(ctx, decodedKey, decodedLabel, "", ""); err != nil {
 				return fmt.Errorf("while unlocking key/label pair %s/%s: %+v", decodedKey, resourceID.Label, err)
 			}
 

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -220,7 +220,7 @@ resource "azurerm_app_configuration_key" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
   key                    = "/acctest/-ackey/-%d"
   content_type           = "test"
-  label                  = "acctest-ackeylabel-%d"
+  label                  = "/acctest/-ackeylabel/-%d"
   value                  = "a test"
 }
 `, t.base(data), data.RandomInteger, data.RandomInteger)


### PR DESCRIPTION
Fix issue [#16835](https://github.com/hashicorp/terraform-provider-azurerm/issues/16835).