### PR TITLE
`azurerm_signalr_service`: Support `Premium_P1` SKU

### DIFF
--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -482,6 +482,7 @@ func resourceArmSignalRServiceSchema() map[string]*pluginsdk.Schema {
 						ValidateFunc: validation.StringInSlice([]string{
 							"Free_F1",
 							"Standard_S1",
+							"Premium_P1",
 						}, false),
 					},
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -93,7 +93,7 @@ An `upstream_endpoint` block supports the following:
 
 A `sku` block supports the following:
 
-* `name` - (Required) Specifies which tier to use. Valid values are `Free_F1` and `Standard_S1`.
+* `name` - (Required) Specifies which tier to use. Valid values are `Free_F1`, `Standard_S1` and `Premium_P1`.
 
 * `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `5`, `10`, `20`, `50` and `100`.
 


### PR DESCRIPTION
Fixes #16873

```
$ TF_ACC=1 go test -v ./internal/services/signalr -timeout=1000m -run='TestAccSignalRService_premium'
=== RUN   TestAccSignalRService_premium
=== PAUSE TestAccSignalRService_premium
=== CONT  TestAccSignalRService_premium
--- PASS: TestAccSignalRService_premium (271.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr	272.966s
```