### PR TITLE
`azurerm_key_vault` data source: cache the `vault_uri` once read

### DIFF
--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -191,6 +191,9 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
 		d.Set("vault_uri", props.VaultURI)
+		if props.VaultURI != nil {
+			meta.(*clients.Client).KeyVault.AddToCache(id, *resp.Properties.VaultURI)
+		}
 
 		if sku := props.Sku; sku != nil {
 			if err := d.Set("sku_name", string(sku.Name)); err != nil {


### PR DESCRIPTION
Mitigate #11059.

THe listing resources API won't be called if the [`keyVaultCache`](https://github.com/hashicorp/terraform-provider-azurerm/blob/1e187b53fc498edd65c083341b603921cf997c1e/internal/services/keyvault/client/helpers.go#L16) is populated. Currently, the cache is populated in following places (prior to calling the resource listing API):

- When the key vault resource is created
- When the key vault resource is read

The reports in #11059 are mostly happening when the depending key vault is a data source. This PR adds support for that use case.

In result, as long as users guarantee the correct dependency between key vault (either resource or data source) and the nested items, then the listing resource API is avoided.