### PR TITLE
Add missing possible subscription endpoint types

### DIFF
--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `webhook_endpoint` - (Optional) A `webhook_endpoint` block as defined below.
 
-~> **NOTE:** One of `eventhub_endpoint_id`, `hybrid_connection_endpoint_id`, `service_bus_queue_endpoint_id`, `service_bus_topic_endpoint_id`, `storage_queue_endpoint` or `webhook_endpoint` must be specified.
+~> **NOTE:** One of `eventhub_endpoint_id`, `hybrid_connection_endpoint_id`, `service_bus_queue_endpoint_id`, `service_bus_topic_endpoint_id`, `storage_queue_endpoint`, `webhook_endpoint` or `azure_function_endpoint` must be specified.
 
 * `included_event_types` - (Optional) A list of applicable event types that need to be part of the event subscription.
 


### PR DESCRIPTION
There are 7 possible event subscription endpoint types. The documentation only listed 6.

https://github.com/hashicorp/terraform-provider-azurerm/blob/0ad1931b54d7bd9bcf9d434ef3187029a6e7381e/internal/services/eventgrid/eventgrid_event_subscription_resource.go#L18-L28