### PR TITLE
Migrating eventhub auth rule ID in state

### DIFF
--- a/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -27,6 +28,11 @@ func resourceEventHubAuthorizationRule() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := eventhubs.ParseEventhubAuthorizationRuleID(id)
 			return err
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.EventHubAuthorizationRuleV0ToV1{},
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/eventhub/migration/eventhub_authorization_rule.go
+++ b/internal/services/eventhub/migration/eventhub_authorization_rule.go
@@ -1,0 +1,60 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2017-04-01/eventhubs"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = EventHubAuthorizationRuleV0ToV1{}
+
+type EventHubAuthorizationRuleV0ToV1 struct{}
+
+func (EventHubAuthorizationRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"namespace_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"eventhub_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+	}
+	return s
+}
+
+func (EventHubAuthorizationRuleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+
+		oldID := rawState["id"].(string)
+
+		newID, err := eventhubs.ParseEventhubAuthorizationRuleIDInsensitively(oldID)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldID, newID)
+
+		rawState["id"] = newID.ID()
+
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
fixing the issue:https://github.com/hashicorp/terraform-provider-azurerm/issues/17511

As the issue mentioned, users who are using older versions of azurerm provider are experiencing ID case sensitive issue. In older version, we put the ID that's retrieved from the service side directly into state and we need to add the parser.