### PR TITLE
`azurerm_batch_pool` - Added support for `identity_reference` into `container_registries`

### DIFF
--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -144,7 +144,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},
-									"identity_reference": {
+									"user_assigned_identity_id": {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -144,6 +144,10 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},
+									"identity_reference": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
 									"user_name": {
 										Type:     pluginsdk.TypeString,
 										Computed: true,

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/validate"
+	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -159,15 +160,22 @@ func resourceBatchPool() *pluginsdk.Resource {
 										ForceNew:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
+									"user_assigned_identity_id": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: msivalidate.UserAssignedIdentityID,
+										Description:  "The User Assigned Identity to use for Container Registry access.",
+									},
 									"user_name": {
 										Type:         pluginsdk.TypeString,
-										Required:     true,
+										Optional:     true,
 										ForceNew:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"password": {
 										Type:         pluginsdk.TypeString,
-										Required:     true,
+										Optional:     true,
 										ForceNew:     true,
 										Sensitive:    true,
 										ValidateFunc: validation.StringIsNotEmpty,

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2022-01-01/batch"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/validate"
-	msivalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/msi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -164,7 +164,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
 										ForceNew:     true,
-										ValidateFunc: msivalidate.UserAssignedIdentityID,
+										ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 										Description:  "The User Assigned Identity to use for Container Registry access.",
 									},
 									"user_name": {

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -334,13 +334,13 @@ func TestAccBatchPool_validateResourceFileWithoutSource(t *testing.T) {
 	})
 }
 
-func TestAccBatchPool_container(t *testing.T) {
+func TestAccBatchPool_containerWithUser(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 	r := BatchPoolResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.containerConfiguration(data),
+			Config: r.containerConfigurationWithRegistryUser(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("container_configuration.0.type").HasValue("DockerCompatible"),
@@ -349,11 +349,35 @@ func TestAccBatchPool_container(t *testing.T) {
 				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.registry_server").HasValue("myContainerRegistry.azurecr.io"),
 				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.user_name").HasValue("myUserName"),
 				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.password").HasValue("myPassword"),
+				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.user_assigned_identity_id").IsEmpty(),
 			),
 		},
 		data.ImportStep(
 			"stop_pending_resize_operation",
 			"container_configuration.0.container_registries.0.password",
+		),
+	})
+}
+
+func TestAccBatchPool_containerWithUAMI(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.containerConfigurationWithRegistryUAMI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("container_configuration.0.type").HasValue("DockerCompatible"),
+				check.That(data.ResourceName).Key("container_configuration.0.container_image_names.#").HasValue("1"),
+				check.That(data.ResourceName).Key("container_configuration.0.container_registries.#").HasValue("1"),
+				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.registry_server").HasValue("myContainerRegistry.azurecr.io"),
+				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.user_name").IsEmpty(),
+				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.user_assigned_identity_id").IsSet(),
+			),
+		},
+		data.ImportStep(
+			"stop_pending_resize_operation",
 		),
 	})
 }
@@ -1268,7 +1292,7 @@ resource "azurerm_batch_pool" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
-func (BatchPoolResource) containerConfiguration(data acceptance.TestData) string {
+func (BatchPoolResource) containerConfigurationWithRegistryUser(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1321,6 +1345,73 @@ resource "azurerm_batch_pool" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) containerConfigurationWithRegistryUAMI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccbatch%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "testaccuami%d"
+}
+
+resource "azurerm_container_registry" "test" {
+  name                = "testregistry%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Basic"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+}
+
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 20.04"
+  vm_size             = "Standard_A1"
+
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+
+  storage_image_reference {
+    publisher = "microsoft-azure-batch"
+    offer     = "ubuntu-server-container"
+    sku       = "20-04-lts"
+    version   = "latest"
+  }
+
+  container_configuration {
+    type                  = "DockerCompatible"
+    container_image_names = ["centos7"]
+    container_registries {
+      registry_server           = "myContainerRegistry.azurecr.io"
+      user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString)
 }
 
 func (BatchPoolResource) customImageConfiguration(data acceptance.TestData) string {

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -151,6 +151,8 @@ A `container_registries` block exports the following:
 
 * `password` - The password to log into the registry server.
 
+* `identity_reference` - The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password.
+
 ---
 
 A `network_configuration` block exports the following:

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -151,7 +151,7 @@ A `container_registries` block exports the following:
 
 * `password` - The password to log into the registry server.
 
-* `identity_reference` - The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password.
+* `user_assigned_identity_id` - The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password.
 
 ---
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -281,6 +281,7 @@ A `container_registries` block supports the following:
 
 * `password` - (Optional) The password to log into the registry server. Changing this forces a new resource to be created.
 
+* `identity_reference` - (Optional) The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password. Changing this forces a new resource to be created.
 ---
 
 A `network_configuration` block supports the following:

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -281,7 +281,7 @@ A `container_registries` block supports the following:
 
 * `password` - (Optional) The password to log into the registry server. Changing this forces a new resource to be created.
 
-* `identity_reference` - (Optional) The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password. Changing this forces a new resource to be created.
+* `user_assigned_identity_id` - (Optional) The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password. Changing this forces a new resource to be created.
 ---
 
 A `network_configuration` block supports the following:


### PR DESCRIPTION
Added support for using `identity_reference` inside of `container_registries` of `azurerm_batch_pool`.

API link: https://docs.microsoft.com/en-us/rest/api/batchservice/pool/add#containerregistry

Test
----------
```
$ go test -v -timeout 3000s -run ^TestAccBatchPool_container github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/
=== RUN   TestAccBatchPool_containerWithUser
=== PAUSE TestAccBatchPool_containerWithUser
=== RUN   TestAccBatchPool_containerWithUAMI
=== PAUSE TestAccBatchPool_containerWithUAMI
=== CONT  TestAccBatchPool_containerWithUser
=== CONT  TestAccBatchPool_containerWithUAMI
--- PASS: TestAccBatchPool_containerWithUser (587.65s)
--- PASS: TestAccBatchPool_containerWithUAMI (589.87s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/batch 593.975s
```