### PR TITLE
`d\managed_disk`:add support for `network_access_policy` and `disk_access_id`

### DIFF
--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -35,6 +35,11 @@ func dataSourceManagedDisk() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"disk_access_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"disk_encryption_set_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -56,6 +61,11 @@ func dataSourceManagedDisk() *pluginsdk.Resource {
 			},
 
 			"image_reference_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"network_access_policy": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -135,6 +145,13 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("storage_account_id", creationData.StorageAccountID)
 		}
 
+		diskAccessId := ""
+		if props.DiskAccessID != nil {
+			diskAccessId = *props.DiskAccessID
+		}
+		d.Set("disk_access_id", diskAccessId)
+
+		d.Set("network_access_policy", string(props.NetworkAccessPolicy))
 		d.Set("disk_size_gb", props.DiskSizeGB)
 		d.Set("disk_iops_read_write", props.DiskIOPSReadWrite)
 		d.Set("disk_mbps_read_write", props.DiskMBpsReadWrite)

--- a/internal/services/compute/managed_disk_data_source_test.go
+++ b/internal/services/compute/managed_disk_data_source_test.go
@@ -52,6 +52,21 @@ func TestAccDataSourceManagedDisk_basic_withUltraSSD(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceManagedDisk_diskAccess(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_disk", "test")
+	r := ManagedDiskDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.diskAccess(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_access_policy").HasValue("AllowPrivate"),
+				check.That(data.ResourceName).Key("disk_access_id").Exists(),
+			),
+		},
+	})
+}
+
 func (ManagedDiskDataSource) basic(data acceptance.TestData, name string, resourceGroupName string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -116,4 +131,40 @@ data "azurerm_managed_disk" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, resourceGroupName, data.Locations.Primary, name)
+}
+
+func (ManagedDiskDataSource) diskAccess(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_disk_access" "test" {
+  name                = "accda%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                  = "acctestd-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  storage_account_type  = "Standard_LRS"
+  create_option         = "Empty"
+  disk_size_gb          = "4"
+  zone                  = "1"
+  network_access_policy = "AllowPrivate"
+  disk_access_id        = azurerm_disk_access.test.id
+}
+
+data "azurerm_managed_disk" "test" {
+  name                = azurerm_managed_disk.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Fix #17267, properties are added by #9862 in data source doc but missing in code. [[Current data source doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/managed_disk#network_access_policy)]