### PR TITLE
azurerm_mssql_server : Fix "identity.0.identity_ids" not being accessible in dynamic "identity" block

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -137,7 +137,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 				Computed:     true,
 				ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 				RequiredWith: []string{
-					"identity.0.identity_ids",
+					"identity",
 				},
 			},
 


### PR DESCRIPTION
Fix issue #17531.