### PR TITLE
sdk: extracting the Plugin SDKv2 schema types to their own interface

### DIFF
--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -11,13 +11,23 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type resourceBase interface {
+// resourceWithPluginSdkSchema defines the Arguments and Attributes for this resource
+// using the types defined in Plugin SDKv2
+type resourceWithPluginSdkSchema interface {
 	// Arguments is a list of user-configurable (that is: Required, Optional, or Optional and Computed)
 	// arguments for this Resource
 	Arguments() map[string]*schema.Schema
 
 	// Attributes is a list of read-only (e.g. Computed-only) attributes
 	Attributes() map[string]*schema.Schema
+}
+
+type resourceBase interface {
+	// resourceWithPluginSdkSchema ensure that the Arguments and Attributes are sourced
+	// from Plugin SDKv2 for now - longer term we'll likely introduce a `Typed Schema`
+	// which will cross-compile down to both the Plugin SDKv2 and Plugin Framework, but
+	// that's a story for another day.
+	resourceWithPluginSdkSchema
 
 	// ModelObject is an instance of the object the Schema is decoded/encoded into
 	ModelObject() interface{}


### PR DESCRIPTION
This provides the foundation for switching these out on a per-resource basis later - likely to an intermediate type which compiles down to Plugin SDKv2 and/or Plugin Framework, rather than Plugin Framework types directly - given there's common behaviours we want to expose.

For now defining this as a separate interface allows auto-completion to work for the resources whilst also allowing us (later on) to gradually roll out the replacement schema types.