### PR TITLE
`azurerm_disk_encryption_set`: `encryption_type` supports `ConfidentialVmEncryptedWithCustomerKey`

### DIFF
--- a/internal/services/compute/disk_encryption_set_resource.go
+++ b/internal/services/compute/disk_encryption_set_resource.go
@@ -75,6 +75,7 @@ func resourceDiskEncryptionSet() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(compute.DiskEncryptionSetTypeEncryptionAtRestWithCustomerKey),
 					string(compute.DiskEncryptionSetTypeEncryptionAtRestWithPlatformAndCustomerKeys),
+					string(compute.DiskEncryptionSetTypeConfidentialVMEncryptedWithCustomerKey),
 				}, false),
 			},
 

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `auto_key_rotation_enabled` - (Optional) Boolean flag to specify whether Azure Disk Encryption Set automatically rotates encryption Key to latest version. Defaults to `false`.
 
-* `encryption_type` - (Optional) The type of key used to encrypt the data of the disk. Possible values are `EncryptionAtRestWithCustomerKey` and `EncryptionAtRestWithPlatformAndCustomerKeys`. Defaults to `EncryptionAtRestWithCustomerKey`.
+* `encryption_type` - (Optional) The type of key used to encrypt the data of the disk. Possible values are `EncryptionAtRestWithCustomerKey`, `EncryptionAtRestWithPlatformAndCustomerKeys` and `ConfidentialVmEncryptedWithCustomerKey`. Defaults to `EncryptionAtRestWithCustomerKey`.
 
 * `identity` - (Required) An `identity` block as defined below.
 


### PR DESCRIPTION
This is used in confidential vm

New enum value https://github.com/Azure/azure-sdk-for-go/blob/0885431052e747fc5bfb4409bf97a41565f66fde/services/compute/mgmt/2021-11-01/compute/enums.go#L363
