### PR TITLE
fix: 🐛 Set default for week_of_year

### DIFF
--- a/internal/services/mssql/helper/sql_retention_policies.go
+++ b/internal/services/mssql/helper/sql_retention_policies.go
@@ -51,6 +51,7 @@ func LongTermRetentionPolicySchema() *pluginsdk.Schema {
 					Computed:     true,
 					ValidateFunc: validation.IntBetween(1, 52),
 					AtLeastOneOf: atLeastOneOf,
+					Default:      1,
 				},
 			},
 		},


### PR DESCRIPTION
week_of_year is set as an Optional parameter but did not provide a default value so when omitted it was being defaulted to 0 which does not pass it's validatefunc,

Related to #13035