### PR TITLE
`azurerm_kubernetes_cluster ` - fix test cases

### DIFF
--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-var addOnAppGatewaySubnetCIDR string = "10.241.0.0/16" // AKS will use 10.240.0.0/16 for the aks subnet so use 10.241.0.0/16 for the app gateway subnet
+var addOnAppGatewaySubnetCIDR string = "10.225.0.0/16" // AKS will use 10.224.0.0/12 for the aks subnet so use 10.225.0.0/16 for the app gateway subnet
 
 func TestAccKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
@@ -554,7 +554,11 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayAppGatewayConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {
@@ -635,6 +639,7 @@ resource "azurerm_application_gateway" "test" {
     http_listener_name         = "httplistener"
     backend_address_pool_name  = "backendaddresspool"
     backend_http_settings_name = "backendhttpsettings"
+    priority                   = 1
   }
 }
 
@@ -672,7 +677,11 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewaySubnetCIDRConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {
@@ -810,7 +819,11 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (KubernetesClusterResource) addonProfileOpenServiceMeshConfig(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -2523,6 +2523,14 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 func (KubernetesClusterResource) httpProxyConfigWithTrustedCa(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/internal/services/containers/kubernetes_cluster_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_upgrade_test.go
@@ -15,14 +15,14 @@ func TestAccKubernetesCluster_upgradeAutoScaleMinCount(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeAutoScaleMinCountConfig(data, olderKubernetesVersion, 3, 8),
+			Config: r.upgradeAutoScaleMinCountConfig(data, olderKubernetesVersion, 4, 8),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeAutoScaleMinCountConfig(data, olderKubernetesVersion, 4, 8),
+			Config: r.upgradeAutoScaleMinCountConfig(data, olderKubernetesVersion, 5, 8),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== PAUSE TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== CONT  TestAccKubernetesCluster_upgradeAutoScaleMinCount
--- PASS: TestAccKubernetesCluster_upgradeAutoScaleMinCount (813.29s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
=== PAUSE TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
=== CONT  TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId (1364.07s)
PASS

=== RUN   TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
=== PAUSE TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
=== CONT  TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
--- PASS: TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway (1485.28s)
PASS

=== RUN   TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewaySubnetCIDR
=== PAUSE TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewaySubnetCIDR
=== CONT  TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewaySubnetCIDR
--- PASS: TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewaySubnetCIDR (1280.13s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileOpenServiceMesh
=== PAUSE TestAccKubernetesCluster_addonProfileOpenServiceMesh
=== CONT  TestAccKubernetesCluster_addonProfileOpenServiceMesh
--- PASS: TestAccKubernetesCluster_addonProfileOpenServiceMesh (757.48s)
PASS


=== RUN   TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== PAUSE TestAccKubernetesCluster_upgradeAutoScaleMinCount
=== CONT  TestAccKubernetesCluster_upgradeAutoScaleMinCount
--- PASS: TestAccKubernetesCluster_upgradeAutoScaleMinCount (817.45s)
PASS



```