### PR TITLE
bump go-azure-sdk to v0.20220725.1131927

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.37.0
-	github.com/hashicorp/go-azure-sdk v0.20220722.1091911
+	github.com/hashicorp/go-azure-sdk v0.20220725.1131927
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.37.0 h1:6UOoQ9esE4MJ4wHJr21qU81IJQ9zsXQ9FbANYUbeE4U=
 github.com/hashicorp/go-azure-helpers v0.37.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
-github.com/hashicorp/go-azure-sdk v0.20220722.1091911 h1:JuMp/yYznrR2vf6+rmoA/a//MDMzZoydr6DAqUTL8ew=
-github.com/hashicorp/go-azure-sdk v0.20220722.1091911/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
+github.com/hashicorp/go-azure-sdk v0.20220725.1131927 h1:Tm7L8fsHq/apZ8Q2ulF6Mm0ZxOXKbwGdWoG2DHvgrEE=
+github.com/hashicorp/go-azure-sdk v0.20220725.1131927/go.mod h1:yjQPw8DCOtQR8E8+FNaTxF6yz+tyQGkDNiVAGCNoLOo=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/internal/services/analysisservices/analysis_services_server_resource.go
@@ -107,7 +107,7 @@ func resourceAnalysisServicesServer() *pluginsdk.Resource {
 						},
 					},
 				},
-				Set: hashAnalysisServicesServerIpv4FirewallRule,
+				Set: hashAnalysisServicesServerIPv4FirewallRule,
 			},
 
 			"querypool_connection_mode": {
@@ -323,7 +323,7 @@ func expandAnalysisServicesServerProperties(d *pluginsdk.ResourceData) *servers.
 		AsAdministrators: adminUsers,
 	}
 
-	serverProperties.IpV4FirewallSettings = expandAnalysisServicesServerFirewallSettings(d)
+	serverProperties.IPV4FirewallSettings = expandAnalysisServicesServerFirewallSettings(d)
 
 	if querypoolConnectionMode, ok := d.GetOk("querypool_connection_mode"); ok {
 		connectionMode := servers.ConnectionMode(querypoolConnectionMode.(string))
@@ -344,7 +344,7 @@ func expandAnalysisServicesServerMutableProperties(d *pluginsdk.ResourceData) *s
 		AsAdministrators: adminUsers,
 	}
 
-	serverProperties.IpV4FirewallSettings = expandAnalysisServicesServerFirewallSettings(d)
+	serverProperties.IPV4FirewallSettings = expandAnalysisServicesServerFirewallSettings(d)
 
 	connectionMode := servers.ConnectionMode(d.Get("querypool_connection_mode").(string))
 	serverProperties.QuerypoolConnectionMode = &connectionMode
@@ -393,11 +393,11 @@ func expandAnalysisServicesServerFirewallSettings(d *pluginsdk.ResourceData) *se
 }
 
 func flattenAnalysisServicesServerFirewallSettings(serverProperties *servers.AnalysisServicesServerProperties) (*bool, *pluginsdk.Set) {
-	if serverProperties == nil || serverProperties.IpV4FirewallSettings == nil {
-		return utils.Bool(false), pluginsdk.NewSet(hashAnalysisServicesServerIpv4FirewallRule, make([]interface{}, 0))
+	if serverProperties == nil || serverProperties.IPV4FirewallSettings == nil {
+		return utils.Bool(false), pluginsdk.NewSet(hashAnalysisServicesServerIPv4FirewallRule, make([]interface{}, 0))
 	}
 
-	firewallSettings := serverProperties.IpV4FirewallSettings
+	firewallSettings := serverProperties.IPV4FirewallSettings
 
 	enablePowerBi := utils.Bool(false)
 	if firewallSettings.EnablePowerBIService != nil {
@@ -424,10 +424,10 @@ func flattenAnalysisServicesServerFirewallSettings(serverProperties *servers.Ana
 		}
 	}
 
-	return enablePowerBi, pluginsdk.NewSet(hashAnalysisServicesServerIpv4FirewallRule, fwRules)
+	return enablePowerBi, pluginsdk.NewSet(hashAnalysisServicesServerIPv4FirewallRule, fwRules)
 }
 
-func hashAnalysisServicesServerIpv4FirewallRule(v interface{}) int {
+func hashAnalysisServicesServerIPv4FirewallRule(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -636,10 +636,10 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 	defaultAction := cognitiveservicesaccounts.NetworkRuleAction(v["default_action"].(string))
 
 	ipRulesRaw := v["ip_rules"].(*pluginsdk.Set)
-	ipRules := make([]cognitiveservicesaccounts.IpRule, 0)
+	ipRules := make([]cognitiveservicesaccounts.IPRule, 0)
 
 	for _, v := range ipRulesRaw.List() {
-		rule := cognitiveservicesaccounts.IpRule{
+		rule := cognitiveservicesaccounts.IPRule{
 			Value: v.(string),
 		}
 		ipRules = append(ipRules, rule)
@@ -660,7 +660,7 @@ func expandCognitiveAccountNetworkAcls(d *pluginsdk.ResourceData) (*cognitiveser
 
 	ruleSet := cognitiveservicesaccounts.NetworkRuleSet{
 		DefaultAction:       &defaultAction,
-		IpRules:             &ipRules,
+		IPRules:             &ipRules,
 		VirtualNetworkRules: &networkRules,
 	}
 	return &ruleSet, subnetIds
@@ -735,8 +735,8 @@ func flattenCognitiveAccountNetworkAcls(input *cognitiveservicesaccounts.Network
 	}
 
 	ipRules := make([]interface{}, 0)
-	if input.IpRules != nil {
-		for _, v := range *input.IpRules {
+	if input.IPRules != nil {
+		for _, v := range *input.IPRules {
 			ipRules = append(ipRules, v.Value)
 		}
 	}

--- a/internal/services/containers/container_group_data_source.go
+++ b/internal/services/containers/container_group_data_source.go
@@ -76,8 +76,8 @@ func dataSourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) e
 			return err
 		}
 		props := model.Properties
-		if address := props.IpAddress; address != nil {
-			d.Set("ip_address", address.Ip)
+		if address := props.IPAddress; address != nil {
+			d.Set("ip_address", address.IP)
 			d.Set("fqdn", address.Fqdn)
 		}
 	}

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -63,11 +63,11 @@ func resourceContainerGroup() *pluginsdk.Resource {
 			"ip_address_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(containerinstance.ContainerGroupIpAddressTypePublic),
+				Default:  string(containerinstance.ContainerGroupIPAddressTypePublic),
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(containerinstance.ContainerGroupIpAddressTypePublic),
-					string(containerinstance.ContainerGroupIpAddressTypePrivate),
+					string(containerinstance.ContainerGroupIPAddressTypePublic),
+					string(containerinstance.ContainerGroupIPAddressTypePrivate),
 					"None",
 				}, false),
 			},
@@ -678,13 +678,13 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if IPAddressType != "None" {
-		containerGroup.Properties.IpAddress = &containerinstance.IpAddress{
+		containerGroup.Properties.IPAddress = &containerinstance.IPAddress{
 			Ports: containerGroupPorts,
-			Type:  containerinstance.ContainerGroupIpAddressType(IPAddressType),
+			Type:  containerinstance.ContainerGroupIPAddressType(IPAddressType),
 		}
 
 		if dnsNameLabel := d.Get("dns_name_label").(string); dnsNameLabel != "" {
-			containerGroup.Properties.IpAddress.DnsNameLabel = &dnsNameLabel
+			containerGroup.Properties.IPAddress.DnsNameLabel = &dnsNameLabel
 		}
 	}
 
@@ -800,9 +800,9 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 			return fmt.Errorf("setting `image_registry_credential`: %+v", err)
 		}
 
-		if address := props.IpAddress; address != nil {
+		if address := props.IPAddress; address != nil {
 			d.Set("ip_address_type", address.Type)
-			d.Set("ip_address", address.Ip)
+			d.Set("ip_address", address.IP)
 			exposedPorts := make([]interface{}, len(address.Ports))
 			for i := range address.Ports {
 				exposedPorts[i] = (address.Ports)[i]

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -684,7 +684,7 @@ func flattenWorkspaceCustomParameters(input *workspaces.WorkspaceCustomParameter
 		parameters["nat_gateway_name"] = v.Value
 	}
 
-	if v := input.PublicIpName; v != nil {
+	if v := input.PublicIPName; v != nil {
 		parameters["public_ip_name"] = v.Value
 	}
 
@@ -704,7 +704,7 @@ func flattenWorkspaceCustomParameters(input *workspaces.WorkspaceCustomParameter
 		parameters["machine_learning_workspace_id"] = v.Value
 	}
 
-	if v := input.EnableNoPublicIp; v != nil {
+	if v := input.EnableNoPublicIP; v != nil {
 		parameters["no_public_ip"] = v.Value
 	}
 
@@ -779,7 +779,7 @@ func expandWorkspaceCustomParameters(input []interface{}, customerManagedKeyEnab
 	}
 
 	if v, ok := config["public_ip_name"].(string); ok && v != "" {
-		parameters.PublicIpName = &workspaces.WorkspaceCustomStringParameter{
+		parameters.PublicIPName = &workspaces.WorkspaceCustomStringParameter{
 			Value: v,
 		}
 	}
@@ -809,7 +809,7 @@ func expandWorkspaceCustomParameters(input []interface{}, customerManagedKeyEnab
 	}
 
 	if v, ok := config["no_public_ip"].(bool); ok {
-		parameters.EnableNoPublicIp = &workspaces.WorkspaceCustomBooleanParameter{
+		parameters.EnableNoPublicIP = &workspaces.WorkspaceCustomBooleanParameter{
 			Value: v,
 		}
 	}

--- a/internal/services/domainservices/active_directory_domain_service_replica_set_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_replica_set_resource.go
@@ -231,8 +231,8 @@ func resourceActiveDirectoryDomainServiceReplicaSetRead(d *pluginsdk.ResourceDat
 	}
 
 	var (
-		domainControllerIpAddresses []string
-		externalAccessIpAddress     string
+		domainControllerIPAddresses []string
+		externalAccessIPAddress     string
 		loc                         string
 		serviceStatus               string
 		subnetId                    string
@@ -247,11 +247,11 @@ func resourceActiveDirectoryDomainServiceReplicaSetRead(d *pluginsdk.ResourceDat
 
 		// ReplicaSetName in the ID struct is really the replica set ID
 		if *r.ReplicaSetId == id.ReplicaSetName {
-			if r.DomainControllerIpAddress != nil {
-				domainControllerIpAddresses = *r.DomainControllerIpAddress
+			if r.DomainControllerIPAddress != nil {
+				domainControllerIPAddresses = *r.DomainControllerIPAddress
 			}
-			if r.ExternalAccessIpAddress != nil {
-				externalAccessIpAddress = *r.ExternalAccessIpAddress
+			if r.ExternalAccessIPAddress != nil {
+				externalAccessIPAddress = *r.ExternalAccessIPAddress
 			}
 			if r.Location != nil {
 				loc = location.NormalizeNilable(r.Location)
@@ -265,8 +265,8 @@ func resourceActiveDirectoryDomainServiceReplicaSetRead(d *pluginsdk.ResourceDat
 		}
 	}
 
-	d.Set("domain_controller_ip_addresses", domainControllerIpAddresses)
-	d.Set("external_access_ip_address", externalAccessIpAddress)
+	d.Set("domain_controller_ip_addresses", domainControllerIPAddresses)
+	d.Set("external_access_ip_address", externalAccessIPAddress)
 	d.Set("location", loc)
 	d.Set("service_status", serviceStatus)
 	d.Set("subnet_id", subnetId)

--- a/internal/services/domainservices/active_directory_domain_service_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_resource.go
@@ -565,7 +565,7 @@ func domainServiceControllerRefreshFunc(ctx context.Context, client *domainservi
 			case !strings.EqualFold(*repl.ServiceStatus, "Running"):
 				// If it's not yet running, it isn't ready
 				return resp, "pending", nil
-			case repl.DomainControllerIpAddress == nil || len(*repl.DomainControllerIpAddress) < 2:
+			case repl.DomainControllerIPAddress == nil || len(*repl.DomainControllerIPAddress) < 2:
 				// When a domain controller is online, its IP address will be returned. We're looking for 2 active domain controllers.
 				return resp, "pending", nil
 			}
@@ -744,11 +744,11 @@ func flattenDomainServiceReplicaSets(input *[]domainservices.ReplicaSet) (ret []
 			"service_status":                 "",
 			"subnet_id":                      "",
 		}
-		if in.DomainControllerIpAddress != nil {
-			repl["domain_controller_ip_addresses"] = *in.DomainControllerIpAddress
+		if in.DomainControllerIPAddress != nil {
+			repl["domain_controller_ip_addresses"] = *in.DomainControllerIPAddress
 		}
-		if in.ExternalAccessIpAddress != nil {
-			repl["external_access_ip_address"] = *in.ExternalAccessIpAddress
+		if in.ExternalAccessIPAddress != nil {
+			repl["external_access_ip_address"] = *in.ExternalAccessIPAddress
 		}
 		if in.ReplicaSetId != nil {
 			repl["id"] = *in.ReplicaSetId

--- a/internal/services/domainservices/active_directory_domain_service_trust_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_trust_resource.go
@@ -132,7 +132,7 @@ func (r DomainServiceTrustResource) Create() sdk.ResourceFunc {
 				TrustedDomainFqdn: utils.String(plan.TrustedDomainFqdn),
 				TrustDirection:    utils.String("Inbound"),
 				FriendlyName:      utils.String(id.TrustName),
-				RemoteDnsIps:      utils.String(strings.Join(plan.TrustedDomainDnsIPs, ",")),
+				RemoteDnsIPs:      utils.String(strings.Join(plan.TrustedDomainDnsIPs, ",")),
 				TrustPassword:     utils.String(plan.Password),
 			})
 			params := domainservices.DomainService{
@@ -227,8 +227,8 @@ func (r DomainServiceTrustResource) Read() sdk.ResourceFunc {
 				data.TrustedDomainFqdn = *trust.TrustedDomainFqdn
 			}
 
-			if trust.RemoteDnsIps != nil {
-				data.TrustedDomainDnsIPs = strings.Split(*trust.RemoteDnsIps, ",")
+			if trust.RemoteDnsIPs != nil {
+				data.TrustedDomainDnsIPs = strings.Split(*trust.RemoteDnsIPs, ",")
 			}
 
 			return metadata.Encode(&data)
@@ -352,7 +352,7 @@ func (r DomainServiceTrustResource) Update() sdk.ResourceFunc {
 						trust.TrustedDomainFqdn = utils.String(plan.TrustedDomainFqdn)
 					}
 					if metadata.ResourceData.HasChange("trusted_domain_dns_ips") {
-						trust.RemoteDnsIps = utils.String(strings.Join(plan.TrustedDomainDnsIPs, ","))
+						trust.RemoteDnsIPs = utils.String(strings.Join(plan.TrustedDomainDnsIPs, ","))
 					}
 					trust.TrustPassword = utils.String(plan.Password)
 				}

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -625,11 +625,11 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 
 	if v, ok := block["ip_rule"].([]interface{}); ok {
 		if len(v) > 0 {
-			var rules []networkrulesets.NWRuleSetIpRules
+			var rules []networkrulesets.NWRuleSetIPRules
 			for _, r := range v {
 				rblock := r.(map[string]interface{})
-				rules = append(rules, networkrulesets.NWRuleSetIpRules{
-					IpMask: utils.String(rblock["ip_mask"].(string)),
+				rules = append(rules, networkrulesets.NWRuleSetIPRules{
+					IPMask: utils.String(rblock["ip_mask"].(string)),
 					Action: func() *networkrulesets.NetworkRuleIPAction {
 						v := networkrulesets.NetworkRuleIPAction(rblock["action"].(string))
 						return &v
@@ -637,7 +637,7 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 				})
 			}
 
-			ruleset.IpRules = &rules
+			ruleset.IPRules = &rules
 		}
 	}
 
@@ -668,7 +668,7 @@ func flattenEventHubNamespaceNetworkRuleset(ruleset networkrulesets.NamespacesGe
 		}
 	}
 	ipBlocks := make([]interface{}, 0)
-	if ipRules := ruleset.Model.Properties.IpRules; ipRules != nil {
+	if ipRules := ruleset.Model.Properties.IPRules; ipRules != nil {
 		for _, ipRule := range *ipRules {
 			block := make(map[string]interface{})
 
@@ -679,7 +679,7 @@ func flattenEventHubNamespaceNetworkRuleset(ruleset networkrulesets.NamespacesGe
 
 			block["action"] = action
 
-			if v := ipRule.IpMask; v != nil {
+			if v := ipRule.IPMask; v != nil {
 				block["ip_mask"] = *v
 			}
 

--- a/internal/services/hsm/dedicated_hardware_security_module_resource.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource.go
@@ -264,7 +264,7 @@ func expandDedicatedHsmNetworkInterfacePrivateIPAddresses(input []interface{}) *
 	for _, item := range input {
 		if item != nil {
 			results = append(results, dedicatedhsms.NetworkInterface{
-				PrivateIpAddress: utils.String(item.(string)),
+				PrivateIPAddress: utils.String(item.(string)),
 			})
 		}
 	}
@@ -297,8 +297,8 @@ func flattenDedicatedHsmNetworkInterfacePrivateIPAddresses(input *[]dedicatedhsm
 	}
 
 	for _, item := range *input {
-		if item.PrivateIpAddress != nil {
-			results = append(results, *item.PrivateIpAddress)
+		if item.PrivateIPAddress != nil {
+			results = append(results, *item.PrivateIPAddress)
 		}
 	}
 

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -1084,8 +1084,8 @@ func flattenNetAppVolumeMountIPAddresses(input *[]volumes.MountTargetProperties)
 	}
 
 	for _, item := range *input {
-		if item.IpAddress != nil {
-			results = append(results, item.IpAddress)
+		if item.IPAddress != nil {
+			results = append(results, item.IPAddress)
 		}
 	}
 

--- a/internal/services/postgres/postgresql_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_firewall_rule_resource.go
@@ -91,8 +91,8 @@ func resourcePostgreSQLFirewallRuleCreate(d *pluginsdk.ResourceData, meta interf
 
 	properties := firewallrules.FirewallRule{
 		Properties: firewallrules.FirewallRuleProperties{
-			StartIpAddress: d.Get("start_ip_address").(string),
-			EndIpAddress:   d.Get("end_ip_address").(string),
+			StartIPAddress: d.Get("start_ip_address").(string),
+			EndIPAddress:   d.Get("end_ip_address").(string),
 		},
 	}
 
@@ -130,8 +130,8 @@ func resourcePostgreSQLFirewallRuleRead(d *pluginsdk.ResourceData, meta interfac
 	d.Set("server_name", id.ServerName)
 
 	if model := resp.Model; model != nil {
-		d.Set("start_ip_address", resp.Model.Properties.StartIpAddress)
-		d.Set("end_ip_address", resp.Model.Properties.EndIpAddress)
+		d.Set("start_ip_address", resp.Model.Properties.StartIPAddress)
+		d.Set("end_ip_address", resp.Model.Properties.EndIPAddress)
 	}
 
 	return nil

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
@@ -91,8 +91,8 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 
 	properties := firewallrules.FirewallRule{
 		Properties: firewallrules.FirewallRuleProperties{
-			EndIpAddress:   d.Get("end_ip_address").(string),
-			StartIpAddress: d.Get("start_ip_address").(string),
+			EndIPAddress:   d.Get("end_ip_address").(string),
+			StartIPAddress: d.Get("start_ip_address").(string),
 		},
 	}
 
@@ -128,8 +128,8 @@ func resourcePostgresqlFlexibleServerFirewallRuleRead(d *pluginsdk.ResourceData,
 	d.Set("server_id", firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.ServerName).ID())
 
 	if model := resp.Model; model != nil {
-		d.Set("end_ip_address", model.Properties.EndIpAddress)
-		d.Set("start_ip_address", model.Properties.StartIpAddress)
+		d.Set("end_ip_address", model.Properties.EndIPAddress)
+		d.Set("start_ip_address", model.Properties.StartIPAddress)
 	}
 	return nil
 }

--- a/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/internal/services/privatedns/private_dns_a_record_resource.go
@@ -192,11 +192,11 @@ func flattenAzureRmPrivateDnsARecords(records *[]recordsets.ARecord) []string {
 	}
 
 	for _, record := range *records {
-		if record.Ipv4Address == nil {
+		if record.IPv4Address == nil {
 			continue
 		}
 
-		results = append(results, *record.Ipv4Address)
+		results = append(results, *record.IPv4Address)
 	}
 
 	return results
@@ -209,7 +209,7 @@ func expandAzureRmPrivateDnsARecords(d *pluginsdk.ResourceData) *[]recordsets.AR
 	for i, v := range recordStrings {
 		ipv4 := v.(string)
 		records[i] = recordsets.ARecord{
-			Ipv4Address: &ipv4,
+			IPv4Address: &ipv4,
 		}
 	}
 

--- a/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -188,11 +188,11 @@ func flattenAzureRmPrivateDnsAaaaRecords(records *[]recordsets.AaaaRecord) []str
 	}
 
 	for _, record := range *records {
-		if record.Ipv6Address == nil {
+		if record.IPv6Address == nil {
 			continue
 		}
 
-		results = append(results, *record.Ipv6Address)
+		results = append(results, *record.IPv6Address)
 	}
 
 	return results
@@ -205,7 +205,7 @@ func expandAzureRmPrivateDnsAaaaRecords(d *pluginsdk.ResourceData) *[]recordsets
 	for i, v := range recordStrings {
 		ipv6 := v.(string)
 		records[i] = recordsets.AaaaRecord{
-			Ipv6Address: &ipv6,
+			IPv6Address: &ipv6,
 		}
 	}
 

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -175,7 +175,7 @@ func resourceSearchServiceCreateUpdate(d *pluginsdk.ResourceData, meta interface
 		Properties: &services.SearchServiceProperties{
 			PublicNetworkAccess: &publicNetworkAccess,
 			NetworkRuleSet: &services.NetworkRuleSet{
-				IpRules: expandSearchServiceIPRules(d.Get("allowed_ips").([]interface{})),
+				IPRules: expandSearchServiceIPRules(d.Get("allowed_ips").([]interface{})),
 			},
 		},
 		Identity: expandedIdentity,
@@ -335,15 +335,15 @@ func flattenSearchQueryKeys(input []querykeys.QueryKey) []interface{} {
 	return results
 }
 
-func expandSearchServiceIPRules(input []interface{}) *[]services.IpRule {
-	output := make([]services.IpRule, 0)
+func expandSearchServiceIPRules(input []interface{}) *[]services.IPRule {
+	output := make([]services.IPRule, 0)
 	if input == nil {
 		return &output
 	}
 
 	for _, rule := range input {
 		if rule != nil {
-			output = append(output, services.IpRule{
+			output = append(output, services.IPRule{
 				Value: utils.String(rule.(string)),
 			})
 		}
@@ -353,11 +353,11 @@ func expandSearchServiceIPRules(input []interface{}) *[]services.IpRule {
 }
 
 func flattenSearchServiceIPRules(input *services.NetworkRuleSet) []interface{} {
-	if input == nil || *input.IpRules == nil || len(*input.IpRules) == 0 {
+	if input == nil || *input.IPRules == nil || len(*input.IPRules) == 0 {
 		return nil
 	}
 	result := make([]interface{}, 0)
-	for _, rule := range *input.IpRules {
+	for _, rule := range *input.IPRules {
 		result = append(result, rule.Value)
 	}
 	return result

--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
@@ -158,7 +158,7 @@ func resourceServiceBusNamespaceNetworkRuleSetCreateUpdate(d *pluginsdk.Resource
 		Properties: &namespaces.NetworkRuleSetProperties{
 			DefaultAction:               &defaultAction,
 			VirtualNetworkRules:         vnetRule,
-			IpRules:                     ipRule,
+			IPRules:                     ipRule,
 			PublicNetworkAccess:         &publicNetworkAccess,
 			TrustedServiceAccessEnabled: utils.Bool(d.Get("trusted_services_allowed").(bool)),
 		},
@@ -212,7 +212,7 @@ func resourceServiceBusNamespaceNetworkRuleSetRead(d *pluginsdk.ResourceData, me
 				return fmt.Errorf("failed to set `network_rules`: %+v", err)
 			}
 
-			if err := d.Set("ip_rules", flattenServiceBusNamespaceIPRules(props.IpRules)); err != nil {
+			if err := d.Set("ip_rules", flattenServiceBusNamespaceIPRules(props.IPRules)); err != nil {
 				return fmt.Errorf("failed to set `ip_rules`: %+v", err)
 			}
 		}
@@ -293,16 +293,16 @@ func flattenServiceBusNamespaceVirtualNetworkRules(input *[]namespaces.NWRuleSet
 	return result
 }
 
-func expandServiceBusNamespaceIPRules(input []interface{}) *[]namespaces.NWRuleSetIpRules {
+func expandServiceBusNamespaceIPRules(input []interface{}) *[]namespaces.NWRuleSetIPRules {
 	if len(input) == 0 {
 		return nil
 	}
 
 	action := namespaces.NetworkRuleIPActionAllow
-	result := make([]namespaces.NWRuleSetIpRules, 0)
+	result := make([]namespaces.NWRuleSetIPRules, 0)
 	for _, v := range input {
-		result = append(result, namespaces.NWRuleSetIpRules{
-			IpMask: utils.String(v.(string)),
+		result = append(result, namespaces.NWRuleSetIPRules{
+			IPMask: utils.String(v.(string)),
 			Action: &action,
 		})
 	}
@@ -310,15 +310,15 @@ func expandServiceBusNamespaceIPRules(input []interface{}) *[]namespaces.NWRuleS
 	return &result
 }
 
-func flattenServiceBusNamespaceIPRules(input *[]namespaces.NWRuleSetIpRules) []interface{} {
+func flattenServiceBusNamespaceIPRules(input *[]namespaces.NWRuleSetIPRules) []interface{} {
 	result := make([]interface{}, 0)
 	if input == nil || len(*input) == 0 {
 		return result
 	}
 
 	for _, v := range *input {
-		if v.IpMask != nil {
-			result = append(result, *v.IpMask)
+		if v.IPMask != nil {
+			result = append(result, *v.IPMask)
 		}
 	}
 
@@ -347,7 +347,7 @@ func CheckNetworkRuleNullified(resp namespaces.NetworkRuleSet) bool {
 			return false
 		}
 
-		if props.IpRules != nil && len(*props.IpRules) > 0 {
+		if props.IPRules != nil && len(*props.IPRules) > 0 {
 			return false
 		}
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2020-01-01/domainservices/model_foresttrust.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2020-01-01/domainservices/model_foresttrust.go
@@ -5,7 +5,7 @@ package domainservices
 
 type ForestTrust struct {
 	FriendlyName      *string `json:"friendlyName,omitempty"`
-	RemoteDnsIps      *string `json:"remoteDnsIps,omitempty"`
+	RemoteDnsIPs      *string `json:"remoteDnsIps,omitempty"`
 	TrustDirection    *string `json:"trustDirection,omitempty"`
 	TrustPassword     *string `json:"trustPassword,omitempty"`
 	TrustedDomainFqdn *string `json:"trustedDomainFqdn,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2020-01-01/domainservices/model_replicaset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2020-01-01/domainservices/model_replicaset.go
@@ -4,8 +4,8 @@ package domainservices
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ReplicaSet struct {
-	DomainControllerIpAddress *[]string        `json:"domainControllerIpAddress,omitempty"`
-	ExternalAccessIpAddress   *string          `json:"externalAccessIpAddress,omitempty"`
+	DomainControllerIPAddress *[]string        `json:"domainControllerIpAddress,omitempty"`
+	ExternalAccessIPAddress   *string          `json:"externalAccessIpAddress,omitempty"`
 	HealthAlerts              *[]HealthAlert   `json:"healthAlerts,omitempty"`
 	HealthLastEvaluated       *string          `json:"healthLastEvaluated,omitempty"`
 	HealthMonitors            *[]HealthMonitor `json:"healthMonitors,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/model_analysisservicesservermutableproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/model_analysisservicesservermutableproperties.go
@@ -7,7 +7,7 @@ type AnalysisServicesServerMutableProperties struct {
 	AsAdministrators        *ServerAdministrators `json:"asAdministrators,omitempty"`
 	BackupBlobContainerUri  *string               `json:"backupBlobContainerUri,omitempty"`
 	GatewayDetails          *GatewayDetails       `json:"gatewayDetails,omitempty"`
-	IpV4FirewallSettings    *IPv4FirewallSettings `json:"ipV4FirewallSettings,omitempty"`
+	IPV4FirewallSettings    *IPv4FirewallSettings `json:"ipV4FirewallSettings,omitempty"`
 	ManagedMode             *ManagedMode          `json:"managedMode,omitempty"`
 	QuerypoolConnectionMode *ConnectionMode       `json:"querypoolConnectionMode,omitempty"`
 	ServerMonitorMode       *ServerMonitorMode    `json:"serverMonitorMode,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/model_analysisservicesserverproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/model_analysisservicesserverproperties.go
@@ -7,7 +7,7 @@ type AnalysisServicesServerProperties struct {
 	AsAdministrators        *ServerAdministrators `json:"asAdministrators,omitempty"`
 	BackupBlobContainerUri  *string               `json:"backupBlobContainerUri,omitempty"`
 	GatewayDetails          *GatewayDetails       `json:"gatewayDetails,omitempty"`
-	IpV4FirewallSettings    *IPv4FirewallSettings `json:"ipV4FirewallSettings,omitempty"`
+	IPV4FirewallSettings    *IPv4FirewallSettings `json:"ipV4FirewallSettings,omitempty"`
 	ManagedMode             *ManagedMode          `json:"managedMode,omitempty"`
 	ProvisioningState       *ProvisioningState    `json:"provisioningState,omitempty"`
 	QuerypoolConnectionMode *ConnectionMode       `json:"querypoolConnectionMode,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_iprule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_iprule.go
@@ -3,6 +3,6 @@ package cognitiveservicesaccounts
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type IpRule struct {
+type IPRule struct {
 	Value string `json:"value"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_networkruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_networkruleset.go
@@ -5,6 +5,6 @@ package cognitiveservicesaccounts
 
 type NetworkRuleSet struct {
 	DefaultAction       *NetworkRuleAction    `json:"defaultAction,omitempty"`
-	IpRules             *[]IpRule             `json:"ipRules,omitempty"`
+	IPRules             *[]IPRule             `json:"ipRules,omitempty"`
 	VirtualNetworkRules *[]VirtualNetworkRule `json:"virtualNetworkRules,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/constants.go
@@ -5,31 +5,31 @@ import "strings"
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type ContainerGroupIpAddressType string
+type ContainerGroupIPAddressType string
 
 const (
-	ContainerGroupIpAddressTypePrivate ContainerGroupIpAddressType = "Private"
-	ContainerGroupIpAddressTypePublic  ContainerGroupIpAddressType = "Public"
+	ContainerGroupIPAddressTypePrivate ContainerGroupIPAddressType = "Private"
+	ContainerGroupIPAddressTypePublic  ContainerGroupIPAddressType = "Public"
 )
 
-func PossibleValuesForContainerGroupIpAddressType() []string {
+func PossibleValuesForContainerGroupIPAddressType() []string {
 	return []string{
-		string(ContainerGroupIpAddressTypePrivate),
-		string(ContainerGroupIpAddressTypePublic),
+		string(ContainerGroupIPAddressTypePrivate),
+		string(ContainerGroupIPAddressTypePublic),
 	}
 }
 
-func parseContainerGroupIpAddressType(input string) (*ContainerGroupIpAddressType, error) {
-	vals := map[string]ContainerGroupIpAddressType{
-		"private": ContainerGroupIpAddressTypePrivate,
-		"public":  ContainerGroupIpAddressTypePublic,
+func parseContainerGroupIPAddressType(input string) (*ContainerGroupIPAddressType, error) {
+	vals := map[string]ContainerGroupIPAddressType{
+		"private": ContainerGroupIPAddressTypePrivate,
+		"public":  ContainerGroupIPAddressTypePublic,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil
 	}
 
 	// otherwise presume it's an undefined value and best-effort it
-	out := ContainerGroupIpAddressType(input)
+	out := ContainerGroupIPAddressType(input)
 	return &out, nil
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_capabilities.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_capabilities.go
@@ -6,7 +6,7 @@ package containerinstance
 type Capabilities struct {
 	Capabilities  *CapabilitiesCapabilities `json:"capabilities,omitempty"`
 	Gpu           *string                   `json:"gpu,omitempty"`
-	IpAddressType *string                   `json:"ipAddressType,omitempty"`
+	IPAddressType *string                   `json:"ipAddressType,omitempty"`
 	Location      *string                   `json:"location,omitempty"`
 	OsType        *string                   `json:"osType,omitempty"`
 	ResourceType  *string                   `json:"resourceType,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_containergroupproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_containergroupproperties.go
@@ -8,10 +8,10 @@ type ContainerGroupProperties struct {
 	Diagnostics              *ContainerGroupDiagnostics            `json:"diagnostics,omitempty"`
 	DnsConfig                *DnsConfiguration                     `json:"dnsConfig,omitempty"`
 	EncryptionProperties     *EncryptionProperties                 `json:"encryptionProperties,omitempty"`
+	IPAddress                *IPAddress                            `json:"ipAddress,omitempty"`
 	ImageRegistryCredentials *[]ImageRegistryCredential            `json:"imageRegistryCredentials,omitempty"`
 	InitContainers           *[]InitContainerDefinition            `json:"initContainers,omitempty"`
 	InstanceView             *ContainerGroupPropertiesInstanceView `json:"instanceView,omitempty"`
-	IpAddress                *IpAddress                            `json:"ipAddress,omitempty"`
 	NetworkProfile           *ContainerGroupNetworkProfile         `json:"networkProfile,omitempty"`
 	OsType                   OperatingSystemTypes                  `json:"osType"`
 	ProvisioningState        *string                               `json:"provisioningState,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_ipaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/model_ipaddress.go
@@ -3,10 +3,10 @@ package containerinstance
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type IpAddress struct {
+type IPAddress struct {
 	DnsNameLabel *string                     `json:"dnsNameLabel,omitempty"`
 	Fqdn         *string                     `json:"fqdn,omitempty"`
-	Ip           *string                     `json:"ip,omitempty"`
+	IP           *string                     `json:"ip,omitempty"`
 	Ports        []Port                      `json:"ports"`
-	Type         ContainerGroupIpAddressType `json:"type"`
+	Type         ContainerGroupIPAddressType `json:"type"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-03-01/containerinstance/predicates.go
@@ -20,7 +20,7 @@ func (p CachedImagesOperationPredicate) Matches(input CachedImages) bool {
 
 type CapabilitiesOperationPredicate struct {
 	Gpu           *string
-	IpAddressType *string
+	IPAddressType *string
 	Location      *string
 	OsType        *string
 	ResourceType  *string
@@ -32,7 +32,7 @@ func (p CapabilitiesOperationPredicate) Matches(input Capabilities) bool {
 		return false
 	}
 
-	if p.IpAddressType != nil && (input.IpAddressType == nil && *p.IpAddressType != *input.IpAddressType) {
+	if p.IPAddressType != nil && (input.IPAddressType == nil && *p.IPAddressType != *input.IPAddressType) {
 		return false
 	}
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2021-04-01-preview/workspaces/model_workspacecustomparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2021-04-01-preview/workspaces/model_workspacecustomparameters.go
@@ -8,13 +8,13 @@ type WorkspaceCustomParameters struct {
 	CustomPrivateSubnetName         *WorkspaceCustomStringParameter  `json:"customPrivateSubnetName,omitempty"`
 	CustomPublicSubnetName          *WorkspaceCustomStringParameter  `json:"customPublicSubnetName,omitempty"`
 	CustomVirtualNetworkId          *WorkspaceCustomStringParameter  `json:"customVirtualNetworkId,omitempty"`
-	EnableNoPublicIp                *WorkspaceCustomBooleanParameter `json:"enableNoPublicIp,omitempty"`
+	EnableNoPublicIP                *WorkspaceCustomBooleanParameter `json:"enableNoPublicIp,omitempty"`
 	Encryption                      *WorkspaceEncryptionParameter    `json:"encryption,omitempty"`
 	LoadBalancerBackendPoolName     *WorkspaceCustomStringParameter  `json:"loadBalancerBackendPoolName,omitempty"`
 	LoadBalancerId                  *WorkspaceCustomStringParameter  `json:"loadBalancerId,omitempty"`
 	NatGatewayName                  *WorkspaceCustomStringParameter  `json:"natGatewayName,omitempty"`
 	PrepareEncryption               *WorkspaceCustomBooleanParameter `json:"prepareEncryption,omitempty"`
-	PublicIpName                    *WorkspaceCustomStringParameter  `json:"publicIpName,omitempty"`
+	PublicIPName                    *WorkspaceCustomStringParameter  `json:"publicIpName,omitempty"`
 	RequireInfrastructureEncryption *WorkspaceCustomBooleanParameter `json:"requireInfrastructureEncryption,omitempty"`
 	ResourceTags                    *WorkspaceCustomObjectParameter  `json:"resourceTags,omitempty"`
 	StorageAccountName              *WorkspaceCustomStringParameter  `json:"storageAccountName,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/model_networkrulesetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/model_networkrulesetproperties.go
@@ -5,7 +5,7 @@ package networkrulesets
 
 type NetworkRuleSetProperties struct {
 	DefaultAction               *DefaultAction                  `json:"defaultAction,omitempty"`
-	IpRules                     *[]NWRuleSetIpRules             `json:"ipRules,omitempty"`
+	IPRules                     *[]NWRuleSetIPRules             `json:"ipRules,omitempty"`
 	PublicNetworkAccess         *PublicNetworkAccessFlag        `json:"publicNetworkAccess,omitempty"`
 	TrustedServiceAccessEnabled *bool                           `json:"trustedServiceAccessEnabled,omitempty"`
 	VirtualNetworkRules         *[]NWRuleSetVirtualNetworkRules `json:"virtualNetworkRules,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/model_nwrulesetiprules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/model_nwrulesetiprules.go
@@ -3,7 +3,7 @@ package networkrulesets
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type NWRuleSetIpRules struct {
+type NWRuleSetIPRules struct {
 	Action *NetworkRuleIPAction `json:"action,omitempty"`
-	IpMask *string              `json:"ipMask,omitempty"`
+	IPMask *string              `json:"ipMask,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_endpointdetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_endpointdetail.go
@@ -5,7 +5,7 @@ package dedicatedhsms
 
 type EndpointDetail struct {
 	Description *string `json:"description,omitempty"`
-	IpAddress   *string `json:"ipAddress,omitempty"`
+	IPAddress   *string `json:"ipAddress,omitempty"`
 	Port        *int64  `json:"port,omitempty"`
 	Protocol    *string `json:"protocol,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_networkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_networkinterface.go
@@ -5,5 +5,5 @@ package dedicatedhsms
 
 type NetworkInterface struct {
 	Id               *string `json:"id,omitempty"`
-	PrivateIpAddress *string `json:"privateIpAddress,omitempty"`
+	PrivateIPAddress *string `json:"privateIpAddress,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/constants.go
@@ -64,28 +64,28 @@ func parseAppState(input string) (*AppState, error) {
 	return &out, nil
 }
 
-type IpRuleAction string
+type IPRuleAction string
 
 const (
-	IpRuleActionAllow IpRuleAction = "Allow"
+	IPRuleActionAllow IPRuleAction = "Allow"
 )
 
-func PossibleValuesForIpRuleAction() []string {
+func PossibleValuesForIPRuleAction() []string {
 	return []string{
-		string(IpRuleActionAllow),
+		string(IPRuleActionAllow),
 	}
 }
 
-func parseIpRuleAction(input string) (*IpRuleAction, error) {
-	vals := map[string]IpRuleAction{
-		"allow": IpRuleActionAllow,
+func parseIPRuleAction(input string) (*IPRuleAction, error) {
+	vals := map[string]IPRuleAction{
+		"allow": IPRuleActionAllow,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil
 	}
 
 	// otherwise presume it's an undefined value and best-effort it
-	out := IpRuleAction(input)
+	out := IPRuleAction(input)
 	return &out, nil
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/model_networkrulesetiprule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/model_networkrulesetiprule.go
@@ -3,8 +3,8 @@ package apps
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type NetworkRuleSetIpRule struct {
-	Action     *IpRuleAction `json:"action,omitempty"`
+type NetworkRuleSetIPRule struct {
+	Action     *IPRuleAction `json:"action,omitempty"`
 	FilterName *string       `json:"filterName,omitempty"`
-	IpMask     *string       `json:"ipMask,omitempty"`
+	IPMask     *string       `json:"ipMask,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/model_networkrulesets.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/model_networkrulesets.go
@@ -7,5 +7,5 @@ type NetworkRuleSets struct {
 	ApplyToDevices    *bool                   `json:"applyToDevices,omitempty"`
 	ApplyToIoTCentral *bool                   `json:"applyToIoTCentral,omitempty"`
 	DefaultAction     *NetworkAction          `json:"defaultAction,omitempty"`
-	IpRules           *[]NetworkRuleSetIpRule `json:"ipRules,omitempty"`
+	IPRules           *[]NetworkRuleSetIPRule `json:"ipRules,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2021-10-01/volumes/model_mounttargetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2021-10-01/volumes/model_mounttargetproperties.go
@@ -5,7 +5,7 @@ package volumes
 
 type MountTargetProperties struct {
 	FileSystemId  string  `json:"fileSystemId"`
-	IpAddress     *string `json:"ipAddress,omitempty"`
+	IPAddress     *string `json:"ipAddress,omitempty"`
 	MountTargetId *string `json:"mountTargetId,omitempty"`
 	SmbServerFqdn *string `json:"smbServerFqdn,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/model_firewallruleproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/model_firewallruleproperties.go
@@ -4,6 +4,6 @@ package firewallrules
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type FirewallRuleProperties struct {
-	EndIpAddress   string `json:"endIpAddress"`
-	StartIpAddress string `json:"startIpAddress"`
+	EndIPAddress   string `json:"endIpAddress"`
+	StartIPAddress string `json:"startIpAddress"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/firewallrules/model_firewallruleproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/firewallrules/model_firewallruleproperties.go
@@ -4,6 +4,6 @@ package firewallrules
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type FirewallRuleProperties struct {
-	EndIpAddress   string `json:"endIpAddress"`
-	StartIpAddress string `json:"startIpAddress"`
+	EndIPAddress   string `json:"endIpAddress"`
+	StartIPAddress string `json:"startIpAddress"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/model_aaaarecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/model_aaaarecord.go
@@ -4,5 +4,5 @@ package recordsets
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type AaaaRecord struct {
-	Ipv6Address *string `json:"ipv6Address,omitempty"`
+	IPv6Address *string `json:"ipv6Address,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/model_arecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/model_arecord.go
@@ -4,5 +4,5 @@ package recordsets
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ARecord struct {
-	Ipv4Address *string `json:"ipv4Address,omitempty"`
+	IPv4Address *string `json:"ipv4Address,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2020-03-13/services/model_iprule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2020-03-13/services/model_iprule.go
@@ -3,6 +3,6 @@ package services
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type IpRule struct {
+type IPRule struct {
 	Value *string `json:"value,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2020-03-13/services/model_networkruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2020-03-13/services/model_networkruleset.go
@@ -4,5 +4,5 @@ package services
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type NetworkRuleSet struct {
-	IpRules *[]IpRule `json:"ipRules,omitempty"`
+	IPRules *[]IPRule `json:"ipRules,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespaces/model_networkrulesetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespaces/model_networkrulesetproperties.go
@@ -5,7 +5,7 @@ package namespaces
 
 type NetworkRuleSetProperties struct {
 	DefaultAction               *DefaultAction                  `json:"defaultAction,omitempty"`
-	IpRules                     *[]NWRuleSetIpRules             `json:"ipRules,omitempty"`
+	IPRules                     *[]NWRuleSetIPRules             `json:"ipRules,omitempty"`
 	PublicNetworkAccess         *PublicNetworkAccessFlag        `json:"publicNetworkAccess,omitempty"`
 	TrustedServiceAccessEnabled *bool                           `json:"trustedServiceAccessEnabled,omitempty"`
 	VirtualNetworkRules         *[]NWRuleSetVirtualNetworkRules `json:"virtualNetworkRules,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespaces/model_nwrulesetiprules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespaces/model_nwrulesetiprules.go
@@ -3,7 +3,7 @@ package namespaces
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type NWRuleSetIpRules struct {
+type NWRuleSetIPRules struct {
 	Action *NetworkRuleIPAction `json:"action,omitempty"`
-	IpMask *string              `json:"ipMask,omitempty"`
+	IPMask *string              `json:"ipMask,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/model_managedclusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/model_managedclusterproperties.go
@@ -23,7 +23,7 @@ type ManagedClusterProperties struct {
 	FabricSettings                       *[]SettingsSectionDescription         `json:"fabricSettings,omitempty"`
 	Fqdn                                 *string                               `json:"fqdn,omitempty"`
 	HttpGatewayConnectionPort            *int64                                `json:"httpGatewayConnectionPort,omitempty"`
-	Ipv4Address                          *string                               `json:"ipv4Address,omitempty"`
+	IPv4Address                          *string                               `json:"ipv4Address,omitempty"`
 	LoadBalancingRules                   *[]LoadBalancingRule                  `json:"loadBalancingRules,omitempty"`
 	NetworkSecurityRules                 *[]NetworkSecurityRule                `json:"networkSecurityRules,omitempty"`
 	ProvisioningState                    *ManagedResourceProvisioningState     `json:"provisioningState,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/model_sqlvirtualmachineproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/model_sqlvirtualmachineproperties.go
@@ -18,5 +18,5 @@ type SqlVirtualMachineProperties struct {
 	StorageConfigurationSettings           *StorageConfigurationSettings           `json:"storageConfigurationSettings,omitempty"`
 	VirtualMachineResourceId               *string                                 `json:"virtualMachineResourceId,omitempty"`
 	WsfcDomainCredentials                  *WsfcDomainCredentials                  `json:"wsfcDomainCredentials,omitempty"`
-	WsfcStaticIp                           *string                                 `json:"wsfcStaticIp,omitempty"`
+	WsfcStaticIP                           *string                                 `json:"wsfcStaticIp,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20220722.1091911
+# github.com/hashicorp/go-azure-sdk v0.20220725.1131927
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2020-01-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants


### PR DESCRIPTION
Updates SDK to v0.20220725.1131927

Changes across services are a result of fixing a canonicalisation issue in the underlying SDK, updating `Ip` to `IP` in property names. 