### PR TITLE
`data.azurerm_key_vault_access_policy` - Fix `azurerm_key_vault_access_policy` data source return values in lowercase issue

### DIFF
--- a/internal/services/keyvault/key_vault_access_policy_data_source.go
+++ b/internal/services/keyvault/key_vault_access_policy_data_source.go
@@ -64,7 +64,6 @@ func dataSourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}) error {
 	name := d.Get("name").(string)
 	templateManagementPermissions := map[string][]string{}
-
 	if features.FourPointOh() {
 		templateManagementPermissions["key"] = []string{
 			azure.TitleCase(string(keyvault.KeyPermissionsGet)),

--- a/internal/services/keyvault/key_vault_access_policy_data_source.go
+++ b/internal/services/keyvault/key_vault_access_policy_data_source.go
@@ -77,7 +77,6 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			azure.TitleCase(string(keyvault.KeyPermissionsBackup)),
 			azure.TitleCase(string(keyvault.KeyPermissionsRestore)),
 		}
-
 		templateManagementPermissions["secret"] = []string{
 			azure.TitleCase(string(keyvault.SecretPermissionsGet)),
 			azure.TitleCase(string(keyvault.SecretPermissionsList)),
@@ -87,7 +86,6 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			azure.TitleCase(string(keyvault.SecretPermissionsBackup)),
 			azure.TitleCase(string(keyvault.SecretPermissionsRestore)),
 		}
-
 		templateManagementPermissions["certificate"] = []string{
 			azure.TitleCase(string(keyvault.CertificatePermissionsGet)),
 			azure.TitleCase(string(keyvault.CertificatePermissionsList)),
@@ -114,7 +112,6 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			string(keyvault.KeyPermissionsBackup),
 			string(keyvault.KeyPermissionsRestore),
 		}
-
 		templateManagementPermissions["secret"] = []string{
 			string(keyvault.SecretPermissionsGet),
 			string(keyvault.SecretPermissionsList),
@@ -124,7 +121,6 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			string(keyvault.SecretPermissionsBackup),
 			string(keyvault.SecretPermissionsRestore),
 		}
-
 		templateManagementPermissions["certificate"] = []string{
 			string(keyvault.CertificatePermissionsGet),
 			string(keyvault.CertificatePermissionsList),

--- a/internal/services/keyvault/key_vault_access_policy_data_source.go
+++ b/internal/services/keyvault/key_vault_access_policy_data_source.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2021-10-01/keyvault"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -62,38 +63,38 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 	name := d.Get("name").(string)
 	templateManagementPermissions := map[string][]string{
 		"key": {
-			string(keyvault.KeyPermissionsGet),
-			string(keyvault.KeyPermissionsList),
-			string(keyvault.KeyPermissionsUpdate),
-			string(keyvault.KeyPermissionsCreate),
-			string(keyvault.KeyPermissionsImport),
-			string(keyvault.KeyPermissionsDelete),
-			string(keyvault.KeyPermissionsRecover),
-			string(keyvault.KeyPermissionsBackup),
-			string(keyvault.KeyPermissionsRestore),
+			azure.TitleCase(string(keyvault.KeyPermissionsGet)),
+			azure.TitleCase(string(keyvault.KeyPermissionsList)),
+			azure.TitleCase(string(keyvault.KeyPermissionsUpdate)),
+			azure.TitleCase(string(keyvault.KeyPermissionsCreate)),
+			azure.TitleCase(string(keyvault.KeyPermissionsImport)),
+			azure.TitleCase(string(keyvault.KeyPermissionsDelete)),
+			azure.TitleCase(string(keyvault.KeyPermissionsRecover)),
+			azure.TitleCase(string(keyvault.KeyPermissionsBackup)),
+			azure.TitleCase(string(keyvault.KeyPermissionsRestore)),
 		},
 		"secret": {
-			string(keyvault.SecretPermissionsGet),
-			string(keyvault.SecretPermissionsList),
-			string(keyvault.SecretPermissionsSet),
-			string(keyvault.SecretPermissionsDelete),
-			string(keyvault.SecretPermissionsRecover),
-			string(keyvault.SecretPermissionsBackup),
-			string(keyvault.SecretPermissionsRestore),
+			azure.TitleCase(string(keyvault.SecretPermissionsGet)),
+			azure.TitleCase(string(keyvault.SecretPermissionsList)),
+			azure.TitleCase(string(keyvault.SecretPermissionsSet)),
+			azure.TitleCase(string(keyvault.SecretPermissionsDelete)),
+			azure.TitleCase(string(keyvault.SecretPermissionsRecover)),
+			azure.TitleCase(string(keyvault.SecretPermissionsBackup)),
+			azure.TitleCase(string(keyvault.SecretPermissionsRestore)),
 		},
 		"certificate": {
-			string(keyvault.CertificatePermissionsGet),
-			string(keyvault.CertificatePermissionsList),
-			string(keyvault.CertificatePermissionsUpdate),
-			string(keyvault.CertificatePermissionsCreate),
-			string(keyvault.CertificatePermissionsImport),
-			string(keyvault.CertificatePermissionsDelete),
-			string(keyvault.CertificatePermissionsManagecontacts),
-			string(keyvault.CertificatePermissionsManageissuers),
-			string(keyvault.CertificatePermissionsGetissuers),
-			string(keyvault.CertificatePermissionsListissuers),
-			string(keyvault.CertificatePermissionsSetissuers),
-			string(keyvault.CertificatePermissionsDeleteissuers),
+			azure.TitleCase(string(keyvault.CertificatePermissionsGet)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsList)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsUpdate)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsCreate)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsImport)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsDelete)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsManagecontacts)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsManageissuers)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsGetissuers)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsListissuers)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsSetissuers)),
+			azure.TitleCase(string(keyvault.CertificatePermissionsDeleteissuers)),
 		},
 	}
 

--- a/internal/services/keyvault/key_vault_access_policy_data_source.go
+++ b/internal/services/keyvault/key_vault_access_policy_data_source.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2021-10-01/keyvault"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -61,8 +63,10 @@ func dataSourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 
 func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}) error {
 	name := d.Get("name").(string)
-	templateManagementPermissions := map[string][]string{
-		"key": {
+	templateManagementPermissions := map[string][]string{}
+
+	if features.FourPointOh() {
+		templateManagementPermissions["key"] = []string{
 			azure.TitleCase(string(keyvault.KeyPermissionsGet)),
 			azure.TitleCase(string(keyvault.KeyPermissionsList)),
 			azure.TitleCase(string(keyvault.KeyPermissionsUpdate)),
@@ -72,8 +76,9 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			azure.TitleCase(string(keyvault.KeyPermissionsRecover)),
 			azure.TitleCase(string(keyvault.KeyPermissionsBackup)),
 			azure.TitleCase(string(keyvault.KeyPermissionsRestore)),
-		},
-		"secret": {
+		}
+
+		templateManagementPermissions["secret"] = []string{
 			azure.TitleCase(string(keyvault.SecretPermissionsGet)),
 			azure.TitleCase(string(keyvault.SecretPermissionsList)),
 			azure.TitleCase(string(keyvault.SecretPermissionsSet)),
@@ -81,8 +86,9 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			azure.TitleCase(string(keyvault.SecretPermissionsRecover)),
 			azure.TitleCase(string(keyvault.SecretPermissionsBackup)),
 			azure.TitleCase(string(keyvault.SecretPermissionsRestore)),
-		},
-		"certificate": {
+		}
+
+		templateManagementPermissions["certificate"] = []string{
 			azure.TitleCase(string(keyvault.CertificatePermissionsGet)),
 			azure.TitleCase(string(keyvault.CertificatePermissionsList)),
 			azure.TitleCase(string(keyvault.CertificatePermissionsUpdate)),
@@ -95,7 +101,44 @@ func dataSourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, _ interface{}
 			azure.TitleCase(string(keyvault.CertificatePermissionsListissuers)),
 			azure.TitleCase(string(keyvault.CertificatePermissionsSetissuers)),
 			azure.TitleCase(string(keyvault.CertificatePermissionsDeleteissuers)),
-		},
+		}
+	} else {
+		templateManagementPermissions["key"] = []string{
+			string(keyvault.KeyPermissionsGet),
+			string(keyvault.KeyPermissionsList),
+			string(keyvault.KeyPermissionsUpdate),
+			string(keyvault.KeyPermissionsCreate),
+			string(keyvault.KeyPermissionsImport),
+			string(keyvault.KeyPermissionsDelete),
+			string(keyvault.KeyPermissionsRecover),
+			string(keyvault.KeyPermissionsBackup),
+			string(keyvault.KeyPermissionsRestore),
+		}
+
+		templateManagementPermissions["secret"] = []string{
+			string(keyvault.SecretPermissionsGet),
+			string(keyvault.SecretPermissionsList),
+			string(keyvault.SecretPermissionsSet),
+			string(keyvault.SecretPermissionsDelete),
+			string(keyvault.SecretPermissionsRecover),
+			string(keyvault.SecretPermissionsBackup),
+			string(keyvault.SecretPermissionsRestore),
+		}
+
+		templateManagementPermissions["certificate"] = []string{
+			string(keyvault.CertificatePermissionsGet),
+			string(keyvault.CertificatePermissionsList),
+			string(keyvault.CertificatePermissionsUpdate),
+			string(keyvault.CertificatePermissionsCreate),
+			string(keyvault.CertificatePermissionsImport),
+			string(keyvault.CertificatePermissionsDelete),
+			string(keyvault.CertificatePermissionsManagecontacts),
+			string(keyvault.CertificatePermissionsManageissuers),
+			string(keyvault.CertificatePermissionsGetissuers),
+			string(keyvault.CertificatePermissionsListissuers),
+			string(keyvault.CertificatePermissionsSetissuers),
+			string(keyvault.CertificatePermissionsDeleteissuers),
+		}
 	}
 
 	d.SetId(name)


### PR DESCRIPTION
In the [Create keyvault API](https://github.com/Azure/azure-rest-api-specs/blob/01efd1f79d22d073b063554319562978c0bb1b9c/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2021-10-01/keyvault.json#L18), when the value of the specified [accessPolicies](https://github.com/Azure/azure-rest-api-specs/blob/01efd1f79d22d073b063554319562978c0bb1b9c/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2021-10-01/keyvault.json#L1092) permission is lowercase, the [Get API](https://github.com/Azure/azure-rest-api-specs/blob/01efd1f79d22d073b063554319562978c0bb1b9c/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2021-10-01/keyvault.json#L216) returns it in lowercase, and when it is specified as titlecase, the Get API returns it in titlecase. This means that the API return value depends on the setting value.

After terraform provider v3.0, the permission value is case sensitive and it is required for titlecase in terraform. So I assume that `data.azurerm_key_vault_access_policy` should return the values of permission in titlecase to fix issue #17086.