### PR TITLE
`r\iot_time_series_insights_gen2_environment`: fix `id_properties`

### DIFF
--- a/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
+++ b/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
@@ -67,7 +67,7 @@ func resourceIoTTimeSeriesInsightsGen2Environment() *pluginsdk.Resource {
 				ValidateFunc: azValidate.ISO8601Duration,
 			},
 			"id_properties": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Required: true,
 				ForceNew: true,
 				Elem: &pluginsdk.Schema{
@@ -146,7 +146,7 @@ func resourceIoTTimeSeriesInsightsGen2EnvironmentCreateUpdate(d *pluginsdk.Resou
 		Tags:     tags.Expand(t),
 		Sku:      sku,
 		Gen2EnvironmentCreationProperties: &timeseriesinsights.Gen2EnvironmentCreationProperties{
-			TimeSeriesIDProperties: expandIdProperties(d.Get("id_properties").(*pluginsdk.Set).List()),
+			TimeSeriesIDProperties: expandIdProperties(d.Get("id_properties").([]interface{})),
 			StorageConfiguration:   expandStorage(d.Get("storage").([]interface{})),
 		},
 	}

--- a/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
+++ b/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `storage` - (Required) A `storage` block as defined below.
 
-* `id_properties` - (Required) A list of property ids for the Azure IoT Time Series Insights Gen2 Environment
+* `id_properties` - (Required) A list of property ids for the Azure IoT Time Series Insights Gen2 Environment. Changing this forces a new resource to be created. 
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fix #17227