### PR TITLE
azurerm_dev_test_lab_schedule: delete itself rather than a vm extension

### DIFF
--- a/internal/services/devtestlabs/dev_test_lab_schedule_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_schedule_resource.go
@@ -316,7 +316,7 @@ func resourceDevTestLabSchedulesRead(d *pluginsdk.ResourceData, meta interface{}
 }
 
 func resourceDevTestLabSchedulesDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMExtensionClient
+	client := meta.(*clients.Client).DevTestLabs.LabSchedulesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -325,12 +325,10 @@ func resourceDevTestLabSchedulesDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.LabName, id.ScheduleName)
-	if err != nil {
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.LabName, id.ScheduleName); err != nil {
 		return err
 	}
-
-	return future.WaitForCompletionRef(ctx, client.Client)
+	return nil
 }
 
 func expandDevTestScheduleRecurrenceDaily(recurrence interface{}) *dtl.DayDetails {


### PR DESCRIPTION
I have no context why the original code removes a vm extension rathar than using the dev test lab schedule's own client to do the deletion. I've checked with the orignal author about the reason, but he told he forgot why...

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/devtestlabs -run="TestAccDevTestLabSchedule_autoShutdownBasic"

=== RUN   TestAccDevTestLabSchedule_autoShutdownBasic
=== PAUSE TestAccDevTestLabSchedule_autoShutdownBasic
=== CONT  TestAccDevTestLabSchedule_autoShutdownBasic
--- PASS: TestAccDevTestLabSchedule_autoShutdownBasic (1176.73s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/devtestlabs   1176.733s
```