### PR TITLE
Validate shared image identifier attributes

### DIFF
--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -107,19 +107,22 @@ func resourceSharedImage() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"publisher": {
-							Type:     pluginsdk.TypeString,
-							ForceNew: true,
-							Required: true,
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Required:     true,
+							ValidateFunc: validate.SharedImageIdentifierAttribute,
 						},
 						"offer": {
-							Type:     pluginsdk.TypeString,
-							ForceNew: true,
-							Required: true,
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Required:     true,
+							ValidateFunc: validate.SharedImageIdentifierAttribute,
 						},
 						"sku": {
-							Type:     pluginsdk.TypeString,
-							ForceNew: true,
-							Required: true,
+							Type:         pluginsdk.TypeString,
+							ForceNew:     true,
+							Required:     true,
+							ValidateFunc: validate.SharedImageIdentifierAttribute,
 						},
 					},
 				},

--- a/internal/services/compute/validate/compute.go
+++ b/internal/services/compute/validate/compute.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -35,6 +36,25 @@ func SharedImageName(v interface{}, k string) (warnings []string, errors []error
 	length := len(value)
 	if length > 80 {
 		errors = append(errors, fmt.Errorf("%s can be up to 80 characters, currently %d.", k, length))
+	}
+
+	return warnings, errors
+}
+
+func SharedImageIdentifierAttribute(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	length := len(value)
+	if length > 128 {
+		errors = append(errors, fmt.Errorf("%s can be up to 128 characters, currently %d.", k, length))
+	}
+
+	if strings.HasSuffix(value, ".") {
+		errors = append(errors, fmt.Errorf("%q can not end with a '.', got %q", k, value))
+	}
+
+	if !regexp.MustCompile(`^[A-Za-z0-9._-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s can only contain alphanumeric, full stops, dashes and underscores. Got %q.", k, value))
 	}
 
 	return warnings, errors

--- a/internal/services/compute/validate/compute_test.go
+++ b/internal/services/compute/validate/compute_test.go
@@ -123,6 +123,69 @@ func TestSharedImageName(t *testing.T) {
 	}
 }
 
+func TestSharedImageIdentifierAttribute(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ShouldError bool
+	}{
+		{
+			Input:       "",
+			ShouldError: true,
+		},
+		{
+			Input:       "hello",
+			ShouldError: false,
+		},
+		{
+			Input:       "hello.",
+			ShouldError: true,
+		},
+		{
+			Input:       "hello123",
+			ShouldError: false,
+		},
+		{
+			Input:       "hello.123",
+			ShouldError: false,
+		},
+		{
+			Input:       "hello,123",
+			ShouldError: true,
+		},
+		{
+			Input:       "hello_123",
+			ShouldError: false,
+		},
+		{
+			Input:       "hello-123",
+			ShouldError: false,
+		},
+		{
+			Input:       strings.Repeat("a", 128),
+			ShouldError: false,
+		},
+		{
+			Input:       strings.Repeat("a", 129),
+			ShouldError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			_, errors := SharedImageIdentifierAttribute(tc.Input, "test")
+
+			hasErrors := len(errors) > 0
+			if !hasErrors && tc.ShouldError {
+				t.Fatalf("Expected an error but didn't get one for %q", tc.Input)
+			}
+
+			if hasErrors && !tc.ShouldError {
+				t.Fatalf("Expected to get no errors for %q but got %d", tc.Input, len(errors))
+			}
+		})
+	}
+}
+
 func TestSharedImageVersionName(t *testing.T) {
 	cases := []struct {
 		Input       string


### PR DESCRIPTION
To fail fast during the plan stage if there are some violations.