### PR TITLE
docs: fix up `azurerm_eventhub_authorization_rule` to stay in proper category

### DIFF
--- a/website/docs/d/eventhub_authorization_rule.html.markdown
+++ b/website/docs/d/eventhub_authorization_rule.html.markdown
@@ -1,4 +1,3 @@
-
 ---
 subcategory: "Messaging"
 layout: "azurerm"


### PR DESCRIPTION
docs: fix up `azurerm_eventhub_authorization_rule` to stay in proper category