### PR TITLE
` azurerm_synapse_role_assignment` - `role_name` now supports `Synapse Monitoring Operator`

### DIFF
--- a/internal/services/synapse/synapse_role_assignment_resource.go
+++ b/internal/services/synapse/synapse_role_assignment_resource.go
@@ -83,6 +83,7 @@ func resourceSynapseRoleAssignment() *pluginsdk.Resource {
 					"Synapse Contributor",
 					"Synapse Credential User",
 					"Synapse Linked Data Manager",
+					"Synapse Monitoring Operator",
 					"Synapse SQL Administrator",
 					"Synapse User",
 				}, false),

--- a/website/docs/r/synapse_role_assignment.html.markdown
+++ b/website/docs/r/synapse_role_assignment.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `role_name` - (Required) The Role Name of the Synapse Built-In Role. Changing this forces a new resource to be created.
 
--> **NOTE:** Currently, the Synapse built-in roles are `Apache Spark Administrator`, `Synapse Administrator`, `Synapse Artifact Publisher`, `Synapse Artifact User`, `Synapse Compute Operator`, `Synapse Contributor`, `Synapse Credential User`, `Synapse Linked Data Manager`, `Synapse SQL Administrator` and `Synapse User`.
+-> **NOTE:** Currently, the Synapse built-in roles are `Apache Spark Administrator`, `Synapse Administrator`, `Synapse Artifact Publisher`, `Synapse Artifact User`, `Synapse Compute Operator`, `Synapse Contributor`, `Synapse Credential User`, `Synapse Linked Data Manager`, `Synapse Monitoring Operator`, `Synapse SQL Administrator` and `Synapse User`.
 
 -> **NOTE:** Old roles are still supported: `Workspace Admin`, `Apache Spark Admin`, `Sql Admin`. These values will be removed in the next Major Version 3.0.
 


### PR DESCRIPTION
Microsoft introduced a new Synapse role called `Synapse Monitoring Operator`. This PR adds the support for it in Terraform.

Further information:
* https://techcommunity.microsoft.com/t5/azure-synapse-analytics-blog/azure-synapse-analytics-april-update-2022/ba-p/3295633#TOCREF_12
* https://docs.microsoft.com/en-us/azure/synapse-analytics/security/synapse-workspace-synapse-rbac-roles