### PR TITLE
azurerm_application_gateway - ordered zones

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -131,7 +131,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 
 			"location": commonschema.Location(),
 
-			"zones": commonschema.ZonesMultipleOptionalForceNew(),
+			"zones": commonschema.ZonesMultipleOptionalForceNewOrdered(),
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
@@ -1600,7 +1600,7 @@ func resourceApplicationGatewayCreate(d *pluginsdk.ResourceData, meta interface{
 		},
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.Expand(d.Get("zones").([]interface{}))
 	if len(zones) > 0 {
 		gateway.Zones = &zones
 	}
@@ -1855,7 +1855,7 @@ func resourceApplicationGatewayUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("zones") {
-		zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+		zones := zones.Expand(d.Get("zones").([]interface{}))
 		if len(zones) > 0 {
 			applicationGateway.Zones = &zones
 		}

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -131,7 +131,16 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 
 			"location": commonschema.Location(),
 
-			"zones": commonschema.ZonesMultipleOptionalForceNewOrdered(),
+			// app gateway cares about the order of the zones
+			"zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zones.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zones.go
@@ -57,19 +57,6 @@ func ZonesMultipleOptionalForceNew() *schema.Schema {
 	}
 }
 
-// ZonesMultipleOptionalForceNew returns the schema used when multiple Zones can be specified but cannot be changed and the order matters
-func ZonesMultipleOptionalForceNewOrdered() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		ForceNew: true,
-		Elem: &schema.Schema{
-			Type:         schema.TypeString,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-	}
-}
-
 // ZonesMultipleComputed returns the schema used when multiple Zones can be returned
 func ZonesMultipleComputed() *schema.Schema {
 	return &schema.Schema{

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zones.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zones.go
@@ -57,6 +57,19 @@ func ZonesMultipleOptionalForceNew() *schema.Schema {
 	}
 }
 
+// ZonesMultipleOptionalForceNew returns the schema used when multiple Zones can be specified but cannot be changed and the order matters
+func ZonesMultipleOptionalForceNewOrdered() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
 // ZonesMultipleComputed returns the schema used when multiple Zones can be returned
 func ZonesMultipleComputed() *schema.Schema {
 	return &schema.Schema{


### PR DESCRIPTION
We've just been through a support case with Microsoft following a failed configuration update and they told us that the ordering of the zones for application gateway matters