### PR TITLE
Added a note for `vault_key_reference`

### DIFF
--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -106,7 +106,7 @@ resource "azurerm_app_configuration_key" "test" {
   key                    = "key1"
   type                   = "vault"
   label                  = "label1"
-  vault_key_reference    = azurerm_key_vault_secret.kvs.id
+  vault_key_reference    = azurerm_key_vault_secret.kvs.versionless_id
 
   depends_on = [
     azurerm_role_assignment.appconf_dataowner
@@ -133,6 +133,8 @@ The following arguments are supported:
 * `type` - (Optional) The type of the App Configuration Key. It can either be `kv` (simple [key/value](https://docs.microsoft.com/azure/azure-app-configuration/concept-key-value)) or `vault` (where the value is a reference to a [Key Vault Secret](https://azure.microsoft.com/en-gb/services/key-vault/). 
 
 * `vault_key_reference` - (Optional) The ID of the vault secret this App Configuration Key refers to, when `type` is set to `vault`.
+
+~> **NOTE:** When setting the `vault_key_reference` using the `id` will pin the value to specific version of the secret, to reference latest secret value use `versionless_id`
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
When setting `vault_key_reference` think the default behaviour would be to use the latest secret value rather than a pinned version, I have updated the sample and added a note to explain why