### PR TITLE
dependencies: updating to `v0.37.0` of `github.com/hashicorp/go-azure-helpers`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
-	github.com/hashicorp/go-azure-helpers v0.35.0
-	github.com/hashicorp/go-azure-sdk v0.20220711.1181406
+	github.com/hashicorp/go-azure-helpers v0.37.0
+	github.com/hashicorp/go-azure-sdk v0.20220711.1122120
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -214,10 +214,10 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.35.0 h1:/Jpm37dzTmSHobt9SuC8bK6/jSoWw5FdxB9WIqQFXbI=
-github.com/hashicorp/go-azure-helpers v0.35.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
-github.com/hashicorp/go-azure-sdk v0.20220711.1181406 h1:RxJ4xa1qkddJ/5VfQ6icUKsn+NbeAYLED85JtCySWOo=
-github.com/hashicorp/go-azure-sdk v0.20220711.1181406/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
+github.com/hashicorp/go-azure-helpers v0.37.0 h1:6UOoQ9esE4MJ4wHJr21qU81IJQ9zsXQ9FbANYUbeE4U=
+github.com/hashicorp/go-azure-helpers v0.37.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
+github.com/hashicorp/go-azure-sdk v0.20220711.1122120 h1:rMNzN9nnzamkVq/YWDJ3FiGgJn05ycAY83a5+RzIUZ4=
+github.com/hashicorp/go-azure-sdk v0.20220711.1122120/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/environment.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/environment.go
@@ -114,10 +114,16 @@ func AzureEnvironmentByNameFromEndpoint(ctx context.Context, endpoint string, en
 	// while the array contains values
 	for _, env := range environments {
 		if strings.EqualFold(env.Name, environmentName) {
+			// if resourceManager endpoint is empty, assume it's the provided endpoint
+			if env.ResourceManager == "" {
+				env.ResourceManager = fmt.Sprintf("https://%s/", endpoint)
+			}
+
 			aEnv, err := buildAzureEnvironment(env)
 			if err != nil {
 				return nil, err
 			}
+
 			return aEnv, nil
 		}
 	}

--- a/vendor/github.com/hashicorp/go-azure-helpers/lang/response/response.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/lang/response/response.go
@@ -6,20 +6,22 @@ import (
 
 // WasBadRequest returns true if the HttpResponse is non-nil and has a status code of BadRequest
 func WasBadRequest(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusBadRequest)
+	return WasStatusCode(resp, http.StatusBadRequest)
 }
 
 // WasConflict returns true if the HttpResponse is non-nil and has a status code of Conflict
 func WasConflict(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusConflict)
+	return WasStatusCode(resp, http.StatusConflict)
 }
 
 // WasNotFound returns true if the HttpResponse is non-nil and has a status code of NotFound
 func WasNotFound(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusNotFound)
+	return WasStatusCode(resp, http.StatusNotFound)
 }
 
-func responseWasStatusCode(resp *http.Response, statusCode int) bool {
+// WasStatusCode returns true if the HttpResponse is non-nil and matches the Status Code
+// It's recommended to use WasBadRequest/WasConflict/WasNotFound where possible instead
+func WasStatusCode(resp *http.Response, statusCode int) bool {
 	if r := resp; r != nil {
 		if r.StatusCode == statusCode {
 			return true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20220711.1181406
+# github.com/hashicorp/go-azure-sdk v0.20220711.1122120
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants
 github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.35.0
+# github.com/hashicorp/go-azure-helpers v0.37.0
 ## explicit; go 1.17
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates


### PR DESCRIPTION
This enables the use of `WasStatusCode` which lets us workaround some of the Azure API/Swagger issues whilst handling dropped connections