### PR TITLE
resource `azurerm_shared_image` - add architecture option.

### DIFF
--- a/internal/services/compute/shared_image_data_source.go
+++ b/internal/services/compute/shared_image_data_source.go
@@ -41,6 +41,11 @@ func dataSourceSharedImage() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
+			"architecture": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"os_type": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -131,6 +136,7 @@ func dataSourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		d.Set("description", props.Description)
 		d.Set("eula", props.Eula)
 		d.Set("os_type", string(props.OsType))
+		d.Set("architecture", string(props.Architecture))
 		d.Set("specialized", props.OsState == compute.OperatingSystemStateTypesSpecialized)
 		d.Set("hyper_v_generation", string(props.HyperVGeneration))
 		d.Set("privacy_statement_uri", props.PrivacyStatementURI)

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -60,6 +60,17 @@ func resourceSharedImage() *pluginsdk.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			"architecture": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(compute.ArchitectureTypesX64),
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.ArchitectureTypesX64),
+					string(compute.ArchitectureTypesArm64),
+				}, false),
+			},
+
 			"os_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
@@ -277,6 +288,7 @@ func resourceSharedImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 			Identifier:          expandGalleryImageIdentifier(d),
 			PrivacyStatementURI: utils.String(d.Get("privacy_statement_uri").(string)),
 			ReleaseNoteURI:      utils.String(d.Get("release_note_uri").(string)),
+			Architecture:        compute.Architecture(d.Get("architecture").(string)),
 			OsType:              compute.OperatingSystemTypes(d.Get("os_type").(string)),
 			HyperVGeneration:    compute.HyperVGeneration(d.Get("hyper_v_generation").(string)),
 			PurchasePlan:        expandGalleryImagePurchasePlan(d.Get("purchase_plan").([]interface{})),
@@ -392,6 +404,7 @@ func resourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("min_recommended_memory_in_gb", minRecommendedMemoryInGB)
 
 		d.Set("os_type", string(props.OsType))
+		d.Set("architecture", string(props.Architecture))
 		d.Set("specialized", props.OsState == compute.OperatingSystemStateTypesSpecialized)
 		d.Set("hyper_v_generation", string(props.HyperVGeneration))
 		d.Set("privacy_statement_uri", props.PrivacyStatementURI)

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 !> **Note:** It's recommended to Generalize images where possible - Specialized Images reuse the same UUID internally within each Virtual Machine, which can have unintended side-effects.
 
+* `architecture` - (Optional) CPU architecture supported by an OS. Possible values are `x64` and `Arm64`. Defaults to `x64`. Changing this forces a new resource to be created.
+
 * `hyper_v_generation` - (Optional) The generation of HyperV that the Virtual Machine used to create the Shared Image is based on. Possible values are `V1` and `V2`. Defaults to `V1`. Changing this forces a new resource to be created.
 
 * `max_recommended_vcpu_count` - (Optional) Maximum count of vCPUs recommended for the Image.


### PR DESCRIPTION
Add `architecture` option to `azurerm_shared_image` resource.

source doc - https://docs.microsoft.com/en-us/powershell/module/az.compute/new-azgalleryimagedefinition?view=azps-8.0.0