### PR TITLE
`azurerm_container_registry_task` - Fix missing `authentication` when updating

### DIFF
--- a/internal/services/containers/container_registry_task_resource.go
+++ b/internal/services/containers/container_registry_task_resource.go
@@ -903,9 +903,9 @@ func (r ContainerRegistryTaskResource) Update() sdk.ResourceFunc {
 			}
 
 			if existing.TaskProperties.Trigger != nil {
-				if !metadata.ResourceData.HasChange("source_triggers") {
+				if !metadata.ResourceData.HasChange("source_triggers") && existing.TaskProperties.Trigger.SourceTriggers != nil {
 					// For update that is not affecting source_triggers, we need to patch the source_triggers to include the properties missing in the response of GET.
-					existing.TaskProperties.Trigger.SourceTriggers = patchRegistryTaskTriggerSourceTrigger(existing.TaskProperties.Trigger.SourceTriggers, model)
+					existing.TaskProperties.Trigger.SourceTriggers = patchRegistryTaskTriggerSourceTrigger(*existing.TaskProperties.Trigger.SourceTriggers, model)
 				}
 			}
 
@@ -1628,17 +1628,14 @@ func flattenRegistryTaskAgentProperties(input *legacyacr.AgentProperties) []Agen
 	return []AgentConfig{{CPU: cpu}}
 }
 
-func patchRegistryTaskTriggerSourceTrigger(triggers *[]legacyacr.SourceTrigger, model ContainerRegistryTaskModel) *[]legacyacr.SourceTrigger {
-	if triggers == nil {
-		return triggers
-	}
-	if len(*triggers) != len(model.SourceTrigger) {
-		return triggers
+func patchRegistryTaskTriggerSourceTrigger(triggers []legacyacr.SourceTrigger, model ContainerRegistryTaskModel) *[]legacyacr.SourceTrigger {
+	if len(triggers) != len(model.SourceTrigger) {
+		return &triggers
 	}
 
-	result := make([]legacyacr.SourceTrigger, len(*triggers))
+	result := make([]legacyacr.SourceTrigger, len(triggers))
 	for i, trigger := range model.SourceTrigger {
-		t := (*triggers)[i]
+		t := (triggers)[i]
 		if len(trigger.Auth) == 0 {
 			result[i] = t
 			continue


### PR DESCRIPTION
Fix #16959

The `source_trigger.authentication` is not returned in the GET response. When there is an update to other attributes other than `source_trigger`, as we conditionally expand `source_trigger` (only when it `HasChanged`), the content of `source_trigger` was from the GET response, therefore missing the `source_trigger.authentication`. API then complains.

This PR adds a special patch to the `source_trigger.authentication` in this case, right after the conditional expansion.

## Test

```shell
❯ TF_ACC=1 go test -timeout=60m -v -run='TestAccContainerRegistryTask_dockerStepSourceTrigger' ./internal/services/containers
=== RUN   TestAccContainerRegistryTask_dockerStepSourceTrigger                                                                                                                              === PAUSE TestAccContainerRegistryTask_dockerStepSourceTrigger
=== CONT  TestAccContainerRegistryTask_dockerStepSourceTrigger
--- PASS: TestAccContainerRegistryTask_dockerStepSourceTrigger (236.26s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    236.271s
```