### PR TITLE
Fix api_management_api_operation_policy docs: wrong description at property api_name

### DIFF
--- a/website/docs/r/api_management_api_operation_policy.html.markdown
+++ b/website/docs/r/api_management_api_operation_policy.html.markdown
@@ -71,7 +71,7 @@ XML
 
 The following arguments are supported:
 
-* `api_name` - (Required) The ID of the API Management API Operation within the API Management Service. Changing this forces a new resource to be created.
+* `api_name` - (Required) The name of the API within the API Management Service where the Operation exists. Changing this forces a new resource to be created.
 
 * `api_management_name` - (Required) The name of the API Management Service. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Property _api_name_ description is currently misleading, pointing to the _Operation ID_ when should be pointing to the name of the API within the API management Service (as it is properly illustrated in the examples.)