### PR TITLE
`azurerm_shared_image_*` - Fix validation of `gallery_name`

### DIFF
--- a/internal/services/compute/validate/compute.go
+++ b/internal/services/compute/validate/compute.go
@@ -17,7 +17,7 @@ func SharedImageGalleryName(v interface{}, k string) (warnings []string, errors 
 	}
 
 	length := len(value)
-	if length >= 80 {
+	if length > 80 {
 		errors = append(errors, fmt.Errorf("%s can be up to 80 characters, currently %d.", k, length))
 	}
 
@@ -33,7 +33,7 @@ func SharedImageName(v interface{}, k string) (warnings []string, errors []error
 	}
 
 	length := len(value)
-	if length >= 80 {
+	if length > 80 {
 		errors = append(errors, fmt.Errorf("%s can be up to 80 characters, currently %d.", k, length))
 	}
 

--- a/internal/services/compute/validate/compute_test.go
+++ b/internal/services/compute/validate/compute_test.go
@@ -39,11 +39,11 @@ func TestSharedImageGalleryName(t *testing.T) {
 			ShouldError: true,
 		},
 		{
-			Input:       strings.Repeat("a", 79),
+			Input:       strings.Repeat("a", 80),
 			ShouldError: false,
 		},
 		{
-			Input:       strings.Repeat("a", 80),
+			Input:       strings.Repeat("a", 81),
 			ShouldError: true,
 		},
 	}
@@ -98,11 +98,11 @@ func TestSharedImageName(t *testing.T) {
 			ShouldError: false,
 		},
 		{
-			Input:       strings.Repeat("a", 79),
+			Input:       strings.Repeat("a", 80),
 			ShouldError: false,
 		},
 		{
-			Input:       strings.Repeat("a", 80),
+			Input:       strings.Repeat("a", 81),
 			ShouldError: true,
 		},
 	}


### PR DESCRIPTION
length can be equal to 80