### PR TITLE
`azurerm_active_directory_domain_service` - Add supports for `domain_configuration_type`

### DIFF
--- a/internal/services/domainservices/active_directory_domain_service_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_resource.go
@@ -244,6 +244,16 @@ func resourceActiveDirectoryDomainService() *pluginsdk.Resource {
 				},
 			},
 
+			"domain_configuration_type": {
+				Type:     pluginsdk.TypeString,
+				ForceNew: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"FullySynced",
+					"ResourceTrusting",
+				}, false),
+			},
+
 			"tags": tags.Schema(),
 
 			"deployment_id": {
@@ -342,6 +352,10 @@ func resourceActiveDirectoryDomainServiceCreateUpdate(d *pluginsdk.ResourceData,
 		},
 		Location: utils.String(loc),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v := d.Get("domain_configuration_type").(string); v != "" {
+		domainService.DomainServiceProperties.DomainConfigurationType = &v
 	}
 
 	if d.IsNewResource() {
@@ -448,6 +462,7 @@ func resourceActiveDirectoryDomainServiceRead(d *pluginsdk.ResourceData, meta in
 		d.Set("sync_owner", props.SyncOwner)
 		d.Set("tenant_id", props.TenantID)
 		d.Set("version", props.Version)
+		d.Set("domain_configuration_type", props.DomainConfigurationType)
 
 		d.Set("filtered_sync_enabled", false)
 		if props.FilteredSync == aad.FilteredSyncEnabled {

--- a/internal/services/domainservices/active_directory_domain_service_test.go
+++ b/internal/services/domainservices/active_directory_domain_service_test.go
@@ -316,9 +316,10 @@ resource "azurerm_active_directory_domain_service" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  domain_name           = "never.gonna.shut.you.down"
-  sku                   = "Enterprise"
-  filtered_sync_enabled = false
+  domain_name               = "never.gonna.shut.you.down"
+  sku                       = "Enterprise"
+  domain_configuration_type = "ResourceTrusting"
+  filtered_sync_enabled     = false
 
   initial_replica_set {
     subnet_id = azurerm_subnet.aadds.id

--- a/internal/services/domainservices/active_directory_domain_service_test.go
+++ b/internal/services/domainservices/active_directory_domain_service_test.go
@@ -318,7 +318,7 @@ resource "azurerm_active_directory_domain_service" "test" {
 
   domain_name               = "never.gonna.shut.you.down"
   sku                       = "Enterprise"
-  domain_configuration_type = "ResourceTrusting"
+  domain_configuration_type = "FullySynced"
   filtered_sync_enabled     = false
 
   initial_replica_set {

--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -162,6 +162,8 @@ The following arguments are supported:
 
 * `domain_name` - (Required) The Active Directory domain to use. See [official documentation](https://docs.microsoft.com/azure/active-directory-domain-services/tutorial-create-instance#create-a-managed-domain) for constraints and recommendations.
 
+* `domain_configuration_type` - (Optional)  The configuration type of this Active Directory Domain. Possible values are `FullySynced` and `ResourceTrusting`. Changing this forces a new resource to be created.
+
 * `filtered_sync_enabled` - Whether to enable group-based filtered sync (also called scoped synchronisation). Defaults to `false`.
 
 * `secure_ldap` - (Optional) A `secure_ldap` block as defined below.


### PR DESCRIPTION
The enums are not defined in the Swagger, but can be inspected from Portal traffic.

I've locally tested it with the template from the acctest for the `complete()` case:

```shell
...
azurerm_active_directory_domain_service.test: Still creating... [1h20m10s elapsed]
azurerm_active_directory_domain_service.test: Still creating... [1h20m20s elapsed]
azurerm_active_directory_domain_service.test: Still creating... [1h20m30s elapsed]
azurerm_active_directory_domain_service.test: Creation complete after 1h20m35s [id=/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/acclongtestRG-aadds-123/providers/Microsoft.AAD/domainServices/acctest-magodo/initialReplicaSetId/f7bf370b-5c21-4b61-9b72-9e961b228cad]
azurerm_virtual_network_dns_servers.test: Creating...
azurerm_virtual_network_dns_servers.test: Creation complete after 8s [id=/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/acclongtestRG-aadds-123/providers/Microsoft.Network/virtualNetworks/acctestVnet-aadds-123/dnsServers/default]
```