### PR TITLE
Removes duplicate line in route table doc

### DIFF
--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 Elements of `route` support:
 
-* `name` - (Required) The name of the route.(Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
+* `name` - (Required) The name of the route.
 
 * `address_prefix` - (Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
 


### PR DESCRIPTION
The `address_prefix` line is duplicated and appended to the `name` documentation line.
This PR removes the duplicated line.