### PR TITLE
Fixing the incorrect header/title for some documents

### DIFF
--- a/website/docs/r/app_service_source_control_slot.html.markdown
+++ b/website/docs/r/app_service_source_control_slot.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
-page_title: "app_service_source_control_slot: azurerm_app_service_source_control_slot"
+page_title: "Azure Resource Manager: azurerm_app_service_source_control_slot"
 description: |-
   Manages an App Service Source Control Slot.
 ---

--- a/website/docs/r/confidential_ledger.html.markdown
+++ b/website/docs/r/confidential_ledger.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Confidential Ledger"
 layout: "azurerm"
-page_title: "Confidential Ledger: azurerm_confidential_ledger"
+page_title: "Azure Resource Manager: azurerm_confidential_ledger"
 description: |-
   Manages a Confidential Ledger.
 ---

--- a/website/docs/r/function_app_function.html.markdown
+++ b/website/docs/r/function_app_function.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
-page_title: "function_app_function: azurerm_function_app_function"
+page_title: "Azure Resource Manager: azurerm_function_app_function"
 description: |-
   Manages a Function App Function.
 ---

--- a/website/docs/r/function_app_hybrid_connection.html.markdown
+++ b/website/docs/r/function_app_hybrid_connection.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
-page_title: "function_app_hybrid_connection: azurerm_function_app_hybrid_connection"
+page_title: "Azure Resource Manager: azurerm_function_app_hybrid_connection"
 description: |-
   Manages a Function App Hybrid Connection.
 ---

--- a/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
+++ b/website/docs/r/mssql_managed_instance_active_directory_administrator.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource manager: azurerm_mssql_managed_instance_active_directory_administrator"
+page_title: "Azure Resource Manager: azurerm_mssql_managed_instance_active_directory_administrator"
 description: |-
   Manages an Active Directory Administrator on a Microsoft Azure SQL Managed Instance
 ---

--- a/website/docs/r/mysql_active_directory_administrator.html.markdown
+++ b/website/docs/r/mysql_active_directory_administrator.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource manager: azurerm_mysql_active_directory_administrator"
+page_title: "Azure Resource Manager: azurerm_mysql_active_directory_administrator"
 description: |-
   Manages an Active Directory administrator on a MySQL server
 ---

--- a/website/docs/r/policy_management_group_policy_exemption.html.markdown
+++ b/website/docs/r/policy_management_group_policy_exemption.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Policy"
 layout: "azurerm"
-page_title: "Azure Management Manager: azurerm_management_group_policy_exemption"
+page_title: "Azure Resource Manager: azurerm_management_group_policy_exemption"
 description: |-
   Manages a Management Group Policy Exemption.
 ---

--- a/website/docs/r/postgresql_active_directory_administrator.html.markdown
+++ b/website/docs/r/postgresql_active_directory_administrator.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource manager: azurerm_postgresql_active_directory_administrator"
+page_title: "Azure Resource Manager: azurerm_postgresql_active_directory_administrator"
 description: |-
   Manages an Active Directory administrator on a PostgreSQL server
 ---

--- a/website/docs/r/sql_active_directory_administrator.html.markdown
+++ b/website/docs/r/sql_active_directory_administrator.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource manager: azurerm_sql_active_directory_administrator"
+page_title: "Azure Resource Manager: azurerm_sql_active_directory_administrator"
 description: |-
   Manages an Active Directory administrator on a SQL server
 ---

--- a/website/docs/r/sql_managed_instance_active_directory_administrator.html.markdown
+++ b/website/docs/r/sql_managed_instance_active_directory_administrator.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Database"
 layout: "azurerm"
-page_title: "Azure Resource manager: azurerm_sql_managed_instance_active_directory_administrator"
+page_title: "Azure Resource Manager: azurerm_sql_managed_instance_active_directory_administrator"
 description: |-
   Manages an Active Directory administrator on a SQL Managed Instance
 ---

--- a/website/docs/r/virtual_desktop_application.html.markdown
+++ b/website/docs/r/virtual_desktop_application.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Virtual Desktop Application.
 ---
 
-# virtual_desktop_application
+# azurerm_virtual_desktop_application
 
 Manages a Virtual Desktop Application.
 

--- a/website/docs/r/virtual_desktop_application_group.html.markdown
+++ b/website/docs/r/virtual_desktop_application_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Virtual Desktop Application Group.
 ---
 
-# virtual_desktop_application_group
+# azurerm_virtual_desktop_application_group
 
 Manages a Virtual Desktop Application Group.
 

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Virtual Desktop Host Pool.
 ---
 
-# virtual_desktop_host_pool
+# azurerm_virtual_desktop_host_pool
 
 Manages a Virtual Desktop Host Pool.
 

--- a/website/docs/r/web_app_hybrid_connection.html.markdown
+++ b/website/docs/r/web_app_hybrid_connection.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
-page_title: "web_app_hybrid_connection: azurerm_web_app_hybrid_connection"
+page_title: "Azure Resource Manager: azurerm_web_app_hybrid_connection"
 description: |-
   Manages a Web App Hybrid Connection.
 ---


### PR DESCRIPTION
Making the changes to ensure following commands prints the same line count:

```shell
website/docs/r on  fix_doc
💤  ls * | wc -l
786

website/docs/r on  fix_doc
💤  grep -l '^page_title: "Azure Resource Manager: azurerm' * | wc -l
786

website/docs/r on  fix_doc
💤  grep -l '^\# azurerm' * | wc -l
786
```