### PR TITLE
`r\shared_image_version`: update `target_region` to list

### DIFF
--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -66,7 +66,9 @@ func resourceSharedImageVersion() *pluginsdk.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"target_region": {
-				Type:     pluginsdk.TypeSet,
+				// This needs to be a `TypeList` due to the `StateFunc` on the nested property `name`
+				// See: https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+				Type:     pluginsdk.TypeList,
 				Required: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -301,10 +303,10 @@ func sharedImageVersionDeleteStateRefreshFunc(ctx context.Context, client *compu
 }
 
 func expandSharedImageVersionTargetRegions(d *pluginsdk.ResourceData) *[]compute.TargetRegion {
-	vs := d.Get("target_region").(*pluginsdk.Set)
+	vs := d.Get("target_region").([]interface{})
 	results := make([]compute.TargetRegion, 0)
 
-	for _, v := range vs.List() {
+	for _, v := range vs {
 		input := v.(map[string]interface{})
 
 		name := input["name"].(string)


### PR DESCRIPTION
Fix #11411 and #12332. `target_region` is hitting the issue when `StateFunc` inside of a `TypeSet` https://github.com/hashicorp/terraform-plugin-sdk/issues/160, causing the update body to contain extra target regions.
The service also respects the order of target regions in the api requests. After using `TypeList`, when we swap two target regions in the config, the order on service side will also be updated to match the config after the update is done.