### PR TITLE
Doc Update: `azurerm_backup_protected_vm` - Add note about removing `source_vm_id`

### DIFF
--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -54,6 +54,9 @@ The following arguments are supported:
 
 * `source_vm_id` - (Required) Specifies the ID of the VM to backup. Changing this forces a new resource to be created.
 
+~> **NOTE:** After creation, the `source_vm_id` property can be removed without forcing a new resource to be created; however, setting it to a different ID will create a new resource. 
+This allows the source vm to be deleted without having to remove the backup.
+
 * `backup_policy_id` - (Required) Specifies the id of the backup policy to use.
 
 * `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be excluded for VM Protection.


### PR DESCRIPTION
Related to #16939 