### PR TITLE
`document`: Update `kubernetes_cluster` attributes doc

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -698,7 +698,7 @@ A `upgrade_settings` block supports the following:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Kubernetes Managed Cluster ID.
 


### PR DESCRIPTION
Fix #17023
Compared to `Attributes Reference` in some other documents like [linux_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#attributes-reference), seems like we are missing the below statement, which causes some confusion in the above issue.