### PR TITLE
`azurerm_storage_account` - support disable `blob_properties.0.{delete_retention_policy|container_delete_retention_policy}` & `share_properties.0.retention_policy`

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -601,6 +601,8 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 			Config: r.blobPropertiesUpdated2(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.#").DoesNotExist(),
+				check.That(data.ResourceName).Key("blob_properties.0.container_delete_retention_policy.#").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -981,6 +983,14 @@ func TestAccAzureRMStorageAccount_shareSoftDelete(t *testing.T) {
 			Config: r.shareSoftDelete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.shareNoSoftDelete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("share_properties.0.retention_policy.#").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -3164,6 +3174,30 @@ resource "azurerm_storage_account" "test" {
       days = 3
     }
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) shareNoSoftDelete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  share_properties {}
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
Fix #17204

The original issue seems was introduced since https://github.com/hashicorp/terraform-provider-azurerm/pull/11960/files#diff-2c154d637b511904ff11c516331a83f1e3b17cd85d601fd0fc21556fbdfb5a31R1870. This change seems out of topic of that original PR. So I've just reverted that back and verified the expected behavior about disabling the soft delete in the acctest.

## Test

Full storage account test in public cloud:

```shell
❯ TF_ACC=1 go test -timeout=60m -v -parallel 5 -run='TestAccStorageAccount_' ./internal/services/storage
=== RUN   TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== RUN   TestAccStorageAccount_requiresImport
=== PAUSE TestAccStorageAccount_requiresImport
=== RUN   TestAccStorageAccount_noCrossTenantReplication
=== PAUSE TestAccStorageAccount_noCrossTenantReplication
=== RUN   TestAccStorageAccount_tagCount
=== PAUSE TestAccStorageAccount_tagCount
=== RUN   TestAccStorageAccount_writeLock
=== PAUSE TestAccStorageAccount_writeLock
=== RUN   TestAccStorageAccount_premium
=== PAUSE TestAccStorageAccount_premium
=== RUN   TestAccStorageAccount_disappears
=== PAUSE TestAccStorageAccount_disappears
=== RUN   TestAccStorageAccount_blobConnectionString
=== PAUSE TestAccStorageAccount_blobConnectionString
=== RUN   TestAccStorageAccount_enableHttpsTrafficOnly
=== PAUSE TestAccStorageAccount_enableHttpsTrafficOnly
=== RUN   TestAccStorageAccount_minTLSVersion
=== PAUSE TestAccStorageAccount_minTLSVersion
=== RUN   TestAccStorageAccount_isHnsEnabled
=== PAUSE TestAccStorageAccount_isHnsEnabled
=== RUN   TestAccStorageAccount_isNFSv3Enabled
=== PAUSE TestAccStorageAccount_isNFSv3Enabled
=== RUN   TestAccStorageAccount_blobStorageWithUpdate
=== PAUSE TestAccStorageAccount_blobStorageWithUpdate
=== RUN   TestAccStorageAccount_blockBlobStorage
=== PAUSE TestAccStorageAccount_blockBlobStorage
=== RUN   TestAccStorageAccount_fileStorageWithUpdate
=== PAUSE TestAccStorageAccount_fileStorageWithUpdate
=== RUN   TestAccStorageAccount_storageV2WithUpdate
=== PAUSE TestAccStorageAccount_storageV2WithUpdate
=== RUN   TestAccStorageAccount_storageV1ToV2Update
=== PAUSE TestAccStorageAccount_storageV1ToV2Update
=== RUN   TestAccStorageAccount_systemAssignedIdentity
=== PAUSE TestAccStorageAccount_systemAssignedIdentity
=== RUN   TestAccStorageAccount_userAssignedIdentity
=== PAUSE TestAccStorageAccount_userAssignedIdentity
=== RUN   TestAccStorageAccount_systemAssignedUserAssignedIdentity
=== PAUSE TestAccStorageAccount_systemAssignedUserAssignedIdentity
=== RUN   TestAccStorageAccount_updateResourceByEnablingIdentity
=== PAUSE TestAccStorageAccount_updateResourceByEnablingIdentity
=== RUN   TestAccStorageAccount_networkRules
=== PAUSE TestAccStorageAccount_networkRules
=== RUN   TestAccStorageAccount_networkRulesDeleted
=== PAUSE TestAccStorageAccount_networkRulesDeleted
=== RUN   TestAccStorageAccount_privateLinkAccess
=== PAUSE TestAccStorageAccount_privateLinkAccess
=== RUN   TestAccStorageAccount_networkRulesSynapseAccess
=== PAUSE TestAccStorageAccount_networkRulesSynapseAccess
=== RUN   TestAccStorageAccount_blobProperties
=== PAUSE TestAccStorageAccount_blobProperties
=== RUN   TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== PAUSE TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== RUN   TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
=== PAUSE TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
=== RUN   TestAccStorageAccount_queueProperties
=== PAUSE TestAccStorageAccount_queueProperties
=== RUN   TestAccStorageAccount_staticWebsiteEnabled
=== PAUSE TestAccStorageAccount_staticWebsiteEnabled
=== RUN   TestAccStorageAccount_staticWebsitePropertiesForStorageV2
=== PAUSE TestAccStorageAccount_staticWebsitePropertiesForStorageV2
=== RUN   TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
=== PAUSE TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
=== RUN   TestAccStorageAccount_replicationTypeGZRS
=== PAUSE TestAccStorageAccount_replicationTypeGZRS
=== RUN   TestAccStorageAccount_largeFileShare
=== PAUSE TestAccStorageAccount_largeFileShare
=== RUN   TestAccStorageAccount_hnsWithPremiumStorage
=== PAUSE TestAccStorageAccount_hnsWithPremiumStorage
=== RUN   TestAccStorageAccount_allowSharedKeyAccess
=== PAUSE TestAccStorageAccount_allowSharedKeyAccess
=== RUN   TestAccStorageAccount_encryptionKeyType
=== PAUSE TestAccStorageAccount_encryptionKeyType
=== RUN   TestAccStorageAccount_infrastructureEncryption
=== PAUSE TestAccStorageAccount_infrastructureEncryption
=== RUN   TestAccStorageAccount_customerManagedKey
=== PAUSE TestAccStorageAccount_customerManagedKey
=== RUN   TestAccStorageAccount_customerManagedKeyAutoRotation
=== PAUSE TestAccStorageAccount_customerManagedKeyAutoRotation
=== RUN   TestAccStorageAccount_customerManagedKeyUpdated
=== PAUSE TestAccStorageAccount_customerManagedKeyUpdated
=== RUN   TestAccStorageAccount_customerManagedKeyRemoteKeyVault
=== PAUSE TestAccStorageAccount_customerManagedKeyRemoteKeyVault
=== RUN   TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
=== PAUSE TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
=== RUN   TestAccStorageAccount_edgeZone
=== PAUSE TestAccStorageAccount_edgeZone
=== CONT  TestAccStorageAccount_basic
=== CONT  TestAccStorageAccount_networkRulesDeleted
=== CONT  TestAccStorageAccount_largeFileShare
=== CONT  TestAccStorageAccount_queueProperties
=== CONT  TestAccStorageAccount_blobProperties
--- PASS: TestAccStorageAccount_blobProperties (181.40s)
=== CONT  TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders
--- PASS: TestAccStorageAccount_basic (193.06s)
=== CONT  TestAccStorageAccount_customerManagedKeyAutoRotation
--- PASS: TestAccStorageAccount_networkRulesDeleted (209.52s)
=== CONT  TestAccStorageAccount_edgeZone
--- PASS: TestAccStorageAccount_queueProperties (215.74s)
=== CONT  TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey
--- PASS: TestAccStorageAccount_largeFileShare (238.39s)
=== CONT  TestAccStorageAccount_customerManagedKeyRemoteKeyVault
--- PASS: TestAccStorageAccount_blobPropertiesEmptyAllowedExposedHeaders (74.21s)
=== CONT  TestAccStorageAccount_customerManagedKeyUpdated
--- PASS: TestAccStorageAccount_customerManagedKeyAutoRotation (415.47s)
=== CONT  TestAccStorageAccount_isNFSv3Enabled
--- PASS: TestAccStorageAccount_customerManagedKeyRemoteKeyVault (424.27s)
=== CONT  TestAccStorageAccount_networkRules
--- PASS: TestAccStorageAccount_updateToUsingIdentityAndCustomerManagedKey (453.49s)
=== CONT  TestAccStorageAccount_updateResourceByEnablingIdentity
--- PASS: TestAccStorageAccount_isNFSv3Enabled (181.55s)
=== CONT  TestAccStorageAccount_systemAssignedUserAssignedIdentity
--- PASS: TestAccStorageAccount_networkRules (192.37s)
=== CONT  TestAccStorageAccount_userAssignedIdentity
--- PASS: TestAccStorageAccount_updateResourceByEnablingIdentity (230.19s)
=== CONT  TestAccStorageAccount_systemAssignedIdentity
--- PASS: TestAccStorageAccount_customerManagedKeyUpdated (674.11s)
=== CONT  TestAccStorageAccount_storageV1ToV2Update
--- PASS: TestAccStorageAccount_systemAssignedUserAssignedIdentity (158.50s)
=== CONT  TestAccStorageAccount_storageV2WithUpdate
--- PASS: TestAccStorageAccount_userAssignedIdentity (153.09s)
=== CONT  TestAccStorageAccount_fileStorageWithUpdate
--- PASS: TestAccStorageAccount_systemAssignedIdentity (135.89s)
=== CONT  TestAccStorageAccount_blockBlobStorage
--- PASS: TestAccStorageAccount_storageV1ToV2Update (170.42s)
=== CONT  TestAccStorageAccount_blobStorageWithUpdate
--- PASS: TestAccStorageAccount_fileStorageWithUpdate (96.88s)
=== CONT  TestAccStorageAccount_networkRulesSynapseAccess
--- PASS: TestAccStorageAccount_storageV2WithUpdate (161.15s)
=== CONT  TestAccStorageAccount_disappears
--- PASS: TestAccStorageAccount_blockBlobStorage (77.07s)
=== CONT  TestAccStorageAccount_isHnsEnabled
--- PASS: TestAccStorageAccount_disappears (67.69s)
=== CONT  TestAccStorageAccount_minTLSVersion
--- PASS: TestAccStorageAccount_blobStorageWithUpdate (89.83s)
=== CONT  TestAccStorageAccount_enableHttpsTrafficOnly
--- PASS: TestAccStorageAccount_isHnsEnabled (134.11s)
=== CONT  TestAccStorageAccount_blobConnectionString
--- PASS: TestAccStorageAccount_edgeZone (1041.15s)
=== CONT  TestAccStorageAccount_encryptionKeyType
--- PASS: TestAccStorageAccount_enableHttpsTrafficOnly (180.39s)
=== CONT  TestAccStorageAccount_customerManagedKey
--- PASS: TestAccStorageAccount_blobConnectionString (142.38s)
=== CONT  TestAccStorageAccount_infrastructureEncryption
--- PASS: TestAccStorageAccount_encryptionKeyType (230.97s)
=== CONT  TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage
--- PASS: TestAccStorageAccount_infrastructureEncryption (218.00s)
=== CONT  TestAccStorageAccount_replicationTypeGZRS
--- PASS: TestAccStorageAccount_staticWebsitePropertiesForBlockBlobStorage (163.81s)
=== CONT  TestAccStorageAccount_privateLinkAccess
--- PASS: TestAccStorageAccount_replicationTypeGZRS (189.20s)
=== CONT  TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
--- PASS: TestAccStorageAccount_customerManagedKey (430.68s)
=== CONT  TestAccStorageAccount_staticWebsitePropertiesForStorageV2
--- PASS: TestAccStorageAccount_networkRulesSynapseAccess (720.17s)
=== CONT  TestAccStorageAccount_staticWebsiteEnabled
--- PASS: TestAccStorageAccount_staticWebsitePropertiesForStorageV2 (121.77s)
=== CONT  TestAccStorageAccount_tagCount
--- PASS: TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled (174.10s)
=== CONT  TestAccStorageAccount_premium
--- PASS: TestAccStorageAccount_privateLinkAccess (329.17s)
=== CONT  TestAccStorageAccount_writeLock
--- PASS: TestAccStorageAccount_staticWebsiteEnabled (204.16s)
=== CONT  TestAccStorageAccount_allowSharedKeyAccess
--- PASS: TestAccStorageAccount_premium (71.15s)
=== CONT  TestAccStorageAccount_noCrossTenantReplication
--- PASS: TestAccStorageAccount_tagCount (129.56s)
=== CONT  TestAccStorageAccount_requiresImport
--- PASS: TestAccStorageAccount_allowSharedKeyAccess (93.65s)
=== CONT  TestAccStorageAccount_hnsWithPremiumStorage
--- PASS: TestAccStorageAccount_writeLock (155.75s)
--- PASS: TestAccStorageAccount_noCrossTenantReplication (135.94s)
--- PASS: TestAccStorageAccount_hnsWithPremiumStorage (146.66s)
--- PASS: TestAccStorageAccount_minTLSVersion (1124.26s)
--- PASS: TestAccStorageAccount_requiresImport (288.90s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       2341.307s
```

THe test ran in PR #11960 in US Gov cloud:

```shell
❯ TF_ACC=1 go test -timeout=60m -v -parallel 5 -run='TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled' ./internal/services/storage
=== RUN   TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== PAUSE TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
=== CONT  TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled
--- PASS: TestAccStorageAccount_blobProperties_containerAndLastAccessTimeDisabled (104.66s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       104.670s
```