### PR TITLE
`azurerm_hdinsight_kafka_cluster`, `azurerm_hdinsight_spark_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_hadoop_cluster` - add support for `disk_encryption_properties` property

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -267,7 +267,7 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
 	}
 
@@ -435,8 +435,10 @@ func resourceHDInsightHadoopClusterRead(d *pluginsdk.ResourceData, meta interfac
 			flattenedRoles = flattenHDInsightEdgeNode(flattenedRoles, edgeNodeProps)
 		}
 
-		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
+		if props.DiskEncryptionProperties != nil {
+			if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+				return fmt.Errorf("flattening `disk_encryption_properties`: %+v", err)
+			}
 		}
 
 		if err := d.Set("roles", flattenedRoles); err != nil {

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -95,7 +95,7 @@ func resourceHDInsightHadoopCluster() *pluginsdk.Resource {
 				},
 			},
 
-			"disk_encryption_properties": SchemaHDInsightsDiskEncryptionProperties(),
+			"disk_encryption": SchemaHDInsightsDiskEncryptionProperties(),
 
 			"gateway": SchemaHDInsightsGateway(),
 
@@ -266,8 +266,11 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 		Identity: identity,
 	}
 
-	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
+		diskEncryptionProperties, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		if err != nil {
+			return err
+		}
 		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
 	}
 
@@ -436,8 +439,12 @@ func resourceHDInsightHadoopClusterRead(d *pluginsdk.ResourceData, meta interfac
 		}
 
 		if props.DiskEncryptionProperties != nil {
-			if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-				return fmt.Errorf("flattening `disk_encryption_properties`: %+v", err)
+			diskEncryptionProps, err := FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)
+			if err != nil {
+				return err
+			}
+			if err := d.Set("disk_encryption", diskEncryptionProps); err != nil {
+				return fmt.Errorf("flattening `disk_encryption`: %+v", err)
 			}
 		}
 

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -1679,8 +1679,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     username = "acctestusrgw"
     password = "TerrAform123!"
   }
-  disk_encryption_properties {
-    encryption_at_host = true
+  disk_encryption {
+    encryption_at_host_enabled = true
   }
   storage_account {
     storage_container_id = azurerm_storage_container.test.id

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -323,6 +323,26 @@ func TestAccHDInsightHadoopCluster_tls(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHadoopCluster_diskEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	r := HDInsightHadoopClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightHadoopCluster_allMetastores(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
 	r := HDInsightHadoopClusterResource{}
@@ -1639,6 +1659,54 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
   }
 }
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightHadoopClusterResource) diskEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_hdinsight_hadoop_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+  component_version {
+    hadoop = "3.1"
+  }
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+  disk_encryption_properties {
+    encryption_at_host = true
+  }
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+  roles {
+    head_node {
+      vm_size  = "Standard_D4a_V4"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+    worker_node {
+      vm_size               = "Standard_D4a_V4"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+    zookeeper_node {
+      vm_size  = "Standard_DS2_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+
 `, r.template(data), data.RandomInteger)
 }
 

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -233,8 +233,7 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
-		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		params.Properties.DiskEncryptionProperties = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 	}
 
 	future, err := client.Create(ctx, resourceGroup, name, params)
@@ -342,8 +341,10 @@ func resourceHDInsightHBaseClusterRead(d *pluginsdk.ResourceData, meta interface
 			}
 		}
 
-		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
+		if props.DiskEncryptionProperties != nil {
+			if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+				return fmt.Errorf("flattening `disk_encryption_properties`: %+v", err)
+			}
 		}
 
 		hbaseRoles := hdInsightRoleDefinition{

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -89,6 +89,8 @@ func resourceHDInsightHBaseCluster() *pluginsdk.Resource {
 				},
 			},
 
+			"disk_encryption_properties": SchemaHDInsightsDiskEncryptionProperties(),
+
 			"gateway": SchemaHDInsightsGateway(),
 
 			"metastores": SchemaHDInsightsExternalMetastores(),
@@ -230,6 +232,11 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
+		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+	}
+
 	future, err := client.Create(ctx, resourceGroup, name, params)
 	if err != nil {
 		return fmt.Errorf("failure creating HDInsight HBase Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)
@@ -333,6 +340,10 @@ func resourceHDInsightHBaseClusterRead(d *pluginsdk.ResourceData, meta interface
 			if err := d.Set("network", FlattenHDInsightsNetwork(props.NetworkProperties)); err != nil {
 				return fmt.Errorf("flattening `network`: %+v", err)
 			}
+		}
+
+		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
 		}
 
 		hbaseRoles := hdInsightRoleDefinition{

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -221,6 +221,26 @@ func TestAccHDInsightHBaseCluster_tls(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHBaseCluster_diskEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
+	r := HDInsightHBaseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightHBaseCluster_allMetastores(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
 	r := HDInsightHBaseClusterResource{}
@@ -1353,6 +1373,61 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
 
     zookeeper_node {
       vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightHBaseClusterResource) diskEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hbase_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    hbase = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  disk_encryption_properties {
+    encryption_at_host = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D4a_V4"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4a_V4"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D4a_V4"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1408,8 +1408,8 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
     is_default           = true
   }
 
-  disk_encryption_properties {
-    encryption_at_host = true
+  disk_encryption {
+    encryption_at_host_enabled = true
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -82,6 +82,8 @@ func resourceHDInsightInteractiveQueryCluster() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"disk_encryption_properties": SchemaHDInsightsDiskEncryptionProperties(),
+
 			"component_version": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
@@ -230,6 +232,11 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 		Identity: identity,
 	}
 
+	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
+		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+	}
+
 	if v, ok := d.GetOk("security_profile"); ok {
 		params.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
 
@@ -343,6 +350,10 @@ func resourceHDInsightInteractiveQueryClusterRead(d *pluginsdk.ResourceData, met
 
 			if props.EncryptionInTransitProperties != nil {
 				d.Set("encryption_in_transit_enabled", props.EncryptionInTransitProperties.IsEncryptionInTransitEnabled)
+			}
+
+			if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+				return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
 			}
 
 			if props.NetworkProperties != nil {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -233,8 +233,7 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
-		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		params.Properties.DiskEncryptionProperties = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
@@ -352,8 +351,10 @@ func resourceHDInsightInteractiveQueryClusterRead(d *pluginsdk.ResourceData, met
 				d.Set("encryption_in_transit_enabled", props.EncryptionInTransitProperties.IsEncryptionInTransitEnabled)
 			}
 
-			if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-				return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
+			if props.DiskEncryptionProperties != nil {
+				if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+					return fmt.Errorf("flattening `disk_encryption_properties`: %+v", err)
+				}
 			}
 
 			if props.NetworkProperties != nil {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -244,6 +244,26 @@ func TestAccHDInsightInteractiveQueryCluster_encryption_in_transit(t *testing.T)
 	})
 }
 
+func TestAccHDInsightInteractiveQueryCluster_diskEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
+	r := HDInsightInteractiveQueryClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightInteractiveQueryCluster_allMetastores(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
 	r := HDInsightInteractiveQueryClusterResource{}
@@ -1444,6 +1464,61 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
 
     zookeeper_node {
       vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightInteractiveQueryClusterResource) diskEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_interactive_query_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    interactive_hive = "3.1"
+  }
+
+  disk_encryption_properties {
+    encryption_at_host = true
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D8a_V4"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D16a_V4"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_DS2_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1488,8 +1488,8 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     interactive_hive = "3.1"
   }
 
-  disk_encryption_properties {
-    encryption_at_host = true
+  disk_encryption {
+    encryption_at_host_enabled = true
   }
 
   gateway {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -276,8 +276,7 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
-		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		params.Properties.DiskEncryptionProperties = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
@@ -420,8 +419,10 @@ func resourceHDInsightKafkaClusterRead(d *pluginsdk.ResourceData, meta interface
 			}
 		}
 
-		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
+		if props.DiskEncryptionProperties != nil {
+			if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+				return fmt.Errorf("flattening `disk_encryption_properties`: %+v", err)
+			}
 		}
 
 		monitor, err := extensionsClient.GetMonitoringStatus(ctx, resourceGroup, name)

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -115,6 +115,8 @@ func resourceHDInsightKafkaCluster() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"disk_encryption_properties": SchemaHDInsightsDiskEncryptionProperties(),
+
 			"roles": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
@@ -273,6 +275,11 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
+		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+	}
+
 	if v, ok := d.GetOk("security_profile"); ok {
 		params.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
 
@@ -411,6 +418,10 @@ func resourceHDInsightKafkaClusterRead(d *pluginsdk.ResourceData, meta interface
 			if err := d.Set("network", FlattenHDInsightsNetwork(props.NetworkProperties)); err != nil {
 				return fmt.Errorf("flatten `network`: %+v", err)
 			}
+		}
+
+		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
 		}
 
 		monitor, err := extensionsClient.GetMonitoringStatus(ctx, resourceGroup, name)

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1392,8 +1392,8 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
     is_default           = true
   }
 
-  disk_encryption_properties {
-    encryption_at_host = true
+  disk_encryption {
+    encryption_at_host_enabled = true
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -406,6 +406,28 @@ func TestAccHDInsightKafkaCluster_restProxy(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightKafkaCluster_diskEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	r := HDInsightKafkaClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"roles.0.kafka_management_node.0.password",
+			"roles.0.kafka_management_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightKafkaCluster_encryptionInTransitEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
 	r := HDInsightKafkaClusterResource{}
@@ -1342,6 +1364,61 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightKafkaClusterResource) diskEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_kafka_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    kafka = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  disk_encryption_properties {
+    encryption_at_host = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D4a_V4"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size                  = "Standard_D4a_V4"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+      number_of_disks_per_node = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_DS2_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r HDInsightKafkaClusterResource) encryptionInTransitEnabled(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -233,8 +233,7 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
-		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
-		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		params.Properties.DiskEncryptionProperties = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
@@ -359,8 +358,10 @@ func resourceHDInsightSparkClusterRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("encryption_in_transit_enabled", props.EncryptionInTransitProperties.IsEncryptionInTransitEnabled)
 		}
 
-		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
-			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
+		if props.DiskEncryptionProperties != nil {
+			if err := d.Set("disk_encryption_properties", FlattenHDInsightsDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+				return fmt.Errorf("flattening setting `disk_encryption_properties`: %+v", err)
+			}
 		}
 
 		if props.NetworkProperties != nil {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -82,6 +82,8 @@ func resourceHDInsightSparkCluster() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"disk_encryption_properties": SchemaHDInsightsDiskEncryptionProperties(),
+
 			"component_version": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
@@ -230,6 +232,11 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		Identity: identity,
 	}
 
+	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption_properties"); ok {
+		diskEncryptionProperties := ExpandHDInsightDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+	}
+
 	if v, ok := d.GetOk("security_profile"); ok {
 		params.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
 
@@ -350,6 +357,10 @@ func resourceHDInsightSparkClusterRead(d *pluginsdk.ResourceData, meta interface
 
 		if props.EncryptionInTransitProperties != nil {
 			d.Set("encryption_in_transit_enabled", props.EncryptionInTransitProperties.IsEncryptionInTransitEnabled)
+		}
+
+		if err = d.Set("disk_encryption_properties", FlattenHDInsightDiskEncryptionProperties(*props.DiskEncryptionProperties)); err != nil {
+			return fmt.Errorf("failed setting `disk_encryption_properties`: %+v", err)
 		}
 
 		if props.NetworkProperties != nil {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -244,6 +244,26 @@ func TestAccHDInsightSparkCluster_encryption_in_transit(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightSparkCluster_diskEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	r := HDInsightSparkClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightSparkCluster_allMetastores(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
 	r := HDInsightSparkClusterResource{}
@@ -1450,6 +1470,63 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightSparkClusterResource) diskEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_spark_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+
+  component_version {
+    spark = "2.4"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  disk_encryption_properties {
+    encryption_at_host = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D4a_V4"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4a_V4"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_DS2_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+
 }
 
 func (r HDInsightSparkClusterResource) allMetastores(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1500,8 +1500,8 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     is_default           = true
   }
 
-  disk_encryption_properties {
-    encryption_at_host = true
+  disk_encryption {
+    encryption_at_host_enabled = true
   }
 
   roles {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -642,15 +642,6 @@ func SchemaHDInsightsGen2StorageAccounts() *pluginsdk.Schema {
 	}
 }
 
-type DiskEncryptionProperties struct {
-	EncryptionAlgorithm string `tfschema:"encryption_algorithm"`
-	EncryptionAtHost    bool   `tfschema:"encryption_at_host"`
-	KeyName             string `tfschema:"key_name"`
-	KeyVersion          string `tfschema:"key_version"`
-	MsiResourceId       string `tfschema:"msi_resource_id"`
-	VaultUri            string `tfschema:"vault_uri"`
-}
-
 func SchemaHDInsightsDiskEncryptionProperties() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -642,6 +642,112 @@ func SchemaHDInsightsGen2StorageAccounts() *pluginsdk.Schema {
 	}
 }
 
+type DiskEncryptionProperties struct {
+	EncryptionAlgorithm string `tfschema:"encryption_algorithm"`
+	EncryptionAtHost    bool   `tfschema:"encryption_at_host"`
+	KeyName             string `tfschema:"key_name"`
+	KeyVersion          string `tfschema:"key_version"`
+	MsiResourceId       string `tfschema:"msi_resource_id"`
+	VaultUri            string `tfschema:"vault_uri"`
+}
+
+func SchemaHDInsightsDiskEncryptionProperties() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"encryption_algorithm": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(hdinsight.JSONWebKeyEncryptionAlgorithmRSA15),
+						string(hdinsight.JSONWebKeyEncryptionAlgorithmRSAOAEP),
+						string(hdinsight.JSONWebKeyEncryptionAlgorithmRSAOAEP256),
+					}, false),
+				},
+
+				"encryption_at_host": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+
+				"key_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"key_version": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"msi_resource_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+				},
+
+				"vault_uri": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func ExpandHDInsightDiskEncryptionProperties(input []interface{}) *hdinsight.DiskEncryptionProperties {
+	v := input[0].(map[string]interface{})
+
+	encryptionAlgorithm := v["encryption_algorithm"].(string)
+	encryptionAtHost := v["encryption_at_host"].(bool)
+	keyName := v["key_name"].(string)
+	keyVersion := v["key_version"].(string)
+	msiResourceId := v["msi_resource_id"].(string)
+	vaultUri := v["vault_uri"].(string)
+
+	return &hdinsight.DiskEncryptionProperties{
+		EncryptionAlgorithm: hdinsight.JSONWebKeyEncryptionAlgorithm(encryptionAlgorithm),
+		EncryptionAtHost:    &encryptionAtHost,
+		KeyName:             &keyName,
+		KeyVersion:          &keyVersion,
+		MsiResourceID:       &msiResourceId,
+		VaultURI:            &vaultUri,
+	}
+}
+
+func FlattenHDInsightDiskEncryptionProperties(input hdinsight.DiskEncryptionProperties) []interface{} {
+	var encryptionAlgorithm string
+	var encryptionAtHost bool
+	var keyName string
+	var keyVersion string
+	var msiResourceId string
+	var vaultUri string
+
+	if input.EncryptionAtHost != nil {
+		encryptionAtHost = *input.EncryptionAtHost
+	}
+	encryptionAlgorithm = string(input.EncryptionAlgorithm)
+	keyName = *input.KeyName
+	keyVersion = *input.KeyVersion
+	msiResourceId = *input.MsiResourceID
+	vaultUri = *input.VaultURI
+
+	return []interface{}{
+		map[string]interface{}{
+			"encryption_algorithm": encryptionAlgorithm,
+			"encryption_at_host":   encryptionAtHost,
+			"key_name":             keyName,
+			"key_version":          keyVersion,
+			"msi_resource_id":      msiResourceId,
+			"vault_uri":            vaultUri,
+		},
+	}
+}
+
 // ExpandHDInsightsStorageAccounts returns an array of StorageAccount structs, as well as a ClusterIdentity
 // populated with any managed identities required for accessing Data Lake Gen2 storage.
 func ExpandHDInsightsStorageAccounts(storageAccounts []interface{}, gen2storageAccounts []interface{}) (*[]hdinsight.StorageAccount, *hdinsight.ClusterIdentity, error) {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -690,7 +690,7 @@ func SchemaHDInsightsDiskEncryptionProperties() *pluginsdk.Schema {
 	}
 }
 
-func ExpandHDInsightDiskEncryptionProperties(input []interface{}) *hdinsight.DiskEncryptionProperties {
+func ExpandHDInsightsDiskEncryptionProperties(input []interface{}) *hdinsight.DiskEncryptionProperties {
 	v := input[0].(map[string]interface{})
 
 	encryptionAlgorithm := v["encryption_algorithm"].(string)
@@ -710,7 +710,7 @@ func ExpandHDInsightDiskEncryptionProperties(input []interface{}) *hdinsight.Dis
 	}
 }
 
-func FlattenHDInsightDiskEncryptionProperties(input hdinsight.DiskEncryptionProperties) []interface{} {
+func FlattenHDInsightsDiskEncryptionProperties(input hdinsight.DiskEncryptionProperties) []interface{} {
 	var encryptionAlgorithm string
 	var encryptionAtHost bool
 	var keyName string

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -237,16 +237,12 @@ A `display_encryption_properties` block supports the following:
 
 * `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
 
-* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+* `encryption_at_host_enabled` - (Optional) This is indicator to show whether resource disk encryption is enabled.
 
-* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+* `key_vault_key_id` - (Optional) The ID of the key vault key.
 
-* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+* `key_vault_managed_identity_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
 
-* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
-
-* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
-* 
 ---
 
 A `zookeeper_node` block supports the following:

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -233,6 +233,22 @@ A `worker_node` block supports the following:
 
 ---
 
+A `display_encryption_properties` block supports the following:
+
+* `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
+
+* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+
+* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+
+* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+
+* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
+
+* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+* 
+---
+
 A `zookeeper_node` block supports the following:
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -235,15 +235,11 @@ A `display_encryption_properties` block supports the following:
 
 * `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
 
-* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+* `encryption_at_host_enabled` - (Optional) This is indicator to show whether resource disk encryption is enabled.
 
-* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+* `key_vault_key_id` - (Optional) The ID of the key vault key.
 
-* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
-
-* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
-
-* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+* `key_vault_managed_identity_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
 
 ---
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -231,6 +231,22 @@ A `worker_node` block supports the following:
 
 ---
 
+A `display_encryption_properties` block supports the following:
+
+* `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
+
+* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+
+* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+
+* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+
+* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
+
+* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+
+---
+
 A `zookeeper_node` block supports the following:
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -236,6 +236,22 @@ A `worker_node` block supports the following:
 
 ---
 
+A `display_encryption_properties` block supports the following:
+
+* `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
+
+* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+
+* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+
+* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+
+* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
+
+* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+
+---
+
 A `zookeeper_node` block supports the following:
 
 * `username` - (Required) The Username of the local administrator for the Zookeeper Nodes. Changing this forces a new resource to be created.

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -240,15 +240,11 @@ A `display_encryption_properties` block supports the following:
 
 * `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
 
-* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+* `encryption_at_host_enabled` - (Optional) This is indicator to show whether resource disk encryption is enabled.
 
-* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+* `key_vault_key_id` - (Optional) The ID of the key vault key.
 
-* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
-
-* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
-
-* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+* `key_vault_managed_identity_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
 
 ---
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -260,15 +260,11 @@ A `display_encryption_properties` block supports the following:
 
 * `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
 
-* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+* `encryption_at_host_enabled` - (Optional) This is indicator to show whether resource disk encryption is enabled.
 
-* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+* `key_vault_key_id` - (Optional) The ID of the key vault key.
 
-* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
-
-* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
-
-* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+* `key_vault_managed_identity_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
 
 ---
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -256,6 +256,22 @@ A `zookeeper_node` block supports the following:
 
 ---
 
+A `display_encryption_properties` block supports the following:
+
+* `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
+
+* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+
+* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+
+* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+
+* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
+
+* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+
+---
+
 A `kafka_management_node` block supports the following:
 
 * `username` - (Required) The Username of the local administrator for the Kafka Management Nodes. Changing this forces a new resource to be created.

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -251,7 +251,23 @@ A `zookeeper_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
---- 
+---
+
+A `display_encryption_properties` block supports the following:
+
+* `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
+
+* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+
+* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+
+* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
+
+* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
+
+* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+
+---
 
 A `metastores` block supports the following:
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -257,15 +257,11 @@ A `display_encryption_properties` block supports the following:
 
 * `encryption_algorithm` - (Optional) This is an algorithm identifier for encryption. Possible values are `RSA1_5`, `RSA-OAEP`, `RSA-OAEP-256`.
 
-* `encryption_at_host` - (Optional) This is indicator to show whether resource disk encryption is enabled.
+* `encryption_at_host_enabled` - (Optional) This is indicator to show whether resource disk encryption is enabled.
 
-* `key_name` - (Optional) This is the name of key used for enabling disk encryption.
+* `key_vault_key_id` - (Optional) The ID of the key vault key.
 
-* `key_version` - (Optional) This is the specific version of the key used for enabling disk encryption.
-
-* `msi_resource_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
-
-* `vault_uri` - (Optional) this is the base key vault URI where the customers key is located.
+* `key_vault_managed_identity_id` - (Optional) This is the resource ID of Managed Identity used to access the key vault.
 
 ---
 


### PR DESCRIPTION
* Add support for `disk_encryption_properties` to reach 100% coverage for HDInsight service.

* All tests passed.