### PR TITLE
`azurerm_eventhub_authorization_rule` - extend regex char limit for `name` and doc fixes

### DIFF
--- a/internal/services/eventhub/validate/eventhub_names.go
+++ b/internal/services/eventhub/validate/eventhub_names.go
@@ -31,7 +31,7 @@ func ValidateEventHubConsumerName() pluginsdk.SchemaValidateFunc {
 
 func ValidateEventHubAuthorizationRuleName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,62}[a-zA-Z0-9])?$"),
+		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,58}[a-zA-Z0-9])?$"),
 		"The authorization rule name can contain only letters, numbers, periods, hyphens and underscores. The name must start and end with a letter or number and be up to 60 characters long.",
 	)
 }

--- a/internal/services/eventhub/validate/eventhub_names.go
+++ b/internal/services/eventhub/validate/eventhub_names.go
@@ -31,7 +31,7 @@ func ValidateEventHubConsumerName() pluginsdk.SchemaValidateFunc {
 
 func ValidateEventHubAuthorizationRuleName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,48}[a-zA-Z0-9])?$"),
-		"The authorization rule name can contain only letters, numbers, periods, hyphens and underscores. The name must start and end with a letter or number and be up to 50 characters long.",
+		regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,62}[a-zA-Z0-9])?$"),
+		"The authorization rule name can contain only letters, numbers, periods, hyphens and underscores. The name must start and end with a letter or number and be up to 60 characters long.",
 	)
 }

--- a/website/docs/r/policy_subscription_policy_exemption.html.markdown
+++ b/website/docs/r/policy_subscription_policy_exemption.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_subscription_policy_assignment" "example" {
 
 resource "azurerm_subscription_policy_exemption" "example" {
   name                 = "exampleExemption"
-  resource_group_id    = data.azurerm_subscription.example.id
+  subscription_id      = data.azurerm_subscription.example.id
   policy_assignment_id = azurerm_subscription_policy_assignment.example.id
   exemption_category   = "Mitigated"
 }

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `storage_account_name` - (Required) Specifies the storage account in which to create the share.
  Changing this forces a new resource to be created.
 
-* `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`.
+* `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`, `Premium`.
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
@@ -65,8 +65,6 @@ The following arguments are supported:
 * `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1`GB (or higher) and at most `5120` GB (`5` TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and at most `102400` GB (`100` TB).
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
-
-* `access_tier` - (Optional) The tier of the File Share. Can be one of `Hot`, `Cool`, `TransactionOptimized`, `Premium`.
 
 ---
 


### PR DESCRIPTION
Closes #17035
Closes #17054
Closes #17041