### PR TITLE
`azurerm_log_analytics_cluster` - enable Minimum of 500GB

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -59,7 +59,7 @@ func resourceLogAnalyticsCluster() *pluginsdk.Resource {
 			"size_gb": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
-				Default:  500,
+				Default:  1000,
 				ValidateFunc: validation.All(
 					validation.IntAtLeast(500),
 					validation.IntDivisibleBy(100),

--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -53,15 +53,15 @@ func resourceLogAnalyticsCluster() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemAssignedIdentityRequiredForceNew(),
 
-			// Per the documentation cluster capacity must start at 1000 GB and can go above 3000 GB with an exception by Microsoft
+			// Per the documentation cluster capacity must start at 500 GB and can go above 3000 GB with an exception by Microsoft
 			// so I am not limiting the upperbound here by design
-			// https://docs.microsoft.com/en-us/azure/azure-monitor/platform/manage-cost-storage#log-analytics-dedicated-clusters
+			// https://docs.microsoft.com/en-us/azure/azure-monitor/logs/logs-dedicated-clusters
 			"size_gb": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
-				Default:  1000,
+				Default:  500,
 				ValidateFunc: validation.All(
-					validation.IntAtLeast(1000),
+					validation.IntAtLeast(500),
 					validation.IntDivisibleBy(100),
 				),
 			},

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -47,9 +47,9 @@ The following arguments are supported:
 
 * `identity` - (Required) An `identity` block as defined below. Changing this forces a new Log Analytics Cluster to be created.
 
-* `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 1000.
+* `size_gb` - (Optional) The capacity of the Log Analytics Cluster specified in GB/day. Defaults to 500.
 
-~> **NOTE:** The `size_gb` can be in the range of 1000 to 3000 GB per day and must be in steps of 100 GB. For `size_gb` levels higher than 3000 GB per day, please contact your Microsoft contact to enable it.
+~> **NOTE:** The `size_gb` can be in the range of 500 to 3000 GB per day and must be in steps of 100 GB. For `size_gb` levels higher than 3000 GB per day, please contact your Microsoft contact to enable it.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Cluster.
 


### PR DESCRIPTION
Fixes #17787

Enables the minimum to be 500GB/day as per [the Microsoft documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters:~:text=commitment%20level%20of-,at%20least%20500%20GB/day,-.%20Any%20usage%20above)

I'm unable to run the tests for this one as its very expensive with a 30 day commitment. 