### PR TITLE
`automation_dsc_configuratioin` - support for the `hash` and `log_process` properties

### DIFF
--- a/internal/services/automation/automation_dsc_configuration_resource_test.go
+++ b/internal/services/automation/automation_dsc_configuration_resource_test.go
@@ -61,7 +61,7 @@ func TestAccAutomationDscConfiguration_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("log_progress", "hash", "source_version"),
 	})
 }
 
@@ -154,6 +154,10 @@ resource "azurerm_automation_dsc_configuration" "test" {
   content_embedded        = "configuration acctest {}"
   description             = "test"
   log_verbose             = "true"
+  log_progress            = "true"
+  source_version          = "1.0.0"
+  hash_algorithm          = "algm"
+  hash_value              = "hash"
   tags = {
     ENV = "prod"
   }


### PR DESCRIPTION
also fix the read configuration content bug as explained in the comment lines, which caused TeamCity tests to fail before

should be ready after https://github.com/hashicorp/terraform-provider-azurerm/pull/17804 is merged.

--- PASS: TestAccAutomationDscConfiguration_complete (836.81s)
PASS

![image](https://user-images.githubusercontent.com/2633022/181724055-5f9671d4-99f7-4531-b77b-0fae4ba2fde5.png)
