### PR TITLE
`azurerm_hdinsight_kafka_cluster`, `azurerm_hdinsight_spark_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_hadoop_cluster` - Add support for `VMGroupName` and `encryptDataDisks` properties

### DIFF
--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -779,6 +779,7 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			ForceNew: true,
+			Default:  false,
 		},
 	}
 

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -153,6 +153,10 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `roles` block supports the following:
@@ -229,6 +233,10 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 * `autoscale` - (Optional) A `autoscale` block as defined below.
 
 ---
@@ -250,6 +258,10 @@ A `zookeeper_node` block supports the following:
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
+
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
 
 ---
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -153,6 +153,10 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `roles` block supports the following:
@@ -227,6 +231,10 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 * `autoscale` - (Optional) A `autoscale` block as defined below.
 
 ---
@@ -248,6 +256,10 @@ A `zookeeper_node` block supports the following:
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
+
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
 
 --- 
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -156,6 +156,10 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `roles` block supports the following:
@@ -232,6 +236,10 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 * `autoscale` - (Optional) A `autoscale` block as defined below.
 
 ---
@@ -253,6 +261,10 @@ A `zookeeper_node` block supports the following:
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
+
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
 
 --- 
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -158,6 +158,10 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `roles` block supports the following:
@@ -234,6 +238,10 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `zookeeper_node` block supports the following:
@@ -254,6 +262,10 @@ A `zookeeper_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `kafka_management_node` block supports the following:
@@ -273,6 +285,10 @@ A `kafka_management_node` block supports the following:
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Kafka Management Nodes should be provisioned within. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Kafka Management Nodes should be provisioned within. Changing this forces a new resource to be created.
+
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
 
 --- 
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -155,6 +155,10 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 ---
 
 A `roles` block supports the following:
@@ -229,6 +233,10 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
+
 * `autoscale` - (Optional) A `autoscale` block as defined below.
 
 ---
@@ -250,6 +258,10 @@ A `zookeeper_node` block supports the following:
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Zookeeper Nodes should be provisioned within. Changing this forces a new resource to be created.
+
+* `vm_group_name` - (Optional) Name of the virtual machine group. Changing this forces a new resource to be created.
+
+* `encrypt_data_disks` - (Optional) Whether encryption data disks is enabled. Changing this forces a new resource to be created. The default value is `false`.
 
 --- 
 


### PR DESCRIPTION
* Add support for `VMGroupName` and `encryptDataDisks` in HDInsight clusters.
* All tests passed.