### PR TITLE
azurerm_api_management_api  Deprecate `soap_pass_through` in favour of `api_type`

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -8,12 +8,18 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApiManagementApiResource struct{}
+
+const (
+	SkuNameConsumption = "Consumption_0"
+	SkuNameDeveloper   = "Developer_1"
+)
 
 func TestAccApiManagementApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
@@ -24,6 +30,7 @@ func TestAccApiManagementApi_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("http"),
 				check.That(data.ResourceName).Key("soap_pass_through").HasValue("false"),
 				check.That(data.ResourceName).Key("is_current").HasValue("true"),
 				check.That(data.ResourceName).Key("is_online").HasValue("false"),
@@ -59,6 +66,7 @@ func TestAccApiManagementApi_blankPath(t *testing.T) {
 			Config: r.blankPath(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("http"),
 				check.That(data.ResourceName).Key("soap_pass_through").HasValue("false"),
 				check.That(data.ResourceName).Key("is_current").HasValue("true"),
 				check.That(data.ResourceName).Key("is_online").HasValue("false"),
@@ -130,7 +138,58 @@ func TestAccApiManagementApi_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApi_graphql(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.graphql(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("graphql"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementApi_soap(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.soap(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("soap"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApiManagementApi_websocket(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.websocket(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("websocket"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApiManagementApi_soapPassthrough(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skipf("Test does not apply on 4.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}
 
@@ -139,6 +198,7 @@ func TestAccApiManagementApi_soapPassthrough(t *testing.T) {
 			Config: r.soapPassthrough(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_type").HasValue("soap"),
 			),
 		},
 		data.ImportStep(),
@@ -347,7 +407,7 @@ resource "azurerm_api_management_api" "test" {
   protocols           = ["https"]
   revision            = "1"
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) blankPath(data acceptance.TestData) string {
@@ -363,7 +423,7 @@ resource "azurerm_api_management_api" "test" {
   protocols           = ["https"]
   revision            = "1"
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) wordRevision(data acceptance.TestData) string {
@@ -379,7 +439,59 @@ resource "azurerm_api_management_api" "test" {
   protocols           = ["https"]
   revision            = "one-point-oh"
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) graphql(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  api_type            = "graphql"
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) soap(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  api_type            = "soap"
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) websocket(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  api_type            = "websocket"
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["wss"]
+  revision            = "1"
+  service_url         = "wss://example.com/foo/bar"
+}
+`, r.template(data, SkuNameDeveloper), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) soapPassthrough(data acceptance.TestData) string {
@@ -396,7 +508,7 @@ resource "azurerm_api_management_api" "test" {
   revision            = "1"
   soap_pass_through   = true
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) subscriptionRequired(data acceptance.TestData) string {
@@ -413,7 +525,7 @@ resource "azurerm_api_management_api" "test" {
   revision              = "1"
   subscription_required = false
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) requiresImport(data acceptance.TestData) string {
@@ -450,7 +562,7 @@ resource "azurerm_api_management_api" "test" {
     content_format = "swagger-json"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) importWsdl(data acceptance.TestData) string {
@@ -476,7 +588,7 @@ resource "azurerm_api_management_api" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) complete(data acceptance.TestData) string {
@@ -499,7 +611,7 @@ resource "azurerm_api_management_api" "test" {
     query  = "location"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) versionSet(data acceptance.TestData) string {
@@ -525,7 +637,7 @@ resource "azurerm_api_management_api" "test" {
   version             = "v1"
   version_set_id      = azurerm_api_management_api_version_set.test.id
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) oauth2Authorization(data acceptance.TestData) string {
@@ -563,7 +675,7 @@ resource "azurerm_api_management_api" "test" {
     scope                     = "acctest"
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) openidAuthentication(data acceptance.TestData) string {
@@ -596,7 +708,7 @@ resource "azurerm_api_management_api" "test" {
     ]
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data, SkuNameConsumption), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApiManagementApiResource) cloneApi(data acceptance.TestData) string {
@@ -671,7 +783,7 @@ resource "azurerm_api_management_api" "revision" {
 `, r.complete(data), data.RandomInteger)
 }
 
-func (ApiManagementApiResource) template(data acceptance.TestData) string {
+func (ApiManagementApiResource) template(data acceptance.TestData, skuName string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -689,7 +801,7 @@ resource "azurerm_api_management" "test" {
   publisher_name      = "pub1"
   publisher_email     = "pub1@email.com"
 
-  sku_name = "Consumption_0"
+  sku_name = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, skuName)
 }

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -58,11 +58,13 @@ The following arguments are supported:
 
 ---
 
+* `api_type` - (Optional) Type of API. Possible values are `graphql`, `http`, `soap`, and `websocket`. Defaults to `http`.
+
 * `display_name` - (Optional) The display name of the API.
 
 * `path` - (Optional) The Path for this API Management API, which is a relative URL which uniquely identifies this API and all of its resource paths within the API Management Service.
 
-* `protocols` - (Optional) A list of protocols the operations in this API can be invoked. Possible values are `http` and `https`.
+* `protocols` - (Optional) A list of protocols the operations in this API can be invoked. Possible values are `http`, `https`, `ws`, and `wss`.
 
 -> **NOTE:** `display_name`, `path` and `protocols` are required when `source_api_id` is not set.
 
@@ -77,6 +79,8 @@ The following arguments are supported:
 * `service_url` - (Optional) Absolute URL of the backend service implementing this API.
 
 * `soap_pass_through` - (Optional) Should this API expose a SOAP frontend, rather than a HTTP frontend? Defaults to `false`.
+
+-> **NOTE:** This property has been deprecated in favour of the `api_type` property and will be removed in version 4.0 of the provider.
 
 * `subscription_key_parameter_names` - (Optional) A `subscription_key_parameter_names` block as documented below.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request converts a boolean flag for SOAP support in to an enumeration that supports SOAP, GraphQL, and websockets.

Fixes: #16452
Fixes: #14634

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make acctests SERVICE='apimanagement' TESTARGS='-run="TestAccApiManagementApi_"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/apimanagement -run="TestAccApiManagementApi_" -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementApi_basic
=== PAUSE TestAccApiManagementApi_basic
=== RUN   TestAccApiManagementApi_wordRevision
=== PAUSE TestAccApiManagementApi_wordRevision
=== RUN   TestAccApiManagementApi_blankPath
=== PAUSE TestAccApiManagementApi_blankPath
=== RUN   TestAccApiManagementApi_version
=== PAUSE TestAccApiManagementApi_version
=== RUN   TestAccApiManagementApi_oauth2Authorization
=== PAUSE TestAccApiManagementApi_oauth2Authorization
=== RUN   TestAccApiManagementApi_openidAuthentication
=== PAUSE TestAccApiManagementApi_openidAuthentication
=== RUN   TestAccApiManagementApi_requiresImport
=== PAUSE TestAccApiManagementApi_requiresImport
=== RUN   TestAccApiManagementApi_graphql
=== PAUSE TestAccApiManagementApi_graphql
=== RUN   TestAccApiManagementApi_soap
=== PAUSE TestAccApiManagementApi_soap
=== RUN   TestAccApiManagementApi_websocket
=== PAUSE TestAccApiManagementApi_websocket
=== RUN   TestAccApiManagementApi_soapPassthrough
=== PAUSE TestAccApiManagementApi_soapPassthrough
=== RUN   TestAccApiManagementApi_subscriptionRequired
=== PAUSE TestAccApiManagementApi_subscriptionRequired
=== RUN   TestAccApiManagementApi_importSwagger
=== PAUSE TestAccApiManagementApi_importSwagger
=== RUN   TestAccApiManagementApi_importWsdl
=== PAUSE TestAccApiManagementApi_importWsdl
=== RUN   TestAccApiManagementApi_importUpdate
=== PAUSE TestAccApiManagementApi_importUpdate
=== RUN   TestAccApiManagementApi_complete
=== PAUSE TestAccApiManagementApi_complete
=== RUN   TestAccApiManagementApi_cloneApi
=== PAUSE TestAccApiManagementApi_cloneApi
=== RUN   TestAccApiManagementApi_createNewVersionFromExisting
=== PAUSE TestAccApiManagementApi_createNewVersionFromExisting
=== RUN   TestAccApiManagementApi_createRevisionFromExisting
=== PAUSE TestAccApiManagementApi_createRevisionFromExisting
=== RUN   TestAccApiManagementApi_createRevisionFromExistingRevision
=== PAUSE TestAccApiManagementApi_createRevisionFromExistingRevision
=== CONT  TestAccApiManagementApi_basic
=== CONT  TestAccApiManagementApi_soapPassthrough
=== CONT  TestAccApiManagementApi_createRevisionFromExistingRevision
=== CONT  TestAccApiManagementApi_createRevisionFromExisting
=== CONT  TestAccApiManagementApi_importSwagger
=== CONT  TestAccApiManagementApi_subscriptionRequired
=== CONT  TestAccApiManagementApi_importUpdate
=== CONT  TestAccApiManagementApi_createNewVersionFromExisting
--- PASS: TestAccApiManagementApi_createRevisionFromExistingRevision (482.91s)
=== CONT  TestAccApiManagementApi_cloneApi
--- PASS: TestAccApiManagementApi_basic (485.29s)
=== CONT  TestAccApiManagementApi_complete
--- PASS: TestAccApiManagementApi_createRevisionFromExisting (486.22s)
=== CONT  TestAccApiManagementApi_openidAuthentication
--- PASS: TestAccApiManagementApi_subscriptionRequired (536.88s)
=== CONT  TestAccApiManagementApi_websocket
--- PASS: TestAccApiManagementApi_importSwagger (538.44s)
=== CONT  TestAccApiManagementApi_soap
--- PASS: TestAccApiManagementApi_soapPassthrough (542.24s)
=== CONT  TestAccApiManagementApi_graphql
--- PASS: TestAccApiManagementApi_createNewVersionFromExisting (546.80s)
=== CONT  TestAccApiManagementApi_requiresImport
--- PASS: TestAccApiManagementApi_importUpdate (599.75s)
=== CONT  TestAccApiManagementApi_blankPath
--- PASS: TestAccApiManagementApi_complete (476.38s)
=== CONT  TestAccApiManagementApi_oauth2Authorization
--- PASS: TestAccApiManagementApi_openidAuthentication (481.39s)
=== CONT  TestAccApiManagementApi_version
--- PASS: TestAccApiManagementApi_requiresImport (420.99s)
=== CONT  TestAccApiManagementApi_wordRevision
--- PASS: TestAccApiManagementApi_soap (467.23s)
=== CONT  TestAccApiManagementApi_importWsdl
--- PASS: TestAccApiManagementApi_graphql (471.47s)
--- PASS: TestAccApiManagementApi_blankPath (470.15s)
--- PASS: TestAccApiManagementApi_cloneApi (678.76s)
--- PASS: TestAccApiManagementApi_version (405.41s)
--- PASS: TestAccApiManagementApi_oauth2Authorization (458.98s)
--- PASS: TestAccApiManagementApi_wordRevision (465.45s)
--- PASS: TestAccApiManagementApi_importWsdl (467.09s)
--- PASS: TestAccApiManagementApi_websocket (4857.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 5397.663s
```
