### PR TITLE
Changing QoS value and adding CreateOnDate tag

### DIFF
--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -142,6 +142,12 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -150,7 +156,7 @@ resource "azurerm_netapp_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
-    "CreatedOnDate" = timestamp()
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
   }  
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -166,7 +172,7 @@ resource "azurerm_netapp_account" "import" {
   resource_group_name = azurerm_netapp_account.test.resource_group_name
 
   tags = {
-    "CreatedOnDate" = timestamp()
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
   }  
 }
 `, r.basicConfig(data))
@@ -181,6 +187,12 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -198,7 +210,7 @@ resource "azurerm_netapp_account" "test" {
   }
 
   tags = {
-	"CreatedOnDate" = timestamp(),
+	"CreatedOnDate" = "2022-07-08T23:50:21Z",
     "FoO"           = "BaR"
   }
 }

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -85,7 +85,7 @@ func testAccNetAppAccount_complete(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("active_directory.#").HasValue("1"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 			),
 		},
@@ -103,7 +103,7 @@ func testAccNetAppAccount_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("active_directory.#").HasValue("0"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 			),
 		},
 		{
@@ -111,7 +111,7 @@ func testAccNetAppAccount_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("active_directory.#").HasValue("1"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 			),
 		},
@@ -148,6 +148,10 @@ resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate" = timestamp()
+  }  
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -160,6 +164,10 @@ resource "azurerm_netapp_account" "import" {
   name                = azurerm_netapp_account.test.name
   location            = azurerm_netapp_account.test.location
   resource_group_name = azurerm_netapp_account.test.resource_group_name
+
+  tags = {
+    "CreatedOnDate" = timestamp()
+  }  
 }
 `, r.basicConfig(data))
 }
@@ -190,7 +198,8 @@ resource "azurerm_netapp_account" "test" {
   }
 
   tags = {
-    "FoO" = "BaR"
+	"CreatedOnDate" = timestamp(),
+    "FoO"           = "BaR"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -157,7 +157,7 @@ resource "azurerm_netapp_account" "test" {
 
   tags = {
     "CreatedOnDate" = "2022-07-08T23:50:21Z",
-  }  
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -173,7 +173,7 @@ resource "azurerm_netapp_account" "import" {
 
   tags = {
     "CreatedOnDate" = "2022-07-08T23:50:21Z",
-  }  
+  }
 }
 `, r.basicConfig(data))
 }
@@ -210,7 +210,7 @@ resource "azurerm_netapp_account" "test" {
   }
 
   tags = {
-	"CreatedOnDate" = "2022-07-08T23:50:21Z",
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
     "FoO"           = "BaR"
   }
 }

--- a/internal/services/netapp/netapp_pool_resource_test.go
+++ b/internal/services/netapp/netapp_pool_resource_test.go
@@ -59,7 +59,7 @@ func TestAccNetAppPool_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_level").HasValue("Standard"),
 				check.That(data.ResourceName).Key("size_in_tb").HasValue("15"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 				check.That(data.ResourceName).Key("qos_type").HasValue("Auto"),
 			),
@@ -78,7 +78,7 @@ func TestAccNetAppPool_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("size_in_tb").HasValue("4"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("qos_type").HasValue("Auto"),
 			),
 		},
@@ -88,7 +88,7 @@ func TestAccNetAppPool_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("size_in_tb").HasValue("15"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 				check.That(data.ResourceName).Key("qos_type").HasValue("Auto"),
 			),
@@ -99,7 +99,7 @@ func TestAccNetAppPool_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("size_in_tb").HasValue("15"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 				check.That(data.ResourceName).Key("qos_type").HasValue("Manual"),
 			),
@@ -145,6 +145,10 @@ resource "azurerm_netapp_pool" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_level       = "Standard"
   size_in_tb          = 4
+
+  tags = {
+	"CreatedOnDate" = timestamp()
+  }  
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -190,7 +194,8 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Auto"
 
   tags = {
-    "FoO" = "BaR"
+	"CreatedOnDate"    = timestamp(),
+    "FoO"              = "BaR"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -223,7 +228,8 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Manual"
 
   tags = {
-    "FoO" = "BaR"
+	"CreatedOnDate"    = timestamp(),
+    "FoO"              = "BaR"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/netapp/netapp_pool_resource_test.go
+++ b/internal/services/netapp/netapp_pool_resource_test.go
@@ -153,8 +153,8 @@ resource "azurerm_netapp_pool" "test" {
   size_in_tb          = 4
 
   tags = {
-	"CreatedOnDate" = "2022-07-08T23:50:21Z",
-  }  
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -211,7 +211,7 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Auto"
 
   tags = {
-	"CreatedOnDate" = "2022-07-08T23:50:21Z",
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
     "FoO"           = "BaR"
   }
 }
@@ -256,7 +256,7 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Manual"
 
   tags = {
-	"CreatedOnDate" = "2022-07-08T23:50:21Z",
+    "CreatedOnDate" = "2022-07-08T23:50:21Z",
     "FoO"           = "BaR"
   }
 }

--- a/internal/services/netapp/netapp_pool_resource_test.go
+++ b/internal/services/netapp/netapp_pool_resource_test.go
@@ -130,6 +130,12 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -147,7 +153,7 @@ resource "azurerm_netapp_pool" "test" {
   size_in_tb          = 4
 
   tags = {
-	"CreatedOnDate" = timestamp()
+	"CreatedOnDate" = "2022-07-08T23:50:21Z",
   }  
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -176,12 +182,23 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 
 resource "azurerm_netapp_pool" "test" {
@@ -194,8 +211,8 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Auto"
 
   tags = {
-	"CreatedOnDate"    = timestamp(),
-    "FoO"              = "BaR"
+	"CreatedOnDate" = "2022-07-08T23:50:21Z",
+    "FoO"           = "BaR"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -210,12 +227,23 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 
 resource "azurerm_netapp_pool" "test" {
@@ -228,8 +256,8 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Manual"
 
   tags = {
-	"CreatedOnDate"    = timestamp(),
-    "FoO"              = "BaR"
+	"CreatedOnDate" = "2022-07-08T23:50:21Z",
+    "FoO"           = "BaR"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -899,7 +899,8 @@ resource "azurerm_resource_group" "test" {
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true"
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
   }
 }
 

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -930,12 +930,23 @@ resource "azurerm_subnet" "test" {
       actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
     }
   }
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 
 resource "azurerm_netapp_pool" "test" {
@@ -1012,6 +1023,11 @@ resource "azurerm_subnet" "test" {
       name    = "Microsoft.Netapp/volumes"
       actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
     }
+  }
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
   }
 }
 

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -930,12 +930,6 @@ resource "azurerm_subnet" "test" {
       actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
     }
   }
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -1023,11 +1017,6 @@ resource "azurerm_subnet" "test" {
       name    = "Microsoft.Netapp/volumes"
       actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
     }
-  }
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true"
   }
 }
 

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -386,7 +386,7 @@ resource "azurerm_netapp_volume" "test" {
   protocols           = ["NFSv3"]
   security_style      = "Unix"
   storage_quota_in_gb = 100
-  throughput_in_mibps= 1.562
+  throughput_in_mibps = 1.562
 
   data_protection_snapshot_policy {
     snapshot_policy_id = azurerm_netapp_snapshot_policy.test.id

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -156,7 +156,7 @@ func TestAccNetAppVolume_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("service_level").HasValue("Standard"),
 				check.That(data.ResourceName).Key("storage_quota_in_gb").HasValue("101"),
 				check.That(data.ResourceName).Key("export_policy_rule.#").HasValue("3"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("3"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 				check.That(data.ResourceName).Key("mount_ip_addresses.#").HasValue("1"),
 			),
@@ -176,8 +176,8 @@ func TestAccNetAppVolume_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_quota_in_gb").HasValue("100"),
 				check.That(data.ResourceName).Key("export_policy_rule.#").HasValue("3"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
-				check.That(data.ResourceName).Key("throughput_in_mibps").HasValue("1.6"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("3"),
+				check.That(data.ResourceName).Key("throughput_in_mibps").HasValue("1.562"),
 			),
 		},
 		data.ImportStep(),
@@ -187,7 +187,7 @@ func TestAccNetAppVolume_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_quota_in_gb").HasValue("101"),
 				check.That(data.ResourceName).Key("export_policy_rule.#").HasValue("2"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("3"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("4"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 				check.That(data.ResourceName).Key("tags.bAr").HasValue("fOo"),
 				check.That(data.ResourceName).Key("throughput_in_mibps").HasValue("65"),
@@ -286,6 +286,7 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -309,7 +310,7 @@ resource "azurerm_netapp_volume" "test" {
   protocols           = ["NFSv4.1"]
   security_style      = "Unix"
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -320,6 +321,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -345,6 +347,7 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -383,13 +386,14 @@ resource "azurerm_netapp_volume" "test" {
   protocols           = ["NFSv3"]
   security_style      = "Unix"
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps= 1.562
 
   data_protection_snapshot_policy {
     snapshot_policy_id = azurerm_netapp_snapshot_policy.test.id
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -412,7 +416,7 @@ resource "azurerm_netapp_volume" "test_primary" {
   subnet_id           = azurerm_subnet.test.id
   protocols           = ["NFSv3"]
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -423,6 +427,7 @@ resource "azurerm_netapp_volume" "test_primary" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -439,7 +444,7 @@ resource "azurerm_netapp_volume" "test_secondary" {
   protocols                  = ["NFSv3"]
   storage_quota_in_gb        = 100
   snapshot_directory_visible = false
-  throughput_in_mibps        = 1.6
+  throughput_in_mibps        = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -457,6 +462,7 @@ resource "azurerm_netapp_volume" "test_secondary" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -479,7 +485,7 @@ resource "azurerm_netapp_volume" "test" {
   subnet_id           = azurerm_subnet.test.id
   protocols           = ["NFSv3"]
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -490,6 +496,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -525,6 +532,7 @@ resource "azurerm_netapp_volume" "test_snapshot_vol" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -548,7 +556,7 @@ resource "azurerm_netapp_volume" "test_snapshot_directory_visible_false" {
   protocols                  = ["NFSv3"]
   storage_quota_in_gb        = 100
   snapshot_directory_visible = false
-  throughput_in_mibps        = 1.6
+  throughput_in_mibps        = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -559,6 +567,7 @@ resource "azurerm_netapp_volume" "test_snapshot_directory_visible_false" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -625,6 +634,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -647,7 +657,7 @@ resource "azurerm_netapp_volume" "test" {
   subnet_id           = azurerm_subnet.test.id
   protocols           = ["NFSv3"]
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps = 1.562
 
   export_policy_rule {
     rule_index        = 1
@@ -674,6 +684,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -715,6 +726,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "FoO"              = "BaR",
     "bAr"              = "fOo",
     "SkipASMAzSecPack" = "true"
@@ -734,6 +746,7 @@ resource "azurerm_virtual_network" "updated" {
   address_space       = ["10.1.0.0/16"]
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -765,9 +778,10 @@ resource "azurerm_netapp_volume" "test" {
   subnet_id           = azurerm_subnet.updated.id
   protocols           = ["NFSv3"]
   storage_quota_in_gb = 100
-  throughput_in_mibps = 1.6
+  throughput_in_mibps = 1.562
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -800,6 +814,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -818,6 +833,7 @@ resource "azurerm_virtual_network" "test_secondary" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -844,6 +860,7 @@ resource "azurerm_netapp_account" "test_secondary" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -858,6 +875,7 @@ resource "azurerm_netapp_pool" "test_secondary" {
   qos_type            = "Manual"
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -880,6 +898,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -891,6 +910,7 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -926,6 +946,7 @@ resource "azurerm_netapp_pool" "test" {
   size_in_tb          = 4
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -948,6 +969,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -958,6 +980,7 @@ resource "azurerm_network_security_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     environment        = "Production",
     "SkipASMAzSecPack" = "true"
   }
@@ -970,6 +993,7 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -996,6 +1020,7 @@ resource "azurerm_netapp_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -1010,6 +1035,7 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Manual"
 
   tags = {
+    "CreatedOnDate"    = timestamp(),
     "SkipASMAzSecPack" = "true"
   }
 }

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -286,7 +286,7 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -321,7 +321,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -347,7 +347,7 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -393,7 +393,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -427,7 +427,7 @@ resource "azurerm_netapp_volume" "test_primary" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -462,7 +462,7 @@ resource "azurerm_netapp_volume" "test_secondary" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -496,7 +496,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -532,7 +532,7 @@ resource "azurerm_netapp_volume" "test_snapshot_vol" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -567,7 +567,7 @@ resource "azurerm_netapp_volume" "test_snapshot_directory_visible_false" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -634,7 +634,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -684,7 +684,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -726,7 +726,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "FoO"              = "BaR",
     "bAr"              = "fOo",
     "SkipASMAzSecPack" = "true"
@@ -746,7 +746,7 @@ resource "azurerm_virtual_network" "updated" {
   address_space       = ["10.1.0.0/16"]
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -781,7 +781,7 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -814,7 +814,7 @@ resource "azurerm_netapp_volume" "test" {
   }
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "FoO"              = "BaR",
     "SkipASMAzSecPack" = "true"
   }
@@ -833,7 +833,7 @@ resource "azurerm_virtual_network" "test_secondary" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -860,7 +860,7 @@ resource "azurerm_netapp_account" "test_secondary" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -875,7 +875,7 @@ resource "azurerm_netapp_pool" "test_secondary" {
   qos_type            = "Manual"
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -898,7 +898,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -910,7 +910,7 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -946,7 +946,7 @@ resource "azurerm_netapp_pool" "test" {
   size_in_tb          = 4
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -969,7 +969,7 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -980,7 +980,7 @@ resource "azurerm_network_security_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     environment        = "Production",
     "SkipASMAzSecPack" = "true"
   }
@@ -993,7 +993,7 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.6.0.0/16"]
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -1020,7 +1020,7 @@ resource "azurerm_netapp_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }
@@ -1035,7 +1035,7 @@ resource "azurerm_netapp_pool" "test" {
   qos_type            = "Manual"
 
   tags = {
-    "CreatedOnDate"    = timestamp(),
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
   }
 }


### PR DESCRIPTION
This PR fixes some issues caused by service backend changes.

Acceptance test that was failing due to QoS value issues, passing now:

```
pmarques@pmarques-dev:~/go/src/github.com/terraform-providers/terraform-provider-azurerm$ make acctests SERVICE='netapp' TESTARGS=' -run=TestAccNetAppVolume_nfsv41' TESTTIMEOUT='300m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -run=TestAccNetAppVolume_nfsv41 -timeout 300m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetAppVolume_nfsv41
=== PAUSE TestAccNetAppVolume_nfsv41
=== CONT  TestAccNetAppVolume_nfsv41
--- PASS: TestAccNetAppVolume_nfsv41 (740.11s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        740.144s
```