### PR TITLE
azurerm_key_vault : Support public_network_access_enabled proptery for resource azurerm_key_vault

### DIFF
--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -198,6 +198,7 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		if v := props.PublicNetworkAccess; v != nil {
 			d.Set("public_network_access_enabled", *v == "Enabled")
 		}
+
 		d.Set("vault_uri", props.VaultURI)
 		if props.VaultURI != nil {
 			meta.(*clients.Client).KeyVault.AddToCache(id, *resp.Properties.VaultURI)

--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -195,7 +195,9 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 		d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
-		d.Set("public_network_access_enabled", *props.PublicNetworkAccess == "Enabled")
+		if v := props.PublicNetworkAccess; v != nil {
+			d.Set("public_network_access_enabled", *v == "Enabled")
+		}
 		d.Set("vault_uri", props.VaultURI)
 		if props.VaultURI != nil {
 			meta.(*clients.Client).KeyVault.AddToCache(id, *resp.Properties.VaultURI)

--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -155,6 +155,11 @@ func dataSourceKeyVault() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -190,6 +195,7 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 		d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
+		d.Set("public_network_access_enabled", *props.PublicNetworkAccess == "Enabled")
 		d.Set("vault_uri", props.VaultURI)
 		if props.VaultURI != nil {
 			meta.(*clients.Client).KeyVault.AddToCache(id, *resp.Properties.VaultURI)

--- a/internal/services/keyvault/key_vault_data_source_test.go
+++ b/internal/services/keyvault/key_vault_data_source_test.go
@@ -138,14 +138,3 @@ data "azurerm_key_vault" "test" {
 }
 `, KeyVaultResource{}.networkAclsUpdated(data))
 }
-
-func (KeyVaultDataSource) enableSoftDelete(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_key_vault" "test" {
-  name                = azurerm_key_vault.test.name
-  resource_group_name = azurerm_key_vault.test.resource_group_name
-}
-`, KeyVaultResource{}.softDelete(data))
-}

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -662,8 +662,9 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 	d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
 	d.Set("purge_protection_enabled", props.EnablePurgeProtection)
-	d.Set("public_network_access_enabled", *props.PublicNetworkAccess == "Enabled")
-
+	if v := props.PublicNetworkAccess; v != nil {
+		d.Set("public_network_access_enabled", *v == "Enabled")
+	}
 	d.Set("vault_uri", props.VaultURI)
 
 	// @tombuildsstuff: the API doesn't return this field if it's not configured

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -187,6 +187,12 @@ func resourceKeyVault() *pluginsdk.Resource {
 				},
 			},
 
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"purge_protection_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -315,6 +321,12 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 			EnableSoftDelete: utils.Bool(true),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if d.Get("public_network_access_enabled").(bool) {
+		parameters.Properties.PublicNetworkAccess = utils.String("Enabled")
+	} else {
+		parameters.Properties.PublicNetworkAccess = utils.String("Disabled")
 	}
 
 	if purgeProtectionEnabled := d.Get("purge_protection_enabled").(bool); purgeProtectionEnabled {
@@ -523,6 +535,18 @@ func resourceKeyVaultUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if d.HasChange("public_network_access_enabled") {
+		if update.Properties == nil {
+			update.Properties = &keyvault.VaultPatchProperties{}
+		}
+
+		if d.Get("public_network_access_enabled").(bool) {
+			update.Properties.PublicNetworkAccess = utils.String("Enabled")
+		} else {
+			update.Properties.PublicNetworkAccess = utils.String("Disabled")
+		}
+	}
+
 	if d.HasChange("sku_name") {
 		if update.Properties == nil {
 			update.Properties = &keyvault.VaultPatchProperties{}
@@ -638,6 +662,8 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 	d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
 	d.Set("purge_protection_enabled", props.EnablePurgeProtection)
+	d.Set("public_network_access_enabled", *props.PublicNetworkAccess == "Enabled")
+
 	d.Set("vault_uri", props.VaultURI)
 
 	// @tombuildsstuff: the API doesn't return this field if it's not configured

--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -689,6 +689,7 @@ resource "azurerm_key_vault" "test" {
     ]
   }
 
+  public_network_access_enabled   = false
   enabled_for_deployment          = true
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true
@@ -723,6 +724,7 @@ resource "azurerm_key_vault" "test" {
   sku_name                   = "standard"
   soft_delete_retention_days = 7
 
+  public_network_access_enabled   = true
   enabled_for_deployment          = true
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true
@@ -792,6 +794,8 @@ resource "azurerm_key_vault" "test" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
+
+  public_network_access_enabled = false
 
   access_policy {
     tenant_id      = data.azurerm_client_config.current.tenant_id

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -57,6 +57,8 @@ The following attributes are exported:
 
 * `purge_protection_enabled` - Is purge protection enabled on this Key Vault?
 
+* `public_network_access_enabled` - Is network public access enabled on this Key Vault?
+
 * `tags` - A mapping of tags assigned to the Key Vault.
 
 A `access_policy` block supports the following:

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -57,7 +57,7 @@ The following attributes are exported:
 
 * `purge_protection_enabled` - Is purge protection enabled on this Key Vault?
 
-* `public_network_access_enabled` - Is network public access enabled on this Key Vault?
+* `public_network_access_enabled` - Is public network access enabled on this Key Vault?
 
 * `tags` - A mapping of tags assigned to the Key Vault.
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -98,6 +98,10 @@ The following arguments are supported:
 
 !> **Note:** Once Purge Protection has been Enabled it's not possible to Disable it. Support for [disabling purge protection is being tracked in this Azure API issue](https://github.com/Azure/azure-rest-api-specs/issues/8075). Deleting the Key Vault with Purge Protection Enabled will schedule the Key Vault to be deleted (which will happen by Azure in the configured number of days, currently 90 days - which will be configurable in Terraform in the future).
 
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this Key Vault. Defaults to `true`.
+
+-> **Note:** If `public_network_access_enabled` is set to 'disabled', all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, which means that even if the firewall rules are present we will not honor the rules. 
+
 * `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This value can be between `7` and `90` (the default) days.
 
 ~> **Note:** This field can only be configured one time and cannot be updated.

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -100,8 +100,6 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for this Key Vault. Defaults to `true`.
 
--> **Note:** If `public_network_access_enabled` is set to 'disabled', all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, which means that even if the firewall rules are present we will not honor the rules. 
-
 * `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This value can be between `7` and `90` (the default) days.
 
 ~> **Note:** This field can only be configured one time and cannot be updated.


### PR DESCRIPTION
The purpose of this PR:

- Support `public_network_access_enabled ` property for  azurerm_key_vault and data.azurerm_key_vault.
- Delete func `enableSoftDelete` as it is unused.


Fix issue #17533.