### PR TITLE
Align Firewall SKU with SDK enums

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -615,6 +615,7 @@ func resourceFirewallPolicySchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.StringInSlice([]string{
 				string(network.FirewallPolicySkuTierPremium),
 				string(network.FirewallPolicySkuTierStandard),
+				string(network.FirewallPolicySkuTierBasic),
 			}, false),
 		},
 

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -81,6 +81,7 @@ func resourceFirewall() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.AzureFirewallSkuTierPremium),
 					string(network.AzureFirewallSkuTierStandard),
+					string(network.AzureFirewallSkuTierBasic),
 				}, false),
 			},
 


### PR DESCRIPTION
Aligning the Azure Firewall SKU with the SDK: https://github.com/hashicorp/terraform-provider-azurerm/blob/7c35455ad9e7d1f8f811d84120889d55d6116106/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network/enums.go#L475