### PR TITLE
`azurerm_logic_app_standard` - expose `virtual_network_subnet_id` for vNet integration

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -156,6 +156,11 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"virtual_network_subnet_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"site_credential": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -231,6 +236,7 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
+		d.Set("virtual_network_subnet_id", props.VirtualNetworkSubnetID)
 
 		clientCertMode := ""
 		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -236,7 +236,6 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
-		d.Set("virtual_network_subnet_id", props.VirtualNetworkSubnetID)
 
 		clientCertMode := ""
 		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {
@@ -246,6 +245,10 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	appSettings := flattenLogicAppStandardDataSourceAppSettings(appSettingsResp.Properties)
+
+	if err = d.Set("virtual_network_subnet_id", resp.SiteProperties.VirtualNetworkSubnetID); err != nil {
+		return err
+	}
 
 	if err = d.Set("connection_string", flattenLogicAppStandardDataSourceConnectionStrings(connectionStringsResp.Properties)); err != nil {
 		return err

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -523,10 +523,6 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
-	// if subnetId := utils.NormalizeNilableString(resp.VirtualNetworkSubnetID); subnetId != "" {
-	// 	d.Set("virtual_network_subnet_id", resp.VirtualNetworkSubnetID)
-	// }
-
 	if props := resp.SiteProperties; props != nil {
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("enabled", props.Enabled)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -523,9 +523,9 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
-	if subnetId := utils.NormalizeNilableString(resp.VirtualNetworkSubnetID); subnetId != "" {
-		d.Set("virtual_network_subnet_id", resp.VirtualNetworkSubnetID)
-	}
+	// if subnetId := utils.NormalizeNilableString(resp.VirtualNetworkSubnetID); subnetId != "" {
+	// 	d.Set("virtual_network_subnet_id", resp.VirtualNetworkSubnetID)
+	// }
 
 	if props := resp.SiteProperties; props != nil {
 		d.Set("app_service_plan_id", props.ServerFarmID)
@@ -536,6 +536,7 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
+		d.Set("virtual_network_subnet_id", props.VirtualNetworkSubnetID)
 
 		clientCertMode := ""
 		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -358,7 +358,6 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	clientCertMode := d.Get("client_certificate_mode").(string)
 	clientCertEnabled := clientCertMode != ""
 	httpsOnly := d.Get("https_only").(bool)
-	VirtualNetworkSubnetID := d.Get("virtual_network_subnet_id").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	basicAppSettings, err := getBasicLogicAppSettings(d, endpointSuffix)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1720,6 +1720,7 @@ resource "azurerm_app_service_plan" "test" {
 func (LogicAppStandardResource) vNetIntegration_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
@@ -1747,51 +1748,52 @@ resource "azurerm_app_service_plan" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-	name                = "vnet-%[1]d"
-	address_space       = ["10.0.0.0/16"]
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
+  name                = "vnet-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
-	resource "azurerm_subnet" "test1" {
-	name                 = "subnet1"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.1.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test1" {
+  name                 = "subnet1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
-	resource "azurerm_subnet" "test2" {
-	name                 = "subnet2"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.2.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test2" {
+  name                 = "subnet2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
 
 resource "azurerm_logic_app_standard" "test" {
-	name                       = "acctest-%[1]d-func"
-	location                   = azurerm_resource_group.test.location
-	resource_group_name        = azurerm_resource_group.test.name
-	app_service_plan_id        = azurerm_app_service_plan.test.id
-	storage_account_name       = azurerm_storage_account.test.name
-	storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  
-	site_config {
-	  app_scale_limit = 1
-	}
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    app_scale_limit = 1
   }
+}
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -1799,6 +1801,7 @@ resource "azurerm_logic_app_standard" "test" {
 func (LogicAppStandardResource) vNetIntegration_subnet1(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
@@ -1826,52 +1829,53 @@ resource "azurerm_app_service_plan" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-	name                = "vnet-%[1]d"
-	address_space       = ["10.0.0.0/16"]
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
+  name                = "vnet-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
-	resource "azurerm_subnet" "test1" {
-	name                 = "subnet1"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.1.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test1" {
+  name                 = "subnet1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
-	resource "azurerm_subnet" "test2" {
-	name                 = "subnet2"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.2.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test2" {
+  name                 = "subnet2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
 
 resource "azurerm_logic_app_standard" "test" {
-	name                       = "acctest-%[1]d-func"
-	location                   = azurerm_resource_group.test.location
-	resource_group_name        = azurerm_resource_group.test.name
-	app_service_plan_id        = azurerm_app_service_plan.test.id
-	storage_account_name       = azurerm_storage_account.test.name
-	storage_account_access_key = azurerm_storage_account.test.primary_access_key
-	virtual_network_subnet_id  = azurerm_subnet.test1.id
-  
-	site_config {
-	  app_scale_limit = 1
-	}
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  virtual_network_subnet_id  = azurerm_subnet.test1.id
+
+  site_config {
+    app_scale_limit = 1
   }
+}
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -1879,6 +1883,7 @@ resource "azurerm_logic_app_standard" "test" {
 func (LogicAppStandardResource) vNetIntegration_subnet2(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
@@ -1906,52 +1911,53 @@ resource "azurerm_app_service_plan" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-	name                = "vnet-%[1]d"
-	address_space       = ["10.0.0.0/16"]
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
+  name                = "vnet-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 }
 
-	resource "azurerm_subnet" "test1" {
-	name                 = "subnet1"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.1.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test1" {
+  name                 = "subnet1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
-	resource "azurerm_subnet" "test2" {
-	name                 = "subnet2"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.2.0/24"]
-	delegation {
-		name = "delegation"
-		service_delegation {
-		name    = "Microsoft.Web/serverFarms"
-		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-		}
-	}
+resource "azurerm_subnet" "test2" {
+  name                 = "subnet2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
 
 resource "azurerm_logic_app_standard" "test" {
-	name                       = "acctest-%[1]d-func"
-	location                   = azurerm_resource_group.test.location
-	resource_group_name        = azurerm_resource_group.test.name
-	app_service_plan_id        = azurerm_app_service_plan.test.id
-	storage_account_name       = azurerm_storage_account.test.name
-	storage_account_access_key = azurerm_storage_account.test.primary_access_key
-	virtual_network_subnet_id  = azurerm_subnet.test2.id
-  
-	site_config {
-	  app_scale_limit = 1
-	}
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  virtual_network_subnet_id  = azurerm_subnet.test2.id
+
+  site_config {
+    app_scale_limit = 1
   }
+}
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -727,6 +727,66 @@ func TestAccLogicAppStandard_dotnetVersion6(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_vNetIntegration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vNetIntegration_subnet1(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_network_subnet_id").MatchesOtherKey(
+					check.That("azurerm_subnet.test1").Key("id"),
+				),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppStandard_vNetIntegrationUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vNetIntegration_basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.vNetIntegration_subnet1(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_network_subnet_id").MatchesOtherKey(
+					check.That("azurerm_subnet.test1").Key("id"),
+				),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.vNetIntegration_subnet2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_network_subnet_id").MatchesOtherKey(
+					check.That("azurerm_subnet.test2").Key("id"),
+				),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.vNetIntegration_basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LogicAppStandardResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LogicAppStandardID(state.ID)
 	if err != nil {
@@ -1654,5 +1714,244 @@ resource "azurerm_app_service_plan" "test" {
     size = "WS1"
   }
 }
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (LogicAppStandardResource) vNetIntegration_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "elastic"
+  reserved            = true
+
+  sku {
+    tier = "WorkflowStandard"
+    size = "WS1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+	name                = "vnet-%[1]d"
+	address_space       = ["10.0.0.0/16"]
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+}
+
+	resource "azurerm_subnet" "test1" {
+	name                 = "subnet1"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.1.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+	resource "azurerm_subnet" "test2" {
+	name                 = "subnet2"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.2.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+
+resource "azurerm_logic_app_standard" "test" {
+	name                       = "acctest-%[1]d-func"
+	location                   = azurerm_resource_group.test.location
+	resource_group_name        = azurerm_resource_group.test.name
+	app_service_plan_id        = azurerm_app_service_plan.test.id
+	storage_account_name       = azurerm_storage_account.test.name
+	storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  
+	site_config {
+	  app_scale_limit = 1
+	}
+  }
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (LogicAppStandardResource) vNetIntegration_subnet1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "elastic"
+  reserved            = true
+
+  sku {
+    tier = "WorkflowStandard"
+    size = "WS1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+	name                = "vnet-%[1]d"
+	address_space       = ["10.0.0.0/16"]
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+}
+
+	resource "azurerm_subnet" "test1" {
+	name                 = "subnet1"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.1.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+	resource "azurerm_subnet" "test2" {
+	name                 = "subnet2"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.2.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+
+resource "azurerm_logic_app_standard" "test" {
+	name                       = "acctest-%[1]d-func"
+	location                   = azurerm_resource_group.test.location
+	resource_group_name        = azurerm_resource_group.test.name
+	app_service_plan_id        = azurerm_app_service_plan.test.id
+	storage_account_name       = azurerm_storage_account.test.name
+	storage_account_access_key = azurerm_storage_account.test.primary_access_key
+	virtual_network_subnet_id  = azurerm_subnet.test1.id
+  
+	site_config {
+	  app_scale_limit = 1
+	}
+  }
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (LogicAppStandardResource) vNetIntegration_subnet2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "elastic"
+  reserved            = true
+
+  sku {
+    tier = "WorkflowStandard"
+    size = "WS1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+	name                = "vnet-%[1]d"
+	address_space       = ["10.0.0.0/16"]
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+}
+
+	resource "azurerm_subnet" "test1" {
+	name                 = "subnet1"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.1.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+	resource "azurerm_subnet" "test2" {
+	name                 = "subnet2"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.2.0/24"]
+	delegation {
+		name = "delegation"
+		service_delegation {
+		name    = "Microsoft.Web/serverFarms"
+		actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+		}
+	}
+}
+
+resource "azurerm_logic_app_standard" "test" {
+	name                       = "acctest-%[1]d-func"
+	location                   = azurerm_resource_group.test.location
+	resource_group_name        = azurerm_resource_group.test.name
+	app_service_plan_id        = azurerm_app_service_plan.test.id
+	storage_account_name       = azurerm_storage_account.test.name
+	storage_account_access_key = azurerm_storage_account.test.primary_access_key
+	virtual_network_subnet_id  = azurerm_subnet.test2.id
+  
+	site_config {
+	  app_scale_limit = 1
+	}
+  }
+
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -11,9 +11,6 @@ description: |-
 
 Manages a Logic App (Standard / Single Tenant)
 
-~> **Note:** To connect an Azure Logic App and a subnet within the same region `azurerm_app_service_virtual_network_swift_connection` can be used.
-For an example, check the `azurerm_app_service_virtual_network_swift_connection` documentation.
-
 ## Example Usage (with App Service Plan)
 
 ```hcl
@@ -34,6 +31,8 @@ resource "azurerm_app_service_plan" "example" {
   name                = "azure-functions-test-service-plan"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
+  kind                = "elastic"
+
 
   sku {
     tier = "WorkflowStandard"
@@ -149,6 +148,12 @@ The following arguments are supported:
 ~> **Note:**  When using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
 
 * `version` - (Optional) The runtime version associated with the Logic App Defaults to `~1`.
+
+* `virtual_network_subnet_id` - (Optional) The subnet id which will be used by this resource for [regional virtual network integration](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#regional-virtual-network-integration).
+
+~> **NOTE on regional virtual network integration:** The AzureRM Terraform provider provides regional virtual network integration via the standalone resource [app_service_virtual_network_swift_connection](app_service_virtual_network_swift_connection.html) and in-line within this resource using the `virtual_network_subnet_id` property. You cannot use both methods simutaneously.
+
+~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Added support to perform virtual network integration within the `azurerm_logic_app_standard` resource. This enables attaching to subnets with the `join` action, and doesn't require full `write` action (required by the swift network connection resource).

Fixes the example (without kind = elastic, the app service plan re-creates each time terraform apply is run).

Fixes #15213