### PR TITLE
azurerm_postgresql_flexible_server_configuration : Clarify the usage of azure extension for PostgreSQL Flexible Server

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -38,6 +38,29 @@ func TestAccFlexibleServerConfiguration_backslashQuote(t *testing.T) {
 	})
 }
 
+func TestAccFlexibleServerConfiguration_azureExtensions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+	name := "azure.extensions"
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, name, "CUBE,CITEXT,BTREE_GIST"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("name").HasValue(name),
+				check.That(data.ResourceName).Key("value").HasValue("CUBE,CITEXT,BTREE_GIST"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(r.checkReset(name), "azurerm_postgresql_flexible_server.test"),
+			),
+		},
+	})
+}
+
 func TestAccFlexibleServerConfiguration_pgbouncerEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
 	r := PostgresqlFlexibleServerConfigurationResource{}

--- a/website/docs/r/postgresql_flexible_server_configuration.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_configuration.html.markdown
@@ -42,11 +42,45 @@ resource "azurerm_postgresql_flexible_server_configuration" "example" {
 }
 ```
 
+## Example Usage - Azure Extensions
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_postgresql_flexible_server" "example" {
+  name                   = "example-psqlflexibleserver"
+  resource_group_name    = azurerm_resource_group.example.name
+  location               = azurerm_resource_group.example.location
+  version                = "12"
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+
+  storage_mb = 32768
+
+  sku_name = "GP_Standard_D4s_v3"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "example" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.example.id
+  value     = "CUBE,CITEXT,BTREE_GIST"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the PostgreSQL Configuration, which needs [to be a valid PostgreSQL configuration name](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIER). Changing this forces a new resource to be created.
+
+-> **Note:** PostgreSQL provides the ability to extend the functionality using azure extensions, with PostgreSQL azure extensions you should specify the `name` value as `azure.extensions` and the `value` you wish to allow in the [extensions list](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-extensions?WT.mc_id=Portal-Microsoft_Azure_OSSDatabases#postgres-13-extensions).
 
 * `server_id` - (Required) The ID of the PostgreSQL Flexible Server where we want to change configuration. Changing this forces a new PostgreSQL Flexible Server Configuration resource.
 


### PR DESCRIPTION
The purposes of this PR:

- Clarify usage of azure extension for PostgreSQL Flexible Server in terraform doc to fix issue #17540 and # 16061.
- Add test case to test the azure extension for PostgreSQL Flexible Server.
- Add example of using azure extension for PostgreSQL Flexible Server.