### PR TITLE
Update subnet service delegation list with the support of DNS Private Resolvers.

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -120,6 +120,7 @@ func resourceSubnet() *pluginsdk.Resource {
 											"Microsoft.Logic/integrationServiceEnvironments",
 											"Microsoft.MachineLearningServices/workspaces",
 											"Microsoft.Netapp/volumes",
+											"Microsoft.Network/dnsResolvers",
 											"Microsoft.Network/managedResolvers",
 											"Microsoft.PowerPlatform/vnetaccesslinks",
 											"Microsoft.ServiceFabricMesh/networks",


### PR DESCRIPTION
This **PR** adds the capability to create subnets with service delegation required by [Azure DNS Private Resolvers](https://docs.microsoft.com/en-us/azure/dns/dns-private-resolver-overview).
It extends the validation list of service delegation.
Without it, I am not able to create a subnet with the proper delegation and I am getting this error message. 

> Error: expected delegation.0.service_delegation.0.name to be one of [Microsoft.ApiManagement/service Microsoft.AzureCosmosDB/clusters Microsoft.BareMetal/AzureVMware Microsoft.BareMetal/CrayServers Microsoft.Batch/batchAccounts Microsoft.ContainerInstance/containerGroups Microsoft.ContainerService/managedClusters Microsoft.Databricks/workspaces Microsoft.DBforMySQL/flexibleServers Microsoft.DBforMySQL/serversv2 Microsoft.DBforPostgreSQL/flexibleServers Microsoft.DBforPostgreSQL/serversv2 Microsoft.DBforPostgreSQL/singleServers Microsoft.HardwareSecurityModules/dedicatedHSMs Microsoft.Kusto/clusters Microsoft.Logic/integrationServiceEnvironments Microsoft.MachineLearningServices/workspaces Microsoft.Netapp/volumes Microsoft.Network/managedResolvers Microsoft.PowerPlatform/vnetaccesslinks Microsoft.ServiceFabricMesh/networks Microsoft.Sql/managedInstances Microsoft.Sql/servers Microsoft.StoragePool/diskPools Microsoft.StreamAnalytics/streamingJobs Microsoft.Synapse/workspaces Microsoft.Web/hostingEnvironments Microsoft.Web/serverFarms], got **Microsoft.Network/dnsResolvers**

Thanks!