### PR TITLE
`azurerm_kubernetes_cluster` - nil check `APIServerAccessProfile`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1370,8 +1370,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("run_command_enabled") {
 		updateCluster = true
 		if existing.ManagedClusterProperties.APIServerAccessProfile == nil {
-			existing.ManagedClusterProperties.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-			}
+			existing.ManagedClusterProperties.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{}
 		}
 		existing.ManagedClusterProperties.APIServerAccessProfile.DisableRunCommand = utils.Bool(!d.Get("run_command_enabled").(bool))
 	}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1369,13 +1369,11 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	if d.HasChange("run_command_enabled") {
 		updateCluster = true
-		if existing.ManagedClusterProperties.APIServerAccessProfile != nil {
-			existing.ManagedClusterProperties.APIServerAccessProfile.DisableRunCommand = utils.Bool(!d.Get("run_command_enabled").(bool))
-		} else {
+		if existing.ManagedClusterProperties.APIServerAccessProfile == nil {
 			existing.ManagedClusterProperties.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-				DisableRunCommand: utils.Bool(!d.Get("run_command_enabled").(bool)),
 			}
 		}
+		existing.ManagedClusterProperties.APIServerAccessProfile.DisableRunCommand = utils.Bool(!d.Get("run_command_enabled").(bool))
 	}
 
 	if d.HasChange("auto_scaler_profile") {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1369,7 +1369,13 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	if d.HasChange("run_command_enabled") {
 		updateCluster = true
-		existing.ManagedClusterProperties.APIServerAccessProfile.DisableRunCommand = utils.Bool(!d.Get("run_command_enabled").(bool))
+		if existing.ManagedClusterProperties.APIServerAccessProfile != nil {
+			existing.ManagedClusterProperties.APIServerAccessProfile.DisableRunCommand = utils.Bool(!d.Get("run_command_enabled").(bool))
+		} else {
+			existing.ManagedClusterProperties.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+				DisableRunCommand: utils.Bool(!d.Get("run_command_enabled").(bool)),
+			}
+		}
 	}
 
 	if d.HasChange("auto_scaler_profile") {


### PR DESCRIPTION
Fixes #16967