### PR TITLE
Doc Fix : azurerm_subnet - Add note to address_prefixes that "AllowMultipleAddressPrefixesOnSubnet" is currently not supported

### DIFF
--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `address_prefixes` - (Required) The address prefixes to use for the subnet.
 
--> **NOTE:** The feature of `AllowMultipleAddressPrefixesOnSubnet` is not available for public as of now, so `address_prefixes` only supports setting one address prefix. 
+-> **NOTE:** Currently only a single address prefix can be set as the [Multiple Subnet Address Prefixes Feature](https://github.com/Azure/azure-cli/issues/18194#issuecomment-880484269) is not yet in public preview or general availability.
 
 ---
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `address_prefixes` - (Required) The address prefixes to use for the subnet.
 
+-> **NOTE:** The feature of `AllowMultipleAddressPrefixesOnSubnet` is not available for public as of now, so `address_prefixes` only supports setting one address prefix. 
+
 ---
 
 * `delegation` - (Optional) One or more `delegation` blocks as defined below.


### PR DESCRIPTION
Although I didn't find any documentation stating that `address_prefixes` doesn't support multiple prefixes. However, someone ever mentioned "The feature AllowMultipleAddressPrefixesOnSubnet is not available for public as of now", [here ](https://github.com/Azure/azure-cli/issues/18194#issuecomment-880484269) is the link. So I assume we should add a comment explaining it to fix issue [#17052](https://github.com/hashicorp/terraform-provider-azurerm/issues/17052), WDYT?