### PR TITLE
azurerm_cosmosdb_account - primary_sql_connection_string, secondary_sql_connection_string, primary_readonly_sql_connection_string, secondary_readonly_sql_connection_string

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -571,6 +571,12 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
+			"secondary_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -1114,6 +1120,8 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 			connStrings[i] = *v.ConnectionString
 			if *v.Description == "Primary SQL Connection String" {
 				d.Set("primary_connection_string", *v.ConnectionString)
+			} else if *v.Description == "Secondary SQL Connection String" {
+				d.Set("secondary_connection_string", *v.ConnectionString)
 			}
 		}
 	}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -35,6 +35,13 @@ import (
 
 var CosmosDbAccountResourceName = "azurerm_cosmosdb_account"
 
+var connStringPropertyMap = map[string]string{
+	"Primary SQL Connection String":             "primary_connection_string",
+	"Secondary SQL Connection String":           "secondary_connection_string",
+	"Primary Read-Only SQL Connection String":   "primary_readonly_connection_string",
+	"Secondary Read-Only SQL Connection String": "secondary_readonly_connection_string",
+}
+
 // If the consistency policy of the Cosmos DB Database Account is not bounded staleness,
 // any changes to the configuration for bounded staleness should be suppressed.
 func suppressConsistencyPolicyStalenessConfiguration(_, _, _ string, d *pluginsdk.ResourceData) bool {
@@ -572,6 +579,18 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 			},
 
 			"secondary_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"primary_readonly_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_readonly_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
@@ -1118,10 +1137,8 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		connStrings = make([]string, len(*connStringResp.ConnectionStrings))
 		for i, v := range *connStringResp.ConnectionStrings {
 			connStrings[i] = *v.ConnectionString
-			if *v.Description == "Primary SQL Connection String" {
-				d.Set("primary_connection_string", *v.ConnectionString)
-			} else if *v.Description == "Secondary SQL Connection String" {
-				d.Set("secondary_connection_string", *v.ConnectionString)
+			if propertyName, propertyExists := connStringPropertyMap[*v.Description]; propertyExists {
+				d.Set(propertyName, *v.ConnectionString)
 			}
 		}
 	}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -565,6 +565,12 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"primary_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -1106,6 +1112,9 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		connStrings = make([]string, len(*connStringResp.ConnectionStrings))
 		for i, v := range *connStringResp.ConnectionStrings {
 			connStrings[i] = *v.ConnectionString
+			if *v.Description == "Primary SQL Connection String" {
+				d.Set("primary_connection_string", *v.ConnectionString)
+			}
 		}
 	}
 	d.Set("connection_strings", connStrings)

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -36,10 +36,10 @@ import (
 var CosmosDbAccountResourceName = "azurerm_cosmosdb_account"
 
 var connStringPropertyMap = map[string]string{
-	"Primary SQL Connection String":             "primary_connection_string",
-	"Secondary SQL Connection String":           "secondary_connection_string",
-	"Primary Read-Only SQL Connection String":   "primary_readonly_connection_string",
-	"Secondary Read-Only SQL Connection String": "secondary_readonly_connection_string",
+	"Primary SQL Connection String":             "primary_sql_connection_string",
+	"Secondary SQL Connection String":           "secondary_sql_connection_string",
+	"Primary Read-Only SQL Connection String":   "primary_readonly_sql_connection_string",
+	"Secondary Read-Only SQL Connection String": "secondary_readonly_sql_connection_string",
 }
 
 // If the consistency policy of the Cosmos DB Database Account is not bounded staleness,
@@ -572,25 +572,25 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"primary_connection_string": {
+			"primary_sql_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
 			},
 
-			"secondary_connection_string": {
+			"secondary_sql_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
 			},
 
-			"primary_readonly_connection_string": {
+			"primary_readonly_sql_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
 			},
 
-			"secondary_readonly_connection_string": {
+			"secondary_readonly_sql_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -2134,6 +2134,7 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documen
 		check.That(data.ResourceName).Key("secondary_key").Exists(),
 		check.That(data.ResourceName).Key("primary_readonly_key").Exists(),
 		check.That(data.ResourceName).Key("secondary_readonly_key").Exists(),
+		check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 	)
 }
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -2136,6 +2136,8 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documen
 		check.That(data.ResourceName).Key("secondary_readonly_key").Exists(),
 		check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 		check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
+		check.That(data.ResourceName).Key("primary_readonly_connection_string").Exists(),
+		check.That(data.ResourceName).Key("secondary_readonly_connection_string").Exists(),
 	)
 }
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -61,7 +61,7 @@ func TestAccCosmosDBAccount_basic_mongo_strong(t *testing.T) {
 }
 
 func TestAccCosmosDBAccount_basic_mongo_strong_without_capability(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong)
+	testAccCosmosDBAccount_basicMongoDBWith(t, documentdb.DefaultConsistencyLevelStrong)
 }
 
 func TestAccCosmosDBAccount_basic_parse_boundedStaleness(t *testing.T) {
@@ -2140,10 +2140,10 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documen
 
 func checkAccCosmosDBAccount_sql(data acceptance.TestData) acceptance.TestCheckFunc {
 	return acceptance.ComposeTestCheckFunc(
-		check.That(data.ResourceName).Key("primary_connection_string").Exists(),
-		check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
-		check.That(data.ResourceName).Key("primary_readonly_connection_string").Exists(),
-		check.That(data.ResourceName).Key("secondary_readonly_connection_string").Exists(),
+		check.That(data.ResourceName).Key("primary_sql_connection_string").Exists(),
+		check.That(data.ResourceName).Key("secondary_sql_connection_string").Exists(),
+		check.That(data.ResourceName).Key("primary_readonly_sql_connection_string").Exists(),
+		check.That(data.ResourceName).Key("secondary_readonly_sql_connection_string").Exists(),
 	)
 }
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -185,6 +185,7 @@ func testAccCosmosDBAccount_basicWith(t *testing.T, kind documentdb.DatabaseAcco
 			Config: r.basic(data, kind, consistency),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, consistency, 1),
+				checkAccCosmosDBAccount_sql(data),
 			),
 		},
 		data.ImportStep(),
@@ -2134,6 +2135,11 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documen
 		check.That(data.ResourceName).Key("secondary_key").Exists(),
 		check.That(data.ResourceName).Key("primary_readonly_key").Exists(),
 		check.That(data.ResourceName).Key("secondary_readonly_key").Exists(),
+	)
+}
+
+func checkAccCosmosDBAccount_sql(data acceptance.TestData) acceptance.TestCheckFunc {
+	return acceptance.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 		check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
 		check.That(data.ResourceName).Key("primary_readonly_connection_string").Exists(),

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -21,23 +21,23 @@ import (
 type CosmosDBAccountResource struct{}
 
 func TestAccCosmosDBAccount_basic_global_boundedStaleness(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindGlobalDocumentDB, documentdb.DefaultConsistencyLevelBoundedStaleness)
+	testAccCosmosDBAccount_basicDocumentDbWith(t, documentdb.DefaultConsistencyLevelBoundedStaleness)
 }
 
 func TestAccCosmosDBAccount_basic_global_consistentPrefix(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindGlobalDocumentDB, documentdb.DefaultConsistencyLevelConsistentPrefix)
+	testAccCosmosDBAccount_basicDocumentDbWith(t, documentdb.DefaultConsistencyLevelConsistentPrefix)
 }
 
 func TestAccCosmosDBAccount_basic_global_eventual(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindGlobalDocumentDB, documentdb.DefaultConsistencyLevelEventual)
+	testAccCosmosDBAccount_basicDocumentDbWith(t, documentdb.DefaultConsistencyLevelEventual)
 }
 
 func TestAccCosmosDBAccount_basic_global_session(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindGlobalDocumentDB, documentdb.DefaultConsistencyLevelSession)
+	testAccCosmosDBAccount_basicDocumentDbWith(t, documentdb.DefaultConsistencyLevelSession)
 }
 
 func TestAccCosmosDBAccount_basic_global_strong(t *testing.T) {
-	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindGlobalDocumentDB, documentdb.DefaultConsistencyLevelStrong)
+	testAccCosmosDBAccount_basicDocumentDbWith(t, documentdb.DefaultConsistencyLevelStrong)
 }
 
 func TestAccCosmosDBAccount_basic_mongo_boundedStaleness(t *testing.T) {
@@ -183,6 +183,21 @@ func testAccCosmosDBAccount_basicWith(t *testing.T, kind documentdb.DatabaseAcco
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data, kind, consistency),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, consistency, 1),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccCosmosDBAccount_basicDocumentDbWith(t *testing.T, consistency documentdb.DefaultConsistencyLevel) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, documentdb.DatabaseAccountKindGlobalDocumentDB, consistency),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, consistency, 1),
 				checkAccCosmosDBAccount_sql(data),

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -2135,6 +2135,7 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documen
 		check.That(data.ResourceName).Key("primary_readonly_key").Exists(),
 		check.That(data.ResourceName).Key("secondary_readonly_key").Exists(),
 		check.That(data.ResourceName).Key("primary_connection_string").Exists(),
+		check.That(data.ResourceName).Key("secondary_connection_string").Exists(),
 	)
 }
 

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -93,13 +93,13 @@ The following attributes are exported:
 
 * `secondary_readonly_key` - The secondary read-only key for the CosmosDB account.
 
-* `primary_connection_string` - The primary connection string for the CosmosDB account.
+* `primary_sql_connection_string` - The primary SQL connection string for the CosmosDB account.
 
-* `secondary_connection_string` - The secondary connection string for the CosmosDB account.
+* `secondary_sql_connection_string` - The secondary SQL connection string for the CosmosDB account.
 
-* `primary_readonly_connection_string` - The primary read-only connection string for the CosmosDB account.
+* `primary_readonly_sql_connection_string` - The primary read-only SQL connection string for the CosmosDB account.
 
-* `secondary_readonly_connection_string` - The secondary read-only connection string for the CosmosDB account.
+* `secondary_readonly_sql_connection_string` - The secondary read-only SQL connection string for the CosmosDB account.
 
 ## Timeouts
 

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -97,6 +97,10 @@ The following attributes are exported:
 
 * `secondary_connection_string` - The secondary connection string for the CosmosDB account.
 
+* `primary_readonly_connection_string` - The primary read-only connection string for the CosmosDB account.
+
+* `secondary_readonly_connection_string` - The secondary read-only connection string for the CosmosDB account.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -93,6 +93,10 @@ The following attributes are exported:
 
 * `secondary_readonly_key` - The Secondary read-only key for the CosmosDB Account.
 
+* `primary_connection_string` - The primary connection string for the CosmosDB account.
+
+* `secondary_connection_string` - The secondary connection string for the CosmosDB account.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -85,13 +85,13 @@ The following attributes are exported:
 
 * `write_endpoints` - A list of write endpoints available for this CosmosDB account.
 
-* `primary_key` - The Primary key for the CosmosDB Account.
+* `primary_key` - The primary key for the CosmosDB account.
 
-* `secondary_key` - The Secondary key for the CosmosDB Account.
+* `secondary_key` - The secondary key for the CosmosDB account.
 
-* `primary_readonly_key` - The Primary read-only Key for the CosmosDB Account.
+* `primary_readonly_key` - The primary read-only Key for the CosmosDB account.
 
-* `secondary_readonly_key` - The Secondary read-only key for the CosmosDB Account.
+* `secondary_readonly_key` - The secondary read-only key for the CosmosDB account.
 
 * `primary_connection_string` - The primary connection string for the CosmosDB account.
 


### PR DESCRIPTION
Add individual connection string attributes to `cosmosdb_account` resource

Closes #15947