### PR TITLE
azurerm_orchestrated_virtual_machine_scale_set - fix source_image_id processing

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -302,7 +302,10 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference := expandOrchestratedSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	if err != nil {
+		return err
+	}
 	virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
 
 	osType := compute.OperatingSystemTypesWindows


### PR DESCRIPTION
This is a proposed fix for issue #14820

As discussed in the issue, there is an issue with the azurerm_orchestrated_virtual_machine_scale_set resource, whereby the `source_image_id` attribute is not sent through to the Azure API.  This is a result of an error in the expandOrchestratedSourceImageReference function.  We can see on lines [1339-1341](https://github.com/hashicorp/terraform-provider-azurerm/blob/5fd32b3b3cf8a4a1891dee79e8890a125a2f36ce/internal/services/compute/orchestrated_virtual_machine_scale_set.go#L1339) that the function will exit before checking the `source_image_id` value if the `source_image_reference` block is empty, which it should be if a `source_image_id` is provided.

As mentioned, I'm not sure if the prefered fix would be to fix the new function, or simply to make a call to the pre-existing `expandSourceImageReference` like I have done in this PR. Either way, I figured opening this PR would be a good start to getting this issue resolved as it's been outstanding for 7 months. 