### PR TITLE
`azurerm_key_vault_{key|secret}` - Expose attributes `resource_id` and `resource_versionless_id`

### DIFF
--- a/internal/services/keyvault/key_vault_key_data_source.go
+++ b/internal/services/keyvault/key_vault_key_data_source.go
@@ -103,6 +103,16 @@ func dataSourceKeyVaultKey() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"resource_versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -209,6 +219,9 @@ func dataSourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("version", parsedId.Version)
+
+	d.Set("resource_id", parse.NewKeyID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, parsedId.Name, parsedId.Version).ID())
+	d.Set("resource_versionless_id", parse.NewKeyVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, parsedId.Name).ID())
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/keyvault/key_vault_key_data_source_test.go
+++ b/internal/services/keyvault/key_vault_key_data_source_test.go
@@ -2,6 +2,7 @@ package keyvault_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -21,6 +22,8 @@ func TestAccDataSourceKeyVaultKey_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("key_type").HasValue("RSA"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/keys/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/keys/[\w-]+$`)),
 			),
 		},
 	})

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -179,6 +179,16 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"resource_versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -491,6 +501,9 @@ func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			}
 		}
 	}
+
+	d.Set("resource_id", parse.NewKeyID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, id.Name, id.Version).ID())
+	d.Set("resource_versionless_id", parse.NewKeyVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, id.Name).ID())
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -3,6 +3,7 @@ package keyvault_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -27,6 +28,8 @@ func TestAccKeyVaultKey_basicEC(t *testing.T) {
 			Config: r.basicEC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/keys/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/keys/[\w-]+$`)),
 			),
 		},
 		data.ImportStep("key_size", "key_vault_id"),

--- a/internal/services/keyvault/key_vault_secret_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_data_source.go
@@ -55,6 +55,16 @@ func dataSourceKeyVaultSecret() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"resource_versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -100,6 +110,9 @@ func dataSourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
 	d.Set("versionless_id", respID.VersionlessID())
+
+	d.Set("resource_id", parse.NewSecretID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, respID.Name, respID.Version).ID())
+	d.Set("resource_versionless_id", parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, respID.Name).ID())
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -2,6 +2,7 @@ package keyvault_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -20,6 +21,8 @@ func TestAccDataSourceKeyVaultSecret_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+$`)),
 			),
 		},
 	})

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -86,6 +86,16 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"resource_versionless_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaWithMax(15),
 		},
 	}
@@ -357,6 +367,9 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 			d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
 		}
 	}
+
+	d.Set("resource_id", parse.NewSecretID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, id.Name, id.Version).ID())
+	d.Set("resource_versionless_id", parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, id.Name).ID())
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -3,6 +3,7 @@ package keyvault_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
@@ -26,6 +27,8 @@ func TestAccKeyVaultSecret_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+$`)),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/keyvault/parse/key.go
+++ b/internal/services/keyvault/parse/key.go
@@ -1,0 +1,81 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type KeyId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	VaultName      string
+	Name           string
+	VersionName    string
+}
+
+func NewKeyID(subscriptionId, resourceGroup, vaultName, name, versionName string) KeyId {
+	return KeyId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		VaultName:      vaultName,
+		Name:           name,
+		VersionName:    versionName,
+	}
+}
+
+func (id KeyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Version Name %q", id.VersionName),
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Vault Name %q", id.VaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Key", segmentsStr)
+}
+
+func (id KeyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/keys/%s/versions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VaultName, id.Name, id.VersionName)
+}
+
+// KeyID parses a Key ID into an KeyId struct
+func KeyID(input string) (*KeyId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := KeyId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VaultName, err = id.PopSegment("vaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("keys"); err != nil {
+		return nil, err
+	}
+	if resourceId.VersionName, err = id.PopSegment("versions"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/keyvault/parse/key_test.go
+++ b/internal/services/keyvault/parse/key_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = KeyId{}
+
+func TestKeyIDFormatter(t *testing.T) {
+	actual := NewKeyID("12345678-1234-9876-4563-123456789012", "resGroup1", "vault1", "key1", "version1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/version1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestKeyID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *KeyId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Error: true,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/",
+			Error: true,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/",
+			Error: true,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/version1",
+			Expected: &KeyId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				VaultName:      "vault1",
+				Name:           "key1",
+				VersionName:    "version1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/KEYS/KEY1/VERSIONS/VERSION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := KeyID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VaultName != v.Expected.VaultName {
+			t.Fatalf("Expected %q but got %q for VaultName", v.Expected.VaultName, actual.VaultName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+		if actual.VersionName != v.Expected.VersionName {
+			t.Fatalf("Expected %q but got %q for VersionName", v.Expected.VersionName, actual.VersionName)
+		}
+	}
+}

--- a/internal/services/keyvault/parse/key_versionless.go
+++ b/internal/services/keyvault/parse/key_versionless.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type KeyVersionlessId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	VaultName      string
+	KeyName        string
+}
+
+func NewKeyVersionlessID(subscriptionId, resourceGroup, vaultName, keyName string) KeyVersionlessId {
+	return KeyVersionlessId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		VaultName:      vaultName,
+		KeyName:        keyName,
+	}
+}
+
+func (id KeyVersionlessId) String() string {
+	segments := []string{
+		fmt.Sprintf("Key Name %q", id.KeyName),
+		fmt.Sprintf("Vault Name %q", id.VaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Key Versionless", segmentsStr)
+}
+
+func (id KeyVersionlessId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/keys/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VaultName, id.KeyName)
+}
+
+// KeyVersionlessID parses a KeyVersionless ID into an KeyVersionlessId struct
+func KeyVersionlessID(input string) (*KeyVersionlessId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := KeyVersionlessId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VaultName, err = id.PopSegment("vaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.KeyName, err = id.PopSegment("keys"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/keyvault/parse/key_versionless_test.go
+++ b/internal/services/keyvault/parse/key_versionless_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = KeyVersionlessId{}
+
+func TestKeyVersionlessIDFormatter(t *testing.T) {
+	actual := NewKeyVersionlessID("12345678-1234-9876-4563-123456789012", "resGroup1", "vault1", "key1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestKeyVersionlessID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *KeyVersionlessId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Error: true,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Error: true,
+		},
+
+		{
+			// missing KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1",
+			Expected: &KeyVersionlessId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				VaultName:      "vault1",
+				KeyName:        "key1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/KEYS/KEY1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := KeyVersionlessID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VaultName != v.Expected.VaultName {
+			t.Fatalf("Expected %q but got %q for VaultName", v.Expected.VaultName, actual.VaultName)
+		}
+		if actual.KeyName != v.Expected.KeyName {
+			t.Fatalf("Expected %q but got %q for KeyName", v.Expected.KeyName, actual.KeyName)
+		}
+	}
+}

--- a/internal/services/keyvault/parse/secret.go
+++ b/internal/services/keyvault/parse/secret.go
@@ -1,0 +1,81 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SecretId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	VaultName      string
+	Name           string
+	VersionName    string
+}
+
+func NewSecretID(subscriptionId, resourceGroup, vaultName, name, versionName string) SecretId {
+	return SecretId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		VaultName:      vaultName,
+		Name:           name,
+		VersionName:    versionName,
+	}
+}
+
+func (id SecretId) String() string {
+	segments := []string{
+		fmt.Sprintf("Version Name %q", id.VersionName),
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Vault Name %q", id.VaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Secret", segmentsStr)
+}
+
+func (id SecretId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/secrets/%s/versions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VaultName, id.Name, id.VersionName)
+}
+
+// SecretID parses a Secret ID into an SecretId struct
+func SecretID(input string) (*SecretId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SecretId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VaultName, err = id.PopSegment("vaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("secrets"); err != nil {
+		return nil, err
+	}
+	if resourceId.VersionName, err = id.PopSegment("versions"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/keyvault/parse/secret_test.go
+++ b/internal/services/keyvault/parse/secret_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = SecretId{}
+
+func TestSecretIDFormatter(t *testing.T) {
+	actual := NewSecretID("12345678-1234-9876-4563-123456789012", "resGroup1", "vault1", "secret1", "version1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/version1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestSecretID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SecretId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Error: true,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/",
+			Error: true,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/",
+			Error: true,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/version1",
+			Expected: &SecretId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				VaultName:      "vault1",
+				Name:           "secret1",
+				VersionName:    "version1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/SECRETS/SECRET1/VERSIONS/VERSION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := SecretID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VaultName != v.Expected.VaultName {
+			t.Fatalf("Expected %q but got %q for VaultName", v.Expected.VaultName, actual.VaultName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+		if actual.VersionName != v.Expected.VersionName {
+			t.Fatalf("Expected %q but got %q for VersionName", v.Expected.VersionName, actual.VersionName)
+		}
+	}
+}

--- a/internal/services/keyvault/parse/secret_versionless.go
+++ b/internal/services/keyvault/parse/secret_versionless.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SecretVersionlessId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	VaultName      string
+	SecretName     string
+}
+
+func NewSecretVersionlessID(subscriptionId, resourceGroup, vaultName, secretName string) SecretVersionlessId {
+	return SecretVersionlessId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		VaultName:      vaultName,
+		SecretName:     secretName,
+	}
+}
+
+func (id SecretVersionlessId) String() string {
+	segments := []string{
+		fmt.Sprintf("Secret Name %q", id.SecretName),
+		fmt.Sprintf("Vault Name %q", id.VaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Secret Versionless", segmentsStr)
+}
+
+func (id SecretVersionlessId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/secrets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VaultName, id.SecretName)
+}
+
+// SecretVersionlessID parses a SecretVersionless ID into an SecretVersionlessId struct
+func SecretVersionlessID(input string) (*SecretVersionlessId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SecretVersionlessId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VaultName, err = id.PopSegment("vaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.SecretName, err = id.PopSegment("secrets"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/keyvault/parse/secret_versionless_test.go
+++ b/internal/services/keyvault/parse/secret_versionless_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = SecretVersionlessId{}
+
+func TestSecretVersionlessIDFormatter(t *testing.T) {
+	actual := NewSecretVersionlessID("12345678-1234-9876-4563-123456789012", "resGroup1", "vault1", "secret1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestSecretVersionlessID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SecretVersionlessId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Error: true,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Error: true,
+		},
+
+		{
+			// missing SecretName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for SecretName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1",
+			Expected: &SecretVersionlessId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				VaultName:      "vault1",
+				SecretName:     "secret1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/SECRETS/SECRET1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := SecretVersionlessID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VaultName != v.Expected.VaultName {
+			t.Fatalf("Expected %q but got %q for VaultName", v.Expected.VaultName, actual.VaultName)
+		}
+		if actual.SecretName != v.Expected.SecretName {
+			t.Fatalf("Expected %q but got %q for SecretName", v.Expected.SecretName, actual.SecretName)
+		}
+	}
+}

--- a/internal/services/keyvault/resourceids.go
+++ b/internal/services/keyvault/resourceids.go
@@ -6,3 +6,7 @@ package keyvault
 // KeyVault Access Policies are Terraform specific, but can be either an Object ID or an Application ID
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AccessPolicyApplication -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/objectId/object1/applicationId/application1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AccessPolicyObject -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/objectId/object1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Key -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/version1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=KeyVersionless -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Secret -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/version1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SecretVersionless -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1

--- a/internal/services/keyvault/validate/key_id.go
+++ b/internal/services/keyvault/validate/key_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func KeyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.KeyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/key_id_test.go
+++ b/internal/services/keyvault/validate/key_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestKeyID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/",
+			Valid: false,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1/versions/version1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/KEYS/KEY1/VERSIONS/VERSION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := KeyID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/keyvault/validate/key_versionless_id.go
+++ b/internal/services/keyvault/validate/key_versionless_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func KeyVersionlessID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.KeyVersionlessID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/key_versionless_id_test.go
+++ b/internal/services/keyvault/validate/key_versionless_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestKeyVersionlessID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Valid: false,
+		},
+
+		{
+			// missing KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/keys/key1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/KEYS/KEY1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := KeyVersionlessID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/keyvault/validate/secret_id.go
+++ b/internal/services/keyvault/validate/secret_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func SecretID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.SecretID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/secret_id_test.go
+++ b/internal/services/keyvault/validate/secret_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestSecretID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/",
+			Valid: false,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1/versions/version1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/SECRETS/SECRET1/VERSIONS/VERSION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := SecretID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/keyvault/validate/secret_versionless_id.go
+++ b/internal/services/keyvault/validate/secret_versionless_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func SecretVersionlessID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.SecretVersionlessID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/secret_versionless_id_test.go
+++ b/internal/services/keyvault/validate/secret_versionless_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestSecretVersionlessID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/",
+			Valid: false,
+		},
+
+		{
+			// missing SecretName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SecretName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/secrets/secret1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/VAULT1/SECRETS/SECRET1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := SecretVersionlessID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -59,6 +59,10 @@ The following attributes are exported:
 
 * `public_key_openssh` - The OpenSSH encoded public key of this Key Vault Key.
 
+* `resource_id` - The Azure control plane ID of the Key Vault Key.
+
+* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Key.
+
 * `tags` - A mapping of tags assigned to this Key Vault Key.
 
 * `version` - The current version of the Key Vault Key.

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -59,9 +59,9 @@ The following attributes are exported:
 
 * `public_key_openssh` - The OpenSSH encoded public key of this Key Vault Key.
 
-* `resource_id` - The Azure control plane ID of the Key Vault Key.
+* `resource_id` - The (Versioned) ID for this Key Vault Key. This property points to a specific version of a Key Vault Key, as such using this won't auto-rotate values if used in other Azure Services.
 
-* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Key.
+* `resource_versionless_id` - The Versionless ID of the Key Vault Key. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Key is updated.
 
 * `tags` - A mapping of tags assigned to this Key Vault Key.
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Secret ID.
+* `resource_id` - The Azure control plane ID of the Key Vault Secret.
+* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Secret.
 * `value` - The value of the Key Vault Secret.
 * `version` - The current version of the Key Vault Secret.
 * `content_type` - The content type for the Key Vault Secret.

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -42,8 +42,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Secret ID.
-* `resource_id` - The Azure control plane ID of the Key Vault Secret.
-* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Secret.
+* `resource_id` - The (Versioned) ID for this Key Vault Secret. This property points to a specific version of a Key Vault Secret, as such using this won't auto-rotate values if used in other Azure Services.
+* `resource_versionless_id` - The Versionless ID of the Key Vault Secret. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Secret is updated.
 * `value` - The value of the Key Vault Secret.
 * `version` - The current version of the Key Vault Secret.
 * `content_type` - The content type for the Key Vault Secret.

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -90,8 +90,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Key ID.
-* `resource_id` - The Azure control plane ID of the Key Vault Key.
-* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Key.
+* `resource_id` - The (Versioned) ID for this Key Vault Key. This property points to a specific version of a Key Vault Key, as such using this won't auto-rotate values if used in other Azure Services.
+* `resource_versionless_id` - The Versionless ID of the Key Vault Key. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Key is updated.
 * `version` - The current version of the Key Vault Key.
 * `versionless_id` - The Base ID of the Key Vault Key.
 * `n` - The RSA modulus of this Key Vault Key.

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -90,6 +90,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Key ID.
+* `resource_id` - The Azure control plane ID of the Key Vault Key.
+* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Key.
 * `version` - The current version of the Key Vault Key.
 * `versionless_id` - The Base ID of the Key Vault Key.
 * `n` - The RSA modulus of this Key Vault Key.

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Secret ID.
+* `resource_id` - The Azure control plane ID of the Key Vault Secret.
+* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Secret.
 * `version` - The current version of the Key Vault Secret.
 * `versionless_id` - The Base ID of the Key Vault Secret.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -83,8 +83,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Secret ID.
-* `resource_id` - The Azure control plane ID of the Key Vault Secret.
-* `resource_versionless_id` - The Azure control plane Base ID of the Key Vault Secret.
+* `resource_id` - The (Versioned) ID for this Key Vault Secret. This property points to a specific version of a Key Vault Secret, as such using this won't auto-rotate values if used in other Azure Services.
+* `resource_versionless_id` - The Versionless ID of the Key Vault Secret. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Secret is updated.
 * `version` - The current version of the Key Vault Secret.
 * `versionless_id` - The Base ID of the Key Vault Secret.
 


### PR DESCRIPTION
This PR adds attributes `resource_id` and `resource_versionless_id` for `azurerm_key_vault_{key|secret}`. The reason why certificate is not covered is because it is a data plane only resource.

Fix #11529.

## Test

```
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/keyvault -run='TestAccKeyVaultKey_basicEC$|TestAccDataSourceKeyVaultKey_complete$|TestAccKeyVaultSecret_basic$|TestAccDataSourceKeyVaultSecret_basic$'
=== RUN   TestAccDataSourceKeyVaultKey_complete
=== PAUSE TestAccDataSourceKeyVaultKey_complete
=== RUN   TestAccKeyVaultKey_basicEC
=== PAUSE TestAccKeyVaultKey_basicEC
=== RUN   TestAccDataSourceKeyVaultSecret_basic
=== PAUSE TestAccDataSourceKeyVaultSecret_basic
=== RUN   TestAccKeyVaultSecret_basic
=== PAUSE TestAccKeyVaultSecret_basic
=== CONT  TestAccDataSourceKeyVaultKey_complete
=== CONT  TestAccDataSourceKeyVaultSecret_basic
=== CONT  TestAccKeyVaultKey_basicEC
=== CONT  TestAccKeyVaultSecret_basic
--- PASS: TestAccKeyVaultSecret_basic (325.71s)
--- PASS: TestAccKeyVaultKey_basicEC (327.76s)
--- PASS: TestAccDataSourceKeyVaultSecret_basic (334.99s)
--- PASS: TestAccDataSourceKeyVaultKey_complete (339.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      339.452s
```