### PR TITLE
Sentinel data connector document: emphasize that `tenant_id` can only be the current tenant

### DIFF
--- a/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the tenant that this Azure Active Directory Data Connector connects to. Changing this forces a new Azure Active Directory Data Connector to be created.
 
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:

--- a/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the tenant that this Azure Advanced Threat Protection Data Connector connects to. Changing this forces a new Azure Advanced Threat Protection Data Connector to be created.
 
--> **Note:** If unspecified the Tenant ID of the current Subscription will be used.
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
@@ -64,6 +64,8 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the Tenant that this Microsoft Cloud App Security Data Connector connects to. Changing this forces a new Microsoft Cloud App Security Data Connector to be created.
 
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:

--- a/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the tenant that this Microsoft Defender Advanced Threat Protection Data Connector connects to. Changing this forces a new Microsoft Defender Advanced Threat Protection Data Connector to be created.
 
--> If unspecified the Tenant ID of the current Subscription will be used
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_data_connector_office_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the Tenant that this Office 365 Data Connector connects to. Changing this forces a new Office 365 Data Connector to be created.
 
--> **NOTE:** Terraform will use the Tenant ID for the current Subscription if this is unspecified.
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The ID of the tenant that this Threat Intelligence Data Connector connects to. Changing this forces a new Threat Intelligence Data Connector to be created.
 
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
Sentinel data connector document: emphasize that `tenant_id` can only be the current tenant