### PR TITLE
GHA - new actions to add/remove wating-response

### DIFF
--- a/.github/waiting-response.yml
+++ b/.github/waiting-response.yml
@@ -1,0 +1,2 @@
+waiting-response:
+  - "*"

--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -13,6 +13,12 @@ jobs:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           labels: stale
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ !github.event.issue.pull_request }}
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: waiting-response
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: (github.event.issue.pull_request && github.actor == github.event.issue.user.login)
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           labels: waiting-response

--- a/.github/workflows/pull-request-new-commit.yaml
+++ b/.github/workflows/pull-request-new-commit.yaml
@@ -1,0 +1,15 @@
+---
+name: Pull Request New Commit
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  issue_comment_triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: waiting-response

--- a/.github/workflows/pull-request-reviewed.yaml
+++ b/.github/workflows/pull-request-reviewed.yaml
@@ -1,0 +1,16 @@
+---
+name: "Pull Request Reviewed"
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  add-waiting-response:
+    if: github.event.review.state != 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          configuration-path: .github/waiting-response.yml
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This should:
- add a label for "waiting-response" when a PR has been reviewed but not yet approved
- remove "waiting-response" label when new commits are made to a PR.