### PR TITLE
`HDInsight`: Adding support for `httpsEndpoints` and `installScriptAction` in hadoop edge node

### DIFF
--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -321,6 +321,17 @@ func createHDInsightEdgeNodes(ctx context.Context, client *hdinsight.Application
 			ApplicationType:      utils.String("CustomApplication"),
 		},
 	}
+
+	if v, ok := input["https_endpoints"]; ok {
+		httpsEndpoints := expandHDInsightApplicationEdgeNodeHttpsEndpoints(v.([]interface{}))
+		application.Properties.HTTPSEndpoints = httpsEndpoints
+	}
+
+	if v, ok := input["uninstall_script_actions"]; ok {
+		uninstallScriptActions := expandHDInsightApplicationEdgeNodeUninstallScriptActions(v.([]interface{}))
+		application.Properties.UninstallScriptActions = uninstallScriptActions
+	}
+
 	future, err := client.Create(ctx, resourceGroup, name, name, application)
 	if err != nil {
 		return fmt.Errorf("creating edge nodes for HDInsight Hadoop Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -153,9 +153,18 @@ func resourceHDInsightHadoopCluster() *pluginsdk.Resource {
 													Required:     true,
 													ValidateFunc: validation.StringIsNotEmpty,
 												},
+												"parameters": {
+													Type:         pluginsdk.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
 											},
 										},
 									},
+
+									"https_endpoints": SchemaHDInsightsHttpsEndpoints(),
+
+									"uninstall_script_actions": SchemaHDInsightsScriptActions(),
 								},
 							},
 						},
@@ -485,7 +494,30 @@ func flattenHDInsightEdgeNode(roles []interface{}, props *hdinsight.ApplicationP
 		for _, action := range *installScriptActions {
 			actions["name"] = action.Name
 			actions["uri"] = action.URI
+			actions["parameters"] = action.Parameters
 		}
+	}
+
+	if uninstallScriptActions := props.UninstallScriptActions; uninstallScriptActions != nil && len(*uninstallScriptActions) != 0 {
+		uninstallActions := make(map[string]interface{})
+		for _, uninstallAction := range *uninstallScriptActions {
+			actions["name"] = uninstallAction.Name
+			actions["uri"] = uninstallAction.URI
+			actions["parameters"] = uninstallAction.Parameters
+		}
+		edgeNode["uninstall_script_actions"] = []interface{}{uninstallActions}
+	}
+
+	if HTTPSEndpoints := props.HTTPSEndpoints; HTTPSEndpoints != nil && len(*HTTPSEndpoints) != 0 {
+		httpsEndpoints := make(map[string]interface{})
+		for _, HTTPSEndpoint := range *HTTPSEndpoints {
+			httpsEndpoints["access_modes"] = HTTPSEndpoint.AccessModes
+			httpsEndpoints["destination_port"] = HTTPSEndpoint.DestinationPort
+			httpsEndpoints["disable_gateway_auth"] = HTTPSEndpoint.DisableGatewayAuth
+			httpsEndpoints["private_ip_address"] = HTTPSEndpoint.PrivateIPAddress
+			httpsEndpoints["sub_domain_suffix"] = HTTPSEndpoint.SubDomainSuffix
+		}
+		edgeNode["https_endpoints"] = []interface{}{httpsEndpoints}
 	}
 
 	edgeNode["install_script_action"] = []interface{}{actions}
@@ -524,12 +556,69 @@ func expandHDInsightApplicationEdgeNodeInstallScriptActions(input []interface{})
 
 		name := val["name"].(string)
 		uri := val["uri"].(string)
+		parameters := val["parameters"].(string)
 
 		action := hdinsight.RuntimeScriptAction{
 			Name: utils.String(name),
 			URI:  utils.String(uri),
 			// The only role available for edge nodes is edgenode
-			Roles: &[]string{"edgenode"},
+			Parameters: utils.String(parameters),
+			Roles:      &[]string{"edgenode"},
+		}
+
+		actions = append(actions, action)
+	}
+
+	return &actions
+}
+
+func expandHDInsightApplicationEdgeNodeHttpsEndpoints(input []interface{}) *[]hdinsight.ApplicationGetHTTPSEndpoint {
+	endpoints := make([]hdinsight.ApplicationGetHTTPSEndpoint, 0)
+	if len(input) == 0 || input[0] == nil {
+		return &endpoints
+	}
+
+	for _, v := range input {
+		val := v.(map[string]interface{})
+
+		accessModes := val["access_modes"].([]string)
+		destinationPort := val["destination_port"].(int32)
+		disableGatewayAuth := val["disable_gateway_auth"].(bool)
+		privateIpAddress := val["private_ip_address"].(string)
+		subDomainSuffix := val["sub_domain_suffix"].(string)
+
+		endPoint := hdinsight.ApplicationGetHTTPSEndpoint{
+			AccessModes:        &accessModes,
+			DestinationPort:    utils.Int32(destinationPort),
+			PrivateIPAddress:   utils.String(privateIpAddress),
+			SubDomainSuffix:    utils.String(subDomainSuffix),
+			DisableGatewayAuth: utils.Bool(disableGatewayAuth),
+		}
+
+		endpoints = append(endpoints, endPoint)
+	}
+
+	return &endpoints
+}
+
+func expandHDInsightApplicationEdgeNodeUninstallScriptActions(input []interface{}) *[]hdinsight.RuntimeScriptAction {
+	actions := make([]hdinsight.RuntimeScriptAction, 0)
+	if len(input) == 0 || input[0] == nil {
+		return &actions
+	}
+
+	for _, v := range input {
+		val := v.(map[string]interface{})
+
+		name := val["name"].(string)
+		uri := val["uri"].(string)
+		parameters := val["parameters"].(string)
+
+		action := hdinsight.RuntimeScriptAction{
+			Name:       utils.String(name),
+			URI:        utils.String(uri),
+			Parameters: utils.String(parameters),
+			Roles:      &[]string{"edgenode"},
 		}
 
 		actions = append(actions, action)

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/hdinsight/mgmt/2018-06-01/hdinsight"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hdinsight/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -287,6 +288,86 @@ func SchemaHDInsightsSecurityProfile() *pluginsdk.Schema {
 			},
 		},
 	}
+}
+
+func SchemaHDInsightsScriptActions() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"uri": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				},
+
+				"parameters": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func SchemaHDInsightsHttpsEndpoints() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"access_modes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+
+				"destination_port": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: azValidate.PortNumber,
+				},
+
+				"disable_gateway_auth": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+
+				"private_ip_address": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.IsIPAddress,
+				},
+
+				"sub_domain_suffix": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+type HttpEndpointModel struct {
+	AccessModes        []string `tfschema:"access_modes"`
+	DestinationPort    int32    `tfschema:"destination_port"`
+	DisableGatewayAuth bool     `tfschema:"disable_gateway_auth"`
+	PrivateIpAddress   string   `tfschema:"private_ip_address"`
+	SubDomainSuffix    string   `tfschema:"sub_domain_suffix"`
 }
 
 func ExpandHDInsightsConfigurations(input []interface{}) map[string]interface{} {

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -267,7 +267,33 @@ A `install_script_action` block supports the following:
 
 * `uri` - (Required) The URI pointing to the script to run during the installation of the edge node. Changing this forces a new resource to be created.
 
---- 
+* `parameters` - (Optional) The parameters for the script.
+
+---
+
+A `https_endpints` block supports the following:
+
+* `access_modes` - (Optional) A list of access modes for the application.
+
+* `destination_port` - (Optional) The destination port to connect to.
+
+* `disable_gateway_auth` - (Optional) The value indicates whether the gateway authentication is enabled or not.
+
+* `private_ip_address` - (Optional) The private ip address of the endpoint.
+
+* `sub_domain_suffix` - (Optional) The application's subdomain suffix.
+
+---
+
+A `uninstall_script_actions` block supports the following:
+
+* `name` - (Required) The name of the uninstall script action. Changing this forces a new resource to be created.
+
+* `uri` - (Required) The URI pointing to the script to run during the installation of the edge node. Changing this forces a new resource to be created.
+
+* `parameters` - (Optional) The parameters for the script.
+
+---
 
 A `metastores` block supports the following:
 


### PR DESCRIPTION
* Add support for `httpsEndpoints` and `installScriptAction` to reach 100% coverage for HDInsight service.

* All tests passed.