### PR TITLE
`azurerm_log_analytics_workspace` - Allow field value updates while workspace is linked to a cluster

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster.go
+++ b/internal/services/loganalytics/log_analytics_cluster.go
@@ -38,7 +38,7 @@ func logAnalyticsClusterRefresh(ctx context.Context, meta interface{}, resourceG
 
 		if resp.ClusterProperties != nil {
 			if resp.ClusterProperties.ProvisioningState != operationalinsights.Updating && resp.ClusterProperties.ProvisioningState != operationalinsights.Succeeded {
-				return nil, "nil", fmt.Errorf("Log Analytics Cluster %q (Resource Group %q) unexpected Provisioning State encountered: %q", clusterName, resourceGroup, string(resp.ClusterProperties.ProvisioningState))
+				return nil, "nil", fmt.Errorf("log analytics Cluster %q (Resource Group %q) unexpected Provisioning State encountered: %q", clusterName, resourceGroup, string(resp.ClusterProperties.ProvisioningState))
 			}
 
 			return resp, string(resp.ClusterProperties.ProvisioningState), nil

--- a/internal/services/loganalytics/log_analytics_datasource_import.go
+++ b/internal/services/loganalytics/log_analytics_datasource_import.go
@@ -24,7 +24,7 @@ func importLogAnalyticsDataSource(kind operationalinsights.DataSourceKind) plugi
 		}
 
 		if resp.Kind != kind {
-			return nil, fmt.Errorf(`Log Analytics Data Source "kind" mismatch, expected "%s", got "%s"`, kind, resp.Kind)
+			return nil, fmt.Errorf(`log analytics Data Source "kind" mismatch, expected "%s", got "%s"`, kind, resp.Kind)
 		}
 		return []*pluginsdk.ResourceData{d}, nil
 	}

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -79,17 +79,17 @@ func resourceLogAnalyticsLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, me
 
 	workspace, err := parse.LogAnalyticsWorkspaceID(workspaceId)
 	if err != nil {
-		return fmt.Errorf("Linked Service (Resource Group %q) unable to parse workspace id: %+v", resourceGroup, err)
+		return fmt.Errorf("linked service (Resource Group %q) unable to parse workspace id: %+v", resourceGroup, err)
 	}
 
 	id := parse.NewLogAnalyticsLinkedServiceID(subscriptionId, resourceGroup, workspace.WorkspaceName, LogAnalyticsLinkedServiceType(readAccess))
 
 	if strings.EqualFold(id.LinkedServiceName, "Cluster") && writeAccess == "" {
-		return fmt.Errorf("Linked Service '%s/%s' (Resource Group %q): A linked Log Analytics Cluster requires the 'write_access_id' attribute to be set", workspace.WorkspaceName, id.LinkedServiceName, resourceGroup)
+		return fmt.Errorf("linked service '%s/%s' (Resource Group %q): A linked Log Analytics Cluster requires the 'write_access_id' attribute to be set", workspace.WorkspaceName, id.LinkedServiceName, resourceGroup)
 	}
 
 	if strings.EqualFold(id.LinkedServiceName, "Automation") && readAccess == "" {
-		return fmt.Errorf("Linked Service '%s/%s' (Resource Group %q): A linked Automation Account requires the 'read_access_id' attribute to be set", workspace.WorkspaceName, id.LinkedServiceName, resourceGroup)
+		return fmt.Errorf("linked service '%s/%s' (Resource Group %q): A linked Automation Account requires the 'read_access_id' attribute to be set", workspace.WorkspaceName, id.LinkedServiceName, resourceGroup)
 	}
 
 	if d.IsNewResource() {

--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -186,7 +186,7 @@ func resourceLogAnalyticsSolutionRead(d *pluginsdk.ResourceData, meta interface{
 		val := *v
 		segments := strings.Split(*v, "(")
 		if len(segments) != 2 {
-			return fmt.Errorf("Expected %q to match 'Solution(WorkspaceName)'", val)
+			return fmt.Errorf("expected %q to match 'Solution(WorkspaceName)'", val)
 		}
 
 		solutionName := segments[0]

--- a/internal/services/loganalytics/log_analytics_workspace_data_source.go
+++ b/internal/services/loganalytics/log_analytics_workspace_data_source.go
@@ -83,7 +83,7 @@ func dataSourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interfa
 	resp, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: Log Analytics workspaces %q (Resource Group %q) was not found", name, resGroup)
+			return fmt.Errorf("log analytics workspaces %q (Resource Group %q) was not found", name, resGroup)
 		}
 		return fmt.Errorf("making Read request on AzureRM Log Analytics workspaces '%s': %+v", name, err)
 	}

--- a/internal/services/loganalytics/log_analytics_workspace_data_source_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_data_source_test.go
@@ -10,6 +10,7 @@ import (
 
 type LogAnalyticsWorkspaceDataSource struct{}
 
+// NOTE: The RP lowercases the sku return value which is why the tests fail
 func TestAccDataSourceLogAnalyticsWorkspace_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_log_analytics_workspace", "test")
 	r := LogAnalyticsWorkspaceDataSource{}
@@ -18,7 +19,7 @@ func TestAccDataSourceLogAnalyticsWorkspace_basic(t *testing.T) {
 		{
 			Config: r.basicWithDataSource(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue("PerGB2018"),
+				check.That(data.ResourceName).Key("sku").HasValue("pergb2018"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("30"),
 				check.That(data.ResourceName).Key("daily_quota_gb").HasValue("-1"),
 			),
@@ -34,7 +35,7 @@ func TestAccDataSourceLogAnalyticsWorkspace_volumeCapWithDataSource(t *testing.T
 		{
 			Config: r.volumeCapWithDataSource(data, 4.5),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue("PerGB2018"),
+				check.That(data.ResourceName).Key("sku").HasValue("pergb2018"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("30"),
 				check.That(data.ResourceName).Key("daily_quota_gb").HasValue("4.5"),
 			),

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -1,6 +1,7 @@
 package loganalytics
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -27,6 +28,8 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 		Read:   resourceLogAnalyticsWorkspaceRead,
 		Update: resourceLogAnalyticsWorkspaceCreateUpdate,
 		Delete: resourceLogAnalyticsWorkspaceDelete,
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(resourceLogAnalyticsWorkspaceCustomDiff),
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.LogAnalyticsWorkspaceID(id)
@@ -73,8 +76,7 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
-				Default:  string(operationalinsights.WorkspaceSkuNameEnumPerGB2018),
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(operationalinsights.WorkspaceSkuNameEnumFree),
 					string(operationalinsights.WorkspaceSkuNameEnumPerGB2018),
@@ -131,6 +133,26 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 	}
 }
 
+func resourceLogAnalyticsWorkspaceCustomDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+	// Since sku needs to be a force new if the sku changes we need to have this
+	// custom diff here because when you link the workspace to a cluster the
+	// cluster changes the sku to LACluster, so we need to ignore the change
+	// if it is LACluster else invoke the ForceNew as before...
+	//
+	// NOTE: Since LACluster is not in our enum the value is returned as ""
+	if d.HasChange("sku") {
+		old, new := d.GetChange("sku")
+		log.Printf("[INFO] Log Analytics Workspace SKU: OLD: %q, NEW: %q", old, new)
+		// If the old value is not LACluster(e.g. "") return ForceNew because they are
+		// really changing the sku...
+		if !strings.EqualFold(old.(string), "") {
+			d.ForceNew("sku")
+		}
+	}
+
+	return nil
+}
+
 func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).LogAnalytics.WorkspacesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
@@ -138,6 +160,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	defer cancel()
 	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace creation.")
 
+	var isLACluster bool
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
@@ -162,14 +185,15 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	// (@WodansSon) - If the workspace is connected to a cluster via the linked service resource
-	// the workspace cannot be modified since the linked service changes the sku value within
-	// the workspace
+	// the workspace SKU cannot be modified since the linked service owns the sku value within
+	// the workspace once it is linked
 	if !d.IsNewResource() {
 		resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 		if err == nil {
 			if azSku := resp.Sku; azSku != nil {
 				if strings.EqualFold(string(azSku.Name), "lacluster") {
-					return fmt.Errorf("Log Analytics Workspace %q (Resource Group %q): cannot be modified while it is connected to a Log Analytics cluster", name, resourceGroup)
+					isLACluster = true
+					log.Printf("[INFO] Log Analytics Workspace %q (Resource Group %q): SKU is linked to Log Analytics cluster", name, resourceGroup)
 				}
 			}
 		}
@@ -187,6 +211,13 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	retentionInDays := int32(d.Get("retention_in_days").(int))
 
 	t := d.Get("tags").(map[string]interface{})
+
+	if isLACluster {
+		sku.Name = "lacluster"
+	} else if skuName == "" {
+		// Default value if sku is not defined
+		sku.Name = operationalinsights.WorkspaceSkuNameEnumPerGB2018
+	}
 
 	parameters := operationalinsights.Workspace{
 		Name:     &name,

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -73,6 +73,7 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			// TODO 4.0: Clean up lacluster "workaround" to make it more readable and easier to understand. (@WodansSon already has the code written for the clean up)
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type LogAnalyticsWorkspaceResource struct{}
+type LogAnalyticsWorkspaceResource struct {
+	DoNotRunFreeTierTest bool
+}
 
 func TestAccLogAnalyticsWorkspace_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
@@ -65,7 +67,8 @@ func TestAccLogAnalyticsWorkspace_complete(t *testing.T) {
 
 func TestAccLogAnalyticsWorkspace_freeTier(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
-	r := LogAnalyticsWorkspaceResource{}
+	r := LogAnalyticsWorkspaceResource{DoNotRunFreeTierTest: true}
+	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -82,6 +85,12 @@ func TestAccLogAnalyticsWorkspace_freeTier(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
+}
+
+func (r LogAnalyticsWorkspaceResource) preCheck(t *testing.T) {
+	if r.DoNotRunFreeTierTest {
+		t.Skipf("`TestAccLogAnalyticsWorkspace_freeTier` due to subscripton pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)")
+	}
 }
 
 func (LogAnalyticsWorkspaceResource) freeTierWithTags(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -89,7 +89,7 @@ func TestAccLogAnalyticsWorkspace_freeTier(t *testing.T) {
 
 func (r LogAnalyticsWorkspaceResource) preCheck(t *testing.T) {
 	if r.DoNotRunFreeTierTest {
-		t.Skipf("`TestAccLogAnalyticsWorkspace_freeTier` due to subscripton pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)")
+		t.Skipf("`TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)")
 	}
 }
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-~> **NOTE:** If a `azurerm_log_analytics_workspace` is connected to a `azurerm_log_analytics_cluster` via a `azurerm_log_analytics_linked_service` it will not be able to be modified until link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource.
+~> **NOTE:** If a `azurerm_log_analytics_workspace` is connected to a `azurerm_log_analytics_cluster` via a `azurerm_log_analytics_linked_service` you will not be able to modify the workspaces `sku` field until the link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource. All other fields are modifiable while the workspace is linked to a cluster. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
The block on SKU change behavior was implemented incorrectly, this fixes the old implementation for the correct behavior. This is currently blocking customers.