### PR TITLE
`policy_remediation_xxx_resource` - support for the `resource_count`, `parallel_deployments` and `failure_percentage` properties

### DIFF
--- a/helpers/validate/float.go
+++ b/helpers/validate/float.go
@@ -25,3 +25,32 @@ func FloatInSlice(valid []float64) func(interface{}, string) ([]string, []error)
 		return warnings, errors
 	}
 }
+
+func FloatInRange(start, end float64) func(interface{}, string) ([]string, []error) {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(float64)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be float", i))
+			return warnings, errors
+		}
+
+		if v < start || v > end {
+			errors = append(errors, fmt.Errorf("expected %s to be in range [%f, %f], got %f", k, start, end, v))
+		}
+
+		return warnings, errors
+	}
+}
+
+func IntegerPositive(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be int", i))
+		return
+	}
+	if v <= 0 {
+		errors = append(errors, fmt.Errorf("expected %s to be positive, got %d", k, v))
+		return
+	}
+	return
+}

--- a/internal/services/policy/remediation_management_group.go
+++ b/internal/services/policy/remediation_management_group.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	managmentGroupParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/parse"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmManagementGroupPolicyRemediation() *pluginsdk.Resource {
@@ -63,6 +63,24 @@ func resourceArmManagementGroupPolicyRemediation() *pluginsdk.Resource {
 				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validate.PolicyAssignmentID,
+			},
+
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
 			},
 
 			"location_filters": {
@@ -123,16 +141,8 @@ func resourceArmManagementGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resour
 	}
 
 	parameters := remediations.Remediation{
-		Properties: &remediations.RemediationProperties{
-			Filters: &remediations.RemediationFilters{
-				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
-			},
-			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
-		},
+		Properties: readRemediationProperties(d),
 	}
-	mode := remediations.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string))
-	parameters.Properties.ResourceDiscoveryMode = &mode
 
 	if _, err := client.RemediationsCreateOrUpdateAtManagementGroup(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
@@ -167,21 +177,7 @@ func resourceArmManagementGroupPolicyRemediationRead(d *pluginsdk.ResourceData, 
 	managementGroupID := managmentGroupParse.NewManagementGroupId(id.ManagementGroupId)
 	d.Set("management_group_id", managementGroupID.ID())
 
-	if props := resp.Model.Properties; props != nil {
-		locations := []interface{}{}
-		if filters := props.Filters; filters != nil {
-			locations = utils.FlattenStringSlice(filters.Locations)
-		}
-		if err := d.Set("location_filters", locations); err != nil {
-			return fmt.Errorf("setting `location_filters`: %+v", err)
-		}
-
-		d.Set("policy_assignment_id", props.PolicyAssignmentId)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
-		d.Set("resource_discovery_mode", props.ResourceDiscoveryMode)
-	}
-
-	return nil
+	return setRemediationProperties(d, resp.Model.Properties)
 }
 
 func resourceArmManagementGroupPolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/remediation_management_group_test.go
+++ b/internal/services/policy/remediation_management_group_test.go
@@ -78,7 +78,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpa-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
@@ -62,6 +62,24 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validate.PolicyAssignmentID,
+			},
+
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
 			},
 
 			"location_filters": {
@@ -119,16 +137,8 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 	}
 
 	parameters := remediations.Remediation{
-		Properties: &remediations.RemediationProperties{
-			Filters: &remediations.RemediationFilters{
-				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
-			},
-			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
-		},
+		Properties: readRemediationProperties(d),
 	}
-	mode := remediations.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string))
-	parameters.Properties.ResourceDiscoveryMode = &mode
 
 	if _, err = client.RemediationsCreateOrUpdateAtResourceGroup(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
@@ -164,22 +174,7 @@ func resourceArmResourceGroupPolicyRemediationRead(d *pluginsdk.ResourceData, me
 	d.Set("name", id.RemediationName)
 	d.Set("resource_group_id", resourceGroupId.ID())
 
-	if props := resp.Model.Properties; props != nil {
-		locations := []interface{}{}
-		if filters := props.Filters; filters != nil {
-			locations = utils.FlattenStringSlice(filters.Locations)
-		}
-		if err := d.Set("location_filters", locations); err != nil {
-			return fmt.Errorf("setting `location_filters`: %+v", err)
-		}
-
-		d.Set("policy_assignment_id", props.PolicyAssignmentId)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
-		d.Set("resource_discovery_mode", utils.NormalizeNilableString((*string)(props.ResourceDiscoveryMode)))
-
-	}
-
-	return nil
+	return setRemediationProperties(d, resp.Model.Properties)
 }
 
 func resourceArmResourceGroupPolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/remediation_resource_group_test.go
+++ b/internal/services/policy/remediation_resource_group_test.go
@@ -149,6 +149,9 @@ resource "azurerm_resource_group_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage      = 0.5
+  parallel_deployments    = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_resource_group_test.go
+++ b/internal/services/policy/remediation_resource_group_test.go
@@ -109,7 +109,7 @@ PARAMETERS
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[1]s"
+  name                 = "acctestpa-rg-%[1]s"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 

--- a/internal/services/policy/remediation_resource_test.go
+++ b/internal/services/policy/remediation_resource_test.go
@@ -121,6 +121,9 @@ resource "azurerm_resource_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = data.azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage      = 0.5
+  parallel_deployments    = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_resource_test.go
+++ b/internal/services/policy/remediation_resource_test.go
@@ -86,7 +86,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_resource_policy_assignment" "test" {
-  name                 = "acctestpa-%[1]s"
+  name                 = "acctestpa-res-%[1]s"
   resource_id          = azurerm_virtual_network.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({

--- a/internal/services/policy/remediation_subscription.go
+++ b/internal/services/policy/remediation_subscription.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	validate2 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
@@ -61,6 +61,24 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc:     validate.PolicyAssignmentID,
+			},
+
+			"failure_percentage": {
+				Type:         pluginsdk.TypeFloat,
+				Optional:     true,
+				ValidateFunc: validate2.FloatInRange(0, 1.0),
+			},
+
+			"parallel_deployments": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
+			},
+
+			"resource_count": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate2.IntegerPositive,
 			},
 
 			"location_filters": {
@@ -118,16 +136,8 @@ func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	parameters := remediations.Remediation{
-		Properties: &remediations.RemediationProperties{
-			Filters: &remediations.RemediationFilters{
-				Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
-			},
-			PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
-			PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_id").(string)),
-		},
+		Properties: readRemediationProperties(d),
 	}
-	mode := remediations.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string))
-	parameters.Properties.ResourceDiscoveryMode = &mode
 
 	if _, err = client.RemediationsCreateOrUpdateAtSubscription(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
@@ -163,21 +173,7 @@ func resourceArmSubscriptionPolicyRemediationRead(d *pluginsdk.ResourceData, met
 	d.Set("name", id.RemediationName)
 	d.Set("subscription_id", subscriptionId.ID())
 
-	if props := resp.Model.Properties; props != nil {
-		locations := []interface{}{}
-		if filters := props.Filters; filters != nil {
-			locations = utils.FlattenStringSlice(filters.Locations)
-		}
-		if err := d.Set("location_filters", locations); err != nil {
-			return fmt.Errorf("setting `location_filters`: %+v", err)
-		}
-
-		d.Set("policy_assignment_id", props.PolicyAssignmentId)
-		d.Set("policy_definition_id", props.PolicyDefinitionReferenceId)
-		d.Set("resource_discovery_mode", utils.NormalizeNilableString((*string)(props.ResourceDiscoveryMode)))
-	}
-
-	return nil
+	return setRemediationProperties(d, resp.Model.Properties)
 }
 
 func resourceArmSubscriptionPolicyRemediationDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/remediation_subscription_test.go
+++ b/internal/services/policy/remediation_subscription_test.go
@@ -81,11 +81,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%[2]s"]
+      "value" = ["%[2]s", "%[3]s", "%[4]s"]
     }
   })
 }
-`, data.RandomInteger, data.Locations.Secondary)
+`, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary, data.Locations.Ternary)
 }
 
 func (r SubscriptionPolicyRemediationResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/remediation_subscription_test.go
+++ b/internal/services/policy/remediation_subscription_test.go
@@ -76,7 +76,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[1]d"
+  name                 = "acctestpa-sub-%[1]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({

--- a/internal/services/policy/remediation_subscription_test.go
+++ b/internal/services/policy/remediation_subscription_test.go
@@ -81,11 +81,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%[2]s", "%[3]s"]
+      "value" = ["%[2]s"]
     }
   })
 }
-`, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+`, data.RandomInteger, data.Locations.Secondary)
 }
 
 func (r SubscriptionPolicyRemediationResource) basic(data acceptance.TestData) string {
@@ -111,6 +111,9 @@ resource "azurerm_subscription_policy_remediation" "test" {
   location_filters        = ["westus"]
   policy_definition_id    = data.azurerm_policy_definition.test.id
   resource_discovery_mode = "ReEvaluateCompliance"
+  failure_percentage      = 0.5
+  parallel_deployments    = 3
+  resource_count          = 3
 }
 `, r.template(data), data.RandomString)
 }

--- a/website/docs/r/management_group_policy_remediation.html.markdown
+++ b/website/docs/r/management_group_policy_remediation.html.markdown
@@ -57,6 +57,12 @@ The following arguments are supported:
 
 ~> **Note:** This property has been deprecated and will be removed in version 4.0 of the provider as evaluating compliance before remediation is only supported at subscription scope and below.
 
+* `failure_percentage` - (Optional) A number between 0.0 to 1.0 representing the percentage failure threshold. The remediation will fail if the percentage of failed remediation operations (i.e. failed deployments) exceeds this threshold.
+
+* `parallel_deployments` - (Optional) Determines how many resources to remediate at any given time. Can be used to increase or reduce the pace of the remediation. If not provided, the default parallel deployments value is used.
+
+* `resource_count` (Optional) Determines the max number of resources that can be remediated by the remediation job. If not provided, the default resource count is used.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/resource_group_policy_remediation.html.markdown
+++ b/website/docs/r/resource_group_policy_remediation.html.markdown
@@ -82,6 +82,12 @@ The following arguments are supported:
 
 * `resource_discovery_mode` - (Optional) The way that resources to remediate are discovered. Possible values are `ExistingNonCompliant`, `ReEvaluateCompliance`. Defaults to `ExistingNonCompliant`.
 
+* `failure_percentage` - (Optional) A number between 0.0 to 1.0 representing the percentage failure threshold. The remediation will fail if the percentage of failed remediation operations (i.e. failed deployments) exceeds this threshold.
+
+* `parallel_deployments` - (Optional) Determines how many resources to remediate at any given time. Can be used to increase or reduce the pace of the remediation. If not provided, the default parallel deployments value is used.
+
+* `resource_count` (Optional) Determines the max number of resources that can be remediated by the remediation job. If not provided, the default resource count is used.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/resource_policy_remediation.html.markdown
+++ b/website/docs/r/resource_policy_remediation.html.markdown
@@ -72,6 +72,12 @@ The following arguments are supported:
 
 * `resource_discovery_mode` - (Optional) The way that resources to remediate are discovered. Possible values are `ExistingNonCompliant`, `ReEvaluateCompliance`. Defaults to `ExistingNonCompliant`.
 
+* `failure_percentage` - (Optional) A number between 0.0 to 1.0 representing the percentage failure threshold. The remediation will fail if the percentage of failed remediation operations (i.e. failed deployments) exceeds this threshold.
+
+* `parallel_deployments` - (Optional) Determines how many resources to remediate at any given time. Can be used to increase or reduce the pace of the remediation. If not provided, the default parallel deployments value is used.
+
+* `resource_count` (Optional) Determines the max number of resources that can be remediated by the remediation job. If not provided, the default resource count is used.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/subscription_policy_remediation.html.markdown
+++ b/website/docs/r/subscription_policy_remediation.html.markdown
@@ -53,6 +53,12 @@ The following arguments are supported:
 
 * `resource_discovery_mode` - (Optional) The way that resources to remediate are discovered. Possible values are `ExistingNonCompliant`, `ReEvaluateCompliance`. Defaults to `ExistingNonCompliant`.
 
+* `failure_percentage` - (Optional) A number between 0.0 to 1.0 representing the percentage failure threshold. The remediation will fail if the percentage of failed remediation operations (i.e. failed deployments) exceeds this threshold.
+
+* `parallel_deployments` - (Optional) Determines how many resources to remediate at any given time. Can be used to increase or reduce the pace of the remediation. If not provided, the default parallel deployments value is used.
+
+* `resource_count` (Optional) Determines the max number of resources that can be remediated by the remediation job. If not provided, the default resource count is used.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
add support for `resource_count`, `parallel_deployments` and `failure_percentage`


--- PASS: TestAccAzureRMManagementGroupPolicyRemediation_basic (270.60s)
--- PASS: TestAccAzureRMManagementGroupPolicyRemediation_complete (270.16s)
--- PASS: TestAccAzureRMResourceGroupPolicyRemediation_basic (389.06s)
--- PASS: TestAccAzureRMResourceGroupPolicyRemediation_complete (406.42s)
--- PASS: TestAccAzureRMResourcePolicyRemediation_basic (281.65s)
--- PASS: TestAccAzureRMResourcePolicyRemediation_complete (407.79s)
--- PASS: TestAccAzureRMSubscriptionPolicyRemediation_basic (232.30s)
--- PASS: TestAccAzureRMSubscriptionPolicyRemediation_complete (299.02s)
PASS

Process finished with the exit code 0