### PR TITLE
`azurerm_security_center_setting` -  Support for Sentinel security setting in resource `azurerm_security_center_setting`

### DIFF
--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -17,6 +17,32 @@ import (
 
 type SecurityCenterSettingResource struct{}
 
+func TestAccSecurityCenterSetting_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_setting", "test")
+	r := SecurityCenterSettingResource{}
+
+	//lintignore:AT001
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic("MCAS", true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("setting_name").HasValue("MCAS"),
+				check.That(data.ResourceName).Key("enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic("MCAS", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("setting_name").HasValue("MCAS"),
+				check.That(data.ResourceName).Key("enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSecurityCenterSetting_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_setting", "test")
 	r := SecurityCenterSettingResource{}
@@ -168,6 +194,19 @@ resource "azurerm_security_center_setting" "test" {
   kind         = "%s"
 }
 `, settingName, enabled, kind)
+}
+
+func (SecurityCenterSettingResource) basic(settingName string, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_security_center_setting" "test" {
+  setting_name = "%s"
+  enabled      = "%t"
+}
+`, settingName, enabled)
 }
 
 func (r SecurityCenterSettingResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -27,8 +27,9 @@ resource "azurerm_security_center_setting" "example" {
 
 The following arguments are supported:
 
-* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` and `WDATP`. Changing this forces a new resource to be created.
+* `setting_name` - (Required) The setting to manage. Possible values are `MCAS`, `WDATP` and `Sentinel`. Changing this forces a new resource to be created.
 * `enabled` - (Required) Boolean flag to enable/disable data access.
+* `kind` - (Optional) The kind of the settings string. Possible values are `DataExportSettings` and `AlertSyncSettings`. Defaults to `DataExportSettings`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix issue #16846.

Test Results:
```
PASS: TestAccSecurityCenterSetting_basic (226.87s)
PASS: TestAccSecurityCenterSetting_requiresImport (131.64s)
PASS: TestAccSecurityCenterSetting_update (622.76s)
```