### PR TITLE
`azurerm_spring_cloud_service`: Add `zone_redundant` property

### DIFF
--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -273,7 +273,7 @@ func resourceSpringCloudService() *pluginsdk.Resource {
 			"zone_redundant": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 
 			"tags": tags.Schema(),

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -270,6 +270,12 @@ func resourceSpringCloudService() *pluginsdk.Resource {
 				},
 			},
 
+			"zone_redundant": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"tags": tags.Schema(),
 
 			"service_registry_id": {
@@ -308,6 +314,7 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 		Location: utils.String(location),
 		Properties: &appplatform.ClusterResourceProperties{
 			NetworkProfile: expandSpringCloudNetwork(d.Get("network").([]interface{})),
+			ZoneRedundant:  utils.Bool(d.Get("zone_redundant").(bool)),
 		},
 		Sku: &appplatform.Sku{
 			Name: utils.String(d.Get("sku_name").(string)),
@@ -528,6 +535,8 @@ func resourceSpringCloudServiceRead(d *pluginsdk.ResourceData, meta interface{})
 		if err := d.Set("required_network_traffic_rules", flattenRequiredTraffic(props.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting `required_network_traffic_rules`: %+v", err)
 		}
+
+		d.Set("zone_redundant", props.ZoneRedundant)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -273,7 +273,7 @@ func resourceSpringCloudService() *pluginsdk.Resource {
 			"zone_redundant": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 
 			"tags": tags.Schema(),

--- a/internal/services/springcloud/spring_cloud_service_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_service_resource_test.go
@@ -343,6 +343,8 @@ resource "azurerm_spring_cloud_service" "test" {
     sample_rate       = 20
   }
 
+  zone_redundant = true
+
   tags = {
     Env     = "Test"
     version = "1"

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+* `zone_redundant` - (Optional) Whether zone redundancy is enabled for this Spring Cloud Service. 
+
 ---
 
 The `network` block supports the following:

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `zone_redundant` - (Optional) Whether zone redundancy is enabled for this Spring Cloud Service. 
+* `zone_redundant` - (Optional) Whether zone redundancy is enabled for this Spring Cloud Service. Defaults to `false`. 
 
 ---
 


### PR DESCRIPTION
Fixes #16871

```
$ TF_ACC=1 go test -v ./internal/services/springcloud -timeout=1000m -run='TestAccSpringCloudService_complete'
=== RUN   TestAccSpringCloudService_complete
=== PAUSE TestAccSpringCloudService_complete
=== CONT  TestAccSpringCloudService_complete
--- PASS: TestAccSpringCloudService_complete (528.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud	529.925s
```