### PR TITLE
`azurerm_windows_web_app`, `azurerm_linux_web_app`: adding `Off` option to the `application_log`

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -2656,6 +2656,7 @@ func applicationLogSchema() *pluginsdk.Schema {
 						string(web.LogLevelInformation),
 						string(web.LogLevelVerbose),
 						string(web.LogLevelWarning),
+						string(web.LogLevelOff),
 					}, false),
 				},
 
@@ -3431,7 +3432,7 @@ func FlattenLogsConfig(logsConfig web.SiteLogsConfig) []LogsConfig {
 		appLogs := *props.ApplicationLogs
 		applicationLog := ApplicationLog{}
 
-		if appLogs.FileSystem != nil && appLogs.FileSystem.Level != web.LogLevelOff {
+		if appLogs.FileSystem != nil {
 			applicationLog.FileSystemLevel = string(appLogs.FileSystem.Level)
 			if appLogs.AzureBlobStorage != nil && appLogs.AzureBlobStorage.Level != web.LogLevelOff {
 				blobStorage := AzureBlobStorage{

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -711,7 +711,7 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			if metadata.ResourceData.HasChange("logs") {
 				logsUpdate := helpers.ExpandLogsConfig(state.LogsConfig)
 				if logsUpdate.SiteLogsConfigProperties == nil {
-					logsUpdate = helpers.DisabledLogsConfig() // The API is update only, so we need to send an update with everything switched of when a user removes the "logs" block
+					logsUpdate = helpers.DisabledLogsConfig() // The API is update only, so we need to send an update with everything switched off when a user removes the "logs" block
 				}
 				if _, err := client.UpdateDiagnosticLogsConfig(ctx, id.ResourceGroup, id.SiteName, *logsUpdate); err != nil {
 					return fmt.Errorf("updating Logs Config for Linux %s: %+v", id, err)

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -121,7 +121,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Off`, `Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -119,7 +119,7 @@ A `application_logs` block supports the following:
 
 * `azure_blob_storage` - (Optional) An `azure_blob_storage` block as defined below.
 
-* `file_system_level` - (Required) Log level. Possible values include: `Verbose`, `Information`, `Warning`, and `Error`.
+* `file_system_level` - (Required) Log level. Possible values include: `Off`, Verbose`, `Information`, `Warning`, and `Error`.
 
 ---
 


### PR DESCRIPTION
fixing the issue:https://github.com/hashicorp/terraform-provider-azurerm/issues/16876

As the [docs ](https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs)mentioned, the file_system_level is for temporary usage and system turn it off after 12 hours. there will be a diff once it's turned off