### PR TITLE
`policy_insights_remediation` update sdk to 2021-10-01

### DIFF
--- a/helpers/validate/float.go
+++ b/helpers/validate/float.go
@@ -25,3 +25,32 @@ func FloatInSlice(valid []float64) func(interface{}, string) ([]string, []error)
 		return warnings, errors
 	}
 }
+
+func FloatInRange(start, end float64) func(interface{}, string) ([]string, []error) {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(float64)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be float", i))
+			return warnings, errors
+		}
+
+		if v < start || v > end {
+			errors = append(errors, fmt.Errorf("expected %s to be in range [%f, %f], got %f", k, start, end, v))
+		}
+
+		return warnings, errors
+	}
+}
+
+func IntegerPositive(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be int", i))
+		return
+	}
+	if v <= 0 {
+		errors = append(errors, fmt.Errorf("expected %s to be positive, got %d", k, v))
+		return
+	}
+	return
+}

--- a/internal/services/policy/client/client.go
+++ b/internal/services/policy/client/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy"
 	policyPreview "github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	policyinsights2 "github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/sdk/2021-10-01/policyinsights"
 )
 
 type Client struct {
@@ -14,6 +15,7 @@ type Client struct {
 	ExemptionsClient                    *policyPreview.ExemptionsClient
 	SetDefinitionsClient                *policy.SetDefinitionsClient
 	RemediationsClient                  *policyinsights.RemediationsClient
+	PolicyInsightsClient                *policyinsights2.PolicyInsightsClient
 	GuestConfigurationAssignmentsClient *guestconfiguration.AssignmentsClient
 }
 
@@ -33,6 +35,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	remediationsClient := policyinsights.NewRemediationsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&remediationsClient.Client, o.ResourceManagerAuthorizer)
 
+	policyInsightsClient := policyinsights2.NewPolicyInsightsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&policyInsightsClient.Client, o.ResourceManagerAuthorizer)
+
 	guestConfigurationAssignmentsClient := guestconfiguration.NewAssignmentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&guestConfigurationAssignmentsClient.Client, o.ResourceManagerAuthorizer)
 
@@ -42,6 +47,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		ExemptionsClient:                    &exemptionsClient,
 		SetDefinitionsClient:                &setDefinitionsClient,
 		RemediationsClient:                  &remediationsClient,
+		PolicyInsightsClient:                &policyInsightsClient,
 		GuestConfigurationAssignmentsClient: &guestConfigurationAssignmentsClient,
 	}
 }

--- a/internal/services/policy/remediation_resource.go
+++ b/internal/services/policy/remediation_resource.go
@@ -6,14 +6,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-
-	"github.com/Azure/azure-sdk-for-go/services/preview/policyinsights/mgmt/2019-10-01-preview/policyinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/sdk/2021-10-01/policyinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+//var _ = sdk.CreatedByTypeKey
 
 func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -64,6 +66,25 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 				ValidateFunc:     validate.PolicyAssignmentID,
 			},
 
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				Description:  "A number between 0.0 to 1.0 representing the percentage failure threshold.",
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
 			"location_filters": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -84,10 +105,10 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 			"resource_discovery_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(policyinsights.ExistingNonCompliant),
+				Default:  string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(policyinsights.ExistingNonCompliant),
-					string(policyinsights.ReEvaluateCompliance),
+					string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
+					string(policyinsights.ResourceDiscoveryModeReEvaluateCompliance),
 				}, false),
 			},
 		},
@@ -95,38 +116,54 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 }
 
 func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	//client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	resourceId := d.Get("resource_id").(string)
 
-	id := parse.NewResourcePolicyRemediationId(resourceId, d.Get("name").(string))
+	id := policyinsights.NewScopedRemediationID(resourceId, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
+		existing, err := client.RemediationsGetAtResource(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
 			}
 		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_resource_policy_remediation", *existing.ID)
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_resource_policy_remediation", *existing.Model.Id)
 		}
 	}
 
 	parameters := policyinsights.Remediation{
-		RemediationProperties: &policyinsights.RemediationProperties{
+		Name: utils.String(id.RemediationName),
+		Properties: &policyinsights.RemediationProperties{
 			Filters: &policyinsights.RemediationFilters{
 				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
 			},
-			PolicyAssignmentID:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceID: utils.String(d.Get("policy_definition_id").(string)),
-			ResourceDiscoveryMode:       policyinsights.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string)),
+			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
 		},
 	}
+	if v := d.Get("resource_discovery_mode").(string); v != "" {
+		mode := policyinsights.ResourceDiscoveryMode(v)
+		parameters.Properties.ResourceDiscoveryMode = &mode
+	}
+	if v := d.Get("failure_percentage").(float64); v != 0 {
+		parameters.Properties.FailureThreshold = &policyinsights.RemediationPropertiesFailureThreshold{
+			Percentage: utils.Float(v),
+		}
+	}
+	if v := d.Get("parallel_deployments").(int); v != 0 {
+		parameters.Properties.ParallelDeployments = utils.Int64(int64(v))
+	}
+	if v := d.Get("resource_count").(int); v != 0 {
+		parameters.Properties.ResourceCount = utils.Int64(int64(v))
+	}
 
-	if _, err := client.CreateOrUpdateAtResource(ctx, id.ResourceId, id.Name, parameters); err != nil {
+	if _, err := client.RemediationsCreateOrUpdateAtResource(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
@@ -136,18 +173,19 @@ func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData,
 }
 
 func resourceArmResourcePolicyRemediationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	//client := meta.(*clients.Client).Policy.RemediationsClient
+	pCli := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.ResourcePolicyRemediationID(d.Id())
+	id, err := policyinsights.ParseScopedRemediationID(d.Id())
 	if err != nil {
-		return fmt.Errorf("reading Policy Remediation: %+v", err)
+		return fmt.Errorf("reading Scoped Remediation ID: %+v", err)
 	}
-
-	resp, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
+	//resp, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
+	resp, err := pCli.RemediationsGetAtResource(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] %s does not exist - removing from state", id.ID())
 			d.SetId("")
 			return nil
@@ -155,10 +193,10 @@ func resourceArmResourcePolicyRemediationRead(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("reading %s: %+v", id.ID(), err)
 	}
 
-	d.Set("name", id.Name)
+	d.Set("name", id.RemediationName)
 	d.Set("resource_id", id.ResourceId)
 
-	if props := resp.RemediationProperties; props != nil {
+	if props := resp.Model.Properties; props != nil {
 		locations := []interface{}{}
 		if filters := props.Filters; filters != nil {
 			locations = utils.FlattenStringSlice(filters.Locations)
@@ -167,77 +205,91 @@ func resourceArmResourcePolicyRemediationRead(d *pluginsdk.ResourceData, meta in
 			return fmt.Errorf("setting `location_filters`: %+v", err)
 		}
 
-		d.Set("policy_assignment_id", props.PolicyAssignmentID)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceID)
-		d.Set("resource_discovery_mode", string(props.ResourceDiscoveryMode))
+		d.Set("policy_assignment_id", props.PolicyAssignmentId)
+		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
+		d.Set("resource_discovery_mode", utils.NormalizeNilableString((*string)(props.ResourceDiscoveryMode)))
+
+		d.Set("resource_count", props.ResourceCount)
+		d.Set("parallel_deployments", props.ParallelDeployments)
+		if props.FailureThreshold != nil {
+			d.Set("failure_percentage", props.FailureThreshold.Percentage)
+		}
 	}
 
 	return nil
 }
 
 func resourceArmResourcePolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.ResourcePolicyRemediationID(d.Id())
+	//id, err := parse.ResourcePolicyRemediationID(d.Id())
+	//if err != nil {
+	//	return err
+	//}
+
+	id, err := policyinsights.ParseScopedRemediationID(d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("reading Scoped Remediation ID: %+v", err)
 	}
 
 	// we have to cancel the remediation first before deleting it when the resource_discovery_mode is set to ReEvaluateCompliance
 	// therefore we first retrieve the remediation to see if the resource_discovery_mode is switched to ReEvaluateCompliance
-	existing, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
+	existing, err := client.RemediationsGetAtResource(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
+		if response.WasNotFound(existing.HttpResponse) {
 			return nil
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
-		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
-			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-			if _, err := client.CancelAtResource(ctx, id.ResourceId, id.Name); err != nil {
-				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-			}
+	if prop := existing.Model.Properties; prop != nil {
 
-			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-			stateConf := &pluginsdk.StateChangeConf{
-				Pending: []string{"Cancelling"},
-				Target: []string{
-					"Succeeded", "Canceled", "Failed",
-				},
-				Refresh:    resourcePolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-				MinTimeout: 10 * time.Second,
-				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-			}
+		if mode := existing.Model.Properties.ResourceDiscoveryMode; mode != nil && *mode == policyinsights.ResourceDiscoveryModeReEvaluateCompliance {
+			// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+			if state := prop.ProvisioningState; state != nil && *state == "Evaluating" {
+				log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+				if _, err := client.RemediationsCancelAtResource(ctx, *id); err != nil {
+					return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+				}
 
-			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+				stateConf := &pluginsdk.StateChangeConf{
+					Pending: []string{"Cancelling"},
+					Target: []string{
+						"Succeeded", "Canceled", "Failed",
+					},
+					Refresh:    resourcePolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+					MinTimeout: 10 * time.Second,
+					Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+				}
+
+				if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				}
 			}
 		}
 	}
 
-	_, err = client.DeleteAtResource(ctx, id.ResourceId, id.Name)
+	_, err = client.RemediationsDeleteAtResource(ctx, *id)
 
 	return err
 }
 
-func resourcePolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.RemediationsClient, id parse.ResourcePolicyRemediationId) pluginsdk.StateRefreshFunc {
+func resourcePolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.PolicyInsightsClient, id policyinsights.ScopedRemediationId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
+		resp, err := client.RemediationsGetAtResource(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("issuing read request for %s: %+v", id.ID(), err)
 		}
 
-		if resp.RemediationProperties == nil {
+		if resp.Model.Properties == nil {
 			return nil, "", fmt.Errorf("`properties` was nil")
 		}
-		if resp.RemediationProperties.ProvisioningState == nil {
+		if resp.Model.Properties.ProvisioningState == nil {
 			return nil, "", fmt.Errorf("`properties.ProvisioningState` was nil")
 		}
-		return resp, *resp.RemediationProperties.ProvisioningState, nil
+		return resp, *resp.Model.Properties.ProvisioningState, nil
 	}
 }

--- a/internal/services/policy/remediation_resource.go
+++ b/internal/services/policy/remediation_resource.go
@@ -22,8 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//var _ = sdk.CreatedByTypeKey
-
 func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceArmResourcePolicyRemediationCreateUpdate,
@@ -116,7 +114,6 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 }
 
 func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	//client := meta.(*clients.Client).Policy.RemediationsClient
 	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -173,7 +170,6 @@ func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData,
 }
 
 func resourceArmResourcePolicyRemediationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	//client := meta.(*clients.Client).Policy.RemediationsClient
 	pCli := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -182,7 +178,6 @@ func resourceArmResourcePolicyRemediationRead(d *pluginsdk.ResourceData, meta in
 	if err != nil {
 		return fmt.Errorf("reading Scoped Remediation ID: %+v", err)
 	}
-	//resp, err := client.GetAtResource(ctx, id.ResourceId, id.Name)
 	resp, err := pCli.RemediationsGetAtResource(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -223,11 +218,6 @@ func resourceArmResourcePolicyRemediationDelete(d *pluginsdk.ResourceData, meta 
 	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	//id, err := parse.ResourcePolicyRemediationID(d.Id())
-	//if err != nil {
-	//	return err
-	//}
 
 	id, err := policyinsights.ParseScopedRemediationID(d.Id())
 	if err != nil {

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -124,7 +124,6 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 		return err
 	}
 
-	//id := parse.NewResourceGroupPolicyRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
 	id := policyinsights.NewProviderRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -6,12 +6,13 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-
-	"github.com/Azure/azure-sdk-for-go/services/preview/policyinsights/mgmt/2019-10-01-preview/policyinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/sdk/2021-10-01/policyinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	resourceParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
@@ -64,6 +65,25 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 				ValidateFunc:     validate.PolicyAssignmentID,
 			},
 
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				Description:  "A number between 0.0 to 1.0 representing the percentage failure threshold.",
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
 			"location_filters": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -84,10 +104,10 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 			"resource_discovery_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(policyinsights.ExistingNonCompliant),
+				Default:  string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(policyinsights.ExistingNonCompliant),
-					string(policyinsights.ReEvaluateCompliance),
+					string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
+					string(policyinsights.ResourceDiscoveryModeReEvaluateCompliance),
 				}, false),
 			},
 		},
@@ -95,7 +115,7 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 }
 
 func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -104,32 +124,48 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 		return err
 	}
 
-	id := parse.NewResourceGroupPolicyRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
+	//id := parse.NewResourceGroupPolicyRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
+	id := policyinsights.NewProviderRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName)
+		existing, err := client.RemediationsGetAtResourceGroup(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
 			}
 		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_resource_group_policy_remediation", *existing.ID)
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_resource_group_policy_remediation", *existing.Model.Id)
 		}
 	}
 
 	parameters := policyinsights.Remediation{
-		RemediationProperties: &policyinsights.RemediationProperties{
+		Name: utils.String(id.RemediationName),
+		Properties: &policyinsights.RemediationProperties{
 			Filters: &policyinsights.RemediationFilters{
 				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
 			},
-			PolicyAssignmentID:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceID: utils.String(d.Get("policy_definition_id").(string)),
-			ResourceDiscoveryMode:       policyinsights.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string)),
+			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
 		},
 	}
+	if v := d.Get("resource_discovery_mode").(string); v != "" {
+		mode := policyinsights.ResourceDiscoveryMode(v)
+		parameters.Properties.ResourceDiscoveryMode = &mode
+	}
+	if v := d.Get("failure_percentage").(float64); v != 0 {
+		parameters.Properties.FailureThreshold = &policyinsights.RemediationPropertiesFailureThreshold{
+			Percentage: utils.Float(v),
+		}
+	}
+	if v := d.Get("parallel_deployments").(int); v != 0 {
+		parameters.Properties.ParallelDeployments = utils.Int64(int64(v))
+	}
+	if v := d.Get("resource_count").(int); v != 0 {
+		parameters.Properties.ResourceCount = utils.Int64(int64(v))
+	}
 
-	if _, err = client.CreateOrUpdateAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName, parameters); err != nil {
+	if _, err = client.RemediationsCreateOrUpdateAtResourceGroup(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
@@ -139,20 +175,20 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 }
 
 func resourceArmResourceGroupPolicyRemediationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.ResourceGroupPolicyRemediationID(d.Id())
+	id, err := policyinsights.ParseProviderRemediationID(d.Id())
 	if err != nil {
 		return fmt.Errorf("reading Policy Remediation: %+v", err)
 	}
 
-	resourceGroupId := resourceParse.NewResourceGroupID(id.SubscriptionId, id.ResourceGroup)
+	resourceGroupId := resourceParse.NewResourceGroupID(id.SubscriptionId, id.ResourceGroupName)
 
-	resp, err := client.GetAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName)
+	resp, err := client.RemediationsGetAtResourceGroup(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] %s does not exist - removing from state", id.ID())
 			d.SetId("")
 			return nil
@@ -163,7 +199,7 @@ func resourceArmResourceGroupPolicyRemediationRead(d *pluginsdk.ResourceData, me
 	d.Set("name", id.RemediationName)
 	d.Set("resource_group_id", resourceGroupId.ID())
 
-	if props := resp.RemediationProperties; props != nil {
+	if props := resp.Model.Properties; props != nil {
 		locations := []interface{}{}
 		if filters := props.Filters; filters != nil {
 			locations = utils.FlattenStringSlice(filters.Locations)
@@ -172,77 +208,85 @@ func resourceArmResourceGroupPolicyRemediationRead(d *pluginsdk.ResourceData, me
 			return fmt.Errorf("setting `location_filters`: %+v", err)
 		}
 
-		d.Set("policy_assignment_id", props.PolicyAssignmentID)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceID)
-		d.Set("resource_discovery_mode", string(props.ResourceDiscoveryMode))
+		d.Set("policy_assignment_id", props.PolicyAssignmentId)
+		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
+		d.Set("resource_discovery_mode", utils.NormalizeNilableString((*string)(props.ResourceDiscoveryMode)))
+
+		d.Set("resource_count", props.ResourceCount)
+		d.Set("parallel_deployments", props.ParallelDeployments)
+		if props.FailureThreshold != nil {
+			d.Set("failure_percentage", props.FailureThreshold.Percentage)
+		}
 	}
 
 	return nil
 }
 
 func resourceArmResourceGroupPolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.ResourceGroupPolicyRemediationID(d.Id())
+	id, err := policyinsights.ParseProviderRemediationID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	// we have to cancel the remediation first before deleting it when the resource_discovery_mode is set to ReEvaluateCompliance
 	// therefore we first retrieve the remediation to see if the resource_discovery_mode is switched to ReEvaluateCompliance
-	existing, err := client.GetAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName)
+	existing, err := client.RemediationsGetAtResourceGroup(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
+		if response.WasNotFound(existing.HttpResponse) {
 			return nil
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
-		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
-			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-			if _, err := client.CancelAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName); err != nil {
-				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-			}
+	if prop := existing.Model.Properties; prop != nil {
+		if mode := existing.Model.Properties.ResourceDiscoveryMode; mode != nil && *mode == policyinsights.ResourceDiscoveryModeReEvaluateCompliance {
+			// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+			if existing.Model.Properties.ProvisioningState != nil && *existing.Model.Properties.ProvisioningState == "Evaluating" {
+				log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+				if _, err := client.RemediationsCancelAtResourceGroup(ctx, *id); err != nil {
+					return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+				}
 
-			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-			stateConf := &pluginsdk.StateChangeConf{
-				Pending: []string{"Cancelling"},
-				Target: []string{
-					"Succeeded", "Canceled", "Failed",
-				},
-				Refresh:    resourceGroupPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-				MinTimeout: 10 * time.Second,
-				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-			}
+				log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+				stateConf := &pluginsdk.StateChangeConf{
+					Pending: []string{"Cancelling"},
+					Target: []string{
+						"Succeeded", "Canceled", "Failed",
+					},
+					Refresh:    resourceGroupPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+					MinTimeout: 10 * time.Second,
+					Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+				}
 
-			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				}
 			}
 		}
 	}
 
-	_, err = client.DeleteAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName)
+	_, err = client.RemediationsDeleteAtResourceGroup(ctx, *id)
 
 	return err
 }
 
-func resourceGroupPolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.RemediationsClient, id parse.ResourceGroupPolicyRemediationId) pluginsdk.StateRefreshFunc {
+func resourceGroupPolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.PolicyInsightsClient, id policyinsights.ProviderRemediationId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := client.GetAtResourceGroup(ctx, id.SubscriptionId, id.ResourceGroup, id.RemediationName)
+		resp, err := client.RemediationsGetAtResourceGroup(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("issuing read request for %s: %+v", id.ID(), err)
 		}
 
-		if resp.RemediationProperties == nil {
+		if resp.Model.Properties == nil {
 			return nil, "", fmt.Errorf("`properties` was nil")
 		}
-		if resp.RemediationProperties.ProvisioningState == nil {
+		if resp.Model.Properties.ProvisioningState == nil {
 			return nil, "", fmt.Errorf("`properties.ProvisioningState` was nil")
 		}
-		return resp, *resp.RemediationProperties.ProvisioningState, nil
+		return resp, *resp.Model.Properties.ProvisioningState, nil
 	}
 }

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -245,7 +245,7 @@ func resourceArmResourceGroupPolicyRemediationDelete(d *pluginsdk.ResourceData, 
 	if prop := existing.Model.Properties; prop != nil {
 		if mode := existing.Model.Properties.ResourceDiscoveryMode; mode != nil && *mode == policyinsights.ResourceDiscoveryModeReEvaluateCompliance {
 			// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
-			if existing.Model.Properties.ProvisioningState != nil && *existing.Model.Properties.ProvisioningState == "Evaluating" {
+			if ps := existing.Model.Properties.ProvisioningState; ps != nil && (*ps == "Evaluating" || *ps == "Accepted") {
 				log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
 				if _, err := client.RemediationsCancelAtResourceGroup(ctx, *id); err != nil {
 					return fmt.Errorf("cancelling %s: %+v", id.ID(), err)

--- a/internal/services/policy/remediation_resource_group_test.go
+++ b/internal/services/policy/remediation_resource_group_test.go
@@ -148,6 +148,9 @@ resource "azurerm_resource_group_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage      = 0.5
+  parallel_deployments    = 3
+  resource_count 	      = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_resource_group_test.go
+++ b/internal/services/policy/remediation_resource_group_test.go
@@ -150,7 +150,7 @@ resource "azurerm_resource_group_policy_remediation" "test" {
   resource_discovery_mode = "ReEvaluateCompliance"
   failure_percentage      = 0.5
   parallel_deployments    = 3
-  resource_count 	      = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_resource_test.go
+++ b/internal/services/policy/remediation_resource_test.go
@@ -122,7 +122,7 @@ resource "azurerm_resource_policy_remediation" "test" {
   resource_discovery_mode = "ReEvaluateCompliance"
   failure_percentage      = 0.5
   parallel_deployments    = 3
-  resource_count 	      = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_resource_test.go
+++ b/internal/services/policy/remediation_resource_test.go
@@ -120,6 +120,9 @@ resource "azurerm_resource_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = data.azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage      = 0.5
+  parallel_deployments    = 3
+  resource_count 	      = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_subscription.go
+++ b/internal/services/policy/remediation_subscription.go
@@ -6,14 +6,14 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-
-	"github.com/Azure/azure-sdk-for-go/services/preview/policyinsights/mgmt/2019-10-01-preview/policyinsights"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/sdk/2021-10-01/policyinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -64,6 +64,25 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 				ValidateFunc:     validate.PolicyAssignmentID,
 			},
 
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				Description:  "A number between 0.0 to 1.0 representing the percentage failure threshold.",
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
 			"location_filters": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -84,10 +103,10 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 			"resource_discovery_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(policyinsights.ExistingNonCompliant),
+				Default:  string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
 				ValidateFunc: validation.StringInSlice([]string{
-					string(policyinsights.ExistingNonCompliant),
-					string(policyinsights.ReEvaluateCompliance),
+					string(policyinsights.ResourceDiscoveryModeExistingNonCompliant),
+					string(policyinsights.ResourceDiscoveryModeReEvaluateCompliance),
 				}, false),
 			},
 		},
@@ -95,7 +114,7 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 }
 
 func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -104,32 +123,46 @@ func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceD
 		return err
 	}
 
-	id := parse.NewSubscriptionPolicyRemediationID(subscriptionId.SubscriptionId, d.Get("name").(string))
+	id := policyinsights.NewRemediationID(subscriptionId.SubscriptionId, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtSubscription(ctx, id.SubscriptionId, id.RemediationName)
+		existing, err := client.RemediationsGetAtSubscription(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
 			}
 		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_subscription_policy_remediation", *existing.ID)
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_subscription_policy_remediation", *existing.Model.Id)
 		}
 	}
 
 	parameters := policyinsights.Remediation{
-		RemediationProperties: &policyinsights.RemediationProperties{
+		Properties: &policyinsights.RemediationProperties{
 			Filters: &policyinsights.RemediationFilters{
 				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
 			},
-			PolicyAssignmentID:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceID: utils.String(d.Get("policy_definition_id").(string)),
-			ResourceDiscoveryMode:       policyinsights.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string)),
+			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
 		},
 	}
+	if v := d.Get("resource_discovery_mode").(string); v != "" {
+		mode := policyinsights.ResourceDiscoveryMode(v)
+		parameters.Properties.ResourceDiscoveryMode = &mode
+	}
+	if v := d.Get("failure_percentage").(float64); v != 0 {
+		parameters.Properties.FailureThreshold = &policyinsights.RemediationPropertiesFailureThreshold{
+			Percentage: utils.Float(v),
+		}
+	}
+	if v := d.Get("parallel_deployments").(int); v != 0 {
+		parameters.Properties.ParallelDeployments = utils.Int64(int64(v))
+	}
+	if v := d.Get("resource_count").(int); v != 0 {
+		parameters.Properties.ResourceCount = utils.Int64(int64(v))
+	}
 
-	if _, err = client.CreateOrUpdateAtSubscription(ctx, id.SubscriptionId, id.RemediationName, parameters); err != nil {
+	if _, err = client.RemediationsCreateOrUpdateAtSubscription(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
@@ -139,20 +172,20 @@ func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceD
 }
 
 func resourceArmSubscriptionPolicyRemediationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SubscriptionPolicyRemediationID(d.Id())
+	id, err := policyinsights.ParseRemediationID(d.Id())
 	if err != nil {
 		return fmt.Errorf("reading Policy Remediation: %+v", err)
 	}
 
 	subscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
 
-	resp, err := client.GetAtSubscription(ctx, id.SubscriptionId, id.RemediationName)
+	resp, err := client.RemediationsGetAtSubscription(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] %s does not exist - removing from state", id.ID())
 			d.SetId("")
 			return nil
@@ -163,7 +196,7 @@ func resourceArmSubscriptionPolicyRemediationRead(d *pluginsdk.ResourceData, met
 	d.Set("name", id.RemediationName)
 	d.Set("subscription_id", subscriptionId.ID())
 
-	if props := resp.RemediationProperties; props != nil {
+	if props := resp.Model.Properties; props != nil {
 		locations := []interface{}{}
 		if filters := props.Filters; filters != nil {
 			locations = utils.FlattenStringSlice(filters.Locations)
@@ -172,77 +205,85 @@ func resourceArmSubscriptionPolicyRemediationRead(d *pluginsdk.ResourceData, met
 			return fmt.Errorf("setting `location_filters`: %+v", err)
 		}
 
-		d.Set("policy_assignment_id", props.PolicyAssignmentID)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceID)
-		d.Set("resource_discovery_mode", string(props.ResourceDiscoveryMode))
+		d.Set("policy_assignment_id", props.PolicyAssignmentId)
+		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
+		d.Set("resource_discovery_mode", utils.NormalizeNilableString((*string)(props.ResourceDiscoveryMode)))
+
+		d.Set("resource_count", props.ResourceCount)
+		d.Set("parallel_deployments", props.ParallelDeployments)
+		if props.FailureThreshold != nil {
+			d.Set("failure_percentage", props.FailureThreshold.Percentage)
+		}
 	}
 
 	return nil
 }
 
 func resourceArmSubscriptionPolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.RemediationsClient
+	client := meta.(*clients.Client).Policy.PolicyInsightsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.SubscriptionPolicyRemediationID(d.Id())
+	id, err := policyinsights.ParseRemediationID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	// we have to cancel the remediation first before deleting it when the resource_discovery_mode is set to ReEvaluateCompliance
 	// therefore we first retrieve the remediation to see if the resource_discovery_mode is switched to ReEvaluateCompliance
-	existing, err := client.GetAtSubscription(ctx, id.SubscriptionId, id.RemediationName)
+	existing, err := client.RemediationsGetAtSubscription(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
+		if response.WasNotFound(existing.HttpResponse) {
 			return nil
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if existing.RemediationProperties != nil && existing.RemediationProperties.ResourceDiscoveryMode == policyinsights.ReEvaluateCompliance {
-		// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
-		if existing.RemediationProperties.ProvisioningState != nil && *existing.RemediationProperties.ProvisioningState == "Evaluating" {
-			log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
-			if _, err := client.CancelAtSubscription(ctx, id.SubscriptionId, id.RemediationName); err != nil {
-				return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
-			}
+	if prop := existing.Model.Properties; prop != nil {
+		if mode := existing.Model.Properties.ResourceDiscoveryMode; mode != nil && *mode == policyinsights.ResourceDiscoveryModeReEvaluateCompliance {
+			// Remediation can only be canceld when it is in "Evaluating" status, otherwise, API might raise error (e.g. canceling a "Completed" remediation returns 400).
+			if existing.Model.Properties.ProvisioningState != nil && *existing.Model.Properties.ProvisioningState == "Evaluating" {
+				log.Printf("[DEBUG] cancelling the remediation first before deleting it when `resource_discovery_mode` is set to `ReEvaluateCompliance`")
+				if _, err := client.RemediationsCancelAtSubscription(ctx, *id); err != nil {
+					return fmt.Errorf("cancelling %s: %+v", id.ID(), err)
+				}
 
-			log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
-			stateConf := &pluginsdk.StateChangeConf{
-				Pending: []string{"Cancelling"},
-				Target: []string{
-					"Succeeded", "Canceled", "Failed",
-				},
-				Refresh:    subscriptionPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
-				MinTimeout: 10 * time.Second,
-				Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-			}
+				log.Printf("[DEBUG] waiting for the %s to be canceled", id.ID())
+				stateConf := &pluginsdk.StateChangeConf{
+					Pending: []string{"Cancelling"},
+					Target: []string{
+						"Succeeded", "Canceled", "Failed",
+					},
+					Refresh:    subscriptionPolicyRemediationCancellationRefreshFunc(ctx, client, *id),
+					MinTimeout: 10 * time.Second,
+					Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+				}
 
-			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-				return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("waiting for %s to be canceled: %+v", id.ID(), err)
+				}
 			}
 		}
 	}
 
-	_, err = client.DeleteAtSubscription(ctx, id.SubscriptionId, id.RemediationName)
+	_, err = client.RemediationsDeleteAtSubscription(ctx, *id)
 
 	return err
 }
 
-func subscriptionPolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.RemediationsClient, id parse.SubscriptionPolicyRemediationId) pluginsdk.StateRefreshFunc {
+func subscriptionPolicyRemediationCancellationRefreshFunc(ctx context.Context, client *policyinsights.PolicyInsightsClient, id policyinsights.RemediationId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := client.GetAtSubscription(ctx, id.SubscriptionId, id.RemediationName)
+		resp, err := client.RemediationsGetAtSubscription(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("issuing read request for %s: %+v", id.ID(), err)
 		}
 
-		if resp.RemediationProperties == nil {
+		if resp.Model.Properties == nil {
 			return nil, "", fmt.Errorf("`properties` was nil")
 		}
-		if resp.RemediationProperties.ProvisioningState == nil {
+		if resp.Model.Properties.ProvisioningState == nil {
 			return nil, "", fmt.Errorf("`properties.ProvisioningState` was nil")
 		}
-		return resp, *resp.RemediationProperties.ProvisioningState, nil
+		return resp, *resp.Model.Properties.ProvisioningState, nil
 	}
 }

--- a/internal/services/policy/remediation_subscription_test.go
+++ b/internal/services/policy/remediation_subscription_test.go
@@ -110,9 +110,9 @@ resource "azurerm_subscription_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = data.azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
-  failure_percentage   	  = 0.5
+  failure_percentage      = 0.5
   parallel_deployments    = 3
-  resource_count 	      = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_subscription_test.go
+++ b/internal/services/policy/remediation_subscription_test.go
@@ -110,6 +110,9 @@ resource "azurerm_subscription_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = data.azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage   	  = 0.5
+  parallel_deployments    = 3
+  resource_count 	      = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/client.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/client.go
@@ -1,0 +1,18 @@
+package policyinsights
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyInsightsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewPolicyInsightsClientWithBaseURI(endpoint string) PolicyInsightsClient {
+	return PolicyInsightsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/constants.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/constants.go
@@ -1,0 +1,93 @@
+package policyinsights
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreatedByType string
+
+const (
+	CreatedByTypeApplication     CreatedByType = "Application"
+	CreatedByTypeKey             CreatedByType = "Key"
+	CreatedByTypeManagedIdentity CreatedByType = "ManagedIdentity"
+	CreatedByTypeUser            CreatedByType = "User"
+)
+
+func PossibleValuesForCreatedByType() []string {
+	return []string{
+		string(CreatedByTypeApplication),
+		string(CreatedByTypeKey),
+		string(CreatedByTypeManagedIdentity),
+		string(CreatedByTypeUser),
+	}
+}
+
+func parseCreatedByType(input string) (*CreatedByType, error) {
+	vals := map[string]CreatedByType{
+		"application":     CreatedByTypeApplication,
+		"key":             CreatedByTypeKey,
+		"managedidentity": CreatedByTypeManagedIdentity,
+		"user":            CreatedByTypeUser,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CreatedByType(input)
+	return &out, nil
+}
+
+type ManagementGroupsNamespaceType string
+
+const (
+	ManagementGroupsNamespaceTypeMicrosoftPointManagement ManagementGroupsNamespaceType = "Microsoft.Management"
+)
+
+func PossibleValuesForManagementGroupsNamespaceType() []string {
+	return []string{
+		string(ManagementGroupsNamespaceTypeMicrosoftPointManagement),
+	}
+}
+
+func parseManagementGroupsNamespaceType(input string) (*ManagementGroupsNamespaceType, error) {
+	vals := map[string]ManagementGroupsNamespaceType{
+		"microsoft.management": ManagementGroupsNamespaceTypeMicrosoftPointManagement,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagementGroupsNamespaceType(input)
+	return &out, nil
+}
+
+type ResourceDiscoveryMode string
+
+const (
+	ResourceDiscoveryModeExistingNonCompliant ResourceDiscoveryMode = "ExistingNonCompliant"
+	ResourceDiscoveryModeReEvaluateCompliance ResourceDiscoveryMode = "ReEvaluateCompliance"
+)
+
+func PossibleValuesForResourceDiscoveryMode() []string {
+	return []string{
+		string(ResourceDiscoveryModeExistingNonCompliant),
+		string(ResourceDiscoveryModeReEvaluateCompliance),
+	}
+}
+
+func parseResourceDiscoveryMode(input string) (*ResourceDiscoveryMode, error) {
+	vals := map[string]ResourceDiscoveryMode{
+		"existingnoncompliant": ResourceDiscoveryModeExistingNonCompliant,
+		"reevaluatecompliance": ResourceDiscoveryModeReEvaluateCompliance,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceDiscoveryMode(input)
+	return &out, nil
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_managementgroup.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_managementgroup.go
@@ -1,0 +1,125 @@
+package policyinsights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ManagementGroupId{}
+
+// ManagementGroupId is a struct representing the Resource ID for a Management Group
+type ManagementGroupId struct {
+	ManagementGroupsNamespace ManagementGroupsNamespaceType
+	ManagementGroupId         string
+}
+
+// NewManagementGroupID returns a new ManagementGroupId struct
+func NewManagementGroupID(managementGroupsNamespace ManagementGroupsNamespaceType, managementGroupId string) ManagementGroupId {
+	return ManagementGroupId{
+		ManagementGroupsNamespace: managementGroupsNamespace,
+		ManagementGroupId:         managementGroupId,
+	}
+}
+
+// ParseManagementGroupID parses 'input' into a ManagementGroupId
+func ParseManagementGroupID(input string) (*ManagementGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagementGroupId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagementGroupId{}
+
+	if v, constFound := parsed.Parsed["managementGroupsNamespace"]; true {
+		if !constFound {
+			return nil, fmt.Errorf("the segment 'managementGroupsNamespace' was not found in the resource id %q", input)
+		}
+
+		managementGroupsNamespace, err := parseManagementGroupsNamespaceType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ManagementGroupsNamespace = *managementGroupsNamespace
+	}
+
+	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
+		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseManagementGroupIDInsensitively parses 'input' case-insensitively into a ManagementGroupId
+// note: this method should only be used for API response data and not user input
+func ParseManagementGroupIDInsensitively(input string) (*ManagementGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagementGroupId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagementGroupId{}
+
+	if v, constFound := parsed.Parsed["managementGroupsNamespace"]; true {
+		if !constFound {
+			return nil, fmt.Errorf("the segment 'managementGroupsNamespace' was not found in the resource id %q", input)
+		}
+
+		managementGroupsNamespace, err := parseManagementGroupsNamespaceType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ManagementGroupsNamespace = *managementGroupsNamespace
+	}
+
+	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
+		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateManagementGroupID checks that 'input' can be parsed as a Management Group ID
+func ValidateManagementGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseManagementGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Management Group ID
+func (id ManagementGroupId) ID() string {
+	fmtString := "/providers/%s/managementGroups/%s"
+	return fmt.Sprintf(fmtString, string(id.ManagementGroupsNamespace), id.ManagementGroupId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Management Group ID
+func (id ManagementGroupId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ConstantSegment("managementGroupsNamespace", PossibleValuesForManagementGroupsNamespaceType(), "Microsoft.Management"),
+		resourceids.StaticSegment("staticManagementGroups", "managementGroups", "managementGroups"),
+		resourceids.UserSpecifiedSegment("managementGroupId", "managementGroupIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Management Group ID
+func (id ManagementGroupId) String() string {
+	components := []string{
+		fmt.Sprintf("Management Groups Namespace: %q", string(id.ManagementGroupsNamespace)),
+		fmt.Sprintf("Management Group: %q", id.ManagementGroupId),
+	}
+	return fmt.Sprintf("Management Group (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_managementgroup_test.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_managementgroup_test.go
@@ -1,0 +1,204 @@
+package policyinsights
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ManagementGroupId{}
+
+func TestNewManagementGroupID(t *testing.T) {
+	id := NewManagementGroupID("Microsoft.Management", "managementGroupIdValue")
+
+	if id.ManagementGroupsNamespace != "Microsoft.Management" {
+		t.Fatalf("Expected %q but got %q for Segment 'ManagementGroupsNamespace'", id.ManagementGroupsNamespace, "Microsoft.Management")
+	}
+
+	if id.ManagementGroupId != "managementGroupIdValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ManagementGroupId'", id.ManagementGroupId, "managementGroupIdValue")
+	}
+}
+
+func TestFormatManagementGroupID(t *testing.T) {
+	actual := NewManagementGroupID("Microsoft.Management", "managementGroupIdValue").ID()
+	expected := "/providers/Microsoft.Management/managementGroups/managementGroupIdValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseManagementGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ManagementGroupId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue",
+			Expected: &ManagementGroupId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "managementGroupIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseManagementGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ManagementGroupsNamespace != v.Expected.ManagementGroupsNamespace {
+			t.Fatalf("Expected %q but got %q for ManagementGroupsNamespace", v.Expected.ManagementGroupsNamespace, actual.ManagementGroupsNamespace)
+		}
+
+		if actual.ManagementGroupId != v.Expected.ManagementGroupId {
+			t.Fatalf("Expected %q but got %q for ManagementGroupId", v.Expected.ManagementGroupId, actual.ManagementGroupId)
+		}
+
+	}
+}
+
+func TestParseManagementGroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ManagementGroupId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue",
+			Expected: &ManagementGroupId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "managementGroupIdValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE",
+			Expected: &ManagementGroupId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "mAnAgEmEnTgRoUpIdVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseManagementGroupIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ManagementGroupsNamespace != v.Expected.ManagementGroupsNamespace {
+			t.Fatalf("Expected %q but got %q for ManagementGroupsNamespace", v.Expected.ManagementGroupsNamespace, actual.ManagementGroupsNamespace)
+		}
+
+		if actual.ManagementGroupId != v.Expected.ManagementGroupId {
+			t.Fatalf("Expected %q but got %q for ManagementGroupId", v.Expected.ManagementGroupId, actual.ManagementGroupId)
+		}
+
+	}
+}
+
+func TestSegmentsForManagementGroupId(t *testing.T) {
+	segments := ManagementGroupId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ManagementGroupId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_providerremediation.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_providerremediation.go
@@ -1,0 +1,124 @@
+package policyinsights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ProviderRemediationId{}
+
+// ProviderRemediationId is a struct representing the Resource ID for a Provider Remediation
+type ProviderRemediationId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	RemediationName   string
+}
+
+// NewProviderRemediationID returns a new ProviderRemediationId struct
+func NewProviderRemediationID(subscriptionId string, resourceGroupName string, remediationName string) ProviderRemediationId {
+	return ProviderRemediationId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		RemediationName:   remediationName,
+	}
+}
+
+// ParseProviderRemediationID parses 'input' into a ProviderRemediationId
+func ParseProviderRemediationID(input string) (*ProviderRemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderRemediationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderRemediationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseProviderRemediationIDInsensitively parses 'input' case-insensitively into a ProviderRemediationId
+// note: this method should only be used for API response data and not user input
+func ParseProviderRemediationIDInsensitively(input string) (*ProviderRemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderRemediationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderRemediationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateProviderRemediationID checks that 'input' can be parsed as a Provider Remediation ID
+func ValidateProviderRemediationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderRemediationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Remediation ID
+func (id ProviderRemediationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.PolicyInsights/remediations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.RemediationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Remediation ID
+func (id ProviderRemediationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftPolicyInsights", "Microsoft.PolicyInsights", "Microsoft.PolicyInsights"),
+		resourceids.StaticSegment("staticRemediations", "remediations", "remediations"),
+		resourceids.UserSpecifiedSegment("remediationName", "remediationValue"),
+	}
+}
+
+// String returns a human-readable description of this Provider Remediation ID
+func (id ProviderRemediationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Remediation Name: %q", id.RemediationName),
+	}
+	return fmt.Sprintf("Provider Remediation (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_providerremediation_test.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_providerremediation_test.go
@@ -1,0 +1,279 @@
+package policyinsights
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ProviderRemediationId{}
+
+func TestNewProviderRemediationID(t *testing.T) {
+	id := NewProviderRemediationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "remediationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
+	}
+
+	if id.RemediationName != "remediationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'RemediationName'", id.RemediationName, "remediationValue")
+	}
+}
+
+func TestFormatProviderRemediationID(t *testing.T) {
+	actual := NewProviderRemediationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "remediationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseProviderRemediationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ProviderRemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &ProviderRemediationId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				RemediationName:   "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseProviderRemediationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestParseProviderRemediationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ProviderRemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &ProviderRemediationId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				RemediationName:   "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE",
+			Expected: &ProviderRemediationId{
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				RemediationName:   "rEmEdIaTiOnVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseProviderRemediationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestSegmentsForProviderRemediationId(t *testing.T) {
+	segments := ProviderRemediationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ProviderRemediationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_providers2remediation.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_providers2remediation.go
@@ -1,0 +1,140 @@
+package policyinsights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = Providers2RemediationId{}
+
+// Providers2RemediationId is a struct representing the Resource ID for a Providers 2 Remediation
+type Providers2RemediationId struct {
+	ManagementGroupsNamespace ManagementGroupsNamespaceType
+	ManagementGroupId         string
+	RemediationName           string
+}
+
+// NewProviders2RemediationID returns a new Providers2RemediationId struct
+func NewProviders2RemediationID(managementGroupsNamespace ManagementGroupsNamespaceType, managementGroupId string, remediationName string) Providers2RemediationId {
+	return Providers2RemediationId{
+		ManagementGroupsNamespace: managementGroupsNamespace,
+		ManagementGroupId:         managementGroupId,
+		RemediationName:           remediationName,
+	}
+}
+
+// ParseProviders2RemediationID parses 'input' into a Providers2RemediationId
+func ParseProviders2RemediationID(input string) (*Providers2RemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(Providers2RemediationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := Providers2RemediationId{}
+
+	if v, constFound := parsed.Parsed["managementGroupsNamespace"]; true {
+		if !constFound {
+			return nil, fmt.Errorf("the segment 'managementGroupsNamespace' was not found in the resource id %q", input)
+		}
+
+		managementGroupsNamespace, err := parseManagementGroupsNamespaceType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ManagementGroupsNamespace = *managementGroupsNamespace
+	}
+
+	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
+		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseProviders2RemediationIDInsensitively parses 'input' case-insensitively into a Providers2RemediationId
+// note: this method should only be used for API response data and not user input
+func ParseProviders2RemediationIDInsensitively(input string) (*Providers2RemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(Providers2RemediationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := Providers2RemediationId{}
+
+	if v, constFound := parsed.Parsed["managementGroupsNamespace"]; true {
+		if !constFound {
+			return nil, fmt.Errorf("the segment 'managementGroupsNamespace' was not found in the resource id %q", input)
+		}
+
+		managementGroupsNamespace, err := parseManagementGroupsNamespaceType(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %+v", v, err)
+		}
+		id.ManagementGroupsNamespace = *managementGroupsNamespace
+	}
+
+	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
+		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateProviders2RemediationID checks that 'input' can be parsed as a Providers 2 Remediation ID
+func ValidateProviders2RemediationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviders2RemediationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Providers 2 Remediation ID
+func (id Providers2RemediationId) ID() string {
+	fmtString := "/providers/%s/managementGroups/%s/providers/Microsoft.PolicyInsights/remediations/%s"
+	return fmt.Sprintf(fmtString, string(id.ManagementGroupsNamespace), id.ManagementGroupId, id.RemediationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Providers 2 Remediation ID
+func (id Providers2RemediationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ConstantSegment("managementGroupsNamespace", PossibleValuesForManagementGroupsNamespaceType(), "Microsoft.Management"),
+		resourceids.StaticSegment("staticManagementGroups", "managementGroups", "managementGroups"),
+		resourceids.UserSpecifiedSegment("managementGroupId", "managementGroupIdValue"),
+		resourceids.StaticSegment("staticProviders2", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftPolicyInsights", "Microsoft.PolicyInsights", "Microsoft.PolicyInsights"),
+		resourceids.StaticSegment("staticRemediations", "remediations", "remediations"),
+		resourceids.UserSpecifiedSegment("remediationName", "remediationValue"),
+	}
+}
+
+// String returns a human-readable description of this Providers 2 Remediation ID
+func (id Providers2RemediationId) String() string {
+	components := []string{
+		fmt.Sprintf("Management Groups Namespace: %q", string(id.ManagementGroupsNamespace)),
+		fmt.Sprintf("Management Group: %q", id.ManagementGroupId),
+		fmt.Sprintf("Remediation Name: %q", id.RemediationName),
+	}
+	return fmt.Sprintf("Providers 2 Remediation (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_providers2remediation_test.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_providers2remediation_test.go
@@ -1,0 +1,279 @@
+package policyinsights
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = Providers2RemediationId{}
+
+func TestNewProviders2RemediationID(t *testing.T) {
+	id := NewProviders2RemediationID("Microsoft.Management", "managementGroupIdValue", "remediationValue")
+
+	if id.ManagementGroupsNamespace != "Microsoft.Management" {
+		t.Fatalf("Expected %q but got %q for Segment 'ManagementGroupsNamespace'", id.ManagementGroupsNamespace, "Microsoft.Management")
+	}
+
+	if id.ManagementGroupId != "managementGroupIdValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'ManagementGroupId'", id.ManagementGroupId, "managementGroupIdValue")
+	}
+
+	if id.RemediationName != "remediationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'RemediationName'", id.RemediationName, "remediationValue")
+	}
+}
+
+func TestFormatProviders2RemediationID(t *testing.T) {
+	actual := NewProviders2RemediationID("Microsoft.Management", "managementGroupIdValue", "remediationValue").ID()
+	expected := "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations/remediationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseProviders2RemediationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *Providers2RemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &Providers2RemediationId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "managementGroupIdValue",
+				RemediationName:           "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseProviders2RemediationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ManagementGroupsNamespace != v.Expected.ManagementGroupsNamespace {
+			t.Fatalf("Expected %q but got %q for ManagementGroupsNamespace", v.Expected.ManagementGroupsNamespace, actual.ManagementGroupsNamespace)
+		}
+
+		if actual.ManagementGroupId != v.Expected.ManagementGroupId {
+			t.Fatalf("Expected %q but got %q for ManagementGroupId", v.Expected.ManagementGroupId, actual.ManagementGroupId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestParseProviders2RemediationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *Providers2RemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &Providers2RemediationId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "managementGroupIdValue",
+				RemediationName:           "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroupIdValue/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE",
+			Expected: &Providers2RemediationId{
+				ManagementGroupsNamespace: "Microsoft.Management",
+				ManagementGroupId:         "mAnAgEmEnTgRoUpIdVaLuE",
+				RemediationName:           "rEmEdIaTiOnVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/pRoViDeRs/mIcRoSoFt.mAnAgEmEnT/mAnAgEmEnTgRoUpS/mAnAgEmEnTgRoUpIdVaLuE/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseProviders2RemediationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ManagementGroupsNamespace != v.Expected.ManagementGroupsNamespace {
+			t.Fatalf("Expected %q but got %q for ManagementGroupsNamespace", v.Expected.ManagementGroupsNamespace, actual.ManagementGroupsNamespace)
+		}
+
+		if actual.ManagementGroupId != v.Expected.ManagementGroupId {
+			t.Fatalf("Expected %q but got %q for ManagementGroupId", v.Expected.ManagementGroupId, actual.ManagementGroupId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestSegmentsForProviders2RemediationId(t *testing.T) {
+	segments := Providers2RemediationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("Providers2RemediationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_remediation.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_remediation.go
@@ -1,0 +1,111 @@
+package policyinsights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = RemediationId{}
+
+// RemediationId is a struct representing the Resource ID for a Remediation
+type RemediationId struct {
+	SubscriptionId  string
+	RemediationName string
+}
+
+// NewRemediationID returns a new RemediationId struct
+func NewRemediationID(subscriptionId string, remediationName string) RemediationId {
+	return RemediationId{
+		SubscriptionId:  subscriptionId,
+		RemediationName: remediationName,
+	}
+}
+
+// ParseRemediationID parses 'input' into a RemediationId
+func ParseRemediationID(input string) (*RemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RemediationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RemediationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseRemediationIDInsensitively parses 'input' case-insensitively into a RemediationId
+// note: this method should only be used for API response data and not user input
+func ParseRemediationIDInsensitively(input string) (*RemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RemediationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RemediationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateRemediationID checks that 'input' can be parsed as a Remediation ID
+func ValidateRemediationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRemediationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Remediation ID
+func (id RemediationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.PolicyInsights/remediations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.RemediationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Remediation ID
+func (id RemediationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftPolicyInsights", "Microsoft.PolicyInsights", "Microsoft.PolicyInsights"),
+		resourceids.StaticSegment("staticRemediations", "remediations", "remediations"),
+		resourceids.UserSpecifiedSegment("remediationName", "remediationValue"),
+	}
+}
+
+// String returns a human-readable description of this Remediation ID
+func (id RemediationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Remediation Name: %q", id.RemediationName),
+	}
+	return fmt.Sprintf("Remediation (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_remediation_test.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_remediation_test.go
@@ -1,0 +1,234 @@
+package policyinsights
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = RemediationId{}
+
+func TestNewRemediationID(t *testing.T) {
+	id := NewRemediationID("12345678-1234-9876-4563-123456789012", "remediationValue")
+
+	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
+		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
+	}
+
+	if id.RemediationName != "remediationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'RemediationName'", id.RemediationName, "remediationValue")
+	}
+}
+
+func TestFormatRemediationID(t *testing.T) {
+	actual := NewRemediationID("12345678-1234-9876-4563-123456789012", "remediationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations/remediationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseRemediationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *RemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &RemediationId{
+				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+				RemediationName: "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseRemediationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestParseRemediationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *RemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &RemediationId{
+				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+				RemediationName: "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE",
+			Expected: &RemediationId{
+				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+				RemediationName: "rEmEdIaTiOnVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseRemediationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestSegmentsForRemediationId(t *testing.T) {
+	segments := RemediationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("RemediationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_scopedremediation.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_scopedremediation.go
@@ -1,0 +1,110 @@
+package policyinsights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ScopedRemediationId{}
+
+// ScopedRemediationId is a struct representing the Resource ID for a Scoped Remediation
+type ScopedRemediationId struct {
+	ResourceId      string
+	RemediationName string
+}
+
+// NewScopedRemediationID returns a new ScopedRemediationId struct
+func NewScopedRemediationID(resourceId string, remediationName string) ScopedRemediationId {
+	return ScopedRemediationId{
+		ResourceId:      resourceId,
+		RemediationName: remediationName,
+	}
+}
+
+// ParseScopedRemediationID parses 'input' into a ScopedRemediationId
+func ParseScopedRemediationID(input string) (*ScopedRemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ScopedRemediationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ScopedRemediationId{}
+
+	if id.ResourceId, ok = parsed.Parsed["resourceId"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseScopedRemediationIDInsensitively parses 'input' case-insensitively into a ScopedRemediationId
+// note: this method should only be used for API response data and not user input
+func ParseScopedRemediationIDInsensitively(input string) (*ScopedRemediationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ScopedRemediationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ScopedRemediationId{}
+
+	if id.ResourceId, ok = parsed.Parsed["resourceId"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceId' was not found in the resource id %q", input)
+	}
+
+	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
+		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateScopedRemediationID checks that 'input' can be parsed as a Scoped Remediation ID
+func ValidateScopedRemediationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseScopedRemediationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Scoped Remediation ID
+func (id ScopedRemediationId) ID() string {
+	fmtString := "/%s/providers/Microsoft.PolicyInsights/remediations/%s"
+	return fmt.Sprintf(fmtString, strings.TrimPrefix(id.ResourceId, "/"), id.RemediationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Scoped Remediation ID
+func (id ScopedRemediationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.ScopeSegment("resourceId", "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftPolicyInsights", "Microsoft.PolicyInsights", "Microsoft.PolicyInsights"),
+		resourceids.StaticSegment("staticRemediations", "remediations", "remediations"),
+		resourceids.UserSpecifiedSegment("remediationName", "remediationValue"),
+	}
+}
+
+// String returns a human-readable description of this Scoped Remediation ID
+func (id ScopedRemediationId) String() string {
+	components := []string{
+		fmt.Sprintf("Resource: %q", id.ResourceId),
+		fmt.Sprintf("Remediation Name: %q", id.RemediationName),
+	}
+	return fmt.Sprintf("Scoped Remediation (%s)", strings.Join(components, "\n"))
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/id_scopedremediation_test.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/id_scopedremediation_test.go
@@ -1,0 +1,219 @@
+package policyinsights
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ScopedRemediationId{}
+
+func TestNewScopedRemediationID(t *testing.T) {
+	id := NewScopedRemediationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "remediationValue")
+
+	if id.ResourceId != "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceId'", id.ResourceId, "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+	}
+
+	if id.RemediationName != "remediationValue" {
+		t.Fatalf("Expected %q but got %q for Segment 'RemediationName'", id.RemediationName, "remediationValue")
+	}
+}
+
+func TestFormatScopedRemediationID(t *testing.T) {
+	actual := NewScopedRemediationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "remediationValue").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue"
+	if actual != expected {
+		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseScopedRemediationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ScopedRemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &ScopedRemediationId{
+				ResourceId:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group",
+				RemediationName: "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseScopedRemediationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ResourceId != v.Expected.ResourceId {
+			t.Fatalf("Expected %q but got %q for ResourceId", v.Expected.ResourceId, actual.ResourceId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestParseScopedRemediationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ScopedRemediationId
+	}{
+		{
+			// Incomplete URI
+			Input: "",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp/pRoViDeRs",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS",
+			Error: true,
+		},
+		{
+			// Incomplete URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations",
+			Error: true,
+		},
+		{
+			// Incomplete URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS",
+			Error: true,
+		},
+		{
+			// Valid URI
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue",
+			Expected: &ScopedRemediationId{
+				ResourceId:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group",
+				RemediationName: "remediationValue",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment)
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group/providers/Microsoft.PolicyInsights/remediations/remediationValue/extra",
+			Error: true,
+		},
+		{
+			// Valid URI (mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE",
+			Expected: &ScopedRemediationId{
+				ResourceId:      "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp",
+				RemediationName: "rEmEdIaTiOnVaLuE",
+			},
+		},
+		{
+			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/sOmE-ReSoUrCe-gRoUp/pRoViDeRs/mIcRoSoFt.pOlIcYiNsIgHtS/rEmEdIaTiOnS/rEmEdIaTiOnVaLuE/extra",
+			Error: true,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ParseScopedRemediationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %+v", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.ResourceId != v.Expected.ResourceId {
+			t.Fatalf("Expected %q but got %q for ResourceId", v.Expected.ResourceId, actual.ResourceId)
+		}
+
+		if actual.RemediationName != v.Expected.RemediationName {
+			t.Fatalf("Expected %q but got %q for RemediationName", v.Expected.RemediationName, actual.RemediationName)
+		}
+
+	}
+}
+
+func TestSegmentsForScopedRemediationId(t *testing.T) {
+	segments := ScopedRemediationId{}.Segments()
+	if len(segments) == 0 {
+		t.Fatalf("ScopedRemediationId has no segments")
+	}
+
+	uniqueNames := make(map[string]struct{}, 0)
+	for _, segment := range segments {
+		uniqueNames[segment.Name] = struct{}{}
+	}
+	if len(uniqueNames) != len(segments) {
+		t.Fatalf("Expected the Segments to be unique but got %q unique segments and %d total segments", len(uniqueNames), len(segments))
+	}
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatmanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatmanagementgroup_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCancelAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCancelAtManagementGroup ...
+func (c PolicyInsightsClient) RemediationsCancelAtManagementGroup(ctx context.Context, id Providers2RemediationId) (result RemediationsCancelAtManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCancelAtManagementGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtManagementGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCancelAtManagementGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtManagementGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCancelAtManagementGroup prepares the RemediationsCancelAtManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsCancelAtManagementGroup(ctx context.Context, id Providers2RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/cancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCancelAtManagementGroup handles the response to the RemediationsCancelAtManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCancelAtManagementGroup(resp *http.Response) (result RemediationsCancelAtManagementGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatresource_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCancelAtResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCancelAtResource ...
+func (c PolicyInsightsClient) RemediationsCancelAtResource(ctx context.Context, id ScopedRemediationId) (result RemediationsCancelAtResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCancelAtResource(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResource", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResource", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCancelAtResource(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResource", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCancelAtResource prepares the RemediationsCancelAtResource request.
+func (c PolicyInsightsClient) preparerForRemediationsCancelAtResource(ctx context.Context, id ScopedRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/cancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCancelAtResource handles the response to the RemediationsCancelAtResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCancelAtResource(resp *http.Response) (result RemediationsCancelAtResourceOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatresourcegroup_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCancelAtResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCancelAtResourceGroup ...
+func (c PolicyInsightsClient) RemediationsCancelAtResourceGroup(ctx context.Context, id ProviderRemediationId) (result RemediationsCancelAtResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCancelAtResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCancelAtResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCancelAtResourceGroup prepares the RemediationsCancelAtResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsCancelAtResourceGroup(ctx context.Context, id ProviderRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/cancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCancelAtResourceGroup handles the response to the RemediationsCancelAtResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCancelAtResourceGroup(resp *http.Response) (result RemediationsCancelAtResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscancelatsubscription_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCancelAtSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCancelAtSubscription ...
+func (c PolicyInsightsClient) RemediationsCancelAtSubscription(ctx context.Context, id RemediationId) (result RemediationsCancelAtSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCancelAtSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCancelAtSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCancelAtSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCancelAtSubscription prepares the RemediationsCancelAtSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsCancelAtSubscription(ctx context.Context, id RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/cancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCancelAtSubscription handles the response to the RemediationsCancelAtSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCancelAtSubscription(resp *http.Response) (result RemediationsCancelAtSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatmanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatmanagementgroup_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCreateOrUpdateAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCreateOrUpdateAtManagementGroup ...
+func (c PolicyInsightsClient) RemediationsCreateOrUpdateAtManagementGroup(ctx context.Context, id Providers2RemediationId, input Remediation) (result RemediationsCreateOrUpdateAtManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCreateOrUpdateAtManagementGroup(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtManagementGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCreateOrUpdateAtManagementGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtManagementGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCreateOrUpdateAtManagementGroup prepares the RemediationsCreateOrUpdateAtManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsCreateOrUpdateAtManagementGroup(ctx context.Context, id Providers2RemediationId, input Remediation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCreateOrUpdateAtManagementGroup handles the response to the RemediationsCreateOrUpdateAtManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCreateOrUpdateAtManagementGroup(resp *http.Response) (result RemediationsCreateOrUpdateAtManagementGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatresource_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCreateOrUpdateAtResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCreateOrUpdateAtResource ...
+func (c PolicyInsightsClient) RemediationsCreateOrUpdateAtResource(ctx context.Context, id ScopedRemediationId, input Remediation) (result RemediationsCreateOrUpdateAtResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCreateOrUpdateAtResource(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResource", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResource", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCreateOrUpdateAtResource(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResource", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCreateOrUpdateAtResource prepares the RemediationsCreateOrUpdateAtResource request.
+func (c PolicyInsightsClient) preparerForRemediationsCreateOrUpdateAtResource(ctx context.Context, id ScopedRemediationId, input Remediation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCreateOrUpdateAtResource handles the response to the RemediationsCreateOrUpdateAtResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCreateOrUpdateAtResource(resp *http.Response) (result RemediationsCreateOrUpdateAtResourceOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatresourcegroup_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCreateOrUpdateAtResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCreateOrUpdateAtResourceGroup ...
+func (c PolicyInsightsClient) RemediationsCreateOrUpdateAtResourceGroup(ctx context.Context, id ProviderRemediationId, input Remediation) (result RemediationsCreateOrUpdateAtResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCreateOrUpdateAtResourceGroup(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCreateOrUpdateAtResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCreateOrUpdateAtResourceGroup prepares the RemediationsCreateOrUpdateAtResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsCreateOrUpdateAtResourceGroup(ctx context.Context, id ProviderRemediationId, input Remediation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCreateOrUpdateAtResourceGroup handles the response to the RemediationsCreateOrUpdateAtResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCreateOrUpdateAtResourceGroup(resp *http.Response) (result RemediationsCreateOrUpdateAtResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationscreateorupdateatsubscription_autorest.go
@@ -1,0 +1,65 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsCreateOrUpdateAtSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsCreateOrUpdateAtSubscription ...
+func (c PolicyInsightsClient) RemediationsCreateOrUpdateAtSubscription(ctx context.Context, id RemediationId, input Remediation) (result RemediationsCreateOrUpdateAtSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsCreateOrUpdateAtSubscription(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsCreateOrUpdateAtSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsCreateOrUpdateAtSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsCreateOrUpdateAtSubscription prepares the RemediationsCreateOrUpdateAtSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsCreateOrUpdateAtSubscription(ctx context.Context, id RemediationId, input Remediation) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsCreateOrUpdateAtSubscription handles the response to the RemediationsCreateOrUpdateAtSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsCreateOrUpdateAtSubscription(resp *http.Response) (result RemediationsCreateOrUpdateAtSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatmanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatmanagementgroup_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsDeleteAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsDeleteAtManagementGroup ...
+func (c PolicyInsightsClient) RemediationsDeleteAtManagementGroup(ctx context.Context, id Providers2RemediationId) (result RemediationsDeleteAtManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsDeleteAtManagementGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtManagementGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsDeleteAtManagementGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtManagementGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsDeleteAtManagementGroup prepares the RemediationsDeleteAtManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsDeleteAtManagementGroup(ctx context.Context, id Providers2RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsDeleteAtManagementGroup handles the response to the RemediationsDeleteAtManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsDeleteAtManagementGroup(resp *http.Response) (result RemediationsDeleteAtManagementGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatresource_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsDeleteAtResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsDeleteAtResource ...
+func (c PolicyInsightsClient) RemediationsDeleteAtResource(ctx context.Context, id ScopedRemediationId) (result RemediationsDeleteAtResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsDeleteAtResource(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResource", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResource", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsDeleteAtResource(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResource", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsDeleteAtResource prepares the RemediationsDeleteAtResource request.
+func (c PolicyInsightsClient) preparerForRemediationsDeleteAtResource(ctx context.Context, id ScopedRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsDeleteAtResource handles the response to the RemediationsDeleteAtResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsDeleteAtResource(resp *http.Response) (result RemediationsDeleteAtResourceOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatresourcegroup_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsDeleteAtResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsDeleteAtResourceGroup ...
+func (c PolicyInsightsClient) RemediationsDeleteAtResourceGroup(ctx context.Context, id ProviderRemediationId) (result RemediationsDeleteAtResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsDeleteAtResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsDeleteAtResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsDeleteAtResourceGroup prepares the RemediationsDeleteAtResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsDeleteAtResourceGroup(ctx context.Context, id ProviderRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsDeleteAtResourceGroup handles the response to the RemediationsDeleteAtResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsDeleteAtResourceGroup(resp *http.Response) (result RemediationsDeleteAtResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsdeleteatsubscription_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsDeleteAtSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsDeleteAtSubscription ...
+func (c PolicyInsightsClient) RemediationsDeleteAtSubscription(ctx context.Context, id RemediationId) (result RemediationsDeleteAtSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsDeleteAtSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsDeleteAtSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsDeleteAtSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsDeleteAtSubscription prepares the RemediationsDeleteAtSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsDeleteAtSubscription(ctx context.Context, id RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsDeleteAtSubscription handles the response to the RemediationsDeleteAtSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsDeleteAtSubscription(resp *http.Response) (result RemediationsDeleteAtSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatmanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatmanagementgroup_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsGetAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsGetAtManagementGroup ...
+func (c PolicyInsightsClient) RemediationsGetAtManagementGroup(ctx context.Context, id Providers2RemediationId) (result RemediationsGetAtManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsGetAtManagementGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtManagementGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsGetAtManagementGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtManagementGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsGetAtManagementGroup prepares the RemediationsGetAtManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsGetAtManagementGroup(ctx context.Context, id Providers2RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsGetAtManagementGroup handles the response to the RemediationsGetAtManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsGetAtManagementGroup(resp *http.Response) (result RemediationsGetAtManagementGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatresource_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsGetAtResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsGetAtResource ...
+func (c PolicyInsightsClient) RemediationsGetAtResource(ctx context.Context, id ScopedRemediationId) (result RemediationsGetAtResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsGetAtResource(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResource", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResource", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsGetAtResource(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResource", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsGetAtResource prepares the RemediationsGetAtResource request.
+func (c PolicyInsightsClient) preparerForRemediationsGetAtResource(ctx context.Context, id ScopedRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsGetAtResource handles the response to the RemediationsGetAtResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsGetAtResource(resp *http.Response) (result RemediationsGetAtResourceOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatresourcegroup_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsGetAtResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsGetAtResourceGroup ...
+func (c PolicyInsightsClient) RemediationsGetAtResourceGroup(ctx context.Context, id ProviderRemediationId) (result RemediationsGetAtResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsGetAtResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsGetAtResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsGetAtResourceGroup prepares the RemediationsGetAtResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsGetAtResourceGroup(ctx context.Context, id ProviderRemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsGetAtResourceGroup handles the response to the RemediationsGetAtResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsGetAtResourceGroup(resp *http.Response) (result RemediationsGetAtResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationsgetatsubscription_autorest.go
@@ -1,0 +1,64 @@
+package policyinsights
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsGetAtSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Remediation
+}
+
+// RemediationsGetAtSubscription ...
+func (c PolicyInsightsClient) RemediationsGetAtSubscription(ctx context.Context, id RemediationId) (result RemediationsGetAtSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsGetAtSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRemediationsGetAtSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsGetAtSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRemediationsGetAtSubscription prepares the RemediationsGetAtSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsGetAtSubscription(ctx context.Context, id RemediationId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsGetAtSubscription handles the response to the RemediationsGetAtSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsGetAtSubscription(resp *http.Response) (result RemediationsGetAtSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatmanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatmanagementgroup_autorest.go
@@ -1,0 +1,212 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsListDeploymentsAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]RemediationDeployment
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListDeploymentsAtManagementGroupOperationResponse, error)
+}
+
+type RemediationsListDeploymentsAtManagementGroupCompleteResult struct {
+	Items []RemediationDeployment
+}
+
+func (r RemediationsListDeploymentsAtManagementGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListDeploymentsAtManagementGroupOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListDeploymentsAtManagementGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListDeploymentsAtManagementGroupOperationOptions struct {
+	Top *int64
+}
+
+func DefaultRemediationsListDeploymentsAtManagementGroupOperationOptions() RemediationsListDeploymentsAtManagementGroupOperationOptions {
+	return RemediationsListDeploymentsAtManagementGroupOperationOptions{}
+}
+
+func (o RemediationsListDeploymentsAtManagementGroupOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListDeploymentsAtManagementGroupOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListDeploymentsAtManagementGroup ...
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtManagementGroup(ctx context.Context, id Providers2RemediationId, options RemediationsListDeploymentsAtManagementGroupOperationOptions) (resp RemediationsListDeploymentsAtManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListDeploymentsAtManagementGroup(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListDeploymentsAtManagementGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListDeploymentsAtManagementGroupComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtManagementGroupComplete(ctx context.Context, id Providers2RemediationId, options RemediationsListDeploymentsAtManagementGroupOperationOptions) (RemediationsListDeploymentsAtManagementGroupCompleteResult, error) {
+	return c.RemediationsListDeploymentsAtManagementGroupCompleteMatchingPredicate(ctx, id, options, RemediationDeploymentOperationPredicate{})
+}
+
+// RemediationsListDeploymentsAtManagementGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtManagementGroupCompleteMatchingPredicate(ctx context.Context, id Providers2RemediationId, options RemediationsListDeploymentsAtManagementGroupOperationOptions, predicate RemediationDeploymentOperationPredicate) (resp RemediationsListDeploymentsAtManagementGroupCompleteResult, err error) {
+	items := make([]RemediationDeployment, 0)
+
+	page, err := c.RemediationsListDeploymentsAtManagementGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListDeploymentsAtManagementGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListDeploymentsAtManagementGroup prepares the RemediationsListDeploymentsAtManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtManagementGroup(ctx context.Context, id Providers2RemediationId, options RemediationsListDeploymentsAtManagementGroupOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/listDeployments", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListDeploymentsAtManagementGroupWithNextLink prepares the RemediationsListDeploymentsAtManagementGroup request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtManagementGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListDeploymentsAtManagementGroup handles the response to the RemediationsListDeploymentsAtManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListDeploymentsAtManagementGroup(resp *http.Response) (result RemediationsListDeploymentsAtManagementGroupOperationResponse, err error) {
+	type page struct {
+		Values   []RemediationDeployment `json:"value"`
+		NextLink *string                 `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListDeploymentsAtManagementGroupOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListDeploymentsAtManagementGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListDeploymentsAtManagementGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtManagementGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatresource_autorest.go
@@ -1,0 +1,212 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsListDeploymentsAtResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]RemediationDeployment
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListDeploymentsAtResourceOperationResponse, error)
+}
+
+type RemediationsListDeploymentsAtResourceCompleteResult struct {
+	Items []RemediationDeployment
+}
+
+func (r RemediationsListDeploymentsAtResourceOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListDeploymentsAtResourceOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListDeploymentsAtResourceOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListDeploymentsAtResourceOperationOptions struct {
+	Top *int64
+}
+
+func DefaultRemediationsListDeploymentsAtResourceOperationOptions() RemediationsListDeploymentsAtResourceOperationOptions {
+	return RemediationsListDeploymentsAtResourceOperationOptions{}
+}
+
+func (o RemediationsListDeploymentsAtResourceOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListDeploymentsAtResourceOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListDeploymentsAtResource ...
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResource(ctx context.Context, id ScopedRemediationId, options RemediationsListDeploymentsAtResourceOperationOptions) (resp RemediationsListDeploymentsAtResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListDeploymentsAtResource(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListDeploymentsAtResource(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListDeploymentsAtResourceComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResourceComplete(ctx context.Context, id ScopedRemediationId, options RemediationsListDeploymentsAtResourceOperationOptions) (RemediationsListDeploymentsAtResourceCompleteResult, error) {
+	return c.RemediationsListDeploymentsAtResourceCompleteMatchingPredicate(ctx, id, options, RemediationDeploymentOperationPredicate{})
+}
+
+// RemediationsListDeploymentsAtResourceCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResourceCompleteMatchingPredicate(ctx context.Context, id ScopedRemediationId, options RemediationsListDeploymentsAtResourceOperationOptions, predicate RemediationDeploymentOperationPredicate) (resp RemediationsListDeploymentsAtResourceCompleteResult, err error) {
+	items := make([]RemediationDeployment, 0)
+
+	page, err := c.RemediationsListDeploymentsAtResource(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListDeploymentsAtResourceCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListDeploymentsAtResource prepares the RemediationsListDeploymentsAtResource request.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtResource(ctx context.Context, id ScopedRemediationId, options RemediationsListDeploymentsAtResourceOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/listDeployments", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListDeploymentsAtResourceWithNextLink prepares the RemediationsListDeploymentsAtResource request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtResourceWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListDeploymentsAtResource handles the response to the RemediationsListDeploymentsAtResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListDeploymentsAtResource(resp *http.Response) (result RemediationsListDeploymentsAtResourceOperationResponse, err error) {
+	type page struct {
+		Values   []RemediationDeployment `json:"value"`
+		NextLink *string                 `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListDeploymentsAtResourceOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListDeploymentsAtResourceWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListDeploymentsAtResource(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResource", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatresourcegroup_autorest.go
@@ -1,0 +1,212 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsListDeploymentsAtResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]RemediationDeployment
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListDeploymentsAtResourceGroupOperationResponse, error)
+}
+
+type RemediationsListDeploymentsAtResourceGroupCompleteResult struct {
+	Items []RemediationDeployment
+}
+
+func (r RemediationsListDeploymentsAtResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListDeploymentsAtResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListDeploymentsAtResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListDeploymentsAtResourceGroupOperationOptions struct {
+	Top *int64
+}
+
+func DefaultRemediationsListDeploymentsAtResourceGroupOperationOptions() RemediationsListDeploymentsAtResourceGroupOperationOptions {
+	return RemediationsListDeploymentsAtResourceGroupOperationOptions{}
+}
+
+func (o RemediationsListDeploymentsAtResourceGroupOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListDeploymentsAtResourceGroupOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListDeploymentsAtResourceGroup ...
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResourceGroup(ctx context.Context, id ProviderRemediationId, options RemediationsListDeploymentsAtResourceGroupOperationOptions) (resp RemediationsListDeploymentsAtResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListDeploymentsAtResourceGroup(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListDeploymentsAtResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListDeploymentsAtResourceGroupComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResourceGroupComplete(ctx context.Context, id ProviderRemediationId, options RemediationsListDeploymentsAtResourceGroupOperationOptions) (RemediationsListDeploymentsAtResourceGroupCompleteResult, error) {
+	return c.RemediationsListDeploymentsAtResourceGroupCompleteMatchingPredicate(ctx, id, options, RemediationDeploymentOperationPredicate{})
+}
+
+// RemediationsListDeploymentsAtResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtResourceGroupCompleteMatchingPredicate(ctx context.Context, id ProviderRemediationId, options RemediationsListDeploymentsAtResourceGroupOperationOptions, predicate RemediationDeploymentOperationPredicate) (resp RemediationsListDeploymentsAtResourceGroupCompleteResult, err error) {
+	items := make([]RemediationDeployment, 0)
+
+	page, err := c.RemediationsListDeploymentsAtResourceGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListDeploymentsAtResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListDeploymentsAtResourceGroup prepares the RemediationsListDeploymentsAtResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtResourceGroup(ctx context.Context, id ProviderRemediationId, options RemediationsListDeploymentsAtResourceGroupOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/listDeployments", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListDeploymentsAtResourceGroupWithNextLink prepares the RemediationsListDeploymentsAtResourceGroup request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListDeploymentsAtResourceGroup handles the response to the RemediationsListDeploymentsAtResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListDeploymentsAtResourceGroup(resp *http.Response) (result RemediationsListDeploymentsAtResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []RemediationDeployment `json:"value"`
+		NextLink *string                 `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListDeploymentsAtResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListDeploymentsAtResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListDeploymentsAtResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistdeploymentsatsubscription_autorest.go
@@ -1,0 +1,212 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsListDeploymentsAtSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]RemediationDeployment
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListDeploymentsAtSubscriptionOperationResponse, error)
+}
+
+type RemediationsListDeploymentsAtSubscriptionCompleteResult struct {
+	Items []RemediationDeployment
+}
+
+func (r RemediationsListDeploymentsAtSubscriptionOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListDeploymentsAtSubscriptionOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListDeploymentsAtSubscriptionOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListDeploymentsAtSubscriptionOperationOptions struct {
+	Top *int64
+}
+
+func DefaultRemediationsListDeploymentsAtSubscriptionOperationOptions() RemediationsListDeploymentsAtSubscriptionOperationOptions {
+	return RemediationsListDeploymentsAtSubscriptionOperationOptions{}
+}
+
+func (o RemediationsListDeploymentsAtSubscriptionOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListDeploymentsAtSubscriptionOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListDeploymentsAtSubscription ...
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtSubscription(ctx context.Context, id RemediationId, options RemediationsListDeploymentsAtSubscriptionOperationOptions) (resp RemediationsListDeploymentsAtSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListDeploymentsAtSubscription(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListDeploymentsAtSubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListDeploymentsAtSubscriptionComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtSubscriptionComplete(ctx context.Context, id RemediationId, options RemediationsListDeploymentsAtSubscriptionOperationOptions) (RemediationsListDeploymentsAtSubscriptionCompleteResult, error) {
+	return c.RemediationsListDeploymentsAtSubscriptionCompleteMatchingPredicate(ctx, id, options, RemediationDeploymentOperationPredicate{})
+}
+
+// RemediationsListDeploymentsAtSubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListDeploymentsAtSubscriptionCompleteMatchingPredicate(ctx context.Context, id RemediationId, options RemediationsListDeploymentsAtSubscriptionOperationOptions, predicate RemediationDeploymentOperationPredicate) (resp RemediationsListDeploymentsAtSubscriptionCompleteResult, err error) {
+	items := make([]RemediationDeployment, 0)
+
+	page, err := c.RemediationsListDeploymentsAtSubscription(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListDeploymentsAtSubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListDeploymentsAtSubscription prepares the RemediationsListDeploymentsAtSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtSubscription(ctx context.Context, id RemediationId, options RemediationsListDeploymentsAtSubscriptionOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/listDeployments", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListDeploymentsAtSubscriptionWithNextLink prepares the RemediationsListDeploymentsAtSubscription request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListDeploymentsAtSubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListDeploymentsAtSubscription handles the response to the RemediationsListDeploymentsAtSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListDeploymentsAtSubscription(resp *http.Response) (result RemediationsListDeploymentsAtSubscriptionOperationResponse, err error) {
+	type page struct {
+		Values   []RemediationDeployment `json:"value"`
+		NextLink *string                 `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListDeploymentsAtSubscriptionOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListDeploymentsAtSubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListDeploymentsAtSubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListDeploymentsAtSubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistformanagementgroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistformanagementgroup_autorest.go
@@ -1,0 +1,217 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RemediationsListForManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Remediation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListForManagementGroupOperationResponse, error)
+}
+
+type RemediationsListForManagementGroupCompleteResult struct {
+	Items []Remediation
+}
+
+func (r RemediationsListForManagementGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListForManagementGroupOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListForManagementGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListForManagementGroupOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultRemediationsListForManagementGroupOperationOptions() RemediationsListForManagementGroupOperationOptions {
+	return RemediationsListForManagementGroupOperationOptions{}
+}
+
+func (o RemediationsListForManagementGroupOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListForManagementGroupOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListForManagementGroup ...
+func (c PolicyInsightsClient) RemediationsListForManagementGroup(ctx context.Context, id ManagementGroupId, options RemediationsListForManagementGroupOperationOptions) (resp RemediationsListForManagementGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListForManagementGroup(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListForManagementGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListForManagementGroupComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListForManagementGroupComplete(ctx context.Context, id ManagementGroupId, options RemediationsListForManagementGroupOperationOptions) (RemediationsListForManagementGroupCompleteResult, error) {
+	return c.RemediationsListForManagementGroupCompleteMatchingPredicate(ctx, id, options, RemediationOperationPredicate{})
+}
+
+// RemediationsListForManagementGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListForManagementGroupCompleteMatchingPredicate(ctx context.Context, id ManagementGroupId, options RemediationsListForManagementGroupOperationOptions, predicate RemediationOperationPredicate) (resp RemediationsListForManagementGroupCompleteResult, err error) {
+	items := make([]Remediation, 0)
+
+	page, err := c.RemediationsListForManagementGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListForManagementGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListForManagementGroup prepares the RemediationsListForManagementGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsListForManagementGroup(ctx context.Context, id ManagementGroupId, options RemediationsListForManagementGroupOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.PolicyInsights/remediations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListForManagementGroupWithNextLink prepares the RemediationsListForManagementGroup request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListForManagementGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListForManagementGroup handles the response to the RemediationsListForManagementGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListForManagementGroup(resp *http.Response) (result RemediationsListForManagementGroupOperationResponse, err error) {
+	type page struct {
+		Values   []Remediation `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListForManagementGroupOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListForManagementGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListForManagementGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForManagementGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforresource_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforresource_autorest.go
@@ -1,0 +1,218 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type RemediationsListForResourceOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Remediation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListForResourceOperationResponse, error)
+}
+
+type RemediationsListForResourceCompleteResult struct {
+	Items []Remediation
+}
+
+func (r RemediationsListForResourceOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListForResourceOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListForResourceOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListForResourceOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultRemediationsListForResourceOperationOptions() RemediationsListForResourceOperationOptions {
+	return RemediationsListForResourceOperationOptions{}
+}
+
+func (o RemediationsListForResourceOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListForResourceOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListForResource ...
+func (c PolicyInsightsClient) RemediationsListForResource(ctx context.Context, id commonids.ScopeId, options RemediationsListForResourceOperationOptions) (resp RemediationsListForResourceOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListForResource(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListForResource(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListForResourceComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListForResourceComplete(ctx context.Context, id commonids.ScopeId, options RemediationsListForResourceOperationOptions) (RemediationsListForResourceCompleteResult, error) {
+	return c.RemediationsListForResourceCompleteMatchingPredicate(ctx, id, options, RemediationOperationPredicate{})
+}
+
+// RemediationsListForResourceCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListForResourceCompleteMatchingPredicate(ctx context.Context, id commonids.ScopeId, options RemediationsListForResourceOperationOptions, predicate RemediationOperationPredicate) (resp RemediationsListForResourceCompleteResult, err error) {
+	items := make([]Remediation, 0)
+
+	page, err := c.RemediationsListForResource(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListForResourceCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListForResource prepares the RemediationsListForResource request.
+func (c PolicyInsightsClient) preparerForRemediationsListForResource(ctx context.Context, id commonids.ScopeId, options RemediationsListForResourceOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.PolicyInsights/remediations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListForResourceWithNextLink prepares the RemediationsListForResource request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListForResourceWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListForResource handles the response to the RemediationsListForResource request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListForResource(resp *http.Response) (result RemediationsListForResourceOperationResponse, err error) {
+	type page struct {
+		Values   []Remediation `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListForResourceOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListForResourceWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListForResource(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResource", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforresourcegroup_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforresourcegroup_autorest.go
@@ -1,0 +1,218 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type RemediationsListForResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Remediation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListForResourceGroupOperationResponse, error)
+}
+
+type RemediationsListForResourceGroupCompleteResult struct {
+	Items []Remediation
+}
+
+func (r RemediationsListForResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListForResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListForResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListForResourceGroupOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultRemediationsListForResourceGroupOperationOptions() RemediationsListForResourceGroupOperationOptions {
+	return RemediationsListForResourceGroupOperationOptions{}
+}
+
+func (o RemediationsListForResourceGroupOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListForResourceGroupOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListForResourceGroup ...
+func (c PolicyInsightsClient) RemediationsListForResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options RemediationsListForResourceGroupOperationOptions) (resp RemediationsListForResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListForResourceGroup(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListForResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListForResourceGroupComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListForResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId, options RemediationsListForResourceGroupOperationOptions) (RemediationsListForResourceGroupCompleteResult, error) {
+	return c.RemediationsListForResourceGroupCompleteMatchingPredicate(ctx, id, options, RemediationOperationPredicate{})
+}
+
+// RemediationsListForResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListForResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, options RemediationsListForResourceGroupOperationOptions, predicate RemediationOperationPredicate) (resp RemediationsListForResourceGroupCompleteResult, err error) {
+	items := make([]Remediation, 0)
+
+	page, err := c.RemediationsListForResourceGroup(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListForResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListForResourceGroup prepares the RemediationsListForResourceGroup request.
+func (c PolicyInsightsClient) preparerForRemediationsListForResourceGroup(ctx context.Context, id commonids.ResourceGroupId, options RemediationsListForResourceGroupOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.PolicyInsights/remediations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListForResourceGroupWithNextLink prepares the RemediationsListForResourceGroup request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListForResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListForResourceGroup handles the response to the RemediationsListForResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListForResourceGroup(resp *http.Response) (result RemediationsListForResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []Remediation `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListForResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListForResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListForResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforsubscription_autorest.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/method_remediationslistforsubscription_autorest.go
@@ -1,0 +1,218 @@
+package policyinsights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+type RemediationsListForSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Remediation
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (RemediationsListForSubscriptionOperationResponse, error)
+}
+
+type RemediationsListForSubscriptionCompleteResult struct {
+	Items []Remediation
+}
+
+func (r RemediationsListForSubscriptionOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r RemediationsListForSubscriptionOperationResponse) LoadMore(ctx context.Context) (resp RemediationsListForSubscriptionOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type RemediationsListForSubscriptionOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultRemediationsListForSubscriptionOperationOptions() RemediationsListForSubscriptionOperationOptions {
+	return RemediationsListForSubscriptionOperationOptions{}
+}
+
+func (o RemediationsListForSubscriptionOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RemediationsListForSubscriptionOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+// RemediationsListForSubscription ...
+func (c PolicyInsightsClient) RemediationsListForSubscription(ctx context.Context, id commonids.SubscriptionId, options RemediationsListForSubscriptionOperationOptions) (resp RemediationsListForSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForRemediationsListForSubscription(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForRemediationsListForSubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// RemediationsListForSubscriptionComplete retrieves all of the results into a single object
+func (c PolicyInsightsClient) RemediationsListForSubscriptionComplete(ctx context.Context, id commonids.SubscriptionId, options RemediationsListForSubscriptionOperationOptions) (RemediationsListForSubscriptionCompleteResult, error) {
+	return c.RemediationsListForSubscriptionCompleteMatchingPredicate(ctx, id, options, RemediationOperationPredicate{})
+}
+
+// RemediationsListForSubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PolicyInsightsClient) RemediationsListForSubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options RemediationsListForSubscriptionOperationOptions, predicate RemediationOperationPredicate) (resp RemediationsListForSubscriptionCompleteResult, err error) {
+	items := make([]Remediation, 0)
+
+	page, err := c.RemediationsListForSubscription(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := RemediationsListForSubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForRemediationsListForSubscription prepares the RemediationsListForSubscription request.
+func (c PolicyInsightsClient) preparerForRemediationsListForSubscription(ctx context.Context, id commonids.SubscriptionId, options RemediationsListForSubscriptionOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.PolicyInsights/remediations", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForRemediationsListForSubscriptionWithNextLink prepares the RemediationsListForSubscription request with the given nextLink token.
+func (c PolicyInsightsClient) preparerForRemediationsListForSubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRemediationsListForSubscription handles the response to the RemediationsListForSubscription request. The method always
+// closes the http.Response Body.
+func (c PolicyInsightsClient) responderForRemediationsListForSubscription(resp *http.Response) (result RemediationsListForSubscriptionOperationResponse, err error) {
+	type page struct {
+		Values   []Remediation `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result RemediationsListForSubscriptionOperationResponse, err error) {
+			req, err := c.preparerForRemediationsListForSubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForRemediationsListForSubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "policyinsights.PolicyInsightsClient", "RemediationsListForSubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_errordefinition.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_errordefinition.go
@@ -1,0 +1,12 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorDefinition struct {
+	AdditionalInfo *[]TypedErrorInfo  `json:"additionalInfo,omitempty"`
+	Code           *string            `json:"code,omitempty"`
+	Details        *[]ErrorDefinition `json:"details,omitempty"`
+	Message        *string            `json:"message,omitempty"`
+	Target         *string            `json:"target,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediation.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediation.go
@@ -1,0 +1,12 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Remediation struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RemediationProperties `json:"properties,omitempty"`
+	SystemData *SystemData            `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationdeployment.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationdeployment.go
@@ -1,0 +1,44 @@
+package policyinsights
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemediationDeployment struct {
+	CreatedOn            *string          `json:"createdOn,omitempty"`
+	DeploymentId         *string          `json:"deploymentId,omitempty"`
+	Error                *ErrorDefinition `json:"error,omitempty"`
+	LastUpdatedOn        *string          `json:"lastUpdatedOn,omitempty"`
+	RemediatedResourceId *string          `json:"remediatedResourceId,omitempty"`
+	ResourceLocation     *string          `json:"resourceLocation,omitempty"`
+	Status               *string          `json:"status,omitempty"`
+}
+
+func (o *RemediationDeployment) GetCreatedOnAsTime() (*time.Time, error) {
+	if o.CreatedOn == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedOn, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RemediationDeployment) SetCreatedOnAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedOn = &formatted
+}
+
+func (o *RemediationDeployment) GetLastUpdatedOnAsTime() (*time.Time, error) {
+	if o.LastUpdatedOn == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastUpdatedOn, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RemediationDeployment) SetLastUpdatedOnAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastUpdatedOn = &formatted
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationdeploymentsummary.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationdeploymentsummary.go
@@ -1,0 +1,10 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemediationDeploymentSummary struct {
+	FailedDeployments     *int64 `json:"failedDeployments,omitempty"`
+	SuccessfulDeployments *int64 `json:"successfulDeployments,omitempty"`
+	TotalDeployments      *int64 `json:"totalDeployments,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationfilters.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationfilters.go
@@ -1,0 +1,8 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemediationFilters struct {
+	Locations *[]string `json:"locations,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationproperties.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationproperties.go
@@ -1,0 +1,50 @@
+package policyinsights
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemediationProperties struct {
+	CorrelationId               *string                                `json:"correlationId,omitempty"`
+	CreatedOn                   *string                                `json:"createdOn,omitempty"`
+	DeploymentStatus            *RemediationDeploymentSummary          `json:"deploymentStatus,omitempty"`
+	FailureThreshold            *RemediationPropertiesFailureThreshold `json:"failureThreshold,omitempty"`
+	Filters                     *RemediationFilters                    `json:"filters,omitempty"`
+	LastUpdatedOn               *string                                `json:"lastUpdatedOn,omitempty"`
+	ParallelDeployments         *int64                                 `json:"parallelDeployments,omitempty"`
+	PolicyAssignmentId          *string                                `json:"policyAssignmentId,omitempty"`
+	PolicyDefinitionReferenceId *string                                `json:"policyDefinitionReferenceId,omitempty"`
+	ProvisioningState           *string                                `json:"provisioningState,omitempty"`
+	ResourceCount               *int64                                 `json:"resourceCount,omitempty"`
+	ResourceDiscoveryMode       *ResourceDiscoveryMode                 `json:"resourceDiscoveryMode,omitempty"`
+	StatusMessage               *string                                `json:"statusMessage,omitempty"`
+}
+
+func (o *RemediationProperties) GetCreatedOnAsTime() (*time.Time, error) {
+	if o.CreatedOn == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedOn, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RemediationProperties) SetCreatedOnAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedOn = &formatted
+}
+
+func (o *RemediationProperties) GetLastUpdatedOnAsTime() (*time.Time, error) {
+	if o.LastUpdatedOn == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastUpdatedOn, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RemediationProperties) SetLastUpdatedOnAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastUpdatedOn = &formatted
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationpropertiesfailurethreshold.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_remediationpropertiesfailurethreshold.go
@@ -1,0 +1,8 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemediationPropertiesFailureThreshold struct {
+	Percentage *float64 `json:"percentage,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_systemdata.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_systemdata.go
@@ -1,0 +1,43 @@
+package policyinsights
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemData struct {
+	CreatedAt          *string        `json:"createdAt,omitempty"`
+	CreatedBy          *string        `json:"createdBy,omitempty"`
+	CreatedByType      *CreatedByType `json:"createdByType,omitempty"`
+	LastModifiedAt     *string        `json:"lastModifiedAt,omitempty"`
+	LastModifiedBy     *string        `json:"lastModifiedBy,omitempty"`
+	LastModifiedByType *CreatedByType `json:"lastModifiedByType,omitempty"`
+}
+
+func (o *SystemData) GetCreatedAtAsTime() (*time.Time, error) {
+	if o.CreatedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *SystemData) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o *SystemData) GetLastModifiedAtAsTime() (*time.Time, error) {
+	if o.LastModifiedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastModifiedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *SystemData) SetLastModifiedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastModifiedAt = &formatted
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/model_typederrorinfo.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/model_typederrorinfo.go
@@ -1,0 +1,9 @@
+package policyinsights
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TypedErrorInfo struct {
+	Info *interface{} `json:"info,omitempty"`
+	Type *string      `json:"type,omitempty"`
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/predicates.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/predicates.go
@@ -1,0 +1,62 @@
+package policyinsights
+
+type RemediationOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p RemediationOperationPredicate) Matches(input Remediation) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type RemediationDeploymentOperationPredicate struct {
+	CreatedOn            *string
+	DeploymentId         *string
+	LastUpdatedOn        *string
+	RemediatedResourceId *string
+	ResourceLocation     *string
+	Status               *string
+}
+
+func (p RemediationDeploymentOperationPredicate) Matches(input RemediationDeployment) bool {
+
+	if p.CreatedOn != nil && (input.CreatedOn == nil && *p.CreatedOn != *input.CreatedOn) {
+		return false
+	}
+
+	if p.DeploymentId != nil && (input.DeploymentId == nil && *p.DeploymentId != *input.DeploymentId) {
+		return false
+	}
+
+	if p.LastUpdatedOn != nil && (input.LastUpdatedOn == nil && *p.LastUpdatedOn != *input.LastUpdatedOn) {
+		return false
+	}
+
+	if p.RemediatedResourceId != nil && (input.RemediatedResourceId == nil && *p.RemediatedResourceId != *input.RemediatedResourceId) {
+		return false
+	}
+
+	if p.ResourceLocation != nil && (input.ResourceLocation == nil && *p.ResourceLocation != *input.ResourceLocation) {
+		return false
+	}
+
+	if p.Status != nil && (input.Status == nil && *p.Status != *input.Status) {
+		return false
+	}
+
+	return true
+}

--- a/internal/services/policy/sdk/2021-10-01/policyinsights/version.go
+++ b/internal/services/policy/sdk/2021-10-01/policyinsights/version.go
@@ -1,0 +1,12 @@
+package policyinsights
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2021-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/policyinsights/%s", defaultApiVersion)
+}


### PR DESCRIPTION
Deprecated, split to 2 pr

New feature support with new Pandora SDK with new API version.

--- PASS: TestAccAzureRMSubscriptionPolicyRemediation_basic (230.96s)
--- PASS: TestAccAzureRMManagementGroupPolicyRemediation_basic (272.64s)
--- PASS: TestAccAzureRMManagementGroupPolicyRemediation_complete (272.66s)
--- PASS: TestAccAzureRMSubscriptionPolicyRemediation_complete (297.40s)
--- PASS: TestAccAzureRMResourcePolicyRemediation_basic (343.24s)
--- PASS: TestAccAzureRMResourceGroupPolicyRemediation_complete (345.92s)
--- PASS: TestAccAzureRMResourceGroupPolicyRemediation_basic (393.71s)
--- PASS: TestAccAzureRMResourcePolicyRemediation_complete (406.63s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/policy        406.642s
