### PR TITLE
Update mysql_flexible_server_data_source to create the correct resource id

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_data_source.go
+++ b/internal/services/mysql/mysql_flexible_server_data_source.go
@@ -173,7 +173,7 @@ func dataSourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := parse.NewFlexibleServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {


### PR DESCRIPTION
The id returned is for a standard server Mysql database, not a flexible server.