### PR TITLE
`r\shared_image`: Fix update issue related to unchanged `eula`

### DIFF
--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -109,6 +109,7 @@ func resourceSharedImage() *pluginsdk.Resource {
 			"eula": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"purchase_plan": {
@@ -212,7 +213,6 @@ func resourceSharedImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
 		GalleryImageProperties: &compute.GalleryImageProperties{
 			Description:         utils.String(d.Get("description").(string)),
-			Eula:                utils.String(d.Get("eula").(string)),
 			Identifier:          expandGalleryImageIdentifier(d),
 			PrivacyStatementURI: utils.String(d.Get("privacy_statement_uri").(string)),
 			ReleaseNoteURI:      utils.String(d.Get("release_note_uri").(string)),
@@ -222,6 +222,10 @@ func resourceSharedImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 			Features:            &features,
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("eula"); ok {
+		image.GalleryImageProperties.Eula = utils.String(v.(string))
 	}
 
 	if d.Get("specialized").(bool) {

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of this Shared Image.
 
-* `eula` - (Optional) The End User Licence Agreement for the Shared Image.
+* `eula` - (Optional) The End User Licence Agreement for the Shared Image. Changing this forces a new resource to be created.
 
 * `specialized` - (Optional) Specifies that the Operating System used inside this Image has not been Generalized (for example, `sysprep` on Windows has not been run). Defaults to `false`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
- Fix #16792
- `eula` cannot be changed, mark it as `ForceNew`
- even empty, `eula` cannot be specified as empty string in an update call, so adding it only when it's not empty.
- This is for quick fix for the specified issue, furthermore, I think we should split the Create and Update of this resource, will do that  in a separate pr