### PR TITLE
Doc Fix : azurerm_mssql_database - Removal of doc for deprecated extended_auditing_policy

### DIFF
--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages a MS SQL Database.
 
-~> **Note:** The Database Extended Auditing Policy can be set inline here, as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
-
 ## Example Usage
 
 ```hcl
@@ -79,8 +77,6 @@ The following arguments are supported:
 
 * `elastic_pool_id` - (Optional) Specifies the ID of the elastic pool containing this database.
 
-* `extended_auditing_policy` - (Optional) A `extended_auditing_policy` block as defined below.
-
 * `geo_backup_enabled` - (Optional) A boolean that specifies if the Geo Backup Policy is enabled. 
 
 ~> **Note:** `geo_backup_enabled` is only applicable for DataWarehouse SKUs (DW*). This setting is ignored for all other SKUs.
@@ -137,16 +133,6 @@ a `threat_detection_policy` block supports the following:
 * `retention_days` - (Optional) Specifies the number of days to keep in the Threat Detection audit logs.
 * `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. Required if `state` is `Enabled`.
 * `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://example.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs. Required if `state` is `Enabled`.
-
----
-
-A `extended_auditing_policy` block supports the following:
-
-* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
-* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://example.blob.core.windows.net).
-* `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
-* `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
-* `log_monitoring_enabled` - (Optional) Enable audit events to Azure Monitor? To enable audit events to Log Analytics, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_log_analytics` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/sql_auditing_log_analytics). To enable audit events to Eventhub, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_eventhub` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/sql_auditing_eventhub). 
 
 ---
 


### PR DESCRIPTION
Since the `extended_auditing_policy` was deprecated in PR[ #15952 ](https://github.com/hashicorp/terraform-provider-azurerm/pull/15952), update terraform documentation to fix issue #17439.