### PR TITLE
azurerm_cosmosdb_account: set default_identity_type as default value when it's empty string in older cosmosdb account

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -965,7 +965,7 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		d.Set("analytical_storage_enabled", props.EnableAnalyticalStorage)
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess == documentdb.PublicNetworkAccessEnabled)
 		defaultIdentity := props.DefaultIdentity
-		if defaultIdentity == nil {
+		if defaultIdentity == nil || *defaultIdentity == "" {
 			defaultIdentity = utils.String("FirstPartyIdentity")
 		}
 		d.Set("default_identity_type", defaultIdentity)


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16706
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16892

Symptom:
The existing cosmosdb account that is created very long ago doesn't support default_identity_type and it doesn't return it.
Only the newly created cosmosdb account support it and return default value "FirstPartyIdentity" when it isn't specified.
Currently, TF would set this property as empty string when this property returned by API is empty string. In the meanwhile, TF defined the default value. Hence, TF always output the difference.

Solution:
Update TF to set this property with default value when the property returned by API is empty string.

![image](https://user-images.githubusercontent.com/19754191/170427037-648eee93-23fe-431f-8d84-bf6db39ac267.png)
