### PR TITLE
`azurerm_postgresql_aad_administrator`: Fix state migration

### DIFF
--- a/internal/services/postgres/migration/postgresql_aad_administrator.go
+++ b/internal/services/postgres/migration/postgresql_aad_administrator.go
@@ -62,7 +62,7 @@ func (PostgresqlAADAdministratorV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFun
 
 		newId := serveradministrators.NewServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-		rawState["id"] = newId
+		rawState["id"] = newId.ID()
 
 		return rawState, nil
 	}


### PR DESCRIPTION
Fixes #17727

With 3.14 to 3.15 with OP testcase:
```
[9:46](⎈ |eastus2-fxs-atlas-nonprod-fxc:ingress-controller)➜  terraform-tests/psql git:(kusto) ✗ $ tp
data.azurerm_client_config.current: Reading...
azurerm_resource_group.example: Refreshing state... [id=/subscriptions/442736d8-39d9-418c-9c0c-2cee7f5126a5/resourceGroups/azurerm-debug]
data.azurerm_client_config.current: Read complete after 0s [id=2022-07-23 07:47:07.200831 +0000 UTC]
azurerm_postgresql_server.example: Refreshing state... [id=/subscriptions/442736d8-39d9-418c-9c0c-2cee7f5126a5/resourceGroups/azurerm-debug/providers/Microsoft.DBforPostgreSQL/servers/azurerm-debug-psqlserver]
╷
│ Error: string is required
│
│   with azurerm_postgresql_active_directory_administrator.example,
│   on main.tf line 32, in resource "azurerm_postgresql_active_directory_administrator" "example":
│   32: resource "azurerm_postgresql_active_directory_administrator" "example" {
│
╵
```
With 3.14 to my branch:
```
[9:47](⎈ |eastus2-fxs-atlas-nonprod-fxc:ingress-controller)➜  terraform-tests/psql git:(kusto) ✗ $ tfdev
[9:47](⎈ |eastus2-fxs-atlas-nonprod-fxc:ingress-controller)➜  terraform-tests/psql git:(kusto) ✗ $ tp
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /Users/vlazarenko/go/bin
│  - hashicorp/kubernetes in /Users/vlazarenko/go/bin
│  - favoretti/adx in /Users/vlazarenko/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
azurerm_resource_group.example: Refreshing state... [id=/subscriptions/442736d8-39d9-418c-9c0c-2cee7f5126a5/resourceGroups/azurerm-debug]
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=2022-07-23 07:48:31.214973 +0000 UTC]
azurerm_postgresql_server.example: Refreshing state... [id=/subscriptions/442736d8-39d9-418c-9c0c-2cee7f5126a5/resourceGroups/azurerm-debug/providers/Microsoft.DBforPostgreSQL/servers/azurerm-debug-psqlserver]
azurerm_postgresql_active_directory_administrator.example: Refreshing state... [id=/subscriptions/442736d8-39d9-418c-9c0c-2cee7f5126a5/resourceGroups/azurerm-debug/providers/Microsoft.DBforPostgreSQL/servers/azurerm-debug-psqlserver]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```