### PR TITLE
azurerm_mssql_managed_instance - change storage_size_in_gb from 8192 to 16384

### DIFF
--- a/internal/services/sql/sql_managed_instance_resource.go
+++ b/internal/services/sql/sql_managed_instance_resource.go
@@ -100,7 +100,7 @@ func resourceArmSqlMiServer() *schema.Resource {
 			"storage_size_in_gb": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(32, 8192),
+				ValidateFunc: validation.IntBetween(32, 16384),
 			},
 
 			"license_type": {


### PR DESCRIPTION
When building a SQL Managed Instance with anything higher than 8192 GB of storage, you get an error. 
` #Error: expected storage_size_in_gb to be in the range (32 - 8192), got 16384.
`
 I can see in the GUI and JSON output, the slider goes up to 16384 GB.
#17710