### PR TITLE
`azurerm_hdinsight_kafka_cluster` add support for `network` block

### DIFF
--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -863,9 +863,14 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   storage_account {
+    storage_resource_id  = azurerm_storage_account.test.id
     storage_container_id = azurerm_storage_container.test.id
     storage_account_key  = azurerm_storage_account.test.primary_access_key
     is_default           = true
+  }
+
+  network {
+    connection_direction = "Outbound"
   }
 
   roles {

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -96,6 +96,8 @@ The following arguments are supported:
 
 * `roles` - (Required) A `roles` block as defined below.
 
+* `network` - (Optional) A `network` block as defined below.
+
 * `storage_account` - (Required) One or more `storage_account` block as defined below.
 
 * `storage_account_gen2` - (Required) A `storage_account_gen2` block as defined below.
@@ -167,6 +169,16 @@ A `roles` block supports the following:
 * `zookeeper_node` - (Required) A `zookeeper_node` block as defined below.
 
 * `kafka_management_node` - (Optional) A `kafka_management_node` block as defined below.
+
+---
+
+A `network` block supports the following:
+
+* `connection_direction` - (Optional) The direction of the resource provider connection. Possible values include `Inbound` or `Outbound`. Defaults to `Inbound`. Changing this forces a new resource to be created.
+
+-> **NOTE:** To enabled the private link the `connection_direction` must be set to `Outbound`.
+
+* `private_link_enabled` - (Optional) Is the private link enabled? Possible values include `True` or `False`. Defaults to `False`. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Resolving issue https://github.com/hashicorp/terraform-provider-azurerm/issues/15450