### PR TITLE
fix: update docs for policy_definition and policy_set_definition

### DIFF
--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -76,9 +76,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy definition.
 
-* `management_group_id` -  (Optional) The name of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
-
-~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `name` or `group_id` attribute, but not `id`.
+* `management_group_id` -  (Optional) The id of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
 
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a JSON string representing the rule that contains an if and

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -60,9 +60,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy set definition.
 
-* `management_group_id` -  (Optional) The name of the Management Group where this policy set definition should be defined. Changing this forces a new resource to be created.
-
-~> **NOTE:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `name` or `group_id` attribute, but not `id`.
+* `management_group_id` -  (Optional) The id of the Management Group where this policy set definition should be defined. Changing this forces a new resource to be created.
 
 * `metadata` - (Optional) The metadata for the policy set definition. This is a JSON object representing additional metadata that should be stored with the policy definition.
 


### PR DESCRIPTION
Fix docs regarding management_group_id for v3

Note indicates use of group_id or name attributes for assignment:
- group_id is deprecated
- name results in parser error (i.e., expects an id)