### PR TITLE
Doc Fix : azurerm_application_gateway - Fix incorrect description of property unhealthy_threshold

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -400,7 +400,7 @@ A `probe` block support the following:
 
 * `timeout` - (Required) The Timeout used for this Probe, which indicates when a probe becomes unhealthy. Possible values range from 1 second to a maximum of 86,400 seconds.
 
-* `unhealthy_threshold` - (Required) The Unhealthy Threshold for this Probe, which indicates the amount of retries which should be attempted before a node is deemed unhealthy. Possible values are from 1 - 20 seconds.
+* `unhealthy_threshold` - (Required) The Unhealthy Threshold for this Probe, which indicates the amount of retries which should be attempted before a node is deemed unhealthy. Possible values are from 1 to 20.
 
 * `port` - (Optional) Custom port which will be used for probing the backend servers. The valid value ranges from 1 to 65535. In case not set, port from HTTP settings will be used. This property is valid for Standard_v2 and WAF_v2 only.
 


### PR DESCRIPTION
Per the [doc](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-probe-overview#custom-health-probe-settings), the definition of  `unhealthy_threshold` shoud be "probe retry count". So, removed the `seconds` in tf doc to fix issue #17353.