### PR TITLE
azurerm_traffic_manager_nested_endpoint, azurerm_traffic_manager_external_endpoint, azurerm_traffic_manager_azure_endpoint : Fix issue about "weight is required even with priority traffic manager profile"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.37.0
-	github.com/hashicorp/go-azure-sdk v0.20220711.1122120
+	github.com/hashicorp/go-azure-sdk v0.20220712.1111122
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.37.0 h1:6UOoQ9esE4MJ4wHJr21qU81IJQ9zsXQ9FbANYUbeE4U=
 github.com/hashicorp/go-azure-helpers v0.37.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
-github.com/hashicorp/go-azure-sdk v0.20220711.1122120 h1:rMNzN9nnzamkVq/YWDJ3FiGgJn05ycAY83a5+RzIUZ4=
-github.com/hashicorp/go-azure-sdk v0.20220711.1122120/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
+github.com/hashicorp/go-azure-sdk v0.20220712.1111122 h1:GiUf/gYHKwgqbqvETA6xLRvLc8u0o83Qor2/zmzwDRo=
+github.com/hashicorp/go-azure-sdk v0.20220712.1111122/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/trafficmanager/azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource.go
@@ -67,7 +67,8 @@ func resourceAzureEndpoint() *pluginsdk.Resource {
 
 			"weight": {
 				Type:         pluginsdk.TypeInt,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -174,12 +175,15 @@ func resourceAzureEndpointCreateUpdate(d *pluginsdk.ResourceData, meta interface
 			EndpointStatus:   &status,
 			TargetResourceId: utils.String(d.Get("target_resource_id").(string)),
 			Subnets:          expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
-			Weight:           utils.Int64(int64(d.Get("weight").(int))),
 		},
 	}
 
 	if priority := d.Get("priority").(int); priority != 0 {
 		params.Properties.Priority = utils.Int64(int64(priority))
+	}
+
+	if weight := d.Get("weight").(int); weight != 0 {
+		params.Properties.Weight = utils.Int64(int64(weight))
 	}
 
 	inputMappings := d.Get("geo_mappings").([]interface{})

--- a/internal/services/trafficmanager/azure_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/azure_endpoint_resource_test.go
@@ -31,6 +31,21 @@ func TestAccAzureEndpoint_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureEndpoint_priority(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_azure_endpoint", "test")
+	r := AzureEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.priority(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAzureEndpoint_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_azure_endpoint", "test")
 	r := AzureEndpointResource{}
@@ -131,6 +146,50 @@ resource "azurerm_traffic_manager_azure_endpoint" "test" {
   profile_id         = azurerm_traffic_manager_profile.test.id
 }
 `, template, data.RandomInteger)
+}
+
+func (r AzureEndpointResource) priority(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-traffic-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_traffic_manager_profile" "test" {
+  name                   = "acctest-TMP-%[1]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  traffic_routing_method = "Priority"
+
+  dns_config {
+    relative_name = "acctest-tmp-%[1]d"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "HTTPS"
+    port     = 443
+    path     = "/"
+  }
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  domain_name_label   = "acctestpublicip-%[1]d"
+}
+
+resource "azurerm_traffic_manager_azure_endpoint" "test" {
+  name               = "acctestend-azure%[1]d"
+  target_resource_id = azurerm_public_ip.test.id
+  profile_id         = azurerm_traffic_manager_profile.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r AzureEndpointResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/trafficmanager/external_endpoint_resource.go
+++ b/internal/services/trafficmanager/external_endpoint_resource.go
@@ -67,7 +67,8 @@ func resourceExternalEndpoint() *pluginsdk.Resource {
 
 			"weight": {
 				Type:         pluginsdk.TypeInt,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -182,12 +183,15 @@ func resourceExternalEndpointCreateUpdate(d *pluginsdk.ResourceData, meta interf
 			EndpointStatus: &status,
 			Target:         utils.String(d.Get("target").(string)),
 			Subnets:        expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
-			Weight:         utils.Int64(int64(d.Get("weight").(int))),
 		},
 	}
 
 	if priority := d.Get("priority").(int); priority != 0 {
 		params.Properties.Priority = utils.Int64(int64(priority))
+	}
+
+	if weight := d.Get("weight").(int); weight != 0 {
+		params.Properties.Weight = utils.Int64(int64(weight))
 	}
 
 	if endpointLocation := d.Get("endpoint_location").(string); endpointLocation != "" {

--- a/internal/services/trafficmanager/external_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/external_endpoint_resource_test.go
@@ -164,7 +164,7 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-resource "azurerm_traffic_manager_profile" "test1" {
+resource "azurerm_traffic_manager_profile" "test" {
   name                   = "acctest-TMP-%[1]d"
   resource_group_name    = azurerm_resource_group.test.name
   traffic_routing_method = "Priority"
@@ -184,7 +184,7 @@ resource "azurerm_traffic_manager_profile" "test1" {
 resource "azurerm_traffic_manager_external_endpoint" "test" {
   name       = "acctestend-azure%[1]d"
   target     = "www.example.com"
-  profile_id = azurerm_traffic_manager_profile.test1.id
+  profile_id = azurerm_traffic_manager_profile.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/trafficmanager/external_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/external_endpoint_resource_test.go
@@ -164,7 +164,7 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-resource "azurerm_traffic_manager_profile" "test" {
+resource "azurerm_traffic_manager_profile" "test1" {
   name                   = "acctest-TMP-%[1]d"
   resource_group_name    = azurerm_resource_group.test.name
   traffic_routing_method = "Priority"
@@ -184,7 +184,7 @@ resource "azurerm_traffic_manager_profile" "test" {
 resource "azurerm_traffic_manager_external_endpoint" "test" {
   name       = "acctestend-azure%[1]d"
   target     = "www.example.com"
-  profile_id = azurerm_traffic_manager_profile.test.id
+  profile_id = azurerm_traffic_manager_profile.test1.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/trafficmanager/nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource.go
@@ -68,7 +68,8 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 
 			"weight": {
 				Type:         pluginsdk.TypeInt,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
@@ -201,8 +202,11 @@ func resourceNestedEndpointCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			MinChildEndpoints: utils.Int64(int64(d.Get("minimum_child_endpoints").(int))),
 			TargetResourceId:  utils.String(d.Get("target_resource_id").(string)),
 			Subnets:           expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
-			Weight:            utils.Int64(int64(d.Get("weight").(int))),
 		},
+	}
+
+	if weight := d.Get("weight").(int); weight != 0 {
+		params.Properties.Weight = utils.Int64(int64(weight))
 	}
 
 	minChildEndpointsIPv4 := d.Get("minimum_required_child_endpoints_ipv4").(int)

--- a/internal/services/trafficmanager/nested_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource_test.go
@@ -31,6 +31,21 @@ func TestAccNestedEndpoint_basic(t *testing.T) {
 	})
 }
 
+func TestAccNestedEndpoint_priority(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_nested_endpoint", "test")
+	r := NestedEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.priority(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNestedEndpoint_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_nested_endpoint", "test")
 	r := NestedEndpointResource{}
@@ -122,6 +137,60 @@ resource "azurerm_traffic_manager_nested_endpoint" "test" {
   weight                  = 3
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r NestedEndpointResource) priority(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-traffic-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_traffic_manager_profile" "parent" {
+  name                   = "acctest-TMP-%[1]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  traffic_routing_method = "Priority"
+
+  dns_config {
+    relative_name = "acctest-tmp-%[1]d"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "HTTPS"
+    port     = 443
+    path     = "/"
+  }
+}
+
+resource "azurerm_traffic_manager_profile" "child" {
+  name                   = "acctesttmpchild%[1]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  traffic_routing_method = "Priority"
+
+  dns_config {
+    relative_name = "acctesttmpchild%[1]d"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "HTTPS"
+    port     = 443
+    path     = "/"
+  }
+}
+
+resource "azurerm_traffic_manager_nested_endpoint" "test" {
+  name                    = "acctestend-parent%[1]d"
+  target_resource_id      = azurerm_traffic_manager_profile.child.id
+  profile_id              = azurerm_traffic_manager_profile.parent.id
+  minimum_child_endpoints = 5
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r NestedEndpointResource) requiresImport(data acceptance.TestData) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20220711.1122120
+# github.com/hashicorp/go-azure-sdk v0.20220712.1111122
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants
 github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers

--- a/website/docs/r/traffic_manager_azure_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_azure_endpoint.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `target_resource_id` - (Required) The ID of the Azure Resource which should be used as a target.
 
-* `weight` - (Required) Specifies how much traffic should be distributed to this endpoint. Valid values are between `1` and `1000`.
+* `weight` - (Optional) Specifies how much traffic should be distributed to this endpoint, this must be specified for Profiles using the Weighted traffic routing method. Valid values are between `1` and `1000`.
 
 ---
 

--- a/website/docs/r/traffic_manager_external_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_external_endpoint.html.markdown
@@ -60,8 +60,7 @@ The following arguments are supported:
 
 * `target` - (Required) The FQDN DNS name of the target.
 
-* `weight` - (Required) Specifies how much traffic should be distributed to this
-  endpoint. Valid values are between `1` and `1000`.
+* `weight` - (Optional) Specifies how much traffic should be distributed to this endpoint, this must be specified for Profiles using the Weighted traffic routing method. Valid values are between `1` and `1000`.
 
 * `endpoint_location` - (Optional) Specifies the Azure location of the Endpoint,
     this must be specified for Profiles using the `Performance` routing method.

--- a/website/docs/r/traffic_manager_nested_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_nested_endpoint.html.markdown
@@ -96,8 +96,7 @@ The following arguments are supported:
 * `target_resource_id` - (Required) The resource id of an Azure resource to
   target.
 
-* `weight` - (Required) Specifies how much traffic should be distributed to this
-  endpoint. Valid values are between `1` and `1000`.
+* `weight` - (Optional) Specifies how much traffic should be distributed to this endpoint, this must be specified for Profiles using the Weighted traffic routing method. Valid values are between `1` and `1000`.
 
 ---
 


### PR DESCRIPTION
Since the [description](https://github.com/Azure/azure-rest-api-specs/blob/432872fac1d0f8edcae98a0e8504afc0ee302710/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-08-01/trafficmanager.json#L993) of `weighted` is "The weight of this endpoint when using the 'Weighted' traffic routing method", this means that `weights` is required if `traffic_routing_method` of `azurerm_traffic_manager_profile` is set to `Weighted`. Also, after verifing the azure api, it does. So, submit this PR to update `weighted` as optional to fix  issue #17542.

Also fix the same issue for resource azurerm_traffic_manager_nested_endpoint and azurerm_traffic_manager_external_endpoint.

Test Results:
```
PASS: TestAccNestedEndpoint_subnet (289.87s)
PASS: TestAccNestedEndpoint_priority (257.60s)
PASS: TestAccNestedEndpoint_basic (292.22s)
PASS: TestAccNestedEndpoint_requiresImport (314.34s)
PASS: TestAccNestedEndpoint_complete (478.54s)
PASS: TestAccAzureEndpoint_requiresImport (252.95s)
PASS: TestAccAzureEndpoint_priority (306.52s)
PASS: TestAccAzureEndpoint_basic (308.44s)
PASS: TestAccAzureEndpoint_subnets (320.73s)
PASS: TestAccAzureEndpoint_complete (489.37s)
PASS: TestAccExternalEndpoint_basic (255.48s)
PASS: TestAccExternalEndpoint_subnets (267.24s)
PASS: TestAccExternalEndpoint_priority (269.76s)
PASS: TestAccExternalEndpoint_performancePolicy (269.88s)
PASS: TestAccExternalEndpoint_requiresImport (295.09s)
PASS: TestAccExternalEndpoint_complete (467.98s)
```