### PR TITLE
custom domain verification id is blank unless it's saved to the model

### DIFF
--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -295,16 +295,17 @@ func (d LinuxFunctionAppDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := LinuxFunctionAppDataSourceModel{
-				Name:                 id.SiteName,
-				ResourceGroup:        id.ResourceGroup,
-				ServicePlanId:        utils.NormalizeNilableString(props.ServerFarmID),
-				Location:             location.NormalizeNilable(functionApp.Location),
-				Enabled:              utils.NormaliseNilableBool(functionApp.Enabled),
-				ClientCertMode:       string(functionApp.ClientCertMode),
-				DailyMemoryTimeQuota: int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
-				StickySettings:       helpers.FlattenStickySettings(stickySettings.SlotConfigNames),
-				Tags:                 tags.ToTypedObject(functionApp.Tags),
-				Kind:                 utils.NormalizeNilableString(functionApp.Kind),
+				Name:                       id.SiteName,
+				ResourceGroup:              id.ResourceGroup,
+				ServicePlanId:              utils.NormalizeNilableString(props.ServerFarmID),
+				Location:                   location.NormalizeNilable(functionApp.Location),
+				Enabled:                    utils.NormaliseNilableBool(functionApp.Enabled),
+				ClientCertMode:             string(functionApp.ClientCertMode),
+				DailyMemoryTimeQuota:       int(utils.NormaliseNilableInt32(props.DailyMemoryTimeQuota)),
+				StickySettings:             helpers.FlattenStickySettings(stickySettings.SlotConfigNames),
+				Tags:                       tags.ToTypedObject(functionApp.Tags),
+				Kind:                       utils.NormalizeNilableString(functionApp.Kind),
+				CustomDomainVerificationId: utils.NormalizeNilableString(props.CustomDomainVerificationID),
 			}
 
 			configResp, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -591,6 +591,7 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 				Tags:                        tags.ToTypedObject(functionApp.Tags),
 				Kind:                        utils.NormalizeNilableString(functionApp.Kind),
 				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
+				CustomDomainVerificationId:  utils.NormalizeNilableString(props.CustomDomainVerificationID),
 			}
 
 			configResp, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -567,6 +567,7 @@ func (r LinuxFunctionAppSlotResource) Read() sdk.ResourceFunc {
 				Tags:                        tags.ToTypedObject(functionApp.Tags),
 				Kind:                        utils.NormalizeNilableString(functionApp.Kind),
 				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
+				CustomDomainVerificationId:  utils.NormalizeNilableString(props.CustomDomainVerificationID),
 			}
 
 			configResp, err := client.GetConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)


### PR DESCRIPTION
This issue was just fixed [here](https://github.com/hashicorp/terraform-provider-azurerm/pull/17183/files) for the similar [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/17042) related to the windows-specific versions of Azure Functions

Fixes issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/17444