### PR TITLE
Fix a bug cause TestAccBatchPool_startTask_basic failed

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -449,7 +449,9 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 	}
 	if userNameValue, ok := userIdentityValue["user_name"]; ok {
 		userName := userNameValue.(string)
-		userIdentity.UserName = &userName
+		if len(userName) != 0 {
+			userIdentity.UserName = &userName
+		}
 	}
 
 	resourceFileList := startTaskValue["resource_file"].([]interface{})


### PR DESCRIPTION
Local test result for TestAccBatchPool_startTask_basic after fix:
`GOROOT=C:\Users\yunliu1\sdk\go1.18.1 #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
C:\Users\yunliu1\sdk\go1.18.1\bin\go.exe test -c -o D:\Temp\GoLand\___TestAccBatchPool_startTask_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/batch #gosetup
C:\Users\yunliu1\sdk\go1.18.1\bin\go.exe tool test2json -t D:\Temp\GoLand\___TestAccBatchPool_startTask_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccBatchPool_startTask_basic\E$ #gosetup
=== RUN   TestAccBatchPool_startTask_basic

=== PAUSE TestAccBatchPool_startTask_basic

=== CONT  TestAccBatchPool_startTask_basic

--- PASS: TestAccBatchPool_startTask_basic (642.88s)
PASS


Process finished with the exit code 0`