### PR TITLE
azurerm_storage_account - add feature to not access the data-plane

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -30,6 +30,9 @@ func Default() UserFeatures {
 		ResourceGroup: ResourceGroupFeatures{
 			PreventDeletionIfContainsResources: true,
 		},
+		StorageAccount: StorageAccountFeatures{
+			DoNotAccessDataPlane: false,
+		},
 		TemplateDeployment: TemplateDeploymentFeatures{
 			DeleteNestedItemsDuringDeletion: true,
 		},

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -7,6 +7,7 @@ type UserFeatures struct {
 	VirtualMachine         VirtualMachineFeatures
 	VirtualMachineScaleSet VirtualMachineScaleSetFeatures
 	KeyVault               KeyVaultFeatures
+	StorageAccount         StorageAccountFeatures
 	TemplateDeployment     TemplateDeploymentFeatures
 	LogAnalyticsWorkspace  LogAnalyticsWorkspaceFeatures
 	ResourceGroup          ResourceGroupFeatures
@@ -38,6 +39,10 @@ type KeyVaultFeatures struct {
 	RecoverSoftDeletedKeys           bool
 	RecoverSoftDeletedCerts          bool
 	RecoverSoftDeletedSecrets        bool
+}
+
+type StorageAccountFeatures struct {
+	DoNotAccessDataPlane bool
 }
 
 type TemplateDeploymentFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -165,6 +165,21 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			},
 		},
 
+		"storage_account": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"do_not_access_data_plane": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
+
 		"template_deployment": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
@@ -351,6 +366,16 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			logAnalyticsWorkspaceRaw := items[0].(map[string]interface{})
 			if v, ok := logAnalyticsWorkspaceRaw["permanently_delete_on_destroy"]; ok {
 				featuresMap.LogAnalyticsWorkspace.PermanentlyDeleteOnDestroy = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["storage_account"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			templateRaw := items[0].(map[string]interface{})
+			if v, ok := templateRaw["do_not_access_data_plane"]; ok {
+				featuresMap.StorageAccount.DoNotAccessDataPlane = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -42,6 +42,9 @@ func TestExpandFeatures(t *testing.T) {
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
 					PermanentlyDeleteOnDestroy: true,
 				},
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: false,
+				},
 				TemplateDeployment: features.TemplateDeploymentFeatures{
 					DeleteNestedItemsDuringDeletion: true,
 				},
@@ -108,6 +111,11 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_deletion_if_contains_resources": true,
 						},
 					},
+					"storage_account": []interface{}{
+						map[string]interface{}{
+							"do_not_access_data_plane": true,
+						},
+					},
 					"template_deployment": []interface{}{
 						map[string]interface{}{
 							"delete_nested_items_during_deletion": true,
@@ -156,6 +164,9 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				ResourceGroup: features.ResourceGroupFeatures{
 					PreventDeletionIfContainsResources: true,
+				},
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: true,
 				},
 				TemplateDeployment: features.TemplateDeploymentFeatures{
 					DeleteNestedItemsDuringDeletion: true,
@@ -220,6 +231,11 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_deletion_if_contains_resources": false,
 						},
 					},
+					"storage_account": []interface{}{
+						map[string]interface{}{
+							"do_not_access_data_plane": false,
+						},
+					},
 					"template_deployment": []interface{}{
 						map[string]interface{}{
 							"delete_nested_items_during_deletion": false,
@@ -269,6 +285,9 @@ func TestExpandFeatures(t *testing.T) {
 				ResourceGroup: features.ResourceGroupFeatures{
 					PreventDeletionIfContainsResources: false,
 				},
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: false,
+				},
 				TemplateDeployment: features.TemplateDeploymentFeatures{
 					DeleteNestedItemsDuringDeletion: false,
 				},
@@ -290,7 +309,7 @@ func TestExpandFeatures(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result, testCase.Expected) {
-			t.Fatalf("Expected %+v but got %+v", result, testCase.Expected)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected, result)
 		}
 	}
 }
@@ -360,7 +379,7 @@ func TestExpandFeaturesApiManagement(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.ApiManagement, testCase.Expected.ApiManagement) {
-			t.Fatalf("Expected %+v but got %+v", result.ApiManagement, testCase.Expected.ApiManagement)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.ApiManagement, result.ApiManagement)
 		}
 	}
 }
@@ -425,7 +444,7 @@ func TestExpandFeaturesApplicationInsights(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.ApplicationInsights, testCase.Expected.ApplicationInsights) {
-			t.Fatalf("Expected %+v but got %+v", result.ApplicationInsights, testCase.Expected.ApplicationInsights)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.ApplicationInsights, result.ApplicationInsights)
 		}
 	}
 }
@@ -490,7 +509,7 @@ func TestExpandFeaturesCognitiveServices(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.CognitiveAccount, testCase.Expected.CognitiveAccount) {
-			t.Fatalf("Expected %+v but got %+v", result.CognitiveAccount, testCase.Expected.CognitiveAccount)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.CognitiveAccount, result.CognitiveAccount)
 		}
 	}
 }
@@ -595,7 +614,72 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.KeyVault, testCase.Expected.KeyVault) {
-			t.Fatalf("Expected %+v but got %+v", result.KeyVault, testCase.Expected.KeyVault)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.KeyVault, result.KeyVault)
+		}
+	}
+}
+
+func TestExpandFeaturesStorageAccount(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"storage_account": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: false,
+				},
+			},
+		},
+		{
+			Name: "Delete Nested Items During Deletion Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"storage_account": []interface{}{
+						map[string]interface{}{
+							"do_not_access_data_plane": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: true,
+				},
+			},
+		},
+		{
+			Name: "Delete Nested Items During Deletion Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"storage_account": []interface{}{
+						map[string]interface{}{
+							"do_not_access_data_plane": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				StorageAccount: features.StorageAccountFeatures{
+					DoNotAccessDataPlane: false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.StorageAccount, testCase.Expected.StorageAccount) {
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.StorageAccount, result.StorageAccount)
 		}
 	}
 }
@@ -660,7 +744,7 @@ func TestExpandFeaturesTemplateDeployment(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.TemplateDeployment, testCase.Expected.TemplateDeployment) {
-			t.Fatalf("Expected %+v but got %+v", result.TemplateDeployment, testCase.Expected.TemplateDeployment)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.TemplateDeployment, result.TemplateDeployment)
 		}
 	}
 }
@@ -778,7 +862,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.VirtualMachine, testCase.Expected.VirtualMachine) {
-			t.Fatalf("Expected %+v but got %+v", result.VirtualMachine, testCase.Expected.VirtualMachine)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.VirtualMachine, result.VirtualMachine)
 		}
 	}
 }
@@ -956,7 +1040,7 @@ func TestExpandFeaturesLogAnalyticsWorkspace(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.LogAnalyticsWorkspace, testCase.Expected.LogAnalyticsWorkspace) {
-			t.Fatalf("Expected %+v but got %+v", result.LogAnalyticsWorkspace, testCase.Expected.LogAnalyticsWorkspace)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.LogAnalyticsWorkspace, result.LogAnalyticsWorkspace)
 		}
 	}
 }
@@ -1021,7 +1105,7 @@ func TestExpandFeaturesResourceGroup(t *testing.T) {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.ResourceGroup, testCase.Expected.ResourceGroup) {
-			t.Fatalf("Expected %+v but got %+v", result.ResourceGroup, testCase.Expected.ResourceGroup)
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.ResourceGroup, result.ResourceGroup)
 		}
 	}
 }

--- a/internal/tags/flatten_test.go
+++ b/internal/tags/flatten_test.go
@@ -47,7 +47,7 @@ func TestFlatten(t *testing.T) {
 
 		actual := Flatten(v.Input)
 		if !reflect.DeepEqual(actual, v.Expected) {
-			t.Fatalf("Expected %+v but got %+v", actual, v.Expected)
+			t.Fatalf("Expected %+v but got %+v", v.Expected, actual)
 		}
 	}
 }

--- a/internal/tags/typed_test.go
+++ b/internal/tags/typed_test.go
@@ -67,7 +67,7 @@ func TestToTypedObject(t *testing.T) {
 
 		actual := ToTypedObject(v.Input)
 		if !reflect.DeepEqual(actual, v.Expected) {
-			t.Fatalf("Expected %+v but got %+v", actual, v.Expected)
+			t.Fatalf("Expected %+v but got %+v", v.Expected, actual)
 		}
 	}
 }

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -53,6 +53,10 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = true
     }
 
+    storage_account {
+      do_not_access_data_plane = true
+    }
+    
     template_deployment {
       delete_nested_items_during_deletion = true
     }
@@ -87,6 +91,8 @@ The `features` block supports the following:
 * `log_analytics_workspace` - (Optional) A `log_analytics_workspace` block as defined below.
 
 * `resource_group` - (Optional) A `resource_group` block as defined below.
+
+* `storage_account` - (Optional) A `storage_account` block as defined below.
 
 * `template_deployment` - (Optional) A `template_deployment` block as defined below.
 
@@ -153,6 +159,14 @@ The `resource_group` block supports the following:
 * `prevent_deletion_if_contains_resources` - (Optional) Should the `azurerm_resource_group` resource check that there are no Resources within the Resource Group during deletion? This means that all Resources within the Resource Group must be deleted prior to deleting the Resource Group. Defaults to `false`.
 
 -> **Note:** This will be defaulted to `true` in the next major version of the Azure Provider (3.0).
+
+---
+
+The `storage_account` block supports the following:
+
+* `do_not_access_data_plane` - (Optional) By default the `storage_account` also accesses the data-plane next to the control-plane to fetch
+  details from the Storage Account. This could raise issues when the deployment is initiated from behind a corporate firewall.
+  Set `do_not_access_data_plane` to `true` to circumvent this. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -13,6 +13,14 @@ Manages an Azure Storage Account.
 ## Example Usage
 
 ```hcl
+provider "azurerm" {
+  features {
+    storage_account {
+      do_not_access_data_plane = false
+    }
+  }
+}
+
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"


### PR DESCRIPTION
When deploying a Storage Account from an agent that is behind a corporate firewall that is prohibited access to `*.blob.core.windows.net` and `*.queue.core.windows.net`, the deployment will fail.

This PR adds the option to not-access the data-plane (to fetch the queue properties). The functionality of azurerm_storage_account will be slightly limited, but at least it's possible to deploy and update a Storage Account using the control-plane from behind a corporate firewall.

fixes #16727

Perhaps the provider should show a warning when `blob_properties` or 'queue_properties' is specified by the user, while also `do_not_access_data_plane` is set to `true` (but I didn't know how to implement a validator that shows a warning depending on a feature value and resource property)