### PR TITLE
azurerm_bot_service_azure_bot: support new property MsaAppType

### DIFF
--- a/internal/services/bot/bot_channel_test.go
+++ b/internal/services/bot/bot_channel_test.go
@@ -18,6 +18,7 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 		"bot": {
 			"basic":          testAccBotServiceAzureBot_basic,
 			"completeUpdate": testAccBotServiceAzureBot_completeUpdate,
+			"msaAppType":     testAccBotServiceAzureBot_msaAppType,
 			"requiresImport": testAccBotServiceAzureBot_requiresImport,
 		},
 		"connection": {

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -73,6 +73,21 @@ func testAccBotServiceAzureBot_requiresImport(t *testing.T) {
 	})
 }
 
+func testAccBotServiceAzureBot_msaAppType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_service_azure_bot", "test")
+	r := BotServiceAzureBotResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.msaAppType(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t BotServiceAzureBotResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.BotServiceID(state.ID)
 	if err != nil {
@@ -173,4 +188,38 @@ resource "azurerm_bot_service_azure_bot" "import" {
   microsoft_app_id    = azurerm_bot_service_azure_bot.test.microsoft_app_id
 }
 `, template)
+}
+
+func (BotServiceAzureBotResource) msaAppType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_bot_service_azure_bot" "test" {
+  name                = "acctestdf%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = "global"
+  sku                 = "F0"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
+
+  microsoft_app_type               = "UserAssignedMSI"
+  microsoft_app_tenant_id          = data.azurerm_client_config.current.tenant_id
+  microsoft_app_msi_id             = azurerm_user_assigned_identity.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -217,9 +217,9 @@ resource "azurerm_bot_service_azure_bot" "test" {
   sku                 = "F0"
   microsoft_app_id    = data.azurerm_client_config.current.client_id
 
-  microsoft_app_type               = "UserAssignedMSI"
-  microsoft_app_tenant_id          = data.azurerm_client_config.current.tenant_id
-  microsoft_app_msi_id             = azurerm_user_assigned_identity.test.id
+  microsoft_app_type      = "UserAssignedMSI"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
+  microsoft_app_msi_id    = azurerm_user_assigned_identity.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/bot/bot_service_base_resource.go
+++ b/internal/services/bot/bot_service_base_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -76,6 +77,31 @@ func (br botBaseResource) arguments(fields map[string]*pluginsdk.Schema) map[str
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.IsUUID,
+		},
+
+		"microsoft_app_msi_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.UserAssignedIdentityID,
+		},
+
+		"microsoft_app_tenant_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+
+		"microsoft_app_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(botservice.MsaAppTypeMultiTenant),
+				string(botservice.MsaAppTypeSingleTenant),
+				string(botservice.MsaAppTypeUserAssignedMSI),
+			}, false),
 		},
 
 		"luis_app_ids": {
@@ -149,6 +175,18 @@ func (br botBaseResource) createFunc(resourceName, botKind string) sdk.ResourceF
 					LuisKey:                           utils.String(metadata.ResourceData.Get("luis_key").(string)),
 				},
 				Tags: tags.Expand(metadata.ResourceData.Get("tags").(map[string]interface{})),
+			}
+
+			if v, ok := metadata.ResourceData.GetOk("microsoft_app_type"); ok {
+				props.Properties.MsaAppType = botservice.MsaAppType(v.(string))
+			}
+
+			if v, ok := metadata.ResourceData.GetOk("microsoft_app_tenant_id"); ok {
+				props.Properties.MsaAppTenantID = utils.String(v.(string))
+			}
+
+			if v, ok := metadata.ResourceData.GetOk("microsoft_app_msi_id"); ok {
+				props.Properties.MsaAppMSIResourceID = utils.String(v.(string))
 			}
 
 			if _, err := client.Create(ctx, id.ResourceGroup, id.Name, props); err != nil {
@@ -228,6 +266,24 @@ func (br botBaseResource) readFunc() sdk.ResourceFunc {
 					appInsightsId = *v
 				}
 				metadata.ResourceData.Set("developer_app_insights_application_id", appInsightsId)
+
+				msaAppType := ""
+				if v := props.MsaAppType; v != "" {
+					msaAppType = string(v)
+				}
+				metadata.ResourceData.Set("microsoft_app_type", msaAppType)
+
+				msaAppTenantId := ""
+				if v := props.MsaAppTenantID; v != nil {
+					msaAppTenantId = *v
+				}
+				metadata.ResourceData.Set("microsoft_app_tenant_id", msaAppTenantId)
+
+				msaAppMSIId := ""
+				if v := props.MsaAppMSIResourceID; v != nil {
+					msaAppMSIId = *v
+				}
+				metadata.ResourceData.Set("microsoft_app_msi_id", msaAppMSIId)
 
 				var luisAppIds []string
 				if v := props.LuisAppIds; v != nil {

--- a/website/docs/r/bot_service_azure_bot.html.markdown
+++ b/website/docs/r/bot_service_azure_bot.html.markdown
@@ -72,6 +72,12 @@ The following arguments are supported:
 
 * `endpoint` - (Optional) The Azure Bot Service endpoint.
 
+* `microsoft_app_msi_id` - (Optional) The ID of the Microsoft App Managed Identity for this Azure Bot Service. Changing this forces a new resource to be created.
+
+* `microsoft_app_tenant_id` - (Optional) The Tenant ID of the Microsoft App for this Azure Bot Service. Changing this forces a new resource to be created.
+
+* `microsoft_app_type` - (Optional) The Microsoft App Type for this Azure Bot Service. Possible values are `MultiTenant`, `SingleTenant` and `UserAssignedMSI`. Changing this forces a new resource to be created.
+
 * `luis_app_ids` - (Optional) A list of LUIS App IDs to associate with this Azure Bot Service.
 
 * `luis_key` - (Optional) The LUIS key to associate with this Azure Bot Service.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/14679

This PR is to support new properties `microsoft_app_type`, `microsoft_app_tenant_id` and `microsoft_app_msi_id`.

--- PASS: TestAccBotChannelsRegistration/bot/msaAppType (264.48s)
--- PASS: TestAccBotChannelsRegistration/bot/requiresImport (265.83s)
--- PASS: TestAccBotChannelsRegistration/bot/basic (225.47s)
--- PASS: TestAccBotChannelsRegistration/bot/completeUpdate (399.06s)
