### PR TITLE
Permit additional partner_id formats

### DIFF
--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -82,6 +82,7 @@ func setUserAgent(client *autorest.Client, tfVersion, partnerID string, disableT
 	}
 
 	if partnerID != "" {
-		client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, partnerID)
+		// Tolerate partnerID UUIDs without the "pid-" prefix
+		client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, strings.TrimPrefix(partnerID, "pid-"))
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,6 +25,68 @@ func TestAzureProvider() *schema.Provider {
 	return azureProvider(true)
 }
 
+func ValidatePartnerID(i interface{}, k string) ([]string, []error) {
+	// ValidatePartnerID checks if partner_id is any of the following:
+	//  * empty string
+	//  * a valid UUID - will add "pid-" prefix to the ID if it is not already present
+	//  * a valid UUID prefixed with "pid-"
+	//  * a valid UUID prefixed with "pid-" and suffixed with "-partnercenter"
+
+	debugLog := func(f string, v ...interface{}) {
+		if os.Getenv("TF_LOG") == "" {
+			return
+		}
+
+		if os.Getenv("TF_ACC") != "" {
+			return
+		}
+
+		log.Printf(f, v...)
+	}
+
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if v == "" {
+		return nil, nil
+	}
+
+	// Check for pid=<guid>-partnercenter format
+	if strings.HasPrefix(v, "pid-") && strings.HasSuffix(v, "-partnercenter") {
+		g := strings.TrimPrefix(v, "pid-")
+		g = strings.TrimSuffix(g, "-partnercenter")
+
+		if _, err := validation.IsUUID(g, ""); err != nil {
+			return nil, []error{fmt.Errorf("expected %q to contain a valid UUID", v)}
+		}
+
+		debugLog("[DEBUG] %q partner_id matches pid-<GUID>-partnercenter...", v)
+		return nil, nil
+	}
+
+	// Check for pid=<guid> (without the -partnercenter suffix)
+	if strings.HasPrefix(v, "pid-") && !strings.HasSuffix(v, "-partnercenter") {
+		g := strings.TrimPrefix(v, "pid-")
+
+		if _, err := validation.IsUUID(g, ""); err != nil {
+			return nil, []error{fmt.Errorf("expected %q to be a valid UUID", k)}
+		}
+
+		debugLog("[DEBUG] %q partner_id matches pid-<GUID>...", v)
+		return nil, nil
+	}
+
+	// Check for straight UUID
+	if _, err := validation.IsUUID(v, ""); err != nil {
+		return nil, []error{fmt.Errorf("expected %q to be a valid UUID", k)}
+	} else {
+		debugLog("[DEBUG] %q partner_id is an un-prefixed UUID...", v)
+		return nil, nil
+	}
+}
+
 func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 	// avoids this showing up in test output
 	debugLog := func(f string, v ...interface{}) {
@@ -205,7 +267,7 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 			"partner_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty),
+				ValidateFunc: ValidatePartnerID,
 				DefaultFunc:  schema.EnvDefaultFunc("ARM_PARTNER_ID", ""),
 				Description:  "A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.",
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,7 +27,6 @@ func TestAzureProvider() *schema.Provider {
 
 func ValidatePartnerID(i interface{}, k string) ([]string, []error) {
 	// ValidatePartnerID checks if partner_id is any of the following:
-	//  * empty string
 	//  * a valid UUID - will add "pid-" prefix to the ID if it is not already present
 	//  * a valid UUID prefixed with "pid-"
 	//  * a valid UUID prefixed with "pid-" and suffixed with "-partnercenter"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -267,7 +267,7 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 			"partner_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: ValidatePartnerID,
+				ValidateFunc: validation.Any(ValidatePartnerID, validation.StringIsEmpty),
 				DefaultFunc:  schema.EnvDefaultFunc("ARM_PARTNER_ID", ""),
 				Description:  "A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.",
 			},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -160,7 +160,7 @@ For some advanced scenarios, such as where more granular permissions are necessa
 
 ~> **Note:** `environment` must be set to the requested environment name in the list of available environments held in the `metadata_host`.
 
-* `partner_id` - (Optional) A GUID/UUID that is [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution. This can also be sourced from the `ARM_PARTNER_ID` Environment Variable.
+* `partner_id` - (Optional) A GUID/UUID registered with Microsoft to facilitate partner resource [usage attribution]((https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution)). This can also be sourced from the `ARM_PARTNER_ID` Environment Variable. Supported formats are `<guid>` / `pid-<guid>` (GUIDs [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#other-use-cases) in Partner Center) and `pid-<guid>-partnercenter` (for published [commercial marketplace Azure apps](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#commercial-marketplace-azure-apps)).
 
 * `auxiliary_tenant_ids` - (Optional) Contains a list of (up to 3) other Tenant IDs used for cross-tenant and multi-tenancy scenarios with multiple AzureRM provider definitions. The list of `auxiliary_tenant_ids` in a given AzureRM provider definition contains the other, remote Tenants and should not include its own `subscription_id` (or `ARM_SUBSCRIPTION_ID` Environment Variable).
 


### PR DESCRIPTION
Permits the following formats for the partner_id argument in the azurerm provider block:

| partner_id value | user agent string | 
|---|---|
| `<guid>` (current) | `pid-<guid>` |  
| `pid-<guid>` | `pid-<guid>` | 
| `pid-<guid>-partnercenter` | `pid-<guid>-partnercenter` | 

Closes #17403.