### PR TITLE
Enhance - `azurerm_redis_cache` - Recreate Redis cache when downgrade the SKU

### DIFF
--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -340,11 +340,8 @@ func resourceRedisCache() *pluginsdk.Resource {
 			pluginsdk.ForceNewIfChange("sku_name", func(ctx context.Context, old, new, meta interface{}) bool {
 				// downgrade the SKU is not supported, recreate the resource
 				if old.(string) != "" && new.(string) != "" {
-					if skuWeight[old.(string)] > skuWeight[new.(string)] {
-						return true
-					}
+					return skuWeight[old.(string)] > skuWeight[new.(string)]
 				}
-
 				return false
 			}),
 		),

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of Redis to use. Possible values are `Basic`, `Standard` and `Premium`.
 
+~> **Note** Downgrade the SKU will recreate the redis cache.
+
 ---
 
 * `enable_non_ssl_port` - (Optional) Enable the non-SSL port (6379) - disabled by default.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of Redis to use. Possible values are `Basic`, `Standard` and `Premium`.
 
-~> **Note** Downgrade the SKU forces a new resource to be created.
+~> **Note** Downgrading the SKU will force a new resource to be created.
 
 ---
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of Redis to use. Possible values are `Basic`, `Standard` and `Premium`.
 
-~> **Note** Downgrade the SKU will recreate the redis cache.
+~> **Note** Downgrade the SKU forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Fixes #17740 
Downgrade SKU is not supported by service, custom the `forceNew` to true when users try to downgrade the SKU.