### PR TITLE
azurerm_bot_service_azure_bot - support streaming_endpoint_enabled

### DIFF
--- a/internal/services/bot/bot_channel_test.go
+++ b/internal/services/bot/bot_channel_test.go
@@ -17,10 +17,11 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 			"streamingEndpointEnabled": testAccBotChannelsRegistration_streamingEndpointEnabled,
 		},
 		"bot": {
-			"basic":          testAccBotServiceAzureBot_basic,
-			"completeUpdate": testAccBotServiceAzureBot_completeUpdate,
-			"msaAppType":     testAccBotServiceAzureBot_msaAppType,
-			"requiresImport": testAccBotServiceAzureBot_requiresImport,
+			"basic":                    testAccBotServiceAzureBot_basic,
+			"completeUpdate":           testAccBotServiceAzureBot_completeUpdate,
+			"msaAppType":               testAccBotServiceAzureBot_msaAppType,
+			"requiresImport":           testAccBotServiceAzureBot_requiresImport,
+			"streamingEndpointEnabled": testAccBotServiceAzureBot_streamingEndpointEnabled,
 		},
 		"connection": {
 			"basic":    testAccBotConnection_basic,

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -88,6 +88,28 @@ func testAccBotServiceAzureBot_msaAppType(t *testing.T) {
 	})
 }
 
+func testAccBotServiceAzureBot_streamingEndpointEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_service_azure_bot", "test")
+	r := BotServiceAzureBotResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.steamingEndpointEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.steamingEndpointEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t BotServiceAzureBotResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.BotServiceID(state.ID)
 	if err != nil {
@@ -222,4 +244,29 @@ resource "azurerm_bot_service_azure_bot" "test" {
   microsoft_app_msi_id    = azurerm_user_assigned_identity.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (BotServiceAzureBotResource) steamingEndpointEnabled(data acceptance.TestData, streamingEndpointEnabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_bot_service_azure_bot" "test" {
+  name                       = "acctestdf%[1]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = "global"
+  sku                        = "F0"
+  microsoft_app_id           = data.azurerm_client_config.current.client_id
+  streaming_endpoint_enabled = %[3]t
+}
+`, data.RandomInteger, data.Locations.Primary, streamingEndpointEnabled)
 }

--- a/internal/services/bot/bot_service_base_resource.go
+++ b/internal/services/bot/bot_service_base_resource.go
@@ -120,6 +120,12 @@ func (br botBaseResource) arguments(fields map[string]*pluginsdk.Schema) map[str
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 
+		"streaming_endpoint_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
 		"tags": tags.Schema(),
 	}
 
@@ -173,6 +179,7 @@ func (br botBaseResource) createFunc(resourceName, botKind string) sdk.ResourceF
 					DeveloperAppInsightsApplicationID: utils.String(metadata.ResourceData.Get("developer_app_insights_application_id").(string)),
 					LuisAppIds:                        utils.ExpandStringSlice(metadata.ResourceData.Get("luis_app_ids").([]interface{})),
 					LuisKey:                           utils.String(metadata.ResourceData.Get("luis_key").(string)),
+					IsStreamingSupported:              utils.Bool(metadata.ResourceData.Get("streaming_endpoint_enabled").(bool)),
 				},
 				Tags: tags.Expand(metadata.ResourceData.Get("tags").(map[string]interface{})),
 			}
@@ -290,6 +297,12 @@ func (br botBaseResource) readFunc() sdk.ResourceFunc {
 					luisAppIds = *v
 				}
 				metadata.ResourceData.Set("luis_app_ids", utils.FlattenStringSlice(&luisAppIds))
+
+				streamingEndpointEnabled := false
+				if v := props.IsStreamingSupported; v != nil {
+					streamingEndpointEnabled = *v
+				}
+				metadata.ResourceData.Set("streaming_endpoint_enabled", streamingEndpointEnabled)
 			}
 
 			return nil
@@ -357,6 +370,10 @@ func (br botBaseResource) updateFunc() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("luis_key") {
 				existing.Properties.LuisKey = utils.String(metadata.ResourceData.Get("luis_key").(string))
+			}
+
+			if metadata.ResourceData.HasChange("streaming_endpoint_enabled") {
+				existing.Properties.IsStreamingSupported = utils.Bool(metadata.ResourceData.Get("streaming_endpoint_enabled").(bool))
 			}
 
 			if _, err := client.Update(ctx, id.ResourceGroup, id.Name, existing); err != nil {

--- a/website/docs/r/bot_service_azure_bot.html.markdown
+++ b/website/docs/r/bot_service_azure_bot.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `luis_key` - (Optional) The LUIS key to associate with this Azure Bot Service.
 
+* `streaming_endpoint_enabled` - (Optional) Is the streaming endpoint enabled for this Azure Bot Service. Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to this Azure Bot Service.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR is to support streaming_endpoint_enabled on azurerm_bot_service_azure_bot.

--- PASS: TestAccBotChannelsRegistration/bot/basic (258.29s)
--- PASS: TestAccBotChannelsRegistration/bot/completeUpdate (422.79s)
--- PASS: TestAccBotChannelsRegistration/bot/msaAppType (277.74s)
--- PASS: TestAccBotChannelsRegistration/bot/requiresImport (276.44s)
--- PASS: TestAccBotChannelsRegistration/bot/streamingEndpointEnabled (362.28s)