### PR TITLE
azurerm_key_vault_secret : fix error when creating 16 tags for key vault secret - "Property has invalid value" 

### DIFF
--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -86,16 +86,8 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"tags": tags.Schema(),
+			"tags": tags.SchemaWithMax(15),
 		},
-
-		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(_ context.Context, diff *pluginsdk.ResourceDiff, _ interface{}) error {
-			tags, ok := diff.GetOk("tags")
-			if ok && len(tags.(map[string]interface{})) > 15 {
-				return fmt.Errorf("up to 15 tags can be applied to a secret")
-			}
-			return nil
-		}),
 	}
 }
 

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -136,7 +136,7 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	parameters := keyvault.SecretSetParameters{
 		Value:            utils.String(value),
 		ContentType:      utils.String(contentType),
-		Tags:             tags.Expand(t), //vTags,
+		Tags:             tags.Expand(t),
 		SecretAttributes: &keyvault.SecretAttributes{},
 	}
 

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -133,15 +133,6 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	contentType := d.Get("content_type").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	//vTags := make(map[string]*string, len(t))
-	//if v := tags.Expand(t); v != nil {
-	//	if checkTagsCount(v) {
-	//		vTags = v
-	//	} else {
-	//		return fmt.Errorf("a maximum of 15 tags can be applied to a secret")
-	//	}
-	//}
-
 	parameters := keyvault.SecretSetParameters{
 		Value:            utils.String(value),
 		ContentType:      utils.String(contentType),
@@ -252,15 +243,6 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	contentType := d.Get("content_type").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	//vTags := make(map[string]*string)
-	//if v := tags.Expand(t); v != nil {
-	//	if checkTagsCount(v) {
-	//		vTags = v
-	//	} else {
-	//		return fmt.Errorf("a maximum of 15 tags can be applied to a secret")
-	//	}
-	//}
-
 	secretAttributes := &keyvault.SecretAttributes{}
 
 	if v, ok := d.GetOk("not_before_date"); ok {
@@ -280,7 +262,7 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		parameters := keyvault.SecretSetParameters{
 			Value:            utils.String(value),
 			ContentType:      utils.String(contentType),
-			Tags:             tags.Expand(t), // vTags,
+			Tags:             tags.Expand(t),
 			SecretAttributes: secretAttributes,
 		}
 
@@ -314,14 +296,6 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	return resourceKeyVaultSecretRead(d, meta)
 }
-
-//func checkTagsCount(tags map[string]*string) bool {
-//	// Key Vault supports up to 15 tags
-//	if len(tags) > 15 {
-//		return false
-//	}
-//	return true
-//}
 
 func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault

--- a/internal/tags/schema.go
+++ b/internal/tags/schema.go
@@ -52,6 +52,18 @@ func Schema() *pluginsdk.Schema {
 	}
 }
 
+// SchemaWithMax returns the Schema with the maximum used for Tags
+func SchemaWithMax(max int) *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:         pluginsdk.TypeMap,
+		Optional:     true,
+		ValidateFunc: ValidateWithMax(max),
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}
+
 // SchemaDeprecatedUnsupported returns the Schema used for deprecated Tags which is not supported by the resource
 // TODO remove in 3.0
 func SchemaDeprecatedUnsupported() *pluginsdk.Schema {

--- a/internal/tags/validation_test.go
+++ b/internal/tags/validation_test.go
@@ -23,6 +23,24 @@ func TestValidateMaximumNumberOfTags(t *testing.T) {
 	}
 }
 
+func TestValidateMaximumNumberOfTagsWithMax(t *testing.T) {
+	tagsMap := make(map[string]interface{})
+	for i := 0; i < 16; i++ {
+		tagsMap[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+	}
+
+	result := ValidateWithMax(15)
+
+	_, es := result(tagsMap, "tags")
+	if len(es) != 1 {
+		t.Fatal("Expected one validation error for too many tags")
+	}
+
+	if !strings.Contains(es[0].Error(), "a maximum of 15 tags") {
+		t.Fatal("Wrong validation error message for too many tags")
+	}
+}
+
 func TestValidateTagMaxKeyLength(t *testing.T) {
 	tooLongKey := strings.Repeat("long", 128) + "a"
 	tagsMap := make(map[string]interface{})


### PR DESCRIPTION
Per [doc](https://docs.microsoft.com/en-us/azure/key-vault/secrets/about-secrets#secret-tags), secret supports up to 15 tags instead of 50, so submitted this PR to fix issue #16780.

Test Result:

> PASS: TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted (422.41s)
> PASS: TestAccKeyVaultSecret_disappears (482.11s)
> PASS: TestAccKeyVaultSecret_purge (536.62s)
> PASS: TestAccKeyVaultSecret_basic (545.28s)
> PASS: TestAccKeyVaultSecret_complete (546.91s)
> PASS: TestAccKeyVaultSecret_requiresImport (564.11s)
> PASS: TestAccKeyVaultSecret_update (618.14s)
> PASS: TestAccKeyVaultSecret_withExternalAccessPolicy (626.98s)
> PASS: TestAccKeyVaultSecret_updatingValueChangedExternally (670.66s)
> PASS: TestAccKeyVaultSecret_recovery (1019.69s)
