### PR TITLE
Fixing minor typo in `container_group.html.markdown`

### DIFF
--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -24,7 +24,7 @@ resource "azurerm_container_group" "example" {
   name                = "example-continst"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  ip_address_type     = "public"
+  ip_address_type     = "Public"
   dns_name_label      = "aci-label"
   os_type             = "Linux"
 


### PR DESCRIPTION
The example in `container_group.html.markdown` is using a lowercase `public` instead of `Public` which will not work.