### PR TITLE
`azurerm_key_vault_{key,secret,certificate}`: Resource/DataSource increase read timeout from 5min to 30min

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -76,7 +76,15 @@ func TestResourcesSupportCustomTimeouts(t *testing.T) {
 			if resource.Timeouts.Read == nil {
 				t.Fatalf("Resource %q doesn't define a Read timeout", resourceName)
 			} else if *resource.Timeouts.Read > 5*time.Minute {
-				t.Fatalf("Read timeouts shouldn't be more than 5 minutes, this indicates a bug which needs to be fixed")
+				exceptionResources := map[string]bool{
+					// The key vault item resources have longer read timeout for mitigating issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/11059.
+					"azurerm_key_vault_key":         true,
+					"azurerm_key_vault_secret":      true,
+					"azurerm_key_vault_certificate": true,
+				}
+				if !exceptionResources[resourceName] {
+					t.Fatalf("Read timeouts shouldn't be more than 5 minutes, this indicates a bug which needs to be fixed")
+				}
 			}
 
 			// Optional

--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -23,7 +23,8 @@ func dataSourceKeyVaultCertificate() *pluginsdk.Resource {
 		Read: dataSourceKeyVaultCertificateRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -41,7 +41,8 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read:   pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},

--- a/internal/services/keyvault/key_vault_key_data_source.go
+++ b/internal/services/keyvault/key_vault_key_data_source.go
@@ -24,7 +24,8 @@ func dataSourceKeyVaultKey() *pluginsdk.Resource {
 		Read: dataSourceKeyVaultKeyRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -42,7 +42,8 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read:   pluginsdk.DefaultTimeout(30 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},

--- a/internal/services/keyvault/key_vault_secret_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_data_source.go
@@ -18,7 +18,8 @@ func dataSourceKeyVaultSecret() *pluginsdk.Resource {
 		Read: dataSourceKeyVaultSecretRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -33,7 +33,8 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			// TODO: Change this back to 5min, once https://github.com/hashicorp/terraform-provider-azurerm/issues/11059 is addressed.
+			Read:   pluginsdk.DefaultTimeout(30 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},

--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -147,4 +147,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Certificate.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Certificate.

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -78,4 +78,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Key.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Key.

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -53,4 +53,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Secret.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Secret.

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -327,7 +327,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Key Vault Certificate.
 * `update` - (Defaults to 30 minutes) Used when updating the Key Vault Certificate.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Certificate.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Certificate.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Certificate.
 
 ## Import

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -109,7 +109,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Key Vault Key.
 * `update` - (Defaults to 30 minutes) Used when updating the Key Vault Key.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Key.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Key.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Key.
 
 ## Import

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -96,7 +96,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 30 minutes) Used when creating the Key Vault Secret.
 * `update` - (Defaults to 30 minutes) Used when updating the Key Vault Secret.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Secret.
+* `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Secret.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Secret.
 
 ## Import


### PR DESCRIPTION
`azurerm_key_vault_{key,secret,certificate}`: Resource/DataSource increase read timeout from 5min to 30min.

Related to #11059.