### PR TITLE
Fix typo for TTL Argument Reference in dns_a_record

### DIFF
--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
-* `TTL` - (Required) The Time To Live (TTL) of the DNS record in seconds.
+* `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 
 * `records` - (Optional) List of IPv4 Addresses. Conflicts with `target_resource_id`.
 


### PR DESCRIPTION
change "TTL" to "ttl" to make the docs more consistent