### PR TITLE
postgresql_flexible_server - support version 14

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -100,6 +100,12 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 					string(postgresqlflexibleservers.ServerVersionOneOne),
 					string(postgresqlflexibleservers.ServerVersionOneTwo),
 					string(postgresqlflexibleservers.ServerVersionOneThree),
+					// string(postgresqlflexibleservers.ServerVersionOneThree),
+					// ^ This will eventually for version 14 work when
+					// https://github.com/Azure/azure-sdk-for-go/issues/18506
+					// has been merged.
+					// as a workaround, we can use this:
+					string("14"),
 				}, false),
 			},
 

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -100,7 +100,7 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 					string(postgresqlflexibleservers.ServerVersionOneOne),
 					string(postgresqlflexibleservers.ServerVersionOneTwo),
 					string(postgresqlflexibleservers.ServerVersionOneThree),
-					// string(postgresqlflexibleservers.ServerVersionOneThree),
+					// string(postgresqlflexibleservers.ServerVersionOneFour),
 					// ^ This will eventually for version 14 work when
 					// https://github.com/Azure/azure-sdk-for-go/issues/18506
 					// has been merged.

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -254,6 +254,20 @@ func (PostgresqlFlexibleServerResource) Exists(ctx context.Context, clients *cli
 	return utils.Bool(resp.ServerProperties != nil), nil
 }
 
+func TestAccPostgresqlFlexibleServer_newVersionOneFour(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
+	r := PostgresqlFlexibleServerResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.newVersionOneFour(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode"),
+	})
+}
+
 func (PostgresqlFlexibleServerResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -604,6 +618,24 @@ resource "azurerm_postgresql_flexible_server" "test" {
   zone                         = "2"
   backup_retention_days        = 7
   geo_redundant_backup_enabled = true
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r PostgresqlFlexibleServerResource) newVersionOneFour(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  storage_mb             = 32768
+  version                = "14"
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -262,6 +262,7 @@ func TestAccPostgresqlFlexibleServer_newVersionOneFour(t *testing.T) {
 			Config: r.newVersionOneFour(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("version").HasValue("14"),
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode"),


### PR DESCRIPTION
Add version 14 as a possible choice for postgresql_flexible_server

Once the SDK is updated (https://github.com/Azure/azure-sdk-for-go/issues/18506), we can change 
`string("14")` -> `string(postgresqlflexibleservers.ServerVersionOneThree)`

Fixes issue #17514
