### PR TITLE
`data.azurerm_storage_account` - add supports of `identity`

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -38,6 +38,8 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 
 			"location": commonschema.LocationComputed(),
 
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
 			"account_kind": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -417,6 +419,14 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		storageAccountKeys := *accessKeys
 		d.Set("primary_access_key", storageAccountKeys[0].Value)
 		d.Set("secondary_access_key", storageAccountKeys[1].Value)
+	}
+
+	identity, err := flattenAzureRmStorageAccountIdentity(resp.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	if err := d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -35,6 +35,8 @@ output "storage_account_tier" {
 
 * `location` - The Azure location where the Storage Account exists
 
+* `identity` - An `identity` block as documented below.
+
 * `account_kind` - The Kind of account.
 
 * `account_tier` - The Tier of this storage account.
@@ -135,6 +137,18 @@ output "storage_account_tier" {
 * `custom_domain` supports the following:
 
 * `name` - The Custom Domain Name used for the Storage Account.
+
+---
+
+`identity` supports the following:
+
+* `type` - The type of Managed Service Identity that is configured on this Storage Account
+
+* `identity_ids` - A list of User Assigned Managed Identity IDs assigned with the Identity of this Storage Account.
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Identity of this Storage Account.
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Storage Account.
 
 ## Timeouts
 


### PR DESCRIPTION
Fix #17171

## Test

```
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccDataSourceStorageAccount_.*Identity'
=== RUN   TestAccDataSourceStorageAccount_systemAssignedIdentity
=== PAUSE TestAccDataSourceStorageAccount_systemAssignedIdentity
=== RUN   TestAccDataSourceStorageAccount_userAssignedIdentity
=== PAUSE TestAccDataSourceStorageAccount_userAssignedIdentity
=== RUN   TestAccDataSourceStorageAccount_systemAssignedUserAssignedIdentity
=== PAUSE TestAccDataSourceStorageAccount_systemAssignedUserAssignedIdentity
=== CONT  TestAccDataSourceStorageAccount_systemAssignedIdentity
=== CONT  TestAccDataSourceStorageAccount_systemAssignedUserAssignedIdentity
=== CONT  TestAccDataSourceStorageAccount_userAssignedIdentity
--- PASS: TestAccDataSourceStorageAccount_systemAssignedIdentity (94.45s)
--- PASS: TestAccDataSourceStorageAccount_systemAssignedUserAssignedIdentity (109.28s)
--- PASS: TestAccDataSourceStorageAccount_userAssignedIdentity (178.50s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       178.518s
```