### PR TITLE
remove validation on spring cloud route config route.uri

### DIFF
--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -108,7 +108,7 @@ func resourceSpringCloudGatewayRouteConfig() *pluginsdk.Resource {
 						"uri": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"classification_tags": {


### PR DESCRIPTION
`no://op` is allowed in route.uri