### PR TITLE
`azurerm_container_registry` - Data source supports `data_endpoint_enabled`

### DIFF
--- a/internal/services/containers/container_registry_data_source.go
+++ b/internal/services/containers/container_registry_data_source.go
@@ -53,6 +53,7 @@ func dataSourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}
 	if props := resp.RegistryProperties; props != nil {
 		d.Set("admin_enabled", resp.AdminUserEnabled)
 		d.Set("login_server", resp.LoginServer)
+		d.Set("data_endpoint_enabled", props.DataEndpointEnabled)
 	}
 
 	if sku := resp.Sku; sku != nil {
@@ -102,6 +103,11 @@ func dataSourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 
 		"admin_username": {
 			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"data_endpoint_enabled": {
+			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		},
 

--- a/internal/services/containers/container_registry_data_source_test.go
+++ b/internal/services/containers/container_registry_data_source_test.go
@@ -28,6 +28,20 @@ func TestAccDataSourceAzureRMContainerRegistry_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_registry", "test")
+	r := ContainerRegistryDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.dataEndpointPremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("data_endpoint_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
 func (ContainerRegistryDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -37,4 +51,15 @@ data "azurerm_container_registry" "test" {
   resource_group_name = azurerm_container_registry.test.resource_group_name
 }
 `, ContainerRegistryResource{}.basicManaged(data, "Basic"))
+}
+
+func (ContainerRegistryDataSource) dataEndpointPremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_container_registry" "test" {
+  name                = azurerm_container_registry.test.name
+  resource_group_name = azurerm_container_registry.test.resource_group_name
+}
+`, ContainerRegistryResource{}.dataEndpointPremium(data, true))
 }

--- a/website/docs/d/container_registry.html.markdown
+++ b/website/docs/d/container_registry.html.markdown
@@ -41,7 +41,7 @@ The following attributes are exported:
 
 * `admin_password` - The Password associated with the Container Registry Admin account - if the admin account is enabled.
 
-* `data_endpoint_enabled` - Whether dedicated data endpoints for this Container Registry is enabled?
+* `data_endpoint_enabled` - Whether dedicated data endpoints for this Container Registry are enabled?
 
 * `location` - The Azure Region in which this Container Registry exists.
 

--- a/website/docs/d/container_registry.html.markdown
+++ b/website/docs/d/container_registry.html.markdown
@@ -41,6 +41,8 @@ The following attributes are exported:
 
 * `admin_password` - The Password associated with the Container Registry Admin account - if the admin account is enabled.
 
+* `data_endpoint_enabled` - Whether dedicated data endpoints for this Container Registry is enabled?
+
 * `location` - The Azure Region in which this Container Registry exists.
 
 * `admin_enabled` - Is the Administrator account enabled for this Container Registry.


### PR DESCRIPTION
Fix #17450

## Test

```shell
❯ TF_ACC=1 go test -timeout=60m -v -parallel 5 -run='TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium' ./internal/services/containers
=== RUN   TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
=== PAUSE TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
=== CONT  TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
--- PASS: TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium (143.49s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    143.496s
```