### PR TITLE
`r\digital_twins_instance`: support `identity`

### DIFF
--- a/internal/services/digitaltwins/digital_twins_instance_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_instance_resource_test.go
@@ -104,7 +104,7 @@ func TestAccDigitalTwinsInstance_identity(t *testing.T) {
 	r := DigitalTwinsInstanceResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.identity(data),
+			Config: r.basicWithIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
@@ -113,7 +113,7 @@ func TestAccDigitalTwinsInstance_identity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.identityNone(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("identity.0.principal_id").DoesNotExist(),
@@ -122,7 +122,7 @@ func TestAccDigitalTwinsInstance_identity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.identity(data),
+			Config: r.basicWithIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
@@ -216,7 +216,7 @@ resource "azurerm_digital_twins_instance" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r DigitalTwinsInstanceResource) identity(data acceptance.TestData) string {
+func (r DigitalTwinsInstanceResource) basicWithIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -227,18 +227,6 @@ resource "azurerm_digital_twins_instance" "test" {
   identity {
     type = "SystemAssigned"
   }
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r DigitalTwinsInstanceResource) identityNone(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_digital_twins_instance" "test" {
-  name                = "acctest-DT-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/digital_twins_instance.html.markdown
+++ b/website/docs/r/digital_twins_instance.html.markdown
@@ -42,8 +42,16 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the Resource Group where the Digital Twins instance should exist. Changing this forces a new Digital Twins instance to be created.
 
 * `location` - (Required) The Azure Region where the Digital Twins instance should exist. Changing this forces a new Digital Twins instance to be created.
+* 
+* `identity` - (Optional) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Digital Twins instance.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Service Identity that is configured on this Digital Twins instance. The only possible value is `SystemAssigned`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix #15970