### PR TITLE
`azurerm_data_factory_managed_private_endpoint` - `name` correctly matches regex 

### DIFF
--- a/internal/services/datafactory/validate/datafactory.go
+++ b/internal/services/datafactory/validate/datafactory.go
@@ -37,8 +37,8 @@ func DataFactoryManagedPrivateEndpointName() pluginsdk.SchemaValidateFunc {
 			return
 		}
 
-		if !regexp.MustCompile(`^([_A-Za-z0-9]|([_A-Za-z0-9][-_A-Za-z0-9]{0,125}[_A-Za-z0-9]))$`).MatchString(v) {
-			errors = append(errors, fmt.Errorf("invalid Data Factory Managed Private Endpoint name, must match the regular expression ^([_A-Za-z0-9]|([_A-Za-z0-9][-_A-Za-z0-9]{0,125}[_A-Za-z0-9]))$"))
+		if !regexp.MustCompile(`^([[:alnum:]][-._[:alnum:]]{0,78}[_[:alnum:]])$`).MatchString(v) {
+			errors = append(errors, fmt.Errorf("invalid Data Factory Managed Private Endpoint name, must match the regular expression ^^([[:alnum:]][-._[:alnum:]]{0,78}[_[:alnum:]])$"))
 		}
 
 		return warnings, errors


### PR DESCRIPTION
The function that validates Azure Data Factory Managed Private Endpoint names uses a regular expression that does not match the requirements set in the Azure portal for the private endpoint name, which include:

- Must begin with a letter or number.
- Must end with a letter, number or underscore.
- May contain only letters, numbers, underscores, periods, or hyphens.
- Must be between 1 and 80 characters.

The proposed changes have been validated using the regex101.com regex tester set to the Golang flavour.