### PR TITLE
Modified `azurerm_monitor_metric_alert` to detect `webhook_properties` changes

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -951,6 +951,9 @@ func resourceMonitorMetricAlertActionHash(input interface{}) int {
 	var buf bytes.Buffer
 	if v, ok := input.(map[string]interface{}); ok {
 		buf.WriteString(fmt.Sprintf("%s-", v["action_group_id"].(string)))
+		if m, ok := v["webhook_properties"].(map[string]interface{}); ok && m != nil {
+			buf.WriteString(fmt.Sprintf("%v-", m))
+		}
 	}
 	return pluginsdk.HashString(buf.String())
 }


### PR DESCRIPTION
Current
-------
If you create an action with `webhook_properties` and then change any value inside - it is not detected and so ignored.
That is not correct, since it can contain values for monitoring system.

```
resource "azurerm_monitor_metric_alert" "metric" {
  ...
  action {
    action_group_id = var.actionGroupId
    webhook_properties = {
      Severity             = "1"
      Key = "Value"
    }
  }
}

```

Proposed change
--------
The change is simple, to include `webhook_properties` inside of hashing function.