### PR TITLE
Doc: Fix some incorrect import spec

### DIFF
--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -48,5 +48,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 App Service Source Control Token's can be imported using the `type`, e.g.
 
 ```shell
-terraform import azurerm_app_service_source_control_token.example GitHub
+terraform import azurerm_app_service_source_control_token.example /providers/Microsoft.Web/sourceControls/GitHub
 ```

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -247,6 +247,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 EventGrid Event Subscription's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_eventgrid_event_subscription.eventSubscription1
-/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventGrid/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/eventSubscription1
+terraform import azurerm_eventgrid_event_subscription.eventSubscription1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventGrid/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/eventSubscription1
 ```

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -411,5 +411,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 An Orchestrated Virtual Machine Scale Set can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_orchestrated_virtual_machine_scale_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/Microsoft.Compute/virtualMachineScaleSets/scaleset1
+terraform import azurerm_orchestrated_virtual_machine_scale_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
 ```


### PR DESCRIPTION
I'm working on some resource parsing stuff and used the import specs in the provider doc to test. Identified several incorrect import specs and fixed them.