### PR TITLE
`azurerm_automation_account`  - support for the `encryption` and `local_authentication_enabled` property

### DIFF
--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -73,6 +73,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 							Optional:     true,
 							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 						},
+
 						"key_source": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
@@ -82,6 +83,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 								false,
 							),
 						},
+
 						"key_vault_key_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
@@ -91,7 +93,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"local_auth_enabled": {
+			"local_authentication_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -154,7 +156,7 @@ func resourceAutomationAccountCreate(d *pluginsdk.ResourceData, meta interface{}
 		Location: utils.String(location.Normalize(d.Get("location").(string))),
 	}
 
-	if localAuth := d.Get("local_auth_enabled").(bool); localAuth == false {
+	if localAuth := d.Get("local_authentication_enabled").(bool); localAuth == false {
 		parameters.Properties.DisableLocalAuth = utils.Bool(true)
 	}
 	if encryption := d.Get("encryption").([]interface{}); len(encryption) > 0 {
@@ -204,7 +206,7 @@ func resourceAutomationAccountUpdate(d *pluginsdk.ResourceData, meta interface{}
 		Identity: identity,
 	}
 
-	if localAuth := d.Get("local_auth_enabled").(bool); localAuth == false {
+	if localAuth := d.Get("local_authentication_enabled").(bool); localAuth == false {
 		parameters.Properties.DisableLocalAuth = utils.Bool(true)
 	}
 
@@ -283,7 +285,7 @@ func resourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 	if val := prop.DisableLocalAuth; val != nil && *val == true {
 		localAuthEnabled = false
 	}
-	d.Set("local_auth_enabled", localAuthEnabled)
+	d.Set("local_authentication_enabled", localAuthEnabled)
 
 	if err := d.Set("encryption", flattenEncryption(prop.Encryption)); err != nil {
 		return fmt.Errorf("setting `encryption`: %+v", err)

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -81,6 +81,7 @@ func TestAccAutomationAccount_encryption(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
 				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("encryption.0.key_source").HasValue("Microsoft.Keyvault"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -70,6 +70,23 @@ func TestAccAutomationAccount_complete(t *testing.T) {
 	})
 }
 
+func TestAccAutomationAccount_encryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
+	r := AutomationAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.encryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
+				check.That(data.ResourceName).Key("disable_local_auth").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAutomationAccount_identityUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
 	r := AutomationAccountResource{}
@@ -252,6 +269,128 @@ resource "azurerm_automation_account" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (AutomationAccountResource) encryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "vault%[1]d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "ManageContacts",
+    ]
+
+    key_permissions = [
+      "Create",
+      "Get",
+      "List",
+      "Delete",
+      "Purge",
+    ]
+
+    secret_permissions = [
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    certificate_permissions = []
+
+    key_permissions = [
+      "Get",
+      "Recover",
+      "WrapKey",
+      "UnwrapKey",
+    ]
+
+    secret_permissions = []
+  }
+}
+
+data "azurerm_key_vault" "test" {
+  name                = azurerm_key_vault.test.name
+  resource_group_name = azurerm_key_vault.test.resource_group_name
+}
+
+data "azurerm_key_vault_key" "test" {
+  name         = azurerm_key_vault_key.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+  disable_local_auth = true
+  encryption {
+    key_source       = "Microsoft.Keyvault"
+    user_identity_id = azurerm_user_assigned_identity.test.id
+    key_vault_uri    = azurerm_key_vault.test.vault_uri
+    key_name         = azurerm_key_vault_key.test.name
+    key_version      = azurerm_key_vault_key.test.version
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -379,7 +379,9 @@ resource "azurerm_automation_account" "test" {
       azurerm_user_assigned_identity.test.id
     ]
   }
-  local_auth_enabled = false
+
+  local_authentication_enabled = false
+
   encryption {
     key_source                = "Microsoft.Keyvault"
     user_assigned_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -80,7 +80,7 @@ func TestAccAutomationAccount_encryption(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
-				check.That(data.ResourceName).Key("disable_local_auth").HasValue("true"),
+				check.That(data.ResourceName).Key("local_auth_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -384,7 +384,7 @@ resource "azurerm_automation_account" "test" {
       azurerm_user_assigned_identity.test.id
     ]
   }
-  disable_local_auth = true
+  local_auth_enabled = false
   encryption {
     key_source       = "Microsoft.Keyvault"
     user_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -80,7 +80,7 @@ func TestAccAutomationAccount_encryption(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
-				check.That(data.ResourceName).Key("local_auth_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -351,13 +351,8 @@ data "azurerm_key_vault" "test" {
   resource_group_name = azurerm_key_vault.test.resource_group_name
 }
 
-data "azurerm_key_vault_key" "test" {
-  name         = azurerm_key_vault_key.test.name
-  key_vault_id = azurerm_key_vault.test.id
-}
-
 resource "azurerm_key_vault_key" "test" {
-  name         = "key-%[1]d"
+  name         = "acckvkey-%[1]d"
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
@@ -386,11 +381,9 @@ resource "azurerm_automation_account" "test" {
   }
   local_auth_enabled = false
   encryption {
-    key_source       = "Microsoft.Keyvault"
-    user_identity_id = azurerm_user_assigned_identity.test.id
-    key_vault_uri    = azurerm_key_vault.test.vault_uri
-    key_name         = azurerm_key_vault_key.test.name
-    key_version      = azurerm_key_vault_key.test.version
+    key_source                = "Microsoft.Keyvault"
+    user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+    key_vault_key_id          = azurerm_key_vault_key.test.id
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -68,15 +68,11 @@ An `identity` block supports the following:
 
 An `encryption` block supports the following:
 
-* `user_identity_id` - (Optional) The user identity used for CMK. It will be an ARM resource id.
+* `user_assigned_identity_id` - (Optional) The User Assigned Managed Identity ID to be used for accessing the Customer Managed Key for encryption.
 
 * `key_source` - (Optional) The source of the encryption key. Possible values are `Microsoft.Keyvault` and `Microsoft.Storage`.
 
-* `key_name` - (Optional) The name of the key used to encrypt data.
-
-* `key_version` - (Optional) The version of the key used to encrypt data.
-
-* `key_vault_uri` - (Optional) The URI of the Key Vault key used to encrypt data.
+* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account.
 
 ---
 

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of the account - only `Basic` is supported at this time.
 
-* `disable_local_auth` - (Optional) Whether requests using non-AAD authentication are blocked.
+* `local_authentication_enabled` - (Optional) Whether requests using non-AAD authentication are blocked.
 
 ---
 

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -44,11 +44,15 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of the account - only `Basic` is supported at this time.
 
+* `disable_local_auth` - (Optional) Whether requests using non-AAD authentication are blocked.
+
 ---
 
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+* `encryption` - (Optional) An `encryption` block as defined below.
 
 ---
 
@@ -59,6 +63,20 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) The ID of the User Assigned Identity which should be assigned to this Automation Account.
 
 -> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+--
+
+An `encryption` block supports the following:
+
+* `user_identity_id` - (Optional) The user identity used for CMK. It will be an ARM resource id.
+
+* `key_source` - (Optional) The source of the encryption key. Possible values are `Microsoft.Keyvault` and `Microsoft.Storage`.
+
+* `key_name` - (Optional) The name of the key used to encrypt data.
+
+* `key_version` - (Optional) The version of the key used to encrypt data.
+
+* `key_vault_uri` - (Optional) The URI of the Key Vault key used to encrypt data.
 
 ---
 


### PR DESCRIPTION
support of `encryption` and `disable_local_auth` 

--- PASS: TestAccAutomationAccount_basic (119.18s)
--- PASS: TestAccAutomationAccount_requiresImport (128.41s)
--- PASS: TestAccAutomationAccount_complete (66.28s)
--- PASS: TestAccAutomationAccount_encryption (298.88s)
--- PASS: TestAccAutomationAccount_identityUpdate (157.56s)
--- PASS: TestAccAutomationAccount_systemAssignedIdentity (68.73s)
--- PASS: TestAccAutomationAccount_systemAssignedUserAssignedIdentity (79.94s)
--- PASS: TestAccAutomationAccount_userAssignedIdentity (145.22s)
PASS
