### PR TITLE
[Docs fix]Correct docs for resource azurerm_windows_web_app

### DIFF
--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -417,7 +417,7 @@ A `scm_ip_restriction` block supports the following:
 
 A `site_config` block supports the following:
 
-* `always_on` - (Optional) If this Windows Web App is Always On enabled. Defaults to `false`.
+* `always_on` - (Optional) If this Windows Web App is Always On enabled. Defaults to `true`.
 
 * `api_management_api_id` - (Optional) The API Management API ID this Windows Web App Slot is associated with.
 


### PR DESCRIPTION
The issue that has been reported https://github.com/hashicorp/terraform-provider-azurerm/issues/16830 for azurerm_linux_web_app also exists on `windows_web_app`. If one tries to create an `azurerm_windows_web_app` without always_on disabled then they face the below error:

`web.AppsClient#CreateOrUpdate: Failure sending request: StatusCode=0 — Original Error: autorest/azure: Service returned an error. Status`

The default value of the property `always_on` under `site_config` should be `true`, not `false`

https://github.com/hashicorp/terraform-provider-azurerm/pull/16879

This pull request aims to fix also the documentation regarding `azurerm_windows_web_app` 