### PR TITLE
Updated documentation for Databricks Workspace Resource

### DIFF
--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -82,11 +82,11 @@ A `custom_parameters` block supports the following:
 
 * `public_subnet_name` - (Optional) The name of the Public Subnet within the Virtual Network. Required if `virtual_network_id` is set. Changing this forces a new resource to be created.
 
-* `public_subnet_network_security_group_association_id` - (Optional) The resource ID of the `azurerm_subnet_network_security_group_association` resource which is referred to by the `public_subnet_name` field. Required if `virtual_network_id` is set.
+* `public_subnet_network_security_group_association_id` - (Optional) The resource ID of the `azurerm_subnet_network_security_group_association` resource which is referred to by the `public_subnet_name` field. This is the same as the ID of the subnet referred to by the `public_subnet_name` field. Required if `virtual_network_id` is set.
 
 * `private_subnet_name` - (Optional) The name of the Private Subnet within the Virtual Network. Required if `virtual_network_id` is set. Changing this forces a new resource to be created.
 
-* `private_subnet_network_security_group_association_id` - (Optional) The resource ID of the `azurerm_subnet_network_security_group_association` resource which is referred to by the `private_subnet_name` field. Required if `virtual_network_id` is set.
+* `private_subnet_network_security_group_association_id` - (Optional) The resource ID of the `azurerm_subnet_network_security_group_association` resource which is referred to by the `private_subnet_name` field. This is the same as the ID of the subnet referred to by the `private_subnet_name` field. Required if `virtual_network_id` is set.
 
 * `storage_account_name` - (Optional) Default Databricks File Storage account name. Defaults to a randomized name(e.g. `dbstoragel6mfeghoe5kxu`). Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Currently the documentation for the `azurerm_databricks_workspace` resource has some misleading text for the `public_subnet_network_security_group_association_id` and `private_subnet_network_security_group_association_id` fields, leading to unnecessary debugging and code changes.

Core of the problem is that there is being referred to the resource ID of the `azurerm_subnet_network_security_group_association` resource, since this resource does not have a data source it can be tricky to get it's resource ID when the resource is created in a different configuration file.
However, the ID being exported by the `azurerm_subnet_network_security_group_association` is the same as the `subnet_id` to which the association is made. Therefore, this PR adds two lines to the docs to clarify this. 