### PR TITLE
azurerm_application_gateway - Mark probe.match.body as not required

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -966,7 +966,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"body": {
 										Type:     pluginsdk.TypeString,
-										Required: true,
+										Required: false,
 									},
 
 									"status_code": {

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -966,7 +966,7 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"body": {
 										Type:     pluginsdk.TypeString,
-										Required: false,
+										Optional: true,
 									},
 
 									"status_code": {

--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -343,8 +343,6 @@ The deprecated field `security.enabled_triple_des_ciphers` will be removed in fa
 
 ### Resource: `azurerm_application_gateway`
 
-The field `probe.match.body` will become Required.
-
 The field `probe.match.status_code` will become Required.
 
 ### Resource: `azurerm_app_service`

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -361,7 +361,7 @@ An `ip_configuration` block supports the following:
 
 A `match` block supports the following:
 
-* `body` - (Required) A snippet from the Response Body which must be present in the Response.
+* `body` - A snippet from the Response Body which must be present in the Response.
 
 * `status_code` - (Required) A list of allowed status codes for this Health Probe.
 


### PR DESCRIPTION
The azurerm_application_gateway probe.match.body is currently set as "Required" however this is not a requirement in Azure.

Have updated the bool for the Required flag and the documentation page in this commit.

fixes #16298 