### PR TITLE
Fix `TestAccHPCCache_directoryLDAP`

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -760,7 +760,7 @@ ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f /tmp/rpw.ldif
 # Setup self signed certificate
 cp /etc/ssl/certs/ca-certificates.crt /etc/ldap/sasl2
 cd /etc/ldap/sasl2
-openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=CN/ST=SH/L=SH/O=NA/CN=www.example.com" -keyout server.key -out server.crt
+openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=CN/ST=SH/L=SH/O=NA/CN=${azurerm_network_interface.test.private_ip_address}" -keyout server.key -out server.crt
 chown openldap. /etc/ldap/sasl2/*
 
 cat << EOF > /tmp/cert.ldif


### PR DESCRIPTION
HPC Cache test `TestAccHPCCache_directoryLDAP` fails mostly on `ldapComplete` step. Seems like the subject name of the certificate is not correct. Since we are using private ip to access the server, the subject name should be the private ip instead of a host name. There is also some success run, not sure if it's due to service bug, but by toggling the certificate on the server, I'm able to repro the issue in my local environment. And using the correct subject name eliminates the unstable failure.