### PR TITLE
Add role assignment to azurerm_disk_encryption_set

### DIFF
--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -88,6 +88,12 @@ resource "azurerm_key_vault_access_policy" "example-user" {
   ]
 }
 
+resource "azurerm_role_assignment" "example-disk" {
+  scope                = azurerm_key_vault.example.id
+  role_definition_name = "Key Vault Crypto Service Encryption User"
+  principal_id         = azurerm_disk_encryption_set.example.identity.0.principal_id
+}
+
 ```
 
 ## Argument Reference
@@ -103,6 +109,9 @@ The following arguments are supported:
 * `key_vault_key_id` - (Required) Specifies the URL to a Key Vault Key (either from a Key Vault Key, or the Key URL for the Key Vault Secret).
 
 -> **NOTE** Access to the KeyVault must be granted for this Disk Encryption Set, if you want to further use this Disk Encryption Set in a Managed Disk or Virtual Machine, or Virtual Machine Scale Set. For instructions, please refer to the doc of [Server side encryption of Azure managed disks](https://docs.microsoft.com/azure/virtual-machines/linux/disk-encryption).
+
+-> **NOTE** A KeyVault using [enable_rbac_authorization](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#enable_rbac_authorization) requires to use `azurerm_role_assignment` to assigne the role `Key Vault Crypto Service Encryption User` to this Disk Encryption Set.
+In this case, `azurerm_key_vault_access_policy` is not needed.
 
 * `auto_key_rotation_enabled` - (Optional) Boolean flag to specify whether Azure Disk Encryption Set automatically rotates encryption Key to latest version. Defaults to `false`.
 


### PR DESCRIPTION
When a KeyVault uses RBAC (IAM managed) authorization, assigning the role `Key Vault Crypto Service Encryption User` to the Disk Encryption Set is necessary.
Previously, the `Reader` role was required but it seems to have been changed.