### PR TITLE
`r\hpc_cache`: Add support for encryption key

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -47,7 +47,7 @@ func resourceHPCCache() *pluginsdk.Resource {
 
 		Schema: resourceHPCCacheSchema(),
 
-		CustomizeDiff: pluginsdk.CustomDiffInSequence(
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.ForceNewIfChange("key_vault_key_id", func(ctx context.Context, old, new, meta interface{}) bool {
 				// `key_vault_key_id` cannot be added or removed after created
 				oldValue := old.(string)

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -1,6 +1,7 @@
 package hpccache
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -8,10 +9,17 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storagecache/mgmt/2021-09-01/storagecache"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hpccache/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
+	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	msiparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/parse"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
+	resourcesClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -38,11 +46,20 @@ func resourceHPCCache() *pluginsdk.Resource {
 		}),
 
 		Schema: resourceHPCCacheSchema(),
+
+		CustomizeDiff: pluginsdk.CustomDiffInSequence(
+			pluginsdk.ForceNewIfChange("key_vault_key_id", func(ctx context.Context, old, new, meta interface{}) bool {
+				// `key_vault_key_id` cannot be added or removed after created
+				return (old != "" && new == "") || (old == "" && new != "")
+			}),
+		),
 	}
 }
 
 func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).HPCCache.CachesClient
+	keyVaultsClient := meta.(*clients.Client).KeyVault
+	resourcesClient := meta.(*clients.Client).Resource
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -108,6 +125,11 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	directorySetting := expandStorageCacheDirectorySettings(d)
 
+	identity, err := expandStorageCacheIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
+
 	cache := &storagecache.Cache{
 		Name:     utils.String(name),
 		Location: utils.String(location),
@@ -123,7 +145,41 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 		Sku: &storagecache.CacheSku{
 			Name: utils.String(skuName),
 		},
-		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+		Identity: identity,
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("key_vault_key_id"); ok {
+		autoKeyRotationEnabled := d.Get("auto_key_rotation_enabled").(bool)
+		if !d.IsNewResource() && d.HasChange("key_vault_key_id") && autoKeyRotationEnabled {
+			// It is by design that `auto_key_rotation_enabled` changes to `false` internally in service when `key_vault_key_id` is changed
+			return fmt.Errorf("`auto_key_rotation_enabled` must be set to `false` when updating `key_vault_key_id`")
+		}
+
+		keyVaultKeyId := v.(string)
+		keyVaultDetails, err := storageCacheRetrieveKeyVault(ctx, keyVaultsClient, resourcesClient, keyVaultKeyId)
+		if err != nil {
+			return fmt.Errorf("validating Key Vault Key %q for HPC Cache: %+v", keyVaultKeyId, err)
+		}
+		if azure.NormalizeLocation(keyVaultDetails.location) != azure.NormalizeLocation(location) {
+			return fmt.Errorf("validating Key Vault %q (Resource Group %q) for HPC Cache: Key Vault must be in the same region as HPC Cache!", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
+		}
+		if !keyVaultDetails.softDeleteEnabled {
+			return fmt.Errorf("validating Key Vault %q (Resource Group %q) for HPC Cache: Soft Delete must be enabled but it isn't!", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
+		}
+		if !keyVaultDetails.purgeProtectionEnabled {
+			return fmt.Errorf("validating Key Vault %q (Resource Group %q) for HPC Cache: Purge Protection must be enabled but it isn't!", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
+		}
+
+		cache.CacheProperties.EncryptionSettings = &storagecache.CacheEncryptionSettings{
+			KeyEncryptionKey: &storagecache.KeyVaultKeyReference{
+				KeyURL: utils.String(keyVaultKeyId),
+				SourceVault: &storagecache.KeyVaultKeyReferenceSourceVault{
+					ID: utils.String(keyVaultDetails.keyVaultId),
+				},
+			},
+			RotationToLatestKeyVersionEnabled: utils.Bool(autoKeyRotationEnabled),
+		}
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, cache)
@@ -250,6 +306,28 @@ func resourceHPCCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	if sku := resp.Sku; sku != nil {
 		d.Set("sku_name", sku.Name)
 	}
+
+	identity, err := flattenStorageCacheIdentity(resp.Identity)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
+	keyVaultKeyId := ""
+	autoKeyRotationEnabled := false
+	if props := resp.EncryptionSettings; props != nil {
+		if props.KeyEncryptionKey != nil && props.KeyEncryptionKey.KeyURL != nil {
+			keyVaultKeyId = *props.KeyEncryptionKey.KeyURL
+		}
+
+		if props.RotationToLatestKeyVersionEnabled != nil {
+			autoKeyRotationEnabled = *props.RotationToLatestKeyVersionEnabled
+		}
+	}
+	d.Set("key_vault_key_id", keyVaultKeyId)
+	d.Set("auto_key_rotation_enabled", autoKeyRotationEnabled)
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }
@@ -624,6 +702,109 @@ func expandStorageCacheDirectoryLdapBind(input []interface{}) *storagecache.Cach
 	}
 }
 
+func expandStorageCacheIdentity(input []interface{}) (*storagecache.CacheIdentity, error) {
+	config, err := identity.ExpandUserAssignedMap(input)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := storagecache.CacheIdentity{
+		Type: storagecache.CacheIdentityType(config.Type),
+	}
+
+	if len(config.IdentityIds) != 0 {
+		identityIds := make(map[string]*storagecache.CacheIdentityUserAssignedIdentitiesValue, len(config.IdentityIds))
+		for id := range config.IdentityIds {
+			identityIds[id] = &storagecache.CacheIdentityUserAssignedIdentitiesValue{}
+		}
+		identity.UserAssignedIdentities = identityIds
+	}
+
+	return &identity, nil
+}
+
+func flattenStorageCacheIdentity(input *storagecache.CacheIdentity) (*[]interface{}, error) {
+	var config *identity.UserAssignedMap
+
+	if input != nil {
+		identityIds := map[string]identity.UserAssignedIdentityDetails{}
+		for id := range input.UserAssignedIdentities {
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(id)
+			if err != nil {
+				return nil, err
+			}
+			identityIds[parsedId.ID()] = identity.UserAssignedIdentityDetails{}
+		}
+
+		config = &identity.UserAssignedMap{
+			Type:        identity.Type(string(input.Type)),
+			IdentityIds: identityIds,
+		}
+	}
+
+	return identity.FlattenUserAssignedMap(config)
+}
+
+type storageCacheKeyVault struct {
+	keyVaultId             string
+	resourceGroupName      string
+	keyVaultName           string
+	location               string
+	purgeProtectionEnabled bool
+	softDeleteEnabled      bool
+}
+
+func storageCacheRetrieveKeyVault(ctx context.Context, keyVaultsClient *client.Client, resourcesClient *resourcesClient.Client, id string) (*storageCacheKeyVault, error) {
+	keyVaultKeyId, err := keyVaultParse.ParseNestedItemID(id)
+	if err != nil {
+		return nil, err
+	}
+	keyVaultID, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, keyVaultKeyId.KeyVaultBaseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", keyVaultKeyId.KeyVaultBaseUrl, err)
+	}
+	if keyVaultID == nil {
+		return nil, fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", keyVaultKeyId.KeyVaultBaseUrl)
+	}
+
+	parsedKeyVaultID, err := keyVaultParse.VaultID(*keyVaultID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := keyVaultsClient.VaultsClient.Get(ctx, parsedKeyVaultID.ResourceGroup, parsedKeyVaultID.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *parsedKeyVaultID, err)
+	}
+
+	purgeProtectionEnabled := false
+	softDeleteEnabled := false
+
+	if props := resp.Properties; props != nil {
+		if props.EnableSoftDelete != nil {
+			softDeleteEnabled = *props.EnableSoftDelete
+		}
+
+		if props.EnablePurgeProtection != nil {
+			purgeProtectionEnabled = *props.EnablePurgeProtection
+		}
+	}
+
+	location := ""
+	if resp.Location != nil {
+		location = *resp.Location
+	}
+
+	return &storageCacheKeyVault{
+		keyVaultId:             *keyVaultID,
+		resourceGroupName:      parsedKeyVaultID.ResourceGroup,
+		keyVaultName:           parsedKeyVaultID.Name,
+		location:               location,
+		purgeProtectionEnabled: purgeProtectionEnabled,
+		softDeleteEnabled:      softDeleteEnabled,
+	}, nil
+}
+
 func resourceHPCCacheSchema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
@@ -921,6 +1102,46 @@ func resourceHPCCacheSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
 			Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+		},
+
+		"identity": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							// System-assigned Managed Identity requires manual operation on Portal
+							string(storagecache.CacheIdentityTypeUserAssigned),
+						}, false),
+					},
+					"identity_ids": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: msivalidate.UserAssignedIdentityID,
+						},
+					},
+				},
+			},
+		},
+
+		"key_vault_key_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: keyVaultValidate.NestedItemId,
+			RequiredWith: []string{"identity"},
+		},
+
+		"auto_key_rotation_enabled": {
+			Type:         pluginsdk.TypeBool,
+			Optional:     true,
+			RequiredWith: []string{"key_vault_key_id"},
 		},
 
 		"tags": tags.Schema(),

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -151,9 +151,9 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	requireAdditionalUpdate := false
 	if v, ok := d.GetOk("key_vault_key_id"); ok {
-		autoKeyRotationEnabled := d.Get("auto_key_rotation_enabled").(bool)
+		autoKeyRotationEnabled := d.Get("automatically_rotate_key_to_latest_enabled").(bool)
 		if !d.IsNewResource() && d.HasChange("key_vault_key_id") && autoKeyRotationEnabled {
-			// It is by design that `auto_key_rotation_enabled` changes to `false` when `key_vault_key_id` is changed, needs to do an additional update to set it back
+			// It is by design that `automatically_rotate_key_to_latest_enabled` changes to `false` when `key_vault_key_id` is changed, needs to do an additional update to set it back
 			requireAdditionalUpdate = true
 		}
 
@@ -339,7 +339,7 @@ func resourceHPCCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("key_vault_key_id", keyVaultKeyId)
-	d.Set("auto_key_rotation_enabled", autoKeyRotationEnabled)
+	d.Set("automatically_rotate_key_to_latest_enabled", autoKeyRotationEnabled)
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }
@@ -1125,7 +1125,7 @@ func resourceHPCCacheSchema() map[string]*pluginsdk.Schema {
 			RequiredWith: []string{"identity"},
 		},
 
-		"auto_key_rotation_enabled": {
+		"automatically_rotate_key_to_latest_enabled": {
 			Type:         pluginsdk.TypeBool,
 			Optional:     true,
 			RequiredWith: []string{"key_vault_key_id"},

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -46,15 +46,6 @@ func resourceHPCCache() *pluginsdk.Resource {
 		}),
 
 		Schema: resourceHPCCacheSchema(),
-
-		CustomizeDiff: pluginsdk.CustomDiffWithAll(
-			pluginsdk.ForceNewIfChange("key_vault_key_id", func(ctx context.Context, old, new, meta interface{}) bool {
-				// `key_vault_key_id` cannot be added or removed after created
-				oldValue := old.(string)
-				newValue := new.(string)
-				return (oldValue != "" && newValue == "") || (oldValue == "" && newValue != "")
-			}),
-		),
 	}
 }
 
@@ -149,6 +140,13 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 		},
 		Identity: identity,
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if !d.IsNewResource() {
+		oldKeyVaultKeyId, newKeyVaultKeyId := d.GetChange("key_vault_key_id")
+		if (oldKeyVaultKeyId.(string) != "" && newKeyVaultKeyId.(string) == "") || (oldKeyVaultKeyId.(string) == "" && newKeyVaultKeyId.(string) != "") {
+			return fmt.Errorf("`key_vault_key_id` can not be added or removed after HPC Cache is created")
+		}
 	}
 
 	requireAdditionalUpdate := false

--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -941,8 +941,8 @@ resource "azurerm_hpc_cache" "test" {
     ]
   }
 
-  key_vault_key_id          = azurerm_key_vault_key.test.id
-  auto_key_rotation_enabled = true
+  key_vault_key_id                           = azurerm_key_vault_key.test.id
+  automatically_rotate_key_to_latest_enabled = true
 }
 `, r.customerManagedKeyTemplate(data), data.RandomInteger)
 }
@@ -966,8 +966,8 @@ resource "azurerm_hpc_cache" "test" {
     ]
   }
 
-  key_vault_key_id          = azurerm_key_vault_key.test2.id
-  auto_key_rotation_enabled = true
+  key_vault_key_id                           = azurerm_key_vault_key.test2.id
+  automatically_rotate_key_to_latest_enabled = true
 }
 `, r.customerManagedKeyTemplate(data), data.RandomInteger)
 }

--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -337,6 +337,28 @@ func TestAccHPCCache_directoryFlatFile(t *testing.T) {
 	})
 }
 
+func TestAccHPCCache_customerManagedKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customerManagedKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.customerManagedKeyUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (HPCCacheResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.CacheID(state.ID)
 	if err != nil {
@@ -852,6 +874,170 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HPCCacheResource) customerManagedKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  key_vault_key_id          = azurerm_key_vault_key.test.id
+  auto_key_rotation_enabled = true
+}
+`, r.customerManagedKeyTemplate(data), data.RandomInteger)
+}
+
+func (r HPCCacheResource) customerManagedKeyUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  key_vault_key_id          = azurerm_key_vault_key.test2.id
+  auto_key_rotation_enabled = false
+}
+`, r.customerManagedKeyTemplate(data), data.RandomInteger)
+}
+
+func (HPCCacheResource) customerManagedKeyTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults    = false
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv-%[3]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  sku_name                    = "standard"
+  purge_protection_enabled    = true
+  soft_delete_retention_days  = 7
+  enabled_for_disk_encryption = true
+}
+
+resource "azurerm_key_vault_access_policy" "service-principal" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Update",
+  ]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "examplekey"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
+  depends_on = [azurerm_key_vault_access_policy.service-principal]
+}
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "examplekey2"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
+  depends_on = [azurerm_key_vault_access_policy.service-principal]
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault_access_policy" "service-principal2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+  ]
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-VN-%[2]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsub-%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }
 
 func (HPCCacheResource) template(data acceptance.TestData) string {

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `key_vault_key_id` - (Optional) The ID of the Key Vault Key which should be used to encrypt the data in this HPC Cache.
 
-* `auto_key_rotation_enabled` - (Optional) Specifies whether the HPC Cache automatically rotates Encryption Key to the latest version. Defaults to `false`.
+* `automatically_rotate_key_to_latest_enabled` - (Optional) Specifies whether the HPC Cache automatically rotates Encryption Key to the latest version. Defaults to `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to the HPC Cache.
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -84,11 +84,9 @@ The following arguments are supported:
 
 ~> **Note:** Only one of `directory_active_directory`, `directory_flat_file` and `directory_ldap` can be set.
 
-* `identity` - (Optional) An `identity` block as defined below.
+* `identity` - (Optional) An `identity` block as defined below. Changing this forces a new resource to be created.
 
-* `key_vault_key_id` - (Optional) Specifies the URL to a Key Vault Key.
-
-~> **NOTE:** `auto_key_rotation_enabled` must be set to `false` when updating `key_vault_key_id`.
+* `key_vault_key_id` - (Optional) The ID of the Key Vault Key which should be used to encrypt the data in this HPC Cache.
 
 * `auto_key_rotation_enabled` - (Optional) Specifies whether the HPC Cache automatically rotates Encryption Key to the latest version. Defaults to `false`.
 
@@ -184,9 +182,9 @@ A `dns` block contains the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Possible value is `UserAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Only possible value is `UserAssigned`.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache.
+* `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache.
 
 ## Attributes Reference
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -83,7 +83,15 @@ The following arguments are supported:
 * `directory_ldap` - (Optional) A `directory_ldap` block as defined below.
 
 ~> **Note:** Only one of `directory_active_directory`, `directory_flat_file` and `directory_ldap` can be set.
- 
+
+* `identity` - (Optional) An `identity` block as defined below.
+
+* `key_vault_key_id` - (Optional) Specifies the URL to a Key Vault Key.
+
+~> **NOTE:** `auto_key_rotation_enabled` must be set to `false` when updating `key_vault_key_id`.
+
+* `auto_key_rotation_enabled` - (Optional) Specifies whether the HPC Cache automatically rotates Encryption Key to the latest version. Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to the HPC Cache.
 
 ---
@@ -171,6 +179,14 @@ A `dns` block contains the following:
 * `servers` - (Required) A list of DNS servers for the HPC Cache. At most three IP(s) are allowed to set.
 
 * `search_domain` - (Optional) The DNS search domain for the HPC Cache.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Possible value is `UserAssigned`.
+
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- This feature internally uses Disk Encryption Set so validations for Key Vault are same as it here https://github.com/hashicorp/terraform-provider-azurerm/blob/82de9ae14d58e97d70664acda90b2036852f92df/internal/services/compute/disk_encryption_set_resource.go#L113
- When updating `key_vault_key_id`, `auto_key_rotation_enabled` will be set to `false` at backend, have confirmed with service team that this is by design, so added validation to enforce `auto_key_rotation_enabled` to be `false` when changing `key_vault_key_id`