### PR TITLE
`azurerm_dns_ns_record` documentation update

### DIFF
--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_dns_ns_record" "example" {
   resource_group_name = azurerm_resource_group.example.name
   ttl                 = 300
 
-  records = ["ns1.contoso.com", "ns2.contoso.com"]
+  records = ["ns1.contoso.com.", "ns2.contoso.com."]
 
   tags = {
     Environment = "Production"


### PR DESCRIPTION
Added `.` to the end of the examples as this is more correct (its the absolute DNS name, not a relative name). Not having the trailing `.` can lead to DNS redirection/hijack in [specific situations](http://dnsinstitute.com/research/2020/dns-mistakes-part-1-dots.html).

Having no trailing `.` can cause inconsistencies, and as the examples will be copy-pasted, it should be strictly correct.

Other Terraform provider documentation/examples (e.g. [Hashicorp DNS](https://registry.terraform.io/providers/hashicorp/dns/latest/docs/resources/dns_ns_record_set)) have NS records suffixed with the `.`