### PR TITLE
`azurerm_storage_account` - add supports for `change_feed_retention_in_days`

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -2213,10 +2213,11 @@ resource "azurerm_storage_account" "test" {
       days = 300
     }
 
-    default_service_version  = "2019-07-07"
-    versioning_enabled       = true
-    change_feed_enabled      = true
-    last_access_time_enabled = true
+    default_service_version       = "2019-07-07"
+    versioning_enabled            = true
+    change_feed_enabled           = true
+    change_feed_retention_in_days = 1
+    last_access_time_enabled      = true
     container_delete_retention_policy {
       days = 7
     }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -172,6 +172,8 @@ A `blob_properties` block supports the following:
 
 * `change_feed_enabled` - (Optional) Is the blob service properties for change feed events enabled? Default to `false`.
 
+* `change_feed_retention_in_days` - (Optional) The duration of change feed events retention in days. The possible values are between 1 and 146000 days (400 years). Setting this to null (or omit this in the configuration file) indicates an infinite retention of the change feed.
+
 * `default_service_version` - (Optional) The API Version which should be used by default for requests to the Data Plane API if an incoming request doesn't specify an API Version. Defaults to `2020-06-12`.
 
 * `last_access_time_enabled` - (Optional) Is the last access time based tracking enabled? Default to `false`.


### PR DESCRIPTION
Fix #17117

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_blobProperties$'
=== RUN   TestAccStorageAccount_blobProperties
=== PAUSE TestAccStorageAccount_blobProperties
=== CONT  TestAccStorageAccount_blobProperties
--- PASS: TestAccStorageAccount_blobProperties (485.50s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       485.513s
```