### PR TITLE
Fix crash in `azurerm_application_gateway` when `waf_configuration` block is removed

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4444,6 +4444,9 @@ func flattenApplicationGatewayURLPathMaps(input *[]network.ApplicationGatewayURL
 
 func expandApplicationGatewayWafConfig(d *pluginsdk.ResourceData) *network.ApplicationGatewayWebApplicationFirewallConfiguration {
 	vs := d.Get("waf_configuration").([]interface{})
+	if len(vs) == 0 {
+		return nil
+	}
 	v := vs[0].(map[string]interface{})
 
 	enabled := v["enabled"].(bool)


### PR DESCRIPTION
Fixes issue where a removed `waf_configuration` block in `azurerm_application_gateway` caused a panic/crash. See #17207 for details.