### PR TITLE
updating to `v0.20220711.1122120` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.35.0
-	github.com/hashicorp/go-azure-sdk v0.20220701.1073833
+	github.com/hashicorp/go-azure-sdk v0.20220711.1122120
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.35.0 h1:/Jpm37dzTmSHobt9SuC8bK6/jSoWw5FdxB9WIqQFXbI=
 github.com/hashicorp/go-azure-helpers v0.35.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
-github.com/hashicorp/go-azure-sdk v0.20220701.1073833 h1:cwutAQhHojIpJR0a7gyf4884A4KX3Un1lj9SUZDRdxE=
-github.com/hashicorp/go-azure-sdk v0.20220701.1073833/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
+github.com/hashicorp/go-azure-sdk v0.20220711.1122120 h1:rMNzN9nnzamkVq/YWDJ3FiGgJn05ycAY83a5+RzIUZ4=
+github.com/hashicorp/go-azure-sdk v0.20220711.1122120/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20220701.1073833
+# github.com/hashicorp/go-azure-sdk v0.20220711.1122120
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants
 github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers


### PR DESCRIPTION
This PR updates to `v0.20220711.1122120` of `github.com/hashicorp/go-azure-sdk`