### PR TITLE
`azurerm_container_group` - Add supports of `http_headers`

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"time"
 
@@ -1502,9 +1501,6 @@ func expandContainerProbeHttpHeaders(input map[string]interface{}) *[]containeri
 		}
 		headers = append(headers, header)
 	}
-	sort.Slice(headers, func(i, j int) bool {
-		return *headers[i].Name < *headers[j].Name
-	})
 	return &headers
 }
 

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -740,6 +740,10 @@ resource "azurerm_container_group" "test" {
         path   = "/"
         port   = 443
         scheme = "Http"
+        http_headers = {
+          h1 = "v1"
+          h2 = "v2"
+        }
       }
     }
   }
@@ -1764,6 +1768,10 @@ resource "azurerm_container_group" "test" {
         path   = "/"
         port   = 443
         scheme = "Http"
+        http_headers = {
+          h1 = "v1"
+          h2 = "v2"
+        }
       }
 
       initial_delay_seconds = 1
@@ -1910,6 +1918,10 @@ resource "azurerm_container_group" "test" {
         path   = "/"
         port   = 443
         scheme = "Http"
+        http_headers = {
+          h1 = "v1"
+          h2 = "v2"
+        }
       }
 
       initial_delay_seconds = 1

--- a/internal/services/containers/probe.go
+++ b/internal/services/containers/probe.go
@@ -53,6 +53,14 @@ func SchemaContainerGroupProbe() *pluginsdk.Schema {
 									"Https",
 								}, false),
 							},
+							"http_headers": {
+								Type:     pluginsdk.TypeMap,
+								Optional: true,
+								ForceNew: true,
+								Elem: &pluginsdk.Schema{
+									Type: pluginsdk.TypeString,
+								},
+							},
 						},
 					},
 				},

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -308,6 +308,8 @@ The `http_get` block supports:
 
 * `scheme` - (Optional) Scheme to use for connecting to the host. Possible values are `Http` and `Https`. Changing this forces a new resource to be created.
 
+* `http_headers` - (Optional) A map of HTTP headers used to access on the container. Changing this forces a new resource to be created.
+
 ---
 
 The `dns_config` block supports:


### PR DESCRIPTION
`azurerm_container_group` - Add supports of `http_headers`.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run='TestAccContainerGroup_ProbeHttpGet'
=== RUN   TestAccContainerGroup_ProbeHttpGet
=== PAUSE TestAccContainerGroup_ProbeHttpGet
=== CONT  TestAccContainerGroup_ProbeHttpGet
--- PASS: TestAccContainerGroup_ProbeHttpGet (172.33s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    172.342s
```