### PR TITLE
New resource - `azurerm_active_directory_domain_service_trust`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -120,6 +120,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		containers.Registration{},
 		costmanagement.Registration{},
 		disks.Registration{},
+		domainservices.Registration{},
 		eventhub.Registration{},
 		keyvault.Registration{},
 		loadbalancer.Registration{},

--- a/internal/services/domainservices/active_directory_domain_service_trust_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_trust_resource.go
@@ -1,0 +1,350 @@
+package domainservices
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/domainservices/mgmt/2020-01-01/aad"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type DomainServiceTrustResource struct{}
+
+var _ sdk.ResourceWithUpdate = DomainServiceTrustResource{}
+
+type DomainServiceTrustModel struct {
+	Name                    string   `tfschema:"name"`
+	DomainServiceResourceId string   `tfschema:"domain_service_resource_id"`
+	TrustedDomainFqdn       string   `tfschema:"trusted_domain_fqdn"`
+	TrustedDomainDnsIPs     []string `tfschema:"trusted_domain_dns_ips"`
+	Password                string   `tfschema:"password"`
+}
+
+func (r DomainServiceTrustResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"domain_service_resource_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DomainServiceResourceID,
+		},
+		"trusted_domain_fqdn": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"trusted_domain_dns_ips": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 2,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.IsIPAddress,
+			},
+		},
+		"password": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r DomainServiceTrustResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r DomainServiceTrustResource) ResourceType() string {
+	return "azurerm_active_directory_domain_service_trust"
+}
+
+func (r DomainServiceTrustResource) ModelObject() interface{} {
+	return &DomainServiceTrustModel{}
+}
+
+func (r DomainServiceTrustResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.DomainServiceTrustID
+}
+
+func (r DomainServiceTrustResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DomainServices.DomainServicesClient
+
+			var plan DomainServiceTrustModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			dsid, err := parse.DomainServiceResourceID(plan.DomainServiceResourceId)
+			if err != nil {
+				return err
+			}
+
+			id := parse.NewDomainServiceTrustID(dsid.SubscriptionId, dsid.ResourceGroup, dsid.DomainServiceName, plan.Name)
+
+			locks.ByName(id.DomainServiceName, DomainServiceResourceName)
+			defer locks.UnlockByName(id.DomainServiceName, DomainServiceResourceName)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.DomainServiceName)
+			if err != nil {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			existingTrusts := []aad.ForestTrust{}
+			if props := existing.DomainServiceProperties; props != nil {
+				if fsettings := props.ResourceForestSettings; fsettings != nil {
+					if settings := fsettings.Settings; settings != nil {
+						existingTrusts = *settings
+					}
+				}
+			}
+			for _, setting := range existingTrusts {
+				if setting.FriendlyName != nil && *setting.FriendlyName == id.TrustName {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
+			}
+
+			existingTrusts = append(existingTrusts, aad.ForestTrust{
+				TrustedDomainFqdn: utils.String(plan.TrustedDomainFqdn),
+				TrustDirection:    utils.String("Inbound"),
+				FriendlyName:      utils.String(id.TrustName),
+				RemoteDNSIps:      utils.String(strings.Join(plan.TrustedDomainDnsIPs, ",")),
+				TrustPassword:     utils.String(plan.Password),
+			})
+			params := aad.DomainService{
+				DomainServiceProperties: &aad.DomainServiceProperties{
+					ResourceForestSettings: &aad.ResourceForestSettings{
+						Settings: &existingTrusts,
+					},
+				},
+			}
+
+			future, err := client.Update(ctx, id.ResourceGroup, id.DomainServiceName, params)
+			if err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r DomainServiceTrustResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DomainServices.DomainServicesClient
+			id, err := parse.DomainServiceTrustID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			dsid := parse.NewDomainServiceResourceID(id.SubscriptionId, id.ResourceGroup, id.DomainServiceName)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.DomainServiceName)
+			if err != nil {
+				if utils.ResponseWasNotFound(existing.Response) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", dsid, err)
+			}
+			existingTrusts := []aad.ForestTrust{}
+			if props := existing.DomainServiceProperties; props != nil {
+				if fsettings := props.ResourceForestSettings; fsettings != nil {
+					if settings := fsettings.Settings; settings != nil {
+						existingTrusts = *settings
+					}
+				}
+			}
+			var trust *aad.ForestTrust
+			for _, setting := range existingTrusts {
+				existingTrust := setting
+				if setting.FriendlyName != nil && *setting.FriendlyName == id.TrustName {
+					trust = &existingTrust
+				}
+			}
+			if trust == nil {
+				return metadata.MarkAsGone(id)
+			}
+
+			var state DomainServiceTrustModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			model := DomainServiceTrustModel{
+				DomainServiceResourceId: dsid.ID(),
+				Name:                    id.TrustName,
+				// Setting the password from state as it is not returned by API.
+				Password: state.Password,
+			}
+
+			if trust.TrustedDomainFqdn != nil {
+				model.TrustedDomainFqdn = *trust.TrustedDomainFqdn
+			}
+
+			if trust.RemoteDNSIps != nil {
+				model.TrustedDomainDnsIPs = strings.Split(*trust.RemoteDNSIps, ",")
+			}
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r DomainServiceTrustResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DomainServices.DomainServicesClient
+
+			id, err := parse.DomainServiceTrustID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			dsid := parse.NewDomainServiceResourceID(id.SubscriptionId, id.ResourceGroup, id.DomainServiceName)
+
+			locks.ByName(id.DomainServiceName, DomainServiceResourceName)
+			defer locks.UnlockByName(id.DomainServiceName, DomainServiceResourceName)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.DomainServiceName)
+			if err != nil {
+				if utils.ResponseWasNotFound(existing.Response) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", dsid, err)
+			}
+			existingTrusts := []aad.ForestTrust{}
+			if props := existing.DomainServiceProperties; props != nil {
+				if fsettings := props.ResourceForestSettings; fsettings != nil {
+					if settings := fsettings.Settings; settings != nil {
+						existingTrusts = *settings
+					}
+				}
+			}
+			var found bool
+			newTrusts := []aad.ForestTrust{}
+			for _, trust := range existingTrusts {
+				if trust.FriendlyName != nil && *trust.FriendlyName == id.TrustName {
+					found = true
+					continue
+				}
+				newTrusts = append(newTrusts, trust)
+			}
+
+			if !found {
+				return metadata.MarkAsGone(id)
+			}
+
+			params := aad.DomainService{
+				DomainServiceProperties: &aad.DomainServiceProperties{
+					ResourceForestSettings: &aad.ResourceForestSettings{
+						Settings: &newTrusts,
+					},
+				},
+			}
+
+			future, err := client.Update(ctx, id.ResourceGroup, id.DomainServiceName, params)
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for removal of %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r DomainServiceTrustResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DomainServices.DomainServicesClient
+
+			id, err := parse.DomainServiceTrustID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			dsid := parse.NewDomainServiceResourceID(id.SubscriptionId, id.ResourceGroup, id.DomainServiceName)
+
+			locks.ByName(id.DomainServiceName, DomainServiceResourceName)
+			defer locks.UnlockByName(id.DomainServiceName, DomainServiceResourceName)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.DomainServiceName)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", dsid, err)
+			}
+			existingTrusts := []aad.ForestTrust{}
+			if props := existing.DomainServiceProperties; props != nil {
+				if fsettings := props.ResourceForestSettings; fsettings != nil {
+					if settings := fsettings.Settings; settings != nil {
+						existingTrusts = *settings
+					}
+				}
+			}
+
+			var plan DomainServiceTrustModel
+			if err := metadata.Decode(&plan); err != nil {
+				return err
+			}
+
+			var found bool
+			newTrusts := []aad.ForestTrust{}
+			for _, trust := range existingTrusts {
+				if trust.FriendlyName != nil && *trust.FriendlyName == id.TrustName {
+					found = true
+					if metadata.ResourceData.HasChange("trusted_domain_fqdn") {
+						trust.TrustedDomainFqdn = utils.String(plan.TrustedDomainFqdn)
+					}
+					if metadata.ResourceData.HasChange("trusted_domain_dns_ips") {
+						trust.RemoteDNSIps = utils.String(strings.Join(plan.TrustedDomainDnsIPs, ","))
+					}
+					trust.TrustPassword = utils.String(plan.Password)
+				}
+				newTrusts = append(newTrusts, trust)
+			}
+			if !found {
+				return fmt.Errorf("%s not exists: %+v", id, err)
+			}
+
+			params := aad.DomainService{
+				DomainServiceProperties: &aad.DomainServiceProperties{
+					ResourceForestSettings: &aad.ResourceForestSettings{
+						Settings: &newTrusts,
+					},
+				},
+			}
+
+			future, err := client.Update(ctx, id.ResourceGroup, id.DomainServiceName, params)
+			if err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for update of %s: %+v", id, err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/services/domainservices/active_directory_domain_service_trust_resource_test.go
+++ b/internal/services/domainservices/active_directory_domain_service_trust_resource_test.go
@@ -1,0 +1,185 @@
+package domainservices_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/domainservices/mgmt/2020-01-01/aad"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type DomainServiceTrustResource struct {
+	// The name of the resource group contains the AADDS
+	AADDSResourceGroupName string
+	// The name the AADDS
+	AADDSName string
+	// The FQDN of the on-premise ADDS
+	ADDSFqdn string
+	// The primary IP of the DNS that can resolve the on-premise ADDS
+	ADDSIp1 string
+	// The secondary IP of the DNS that can resolve the on-premise ADDS
+	ADDSIp2 string
+	// The password of the inbound trust set in the on-premise ADDS
+	TrustPassword string
+}
+
+func NewDomainServiceTrustResource() (*DomainServiceTrustResource, error) {
+	aaddsRgName := os.Getenv("ARM_TEST_AADDS_RESOURCE_GROUP_NAME")
+	if aaddsRgName == "" {
+		return nil, fmt.Errorf("`ARM_TEST_AADDS_RESOURCE_GROUP_NAME` is not set")
+	}
+
+	aaddsName := os.Getenv("ARM_TEST_AADDS_NAME")
+	if aaddsName == "" {
+		return nil, fmt.Errorf("`ARM_TEST_AADDS_NAME` is not set")
+	}
+
+	addsFqdn := os.Getenv("ARM_TEST_ADDS_FQDN")
+	if addsFqdn == "" {
+		return nil, fmt.Errorf("`ARM_TEST_ADDS_FQDN` is not set")
+	}
+
+	addsIp1 := os.Getenv("ARM_TEST_ADDS_IP1")
+	if addsIp1 == "" {
+		return nil, fmt.Errorf("`ARM_TEST_ADDS_IP1` is not set")
+	}
+
+	addsIp2 := os.Getenv("ARM_TEST_ADDS_IP2")
+	if addsIp2 == "" {
+		return nil, fmt.Errorf("`ARM_TEST_ADDS_IP2` is not set")
+	}
+
+	password := os.Getenv("ARM_TEST_PASSWORD")
+	if password == "" {
+		return nil, fmt.Errorf("`ARM_TEST_PASSWORD` is not set")
+	}
+
+	return &DomainServiceTrustResource{
+		AADDSResourceGroupName: aaddsRgName,
+		AADDSName:              aaddsName,
+		ADDSFqdn:               addsFqdn,
+		ADDSIp1:                addsIp1,
+		ADDSIp2:                addsIp2,
+		TrustPassword:          password,
+	}, nil
+}
+
+func TestAccDomainServiceTrust_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_active_directory_domain_service_trust", "test")
+	r, err := NewDomainServiceTrustResource()
+	if err != nil {
+		t.Skipf("Skipping: %v", err)
+	}
+
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("password"),
+	})
+}
+
+func TestAccDomainServiceTrust_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_active_directory_domain_service_trust", "test")
+	r, err := NewDomainServiceTrustResource()
+	if err != nil {
+		t.Skipf("Skipping: %v", err)
+	}
+
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r DomainServiceTrustResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.DomainServices.DomainServicesClient
+
+	id, err := parse.DomainServiceTrustID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.DomainServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, err
+	}
+	existingTrusts := []aad.ForestTrust{}
+	if props := resp.DomainServiceProperties; props != nil {
+		if fsettings := props.ResourceForestSettings; fsettings != nil {
+			if settings := fsettings.Settings; settings != nil {
+				existingTrusts = *settings
+			}
+		}
+	}
+	for _, setting := range existingTrusts {
+		if setting.FriendlyName != nil && *setting.FriendlyName == id.TrustName {
+			return utils.Bool(true), nil
+		}
+	}
+
+	return utils.Bool(false), nil
+}
+
+func (r DomainServiceTrustResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_active_directory_domain_service_trust" "test" {
+  domain_service_resource_id = data.azurerm_active_directory_domain_service.test.resource_id
+  name                       = "acctest-trust-%s"
+  trusted_domain_fqdn        = %q
+  trusted_domain_dns_ips     = [%q, %q]
+  password                   = %q
+}
+`, template, data.RandomString, r.ADDSFqdn, r.ADDSIp1, r.ADDSIp2, r.TrustPassword)
+}
+
+func (r DomainServiceTrustResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_active_directory_domain_service_trust" "import" {
+  domain_service_resource_id = azurerm_active_directory_domain_service_trust.test.domain_service_resource_id
+  name                       = azurerm_active_directory_domain_service_trust.test.name
+  trusted_domain_fqdn        = azurerm_active_directory_domain_service_trust.test.trusted_domain_fqdn
+  trusted_domain_dns_ips     = azurerm_active_directory_domain_service_trust.test.trusted_domain_dns_ips
+  password                   = azurerm_active_directory_domain_service_trust.test.password
+}
+`, template)
+}
+
+func (r DomainServiceTrustResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+
+data "azurerm_active_directory_domain_service" "test" {
+  name                = %q
+  resource_group_name = %q
+}
+`, r.AADDSName, r.AADDSResourceGroupName)
+}

--- a/internal/services/domainservices/parse/domain_service_resource.go
+++ b/internal/services/domainservices/parse/domain_service_resource.go
@@ -1,0 +1,69 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type DomainServiceResourceId struct {
+	SubscriptionId    string
+	ResourceGroup     string
+	DomainServiceName string
+}
+
+func NewDomainServiceResourceID(subscriptionId, resourceGroup, domainServiceName string) DomainServiceResourceId {
+	return DomainServiceResourceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroup:     resourceGroup,
+		DomainServiceName: domainServiceName,
+	}
+}
+
+func (id DomainServiceResourceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Domain Service Name %q", id.DomainServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Domain Service Resource", segmentsStr)
+}
+
+func (id DomainServiceResourceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AAD/domainServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DomainServiceName)
+}
+
+// DomainServiceResourceID parses a DomainServiceResource ID into an DomainServiceResourceId struct
+func DomainServiceResourceID(input string) (*DomainServiceResourceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := DomainServiceResourceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.DomainServiceName, err = id.PopSegment("domainServices"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/domainservices/parse/domain_service_resource_test.go
+++ b/internal/services/domainservices/parse/domain_service_resource_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = DomainServiceResourceId{}
+
+func TestDomainServiceResourceIDFormatter(t *testing.T) {
+	actual := NewDomainServiceResourceID("12345678-1234-9876-4563-123456789012", "resGroup1", "DomainService1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestDomainServiceResourceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DomainServiceResourceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/",
+			Error: true,
+		},
+
+		{
+			// missing value for DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1",
+			Expected: &DomainServiceResourceId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:     "resGroup1",
+				DomainServiceName: "DomainService1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.AAD/DOMAINSERVICES/DOMAINSERVICE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := DomainServiceResourceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.DomainServiceName != v.Expected.DomainServiceName {
+			t.Fatalf("Expected %q but got %q for DomainServiceName", v.Expected.DomainServiceName, actual.DomainServiceName)
+		}
+	}
+}

--- a/internal/services/domainservices/parse/domain_service_trust.go
+++ b/internal/services/domainservices/parse/domain_service_trust.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type DomainServiceTrustId struct {
+	SubscriptionId    string
+	ResourceGroup     string
+	DomainServiceName string
+	TrustName         string
+}
+
+func NewDomainServiceTrustID(subscriptionId, resourceGroup, domainServiceName, trustName string) DomainServiceTrustId {
+	return DomainServiceTrustId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroup:     resourceGroup,
+		DomainServiceName: domainServiceName,
+		TrustName:         trustName,
+	}
+}
+
+func (id DomainServiceTrustId) String() string {
+	segments := []string{
+		fmt.Sprintf("Trust Name %q", id.TrustName),
+		fmt.Sprintf("Domain Service Name %q", id.DomainServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Domain Service Trust", segmentsStr)
+}
+
+func (id DomainServiceTrustId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AAD/domainServices/%s/trusts/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DomainServiceName, id.TrustName)
+}
+
+// DomainServiceTrustID parses a DomainServiceTrust ID into an DomainServiceTrustId struct
+func DomainServiceTrustID(input string) (*DomainServiceTrustId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := DomainServiceTrustId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.DomainServiceName, err = id.PopSegment("domainServices"); err != nil {
+		return nil, err
+	}
+	if resourceId.TrustName, err = id.PopSegment("trusts"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/domainservices/parse/domain_service_trust_test.go
+++ b/internal/services/domainservices/parse/domain_service_trust_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = DomainServiceTrustId{}
+
+func TestDomainServiceTrustIDFormatter(t *testing.T) {
+	actual := NewDomainServiceTrustID("12345678-1234-9876-4563-123456789012", "resGroup1", "DomainService1", "trust1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/trust1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestDomainServiceTrustID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DomainServiceTrustId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/",
+			Error: true,
+		},
+
+		{
+			// missing value for DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/",
+			Error: true,
+		},
+
+		{
+			// missing TrustName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/",
+			Error: true,
+		},
+
+		{
+			// missing value for TrustName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/trust1",
+			Expected: &DomainServiceTrustId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:     "resGroup1",
+				DomainServiceName: "DomainService1",
+				TrustName:         "trust1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.AAD/DOMAINSERVICES/DOMAINSERVICE1/TRUSTS/TRUST1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := DomainServiceTrustID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.DomainServiceName != v.Expected.DomainServiceName {
+			t.Fatalf("Expected %q but got %q for DomainServiceName", v.Expected.DomainServiceName, actual.DomainServiceName)
+		}
+		if actual.TrustName != v.Expected.TrustName {
+			t.Fatalf("Expected %q but got %q for TrustName", v.Expected.TrustName, actual.TrustName)
+		}
+	}
+}

--- a/internal/services/domainservices/registration.go
+++ b/internal/services/domainservices/registration.go
@@ -39,3 +39,13 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_active_directory_domain_service_replica_set": resourceActiveDirectoryDomainServiceReplicaSet(),
 	}
 }
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		DomainServiceTrustResource{},
+	}
+}

--- a/internal/services/domainservices/resourceids.go
+++ b/internal/services/domainservices/resourceids.go
@@ -2,3 +2,5 @@ package domainservices
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DomainService -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/initialReplicaSetId/replicaSetID
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DomainServiceReplicaSet -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/replicaSets/replicaSetID
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DomainServiceTrust -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/trust1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=DomainServiceResource -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1

--- a/internal/services/domainservices/validate/domain_service_resource_id.go
+++ b/internal/services/domainservices/validate/domain_service_resource_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/parse"
+)
+
+func DomainServiceResourceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.DomainServiceResourceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/domainservices/validate/domain_service_resource_id_test.go
+++ b/internal/services/domainservices/validate/domain_service_resource_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestDomainServiceResourceID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/",
+			Valid: false,
+		},
+
+		{
+			// missing value for DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.AAD/DOMAINSERVICES/DOMAINSERVICE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := DomainServiceResourceID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/domainservices/validate/domain_service_trust_id.go
+++ b/internal/services/domainservices/validate/domain_service_trust_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/parse"
+)
+
+func DomainServiceTrustID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.DomainServiceTrustID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/domainservices/validate/domain_service_trust_id_test.go
+++ b/internal/services/domainservices/validate/domain_service_trust_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestDomainServiceTrustID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/",
+			Valid: false,
+		},
+
+		{
+			// missing value for DomainServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/",
+			Valid: false,
+		},
+
+		{
+			// missing TrustName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TrustName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/trust1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.AAD/DOMAINSERVICES/DOMAINSERVICE1/TRUSTS/TRUST1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := DomainServiceTrustID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/active_directory_domain_service_trust.html.markdown
+++ b/website/docs/r/active_directory_domain_service_trust.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Active Directory Domain Services"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_active_directory_domain_service_trust"
+description: |-
+  Manages a Active Directory Domain Service Trust.
+---
+
+# azurerm_active_directory_domain_service_trust
+
+Manages a Active Directory Domain Service Trust.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_active_directory_domain_service" "example" {
+  name                = "example-ds"
+  resource_group_name = "example-rg"
+}
+
+resource "azurerm_active_directory_domain_service_trust" "example" {
+  name                       = "example-trust"
+  domain_service_resource_id = data.azurerm_active_directory_domain_service.example.resource_id
+  trusted_domain_fqdn        = "example.com"
+  trusted_domain_dns_ips     = ["10.1.0.3", "10.1.0.4"]
+  password                   = "Password123"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `domain_service_resource_id` - (Required) The `resource_id` of the Active Directory Domain Service. Changing this forces a new Active Directory Domain Service Trust to be created.
+
+* `name` - (Required) The name which should be used for this Active Directory Domain Service Trust. Changing this forces a new Active Directory Domain Service Trust to be created.
+
+* `password` - (Required) The password of the inbound trust set in the on-premise Active Directory Domain Service.
+
+* `trusted_domain_dns_ips` - (Required) Specifies a list of DNS IPs that are used to resolve the on-premise Active Directory Domain Service.
+
+* `trusted_domain_fqdn` - (Required) The FQDN of the on-premise Active Directory Domain Service.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Active Directory Domain Service Trust.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Active Directory Domain Service Trust.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Active Directory Domain Service Trust.
+* `update` - (Defaults to 30 minutes) Used when updating the Active Directory Domain Service Trust.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Active Directory Domain Service Trust.
+
+## Import
+
+Active Directory Domain Service Trusts can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_active_directory_domain_service_trust.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AAD/domainServices/DomainService1/trusts/trust1
+```


### PR DESCRIPTION
This PR adds a new resource `azurerm_active_directory_domain_service_trust`, which is actually a property of the Azure resource: Azure Active Directory Domain Service. This modeling is inspired by the [corresponding powershell cmdlet](https://docs.microsoft.com/en-us/azure/active-directory-domain-services/create-resource-forest-powershell#create-the-managed-domain-side-of-the-trust-relationship).

This resource represents a trust relationship between an AADDS and a on-premise ADDS. To setup the E2E testing, there are following steps needed:

- Setup a on-premise ADDS (manually)
- Setup an AADDS (can via Terraform)
- Setup the network for the on-premise ADDS and the AADDS (can via Terraform)
- Configure DNS in the on-premise ADDS (manually)
- Create an inbound trust in the on-premise ADDS (manually)

(See: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-create-forest-trust)

Therefore, in the acctest, I'm passing in all the needed information which are setup previously via env vars. Also the tests are run in sequential, as at most there is only one AADDS in each tenant.

## Test Result

```shell
❯ TF_ACC=1 go test -timeout=60m -v -run='TestAccDomainServiceTrust_' ./internal/services/domainservices
=== RUN   TestAccDomainServiceTrust_basic
--- PASS: TestAccDomainServiceTrust_basic (187.35s)
=== RUN   TestAccDomainServiceTrust_requiresImport
--- PASS: TestAccDomainServiceTrust_requiresImport (193.09s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices        380.445s
```