### PR TITLE
`r\shared_image`: add `ForceNew` to `publisher``offer``sku``privacy_statement_uri`

### DIFF
--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -87,14 +87,17 @@ func resourceSharedImage() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"publisher": {
 							Type:     pluginsdk.TypeString,
+							ForceNew: true,
 							Required: true,
 						},
 						"offer": {
 							Type:     pluginsdk.TypeString,
+							ForceNew: true,
 							Required: true,
 						},
 						"sku": {
 							Type:     pluginsdk.TypeString,
+							ForceNew: true,
 							Required: true,
 						},
 					},
@@ -142,6 +145,7 @@ func resourceSharedImage() *pluginsdk.Resource {
 
 			"privacy_statement_uri": {
 				Type:     pluginsdk.TypeString,
+				ForceNew: true,
 				Optional: true,
 			},
 

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -124,6 +124,48 @@ func TestAccSharedImage_withAcceleratedNetworkSupportEnabled(t *testing.T) {
 	})
 }
 
+func TestAccSharedImage_description(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.description(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.descriptionUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSharedImage_releaseNoteURI(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.releaseNoteURI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.releaseNoteURIUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t SharedImageResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SharedImageID(state.ID)
 	if err != nil {
@@ -347,4 +389,140 @@ resource "azurerm_shared_image" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (SharedImageResource) description(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%[2]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  description         = "image description"
+
+  identifier {
+    publisher = "AccTesPublisher%[2]d"
+    offer     = "AccTesOffer%[2]d"
+    sku       = "AccTesSku%[2]d"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (SharedImageResource) descriptionUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%[2]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  description         = "image description updated"
+
+  identifier {
+    publisher = "AccTesPublisher%[2]d"
+    offer     = "AccTesOffer%[2]d"
+    sku       = "AccTesSku%[2]d"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (SharedImageResource) releaseNoteURI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%[2]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  release_note_uri    = "https://test.com/changelog.md"
+
+  identifier {
+    publisher = "AccTesPublisher%[2]d"
+    offer     = "AccTesOffer%[2]d"
+    sku       = "AccTesSku%[2]d"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (SharedImageResource) releaseNoteURIUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctestimg%[2]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  release_note_uri    = "https://test.com/changelog2.md"
+
+  identifier {
+    publisher = "AccTesPublisher%[2]d"
+    offer     = "AccTesOffer%[2]d"
+    sku       = "AccTesSku%[2]d"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `hyper_v_generation` - (Optional) The generation of HyperV that the Virtual Machine used to create the Shared Image is based on. Possible values are `V1` and `V2`. Defaults to `V1`. Changing this forces a new resource to be created.
 
-* `privacy_statement_uri` - (Optional) The URI containing the Privacy Statement associated with this Shared Image.
+* `privacy_statement_uri` - (Optional) The URI containing the Privacy Statement associated with this Shared Image. Changing this forces a new resource to be created.
 
 * `release_note_uri` - (Optional) The URI containing the Release Notes associated with this Shared Image.
 
@@ -90,11 +90,11 @@ The following arguments are supported:
 
 A `identifier` block supports the following:
 
-* `offer` - (Required) The Offer Name for this Shared Image.
+* `offer` - (Required) The Offer Name for this Shared Image. Changing this forces a new resource to be created.
 
-* `publisher` - (Required) The Publisher Name for this Gallery Image.
+* `publisher` - (Required) The Publisher Name for this Gallery Image. Changing this forces a new resource to be created.
 
-* `sku` - (Required) The Name of the SKU for this Gallery Image.
+* `sku` - (Required) The Name of the SKU for this Gallery Image. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
- These four properties cannot be updated according to [this doc](https://docs.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli#updating-resources). Also tested locally, API doesn't allow an update.
- Added update tests for the updatable properties
- `release_note_uri` is also not updatable according to the above doc, however it can be updated by API, I've opened https://github.com/MicrosoftDocs/azure-docs/issues/94552 for the doc.