### PR TITLE
bugfix: azurerm_application_gateway: unable to create private DNS record out of frontend_ip_configuration[*].private_ip_address

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -325,6 +325,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						"private_ip_address": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 
 						"public_ip_address_id": {


### PR DESCRIPTION
This PR contains a very small fix to issue #17626 which prevented dependent resources like a (private) DNS Record to read the assigned private IP Address to an private Application Gateway Frontend using Dynamic assignment mode.

@mbfrahry Maybe this Pull Request, due to its very small size and because the bug hinders us in customer projects, can be quickly merged. 😄 @katbyte 