### PR TITLE
`synapse_spark_pool`-`spark_version` supports `3.2`

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -200,6 +200,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
 					"3.1",
+					"3.2",
 				}, false),
 			},
 

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -91,6 +91,38 @@ func TestAccSynapseSparkPool_update(t *testing.T) {
 	})
 }
 
+func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
+	r := SynapseSparkPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sparkVersion(data, "2.4"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.sparkVersion(data, "3.1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.sparkVersion(data, "3.2"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+	})
+}
+
 func TestAccSynapseSparkPool_isolation(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
 	r := SynapseSparkPoolResource{}
@@ -182,6 +214,22 @@ resource "azurerm_synapse_spark_pool" "test" {
   node_count           = 3
 }
 `, template, data.RandomString)
+}
+
+func (r SynapseSparkPoolResource) sparkVersion(data acceptance.TestData, sparkVersion string) string {
+	template := r.template(data, data.Locations.Primary)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_synapse_spark_pool" "test" {
+  name                 = "acctestSSP%s"
+  synapse_workspace_id = azurerm_synapse_workspace.test.id
+  node_size_family     = "MemoryOptimized"
+  node_size            = "Small"
+  node_count           = 3
+  spark_version        = "%s"
+}
+`, template, data.RandomString, sparkVersion)
 }
 
 func (r SynapseSparkPoolResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -115,7 +115,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.1`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.1` and `3.2`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
link to https://github.com/hashicorp/terraform-provider-azurerm/issues/16729
### public pr for `synapse_spark_pool`-`spark_version` supports `3.2`

**test result after update:**

TestAccSynapseSparkPool_sparkVersion:
![image](https://user-images.githubusercontent.com/46072066/169516930-ef545445-2367-4508-a1d7-479c3da423ac.png)
