### PR TITLE
`r\windows_virtual_machine`: Add `ForceNew` to `timezone`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -292,6 +292,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			"timezone": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: computeValidate.VirtualMachineTimeZone(),
 			},
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
-* `timezone` - (Optional) Specifies the Time Zone which should be used by the Virtual Machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
+* `timezone` - (Optional) Specifies the Time Zone which should be used by the Virtual Machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/). Changing this forces a new resource to be created.
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine.
 


### PR DESCRIPTION
Fix #16848

`timezone` cannot be changed. Error: `Code="PropertyChangeNotAllowed" Message="Changing property 'windowsConfiguration.timeZone' is not allowed." Target="windowsConfiguration.timeZone"`

Below is the schema on old vm resource. Seems this is forgot on the new resource (only applicable for windows vm).

The `Update` function doesn't check the `timezone`, so only need to add the `ForceNew`

https://github.com/hashicorp/terraform-provider-azurerm/blob/6406b30e59c92f3ceb711965e31578e4defca9b6/internal/services/legacy/virtual_machine_resource.go#L478-L481