### PR TITLE
Fix 'API version information for RP "microsoft.insights" was not found'

### DIFF
--- a/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -72,7 +72,24 @@ func TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing(t *testing
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+	})
+}
+
+func TestAccResourceGroupTemplateDeployment_inconsistentProviderCasing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_group_template_deployment", "test")
+	r := ResourceGroupTemplateDeploymentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.inconsistentProviderCasing(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		data.ImportStep(),
+		{ // delete item
+			Config: r.inconsistentProviderCasingEmpty(data),
+		},
 	})
 }
 
@@ -450,6 +467,83 @@ TEMPLATE
 PARAM
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, value)
+}
+
+func (ResourceGroupTemplateDeploymentResource) inconsistentProviderCasing(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+  provider "azurerm" {
+    features {}
+  }
+  
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestRG-%d"
+    location = %q
+  }
+  
+  resource "azurerm_resource_group_template_deployment" "test" {
+    name                = "acctest"
+    resource_group_name = azurerm_resource_group.test.name
+    deployment_mode     = "Complete"
+  
+    template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [
+        {
+          "type": "Microsoft.Insights/actionGroups",
+          "apiVersion": "2019-06-01",
+          "name": "acctestTemplateDeployAG1-%d",
+          "location": "Global",
+          "dependsOn": [],
+          "tags": {},
+          "properties": {
+            "groupShortName": "rick-c137",
+            "enabled": true,
+            "emailReceivers": [
+              {
+                "name": "Rick Sanchez",
+                "emailAddress": "rick@example.com"
+              }
+            ],
+            "smsReceivers": [],
+            "webhookReceivers": []
+          }
+        },
+        {
+          "type": "microsoft.insights/actionGroups",
+          "apiVersion": "2019-06-01",
+          "name": "acctestTemplateDeployAG2-%d",
+          "location": "Global",
+          "dependsOn": [],
+          "tags": {},
+          "properties": {
+            "groupShortName": "rick-c138",
+            "enabled": true,
+            "emailReceivers": [
+              {
+                "name": "Rick Sanchez",
+                "emailAddress": "rick@example.com"
+              }
+            ],
+            "smsReceivers": [],
+            "webhookReceivers": []
+          }
+        }
+      ]
+    }
+TEMPLATE
+  }
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+func (ResourceGroupTemplateDeploymentResource) inconsistentProviderCasingEmpty(data acceptance.TestData) string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
 }
 
 func (ResourceGroupTemplateDeploymentResource) singleItemWithParameterConfigAndVariable(data acceptance.TestData, templateVar string, paramVal string) string {

--- a/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -471,21 +471,21 @@ PARAM
 
 func (ResourceGroupTemplateDeploymentResource) inconsistentProviderCasing(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-  provider "azurerm" {
-    features {}
-  }
-  
-  resource "azurerm_resource_group" "test" {
-    name     = "acctestRG-%d"
-    location = %q
-  }
-  
-  resource "azurerm_resource_group_template_deployment" "test" {
-    name                = "acctest"
-    resource_group_name = azurerm_resource_group.test.name
-    deployment_mode     = "Complete"
-  
-    template_content = <<TEMPLATE
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = %q
+}
+
+resource "azurerm_resource_group_template_deployment" "test" {
+  name                = "acctest"
+  resource_group_name = azurerm_resource_group.test.name
+  deployment_mode     = "Complete"
+
+  template_content = <<TEMPLATE
     {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
@@ -535,7 +535,7 @@ func (ResourceGroupTemplateDeploymentResource) inconsistentProviderCasing(data a
       ]
     }
 TEMPLATE
-  }
+}
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 func (ResourceGroupTemplateDeploymentResource) inconsistentProviderCasingEmpty(data acceptance.TestData) string {

--- a/internal/services/resource/template_deployment_common.go
+++ b/internal/services/resource/template_deployment_common.go
@@ -173,11 +173,11 @@ func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client
 			return fmt.Errorf("parsing ID %q from Template Output to delete it: %+v", *nestedResource.ID, err)
 		}
 
-		resourceProviderApiVersion, ok := (*resourceProviderApiVersions)[parsedId.Provider]
+		resourceProviderApiVersion, ok := (*resourceProviderApiVersions)[strings.ToLower(parsedId.Provider)]
 		if !ok {
-			resourceProviderApiVersion, ok = (*resourceProviderApiVersions)[parsedId.SecondaryProvider]
+			resourceProviderApiVersion, ok = (*resourceProviderApiVersions)[strings.ToLower(parsedId.SecondaryProvider)]
 			if !ok {
-				return fmt.Errorf("API version information for RP %q was not found", parsedId.Provider)
+				return fmt.Errorf("API version information for RP %q (%q) was not found - nestedResource=%q", parsedId.Provider, parsedId.SecondaryProvider, *nestedResource.ID)
 			}
 		}
 
@@ -244,7 +244,7 @@ func determineResourceProviderAPIVersionsForResources(ctx context.Context, clien
 
 			// NOTE: there's an enhancement in that not all RP's necessarily offer everything in every version
 			// but the majority do, so this is likely sufficient for now
-			resourceProviderApiVersions[resourceProviderName] = *apiVersion
+			resourceProviderApiVersions[strings.ToLower(resourceProviderName)] = *apiVersion
 			break
 		}
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/applicationinsights/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/applicationinsights/README.md
@@ -77,7 +77,7 @@ if model := read.Model; model != nil {
 
 ```go
 ctx := context.TODO()
-id := applicationinsights.NewResourceGroupID()
+id := applicationinsights.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
 
 // alternatively `client.WorkbooksListByResourceGroup(ctx, id, applicationinsights.DefaultWorkbooksListByResourceGroupOperationOptions())` can be used to do batched pagination
 items, err := client.WorkbooksListByResourceGroupComplete(ctx, id, applicationinsights.DefaultWorkbooksListByResourceGroupOperationOptions())
@@ -94,7 +94,7 @@ for _, item := range items {
 
 ```go
 ctx := context.TODO()
-id := applicationinsights.NewSubscriptionID()
+id := applicationinsights.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
 
 // alternatively `client.WorkbooksListBySubscription(ctx, id, applicationinsights.DefaultWorkbooksListBySubscriptionOperationOptions())` can be used to do batched pagination
 items, err := client.WorkbooksListBySubscriptionComplete(ctx, id, applicationinsights.DefaultWorkbooksListBySubscriptionOperationOptions())


### PR DESCRIPTION
Fixes #17703

When retrieving API version details for a provider on deletion, the casing of the initial resource for that provider is used. As a result, any later (case-sensitive) lookups for that provider will fail if they use an inconsistent casing. This PR forces the provider name to lowercase when generating the lookup data and when performing the lookup