### PR TITLE
New resource `azurerm_ip_group_cidr`

### DIFF
--- a/internal/services/network/ip_group_cidr_resource.go
+++ b/internal/services/network/ip_group_cidr_resource.go
@@ -1,0 +1,182 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceIpGroupCidr() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceIpGroupCidrCreateUpdate,
+		Read:   resourceIpGroupCidrRead,
+		Delete: resourceIpGroupCidrDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.IpGroupCidrID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"ip_group_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.IpGroupID,
+			},
+			"cidr": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+
+func resourceIpGroupCidrCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.IPGroupsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	cidr := d.Get("cidr").(string)
+	cidrName := strings.Replace(cidr, "/", "_", -1)
+	ipGroupId, err := parse.IpGroupID(d.Get("ip_group_id").(string))
+	if err != nil {
+		return err
+	}
+	id := parse.NewIpGroupCidrID(subscriptionId, ipGroupId.ResourceGroup, ipGroupId.Name, cidrName)
+
+	locks.ByID(ipGroupId.ID())
+	defer locks.UnlockByID(ipGroupId.ID())
+
+	existing, err := client.Get(ctx, ipGroupId.ResourceGroup, ipGroupId.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for presence of existing %s: %s", ipGroupId, err)
+		}
+	}
+
+	if d.IsNewResource() {
+		if utils.SliceContainsValue(*existing.IPAddresses, cidr) {
+			return tf.ImportAsExistsError("azurerm_ip_group_cidr", id.ID())
+		}
+	}
+
+	existingIpAddresses := *existing.IPAddresses
+	ipAddresses := append(existingIpAddresses, cidr)
+
+	params := network.IPGroup{
+		Name:     &ipGroupId.Name,
+		Location: existing.Location,
+		Tags:     existing.Tags,
+		IPGroupPropertiesFormat: &network.IPGroupPropertiesFormat{
+			IPAddresses: &ipAddresses,
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, ipGroupId.ResourceGroup, ipGroupId.Name, params)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for the completion of %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceIpGroupCidrRead(d, meta)
+}
+
+func resourceIpGroupCidrRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.IPGroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.IpGroupCidrID(d.Id())
+	if err != nil {
+		return err
+	}
+	ipGroupId := parse.NewIpGroupID(id.SubscriptionId, id.ResourceGroup, id.IpGroupName)
+	cidr := strings.Replace(id.CidrName, "_", "/", -1)
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.IpGroupName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("making Read request on IP Group %q (Resource Group %q): %+v", ipGroupId.Name, ipGroupId.ResourceGroup, err)
+		}
+		if !utils.SliceContainsValue(*resp.IPAddresses, cidr) {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	d.Set("ip_group_id", ipGroupId.ID())
+	d.Set("cidr", cidr)
+
+	return nil
+}
+
+func resourceIpGroupCidrDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.IPGroupsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	cidr := d.Get("cidr").(string)
+	ipGroupId, err := parse.IpGroupID(d.Get("ip_group_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByID(ipGroupId.ID())
+	defer locks.UnlockByID(ipGroupId.ID())
+
+	existing, err := client.Get(ctx, ipGroupId.ResourceGroup, ipGroupId.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("reading existing %s: %s", ipGroupId, err)
+		}
+	}
+
+	existingIpAddresses := *existing.IPAddresses
+	ipAddresses := utils.RemoveFromStringArray(existingIpAddresses, cidr)
+
+	params := network.IPGroup{
+		Name:     &ipGroupId.Name,
+		Location: existing.Location,
+		Tags:     existing.Tags,
+		IPGroupPropertiesFormat: &network.IPGroupPropertiesFormat{
+			IPAddresses: &ipAddresses,
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, ipGroupId.ResourceGroup, ipGroupId.Name, params)
+	if err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", ipGroupId.ID(), err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("deleting IP Group CIDR %q (IP Group %q - Resource Group %q): %+v", cidr, ipGroupId.Name, ipGroupId.ResourceGroup, err)
+	}
+
+	return err
+}

--- a/internal/services/network/ip_group_cidr_resource.go
+++ b/internal/services/network/ip_group_cidr_resource.go
@@ -58,7 +58,7 @@ func resourceIpGroupCidrCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 	defer cancel()
 
 	cidr := d.Get("cidr").(string)
-	cidrName := strings.Replace(cidr, "/", "_", -1)
+	cidrName := strings.ReplaceAll(cidr, "/", "_")
 	ipGroupId, err := parse.IpGroupID(d.Get("ip_group_id").(string))
 	if err != nil {
 		return err
@@ -81,8 +81,8 @@ func resourceIpGroupCidrCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	existingIpAddresses := *existing.IPAddresses
-	ipAddresses := append(existingIpAddresses, cidr)
+	ipAddresses := *existing.IPAddresses
+	ipAddresses = append(ipAddresses, cidr)
 
 	params := network.IPGroup{
 		Name:     &ipGroupId.Name,
@@ -117,7 +117,7 @@ func resourceIpGroupCidrRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		return err
 	}
 	ipGroupId := parse.NewIpGroupID(id.SubscriptionId, id.ResourceGroup, id.IpGroupName)
-	cidr := strings.Replace(id.CidrName, "_", "/", -1)
+	cidr := strings.ReplaceAll(id.CidrName, "_", "/")
 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.IpGroupName, "")
 	if err != nil {
@@ -157,8 +157,8 @@ func resourceIpGroupCidrDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
-	existingIpAddresses := *existing.IPAddresses
-	ipAddresses := utils.RemoveFromStringArray(existingIpAddresses, cidr)
+	ipAddresses := *existing.IPAddresses
+	ipAddresses = utils.RemoveFromStringArray(ipAddresses, cidr)
 
 	params := network.IPGroup{
 		Name:     &ipGroupId.Name,

--- a/internal/services/network/ip_group_cidr_resource_test.go
+++ b/internal/services/network/ip_group_cidr_resource_test.go
@@ -1,0 +1,145 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type IPGroupCidrResource struct{}
+
+func TestAccIpGroupCidr_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ip_group_cidr", "test")
+	r := IPGroupCidrResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_ip_group_cidr.test").ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIpGroupCidr_multiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ip_group_cidr", "test")
+	r := IPGroupCidrResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_ip_group_cidr.test").ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_ip_group.test").Key("tags.env").HasValue("prod"),
+				check.That("azurerm_ip_group_cidr.test").ExistsInAzure(r),
+				check.That("azurerm_ip_group_cidr.multiple_1").ExistsInAzure(r),
+				check.That("azurerm_ip_group_cidr.multiple_2").ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIpGroupCidr_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ip_group_cidr", "test")
+	r := IPGroupCidrResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_ip_group_cidr.test").ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_ip_group_cidr"),
+		},
+	})
+}
+
+func (t IPGroupCidrResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.IpGroupCidrID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Network.IPGroupsClient.Get(ctx, id.ResourceGroup, id.IpGroupName, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading IP Group (%s): %+v", id, err)
+	}
+
+	if !utils.SliceContainsValue(*resp.IPAddresses, state.Attributes["cidr"]) {
+		return utils.Bool(false), nil
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (IPGroupCidrResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-network-%d"
+  location = "%s"
+}
+
+resource "azurerm_ip_group" "test" {
+  name                = "acceptanceTestIpGroup1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tags = {
+    env = "prod"
+  }
+}
+
+resource "azurerm_ip_group_cidr" "test" {
+  ip_group_id = azurerm_ip_group.test.id
+  cidr        = "10.0.0.0/24"
+}
+
+
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IPGroupCidrResource) multiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_ip_group_cidr" "multiple_1" {
+  ip_group_id = azurerm_ip_group.test.id
+  cidr        = "10.10.0.0/24"
+}
+
+resource "azurerm_ip_group_cidr" "multiple_2" {
+  ip_group_id = azurerm_ip_group.test.id
+  cidr        = "10.20.0.0/24"
+}
+`, r.basic(data))
+}
+
+func (r IPGroupCidrResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_ip_group_cidr" "import" {
+  ip_group_id = azurerm_ip_group_cidr.test.ip_group_id
+  cidr        = azurerm_ip_group_cidr.test.cidr
+}
+`, r.basic(data))
+}

--- a/internal/services/network/ip_group_resource.go
+++ b/internal/services/network/ip_group_resource.go
@@ -47,8 +47,10 @@ func resourceIpGroup() *pluginsdk.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"cidrs": {
-				Type:     pluginsdk.TypeSet,
-				Optional: true,
+				Type:       pluginsdk.TypeSet,
+				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Optional:   true,
+				Computed:   true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,

--- a/internal/services/network/parse/ip_group_cidr.go
+++ b/internal/services/network/parse/ip_group_cidr.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type IpGroupCidrId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	IpGroupName    string
+	CidrName       string
+}
+
+func NewIpGroupCidrID(subscriptionId, resourceGroup, ipGroupName, cidrName string) IpGroupCidrId {
+	return IpGroupCidrId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		IpGroupName:    ipGroupName,
+		CidrName:       cidrName,
+	}
+}
+
+func (id IpGroupCidrId) String() string {
+	segments := []string{
+		fmt.Sprintf("Cidr Name %q", id.CidrName),
+		fmt.Sprintf("Ip Group Name %q", id.IpGroupName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Ip Group Cidr", segmentsStr)
+}
+
+func (id IpGroupCidrId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s/cidrs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.IpGroupName, id.CidrName)
+}
+
+// IpGroupCidrID parses a IpGroupCidr ID into an IpGroupCidrId struct
+func IpGroupCidrID(input string) (*IpGroupCidrId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := IpGroupCidrId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.IpGroupName, err = id.PopSegment("ipGroups"); err != nil {
+		return nil, err
+	}
+	if resourceId.CidrName, err = id.PopSegment("cidrs"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/ip_group_cidr_test.go
+++ b/internal/services/network/parse/ip_group_cidr_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = IpGroupCidrId{}
+
+func TestIpGroupCidrIDFormatter(t *testing.T) {
+	actual := NewIpGroupCidrID("4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3", "rg-core-hub-networking-ip-groups", "my-ips", "127.0.0.1_32").ID()
+	expected := "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/cidrs/127.0.0.1_32"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestIpGroupCidrID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *IpGroupCidrId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing IpGroupName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for IpGroupName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/",
+			Error: true,
+		},
+
+		{
+			// missing CidrName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/",
+			Error: true,
+		},
+
+		{
+			// missing value for CidrName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/cidrs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/cidrs/127.0.0.1_32",
+			Expected: &IpGroupCidrId{
+				SubscriptionId: "4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3",
+				ResourceGroup:  "rg-core-hub-networking-ip-groups",
+				IpGroupName:    "my-ips",
+				CidrName:       "127.0.0.1_32",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/4FE7B06F-0EB5-489A-B053-F2AFBDD8A4F3/RESOURCEGROUPS/RG-CORE-HUB-NETWORKING-IP-GROUPS/PROVIDERS/MICROSOFT.NETWORK/IPGROUPS/MY-IPS/CIDRS/127.0.0.1_32",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := IpGroupCidrID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.IpGroupName != v.Expected.IpGroupName {
+			t.Fatalf("Expected %q but got %q for IpGroupName", v.Expected.IpGroupName, actual.IpGroupName)
+		}
+		if actual.CidrName != v.Expected.CidrName {
+			t.Fatalf("Expected %q but got %q for CidrName", v.Expected.CidrName, actual.CidrName)
+		}
+	}
+}

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -65,6 +65,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_express_route_gateway":                    resourceExpressRouteGateway(),
 		"azurerm_express_route_port":                       resourceArmExpressRoutePort(),
 		"azurerm_ip_group":                                 resourceIpGroup(),
+		"azurerm_ip_group_cidr":                            resourceIpGroupCidr(),
 		"azurerm_local_network_gateway":                    resourceLocalNetworkGateway(),
 		"azurerm_nat_gateway":                              resourceNatGateway(),
 		"azurerm_nat_gateway_public_ip_association":        resourceNATGatewayPublicIpAssociation(),

--- a/internal/services/network/validate/ip_group_cidr_id.go
+++ b/internal/services/network/validate/ip_group_cidr_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func IpGroupCidrID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.IpGroupCidrID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/ip_group_cidr_id_test.go
+++ b/internal/services/network/validate/ip_group_cidr_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestIpGroupCidrID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing IpGroupName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IpGroupName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing CidrName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CidrName
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/cidrs/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/4fe7b06f-0eb5-489a-b053-f2afbdd8a4f3/resourceGroups/rg-core-hub-networking-ip-groups/providers/Microsoft.Network/ipGroups/my-ips/cidrs/127.0.0.1_32",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/4FE7B06F-0EB5-489A-B053-F2AFBDD8A4F3/RESOURCEGROUPS/RG-CORE-HUB-NETWORKING-IP-GROUPS/PROVIDERS/MICROSOFT.NETWORK/IPGROUPS/MY-IPS/CIDRS/127.0.0.1_32",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := IpGroupCidrID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/ip_group_cidr.html.markdown
+++ b/website/docs/r/ip_group_cidr.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_ip_group_cidr
 
-Manages a IP Group CIDR records.
+Manages IP Group CIDR records.
 
 ~> Warning Do not use this resource at the same time as the `cidrs` property of the
 `azurerm_ip_group` resource for the same IP Group. Doing so will cause a conflict and
@@ -61,7 +61,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 ## Import
 
 IP Group CIDRs can be imported using the `resource id` of the IP Group and
-the CIDR value (`/` have to be replaced by `_`), e.g.
+the CIDR value (`/` characters have to be replaced by `_`), e.g.
 
 ```shell
 terraform import azurerm_ip_group_cidr.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/ipGroups/test-ipgroup/cidrs/10.1.0.0_24

--- a/website/docs/r/ip_group_cidr.html.markdown
+++ b/website/docs/r/ip_group_cidr.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_ip_group_cidr"
+description: |-
+  Manages a IP Group CIDR.
+---
+
+# azurerm_ip_group_cidr
+
+Manages a IP Group CIDR records.
+
+~> Warning Do not use this resource at the same time as the `cidrs` property of the
+`azurerm_ip_group` resource for the same IP Group. Doing so will cause a conflict and
+CIDRS will be removed.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "test-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_ip_group" "example" {
+  name                = "test-ipgroup"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_ip_group_cidr" "example" {
+  ip_group_id = azurerm_ip_group.example.id
+  cidr        = "10.10.10.0/24"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `ip_group_id` - (Required) The ID of the destination IP Group.
+Changing this forces a new IP Group CIDR to be created.
+
+* `cidr` - (Required) The `CIDR` that should be added to the IP Group.
+Changing this forces a new IP Group CIDR to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the IP Group CIDR.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the IP Group CIDR.
+* `read` - (Defaults to 5 minutes) Used when retrieving the IP Group CIDR.
+* `delete` - (Defaults to 30 minutes) Used when deleting the IP Group CIDR.
+
+## Import
+
+IP Group CIDRs can be imported using the `resource id` of the IP Group and
+the CIDR value (`/` have to be replaced by `_`), e.g.
+
+```shell
+terraform import azurerm_ip_group_cidr.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/ipGroups/test-ipgroup/cidrs/10.1.0.0_24
+```


### PR DESCRIPTION
This adds a new resource that allows us to manage the `CIDRs/IPs` in an existing `IP Group`

## Example Usage

```hcl
resource "azurerm_resource_group" "example" {
  name     = "test-rg"
  location = "West Europe"
}

resource "azurerm_ip_group" "example" {
  name                = "test-ipgroup"
  location            = azurerm_resource_group.test.location
  resource_group_name = azurerm_resource_group.test.name
}

resource "azurerm_ip_group_cidr" "example" {
  ip_group_id = azurerm_ip_group.example.id
  cidr        = "10.10.10.0/24"
}
```


![CleanShot 2022-06-21 at 3 59 29](https://user-images.githubusercontent.com/6249819/174818388-056bce6a-7850-4f7f-a768-daa92df747be.png)
