### PR TITLE
azurerm_log_analytics_cluster - update the validation for size_gb

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -56,7 +56,7 @@ func resourceLogAnalyticsCluster() *pluginsdk.Resource {
 			"size_gb": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
-				Default:      500,
+				Default:      1000,
 				ValidateFunc: validation.IntInSlice([]int{500, 1000, 2000, 5000}),
 			},
 

--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -53,17 +53,11 @@ func resourceLogAnalyticsCluster() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemAssignedIdentityRequiredForceNew(),
 
-			// Per the documentation cluster capacity must start at 500 GB and can go above 3000 GB with an exception by Microsoft
-			// so I am not limiting the upperbound here by design
-			// https://docs.microsoft.com/en-us/azure/azure-monitor/logs/logs-dedicated-clusters
 			"size_gb": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Default:  1000,
-				ValidateFunc: validation.All(
-					validation.IntAtLeast(500),
-					validation.IntDivisibleBy(100),
-				),
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				Default:      500,
+				ValidateFunc: validation.IntInSlice([]int{500, 1000, 2000, 5000}),
 			},
 
 			"cluster_id": {

--- a/internal/services/loganalytics/log_analytics_cluster_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource_test.go
@@ -118,7 +118,7 @@ resource "azurerm_log_analytics_cluster" "test" {
   name                = "acctest-LA-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size_gb             = 2000
+  size_gb             = 1000
 
   identity {
     type = "SystemAssigned"

--- a/internal/services/loganalytics/log_analytics_cluster_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource_test.go
@@ -3,7 +3,6 @@ package loganalytics_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -20,11 +19,6 @@ func TestAccLogAnalyticsCluster_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
 
-	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
-		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
-		return
-	}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -39,11 +33,6 @@ func TestAccLogAnalyticsCluster_basic(t *testing.T) {
 func TestAccLogAnalyticsCluster_resize(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
-
-	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
-		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
-		return
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -66,11 +55,6 @@ func TestAccLogAnalyticsCluster_resize(t *testing.T) {
 func TestAccLogAnalyticsCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
-
-	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
-		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
-		return
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -134,7 +118,7 @@ resource "azurerm_log_analytics_cluster" "test" {
   name                = "acctest-LA-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size_gb             = 1100
+  size_gb             = 2000
 
   identity {
     type = "SystemAssigned"

--- a/internal/services/loganalytics/log_analytics_cluster_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource_test.go
@@ -3,6 +3,7 @@ package loganalytics_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -19,6 +20,11 @@ func TestAccLogAnalyticsCluster_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
 
+	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
+		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
+		return
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -33,6 +39,11 @@ func TestAccLogAnalyticsCluster_basic(t *testing.T) {
 func TestAccLogAnalyticsCluster_resize(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
+
+	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
+		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
+		return
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -55,6 +66,11 @@ func TestAccLogAnalyticsCluster_resize(t *testing.T) {
 func TestAccLogAnalyticsCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_cluster", "test")
 	r := LogAnalyticsClusterResource{}
+
+	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
+		t.Skip("Skipping as ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS is not specified")
+		return
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `identity` - (Required) An `identity` block as defined below. Changing this forces a new Log Analytics Cluster to be created.
 
-* `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 1000.
+* `size_gb` - (Optional) The capacity of the Log Analytics Cluster is specified in GB/day. Possible values include `500`, `1000`, `2000` or `5000`. Defaults to `1000`.
 
 ~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters).
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 500.
 
-~> **NOTE:** The `size_gb` can be in the range of 500 to 3000 GB per day and must be in steps of 100 GB. For `size_gb` levels higher than 3000 GB per day, please contact your Microsoft contact to enable it.
+~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters).
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Cluster.
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `identity` - (Required) An `identity` block as defined below. Changing this forces a new Log Analytics Cluster to be created.
 
-* `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 500.
+* `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 1000.
 
 ~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters).
 


### PR DESCRIPTION
This PR is to update the validation for `size_gb`.

--- PASS: TestAccLogAnalyticsCluster_resize (1932.09s)
--- PASS: TestAccLogAnalyticsCluster_basic (2118.79s)
--- PASS: TestAccLogAnalyticsCluster_requiresImport (2191.80s)