### PR TITLE
`azurerm_storage_account` support for setting defaultToOAuthAuthentication

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -289,6 +289,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			"default_to_oauth_authentication": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"network_rules": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -968,6 +974,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	nfsV3Enabled := d.Get("nfsv3_enabled").(bool)
 	allowBlobPublicAccess := d.Get("allow_nested_items_to_be_public").(bool)
 	allowSharedKeyAccess := d.Get("shared_access_key_enabled").(bool)
+	defaultToOAuthAuthentication := d.Get("default_to_oauth_authentication").(bool)
 	crossTenantReplication := d.Get("cross_tenant_replication_enabled").(bool)
 
 	accountTier := d.Get("account_tier").(string)
@@ -983,12 +990,13 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Tags: tags.Expand(t),
 		Kind: storage.Kind(accountKind),
 		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
-			EnableHTTPSTrafficOnly:      &enableHTTPSTrafficOnly,
-			NetworkRuleSet:              expandStorageAccountNetworkRules(d, tenantId),
-			IsHnsEnabled:                &isHnsEnabled,
-			EnableNfsV3:                 &nfsV3Enabled,
-			AllowSharedKeyAccess:        &allowSharedKeyAccess,
-			AllowCrossTenantReplication: &crossTenantReplication,
+			EnableHTTPSTrafficOnly:       &enableHTTPSTrafficOnly,
+			NetworkRuleSet:               expandStorageAccountNetworkRules(d, tenantId),
+			IsHnsEnabled:                 &isHnsEnabled,
+			EnableNfsV3:                  &nfsV3Enabled,
+			AllowSharedKeyAccess:         &allowSharedKeyAccess,
+			DefaultToOAuthAuthentication: &defaultToOAuthAuthentication,
+			AllowCrossTenantReplication:  &crossTenantReplication,
 		},
 	}
 
@@ -1315,6 +1323,11 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
 			AllowSharedKeyAccess: &allowSharedKeyAccess,
 		},
+	}
+
+	if d.HasChange("default_to_oauth_authentication") {
+		defaultToOAuthAuthentication := d.Get("default_to_oauth_authentication").(bool)
+		opts.AccountPropertiesUpdateParameters.DefaultToOAuthAuthentication = &defaultToOAuthAuthentication
 	}
 
 	if d.HasChange("cross_tenant_replication_enabled") {
@@ -1817,6 +1830,12 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 			allowSharedKeyAccess = *props.AllowSharedKeyAccess
 		}
 		d.Set("shared_access_key_enabled", allowSharedKeyAccess)
+
+		defaultToOAuthAuthentication := false
+		if props.DefaultToOAuthAuthentication != nil {
+			defaultToOAuthAuthentication = *props.DefaultToOAuthAuthentication
+		}
+		d.Set("default_to_oauth_authentication", defaultToOAuthAuthentication)
 
 		// Setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response.
 		// So defaults to setting the encryption key type to "Service" if it is absent in the GET response. Also, define the default value as "Service" in the schema.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -115,6 +115,8 @@ The following arguments are supported:
 
 ~> **Note:** Terraform uses Shared Key Authorisation to provision Storage Containers, Blobs and other items - when Shared Key Access is disabled, you will need to enable [the `storage_use_azuread` flag in the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to use Azure AD for authentication, however not all Azure Storage services support Active Directory authentication.
 
+* `default_to_oauth_authentication` - (Optional) Default to Azure Active Directory authorization in the Azure portal when accessing the Storage Account. The default value is `false`
+
 * `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be `true` when `account_tier` is `Standard` or when `account_tier` is `Premium` *and* `account_kind` is `BlockBlobStorage`


### PR DESCRIPTION
Adds a setting to the `azurerm_storage_account` resource which allows for configuring the Storage Account to default to Azure AD authorization in the portal. 

Closes #17083 
