### PR TITLE
Changes documentation to reflect ISE network requirements

### DIFF
--- a/internal/services/logic/integration_service_environment_resource_test.go
+++ b/internal/services/logic/integration_service_environment_resource_test.go
@@ -219,7 +219,7 @@ resource "azurerm_subnet" "isesubnet1" {
   name                 = "isesubnet1"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/26"]
+  address_prefixes     = ["10.0.1.0/27"]
 
   delegation {
     name = "integrationServiceEnvironments"
@@ -234,21 +234,21 @@ resource "azurerm_subnet" "isesubnet2" {
   name                 = "isesubnet2"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.64/26"]
+  address_prefixes     = ["10.0.1.32/27"]
 }
 
 resource "azurerm_subnet" "isesubnet3" {
   name                 = "isesubnet3"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.128/26"]
+  address_prefixes     = ["10.0.1.64/27"]
 }
 
 resource "azurerm_subnet" "isesubnet4" {
   name                 = "isesubnet4"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.192/26"]
+  address_prefixes     = ["10.0.1.96/27"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/integration_service_environment.html.markdown
+++ b/website/docs/r/integration_service_environment.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "isesubnet1" {
   name                 = "isesubnet1"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.1.0/26"]
+  address_prefixes     = ["10.0.1.0/27"]
 
   delegation {
     name = "integrationServiceEnvironments"
@@ -43,21 +43,21 @@ resource "azurerm_subnet" "isesubnet2" {
   name                 = "isesubnet2"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.1.64/26"]
+  address_prefixes     = ["10.0.1.32/27"]
 }
 
 resource "azurerm_subnet" "isesubnet3" {
   name                 = "isesubnet3"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.1.128/26"]
+  address_prefixes     = ["10.0.1.64/27"]
 }
 
 resource "azurerm_subnet" "isesubnet4" {
   name                 = "isesubnet4"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.0.1.192/26"]
+  address_prefixes     = ["10.0.1.96/27"]
 }
 
 resource "azurerm_integration_service_environment" "example" {
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `access_endpoint_type` - (Required) The type of access endpoint to use for the Integration Service Environment. Possible Values are `Internal` and `External`. Changing this forces a new Integration Service Environment to be created.
 
-* `virtual_network_subnet_ids` - (Required) A list of virtual network subnet ids to be used by Integration Service Environment. Exactly four distinct ids to subnets must be provided. Changing this forces a new Integration Service Environment to be created.
+* `virtual_network_subnet_ids` - (Required) A list of virtual network subnet ids to be used by Integration Service Environment. Exactly four distinct ids to `/27` subnets must be provided. Changing this forces a new Integration Service Environment to be created.
 
 ---
 


### PR DESCRIPTION
This PR updates documentation examples and tests to reflect required subnet configurations for Integration Service Environments (ISE). The `/26` subnets used in the examples are larger than needed and don't provide any additional functionality.

Source ISE documentation with networking requirements can be found here: https://docs.microsoft.com/en-us/azure/logic-apps/connect-virtual-network-vnet-isolated-environment

The relevant section:
![image](https://user-images.githubusercontent.com/17042203/179686976-232eceb9-782a-47eb-b73d-6e82ff761049.png)

