### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/internal/services/apimanagement/api_management_api_schema_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_schema_resource_test.go
@@ -3,7 +3,7 @@ package apimanagement_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -20,7 +20,7 @@ type ApiManagementApiSchemaResource struct{}
 func TestAccApiManagementApiSchema_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_schema", "test")
 	r := ApiManagementApiSchemaResource{}
-	schema, _ := ioutil.ReadFile("testdata/api_management_api_schema.xml")
+	schema, _ := os.ReadFile("testdata/api_management_api_schema.xml")
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -37,7 +37,7 @@ func TestAccApiManagementApiSchema_basic(t *testing.T) {
 func TestAccApiManagementApiSchema_basicSwagger(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_schema", "test")
 	r := ApiManagementApiSchemaResource{}
-	schema, _ := ioutil.ReadFile("testdata/api_management_api_schema_swagger.json")
+	schema, _ := os.ReadFile("testdata/api_management_api_schema_swagger.json")
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{

--- a/internal/services/appservice/helpers/publish_app.go
+++ b/internal/services/appservice/helpers/publish_app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -182,7 +182,7 @@ func checkZipDeploymentStatusRefresh(r *http.Request) pluginsdk.StateRefreshFunc
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 			return nil, "", fmt.Errorf("failed to read Zip Deployment status: %s", resp.Status)
 		}
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, "", fmt.Errorf("reading status response body for Zip Deploy")
 		}

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -960,7 +960,7 @@ func TestAccAzureRMStorageAccount_sharePropertiesUpdate(t *testing.T) {
 func TestAccAzureRMStorageAccount_shareSoftDelete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
-	sourceBlob, err := ioutil.TempFile("", "")
+	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
 	}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

Do note that the switch from `ioutil.TempFile` to `os.CreateTemp` in the go doc itself (i.e. the former just calls the later) was only done in Go 1.17, but the functionality of os.CreateTemp was already available in 1.16 and thus is safe for use with Go 1.16 as well.
