### PR TITLE
Update `azurerm_application_gateway` to make `priority` optional

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -663,7 +663,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 
 						"priority": {
 							Type:         pluginsdk.TypeInt,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 20000),
 						},
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -434,7 +434,8 @@ A `request_routing_rule` block supports the following:
 * `priority` - (Required)  Rule evaluation order can be dictated by specifying an integer value from `1` to `20000` with `1` being the highest priority and `20000` being the lowest priority. Only valid for v2 SKUs.
 
 -> **NOTE - v1 SKUs** The `priority` field must not be specified. It is not supported in v1 SKUs.
-~> **NOTE - v2 SKUs** The `priority` field is mandatory with AzureRM release 3.6.0 and later on [v2 SKUs](https://docs.microsoft.com/en-us/azure/application-gateway/multiple-site-overview#request-routing-rules-evaluation-order).
+
+~> **NOTE - v2 SKUs** The `priority` field is [mandatory](https://docs.microsoft.com/en-us/azure/application-gateway/multiple-site-overview#request-routing-rules-evaluation-order) with AzureRM release 3.6.0 and later.
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -433,9 +433,9 @@ A `request_routing_rule` block supports the following:
 
 * `priority` - (Required)  Rule evaluation order can be dictated by specifying an integer value from `1` to `20000` with `1` being the highest priority and `20000` being the lowest priority. Only valid for v2 SKUs.
 
--> **NOTE - v1 SKUs** The `priority` field must not be specified. It is not supported in v1 SKUs.
+-> **NOTE - v1 SKUs** v1 SKUs do not support the `priority` field.
 
-~> **NOTE - v2 SKUs** The `priority` field is [mandatory](https://docs.microsoft.com/en-us/azure/application-gateway/multiple-site-overview#request-routing-rules-evaluation-order) with AzureRM release 3.6.0 and later.
+~> **NOTE - v2 SKUs** v2 SKUs support the `priority` field. It is [required](https://docs.microsoft.com/en-us/azure/application-gateway/multiple-site-overview#request-routing-rules-evaluation-order) with AzureRM release 3.6.0 and later.
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -109,7 +109,6 @@ resource "azurerm_application_gateway" "network" {
     http_listener_name         = local.listener_name
     backend_address_pool_name  = local.backend_address_pool_name
     backend_http_settings_name = local.http_setting_name
-    priority                   = 10
   }
 }
 ```
@@ -432,9 +431,10 @@ A `request_routing_rule` block supports the following:
 
 * `url_path_map_name` - (Optional) The Name of the URL Path Map which should be associated with this Routing Rule.
 
-* `priority` - (Required) Rule evaluation order can be dictated by specifying an integer value from `1` to `20000` with `1` being the highest priority and `20000` being the lowest priority.
+* `priority` - (Required)  Rule evaluation order can be dictated by specifying an integer value from `1` to `20000` with `1` being the highest priority and `20000` being the lowest priority. Only valid for v2 SKUs.
 
-~> **NOTE:** The `priority` field is mandatory with AzureRM release 3.6.0 and later. 
+-> **NOTE - v1 SKUs** The `priority` field must not be specified. It is not supported in v1 SKUs.
+~> **NOTE - v2 SKUs** The `priority` field is mandatory with AzureRM release 3.6.0 and later on [v2 SKUs](https://docs.microsoft.com/en-us/azure/application-gateway/multiple-site-overview#request-routing-rules-evaluation-order).
 
 ---
 


### PR DESCRIPTION
AppGateway v2 SKUs require Priority. AppGateway v1 SKUs do not. Marking this as Optional and let the underlying API advise if the field is required on the V2 SKUs.
