### PR TITLE
`d/shared_image_version`: fix `id`

### DIFF
--- a/internal/services/compute/shared_image_version_data_source.go
+++ b/internal/services/compute/shared_image_version_data_source.go
@@ -118,9 +118,14 @@ func dataSourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	exactId := parse.NewSharedImageVersionID(subscriptionId, id.ResourceGroup, id.GalleryName, id.ImageName, *image.Name)
+	name := ""
+	if image.Name != nil {
+		name = *image.Name
+	}
+
+	exactId := parse.NewSharedImageVersionID(subscriptionId, id.ResourceGroup, id.GalleryName, id.ImageName, name)
 	d.SetId(exactId.ID())
-	d.Set("name", image.Name)
+	d.Set("name", name)
 	d.Set("image_name", id.ImageName)
 	d.Set("gallery_name", id.GalleryName)
 	d.Set("resource_group_name", id.ResourceGroup)

--- a/internal/services/compute/shared_image_version_data_source.go
+++ b/internal/services/compute/shared_image_version_data_source.go
@@ -118,7 +118,8 @@ func dataSourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	d.SetId(id.ID())
+	exactId := parse.NewSharedImageVersionID(subscriptionId, id.ResourceGroup, id.GalleryName, id.ImageName, *image.Name)
+	d.SetId(exactId.ID())
 	d.Set("name", image.Name)
 	d.Set("image_name", id.ImageName)
 	d.Set("gallery_name", id.GalleryName)


### PR DESCRIPTION
Fix #17307. id seems to be set to `latest` by mistake in [this change](https://github.com/hashicorp/terraform-provider-azurerm/pull/14934/files#diff-12e064c48daacb4c1b9cb364b8c84324c957c44bf2ea72af2d0f41ab3dc9dcf6), updating it with the exact version name retrieved from the image version.