### PR TITLE
`azurerm_subscription_policy_assignment` & `azurerm_management_group_policy_assignment` Add `UserAssignedIdentities` to the update request to fix #17082 and #16898

### DIFF
--- a/internal/services/policy/assignment_base_resource.go
+++ b/internal/services/policy/assignment_base_resource.go
@@ -212,7 +212,8 @@ func (br assignmentBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 			if existing.Identity != nil {
 				update.Identity = &policy.Identity{
-					Type: existing.Identity.Type,
+					Type:                   existing.Identity.Type,
+					UserAssignedIdentities: existing.Identity.UserAssignedIdentities,
 				}
 			}
 

--- a/internal/services/policy/assignment_subscription_resource_test.go
+++ b/internal/services/policy/assignment_subscription_resource_test.go
@@ -660,7 +660,7 @@ resource "azurerm_subscription_policy_assignment" "test" {
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
-  description		   = "%[4]s"
+  description          = "%[4]s"
 
   identity {
     type         = "UserAssigned"

--- a/internal/services/policy/assignment_subscription_resource_test.go
+++ b/internal/services/policy/assignment_subscription_resource_test.go
@@ -120,10 +120,14 @@ func TestAccSubscriptionPolicyAssignment_identity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.userAssignedIdentity(data),
+			Config: r.userAssignedIdentity(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userAssignedIdentity(data, "description"),
 		},
 		data.ImportStep(),
 	})
@@ -627,7 +631,7 @@ resource "azurerm_subscription_policy_assignment" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r SubscriptionAssignmentTestResource) userAssignedIdentity(data acceptance.TestData) string {
+func (r SubscriptionAssignmentTestResource) userAssignedIdentity(data acceptance.TestData, description string) string {
 	template := r.template()
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -656,11 +660,12 @@ resource "azurerm_subscription_policy_assignment" "test" {
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
+  description		   = "%[4]s"
 
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
-`, template, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger, data.Locations.Primary, description)
 }


### PR DESCRIPTION
The update method missed `UserAssignedIdentities` in `assignment_base_resource.go`'s `updateFunc` method. This patch should fix #17082 and #16898.

Acc tests:

=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicy (762.20s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage (761.55s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySet (632.69s)
=== RUN   TestAccSubscriptionPolicyAssignment_identity
=== PAUSE TestAccSubscriptionPolicyAssignment_identity
=== CONT  TestAccSubscriptionPolicyAssignment_identity
--- PASS: TestAccSubscriptionPolicyAssignment_identity (636.77s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicySetNonComplianceMessage (730.35s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicy (711.13s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyComplete (811.86s)
=== RUN   TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
=== PAUSE TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
=== CONT  TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport
--- PASS: TestAccSubscriptionPolicyAssignment_basicWithCustomPolicyRequiresImport (456.61s)

(fixes #17082, fixes #16898)