### PR TITLE
`d\virtual_machine_extension`: Fix `settings` to be Optional in doc

### DIFF
--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -150,7 +150,7 @@ $ az vm extension image list --location westus -o table
     the latest minor version update to the `type_handler_version` specified.
 
 * `automatic_upgrade_enabled` - (Optional) Should the Extension be automatically updated whenever the Publisher releases a new version of this VM Extension? Defaults to `false`.
-* `settings` - (Required) The settings passed to the extension, these are
+* `settings` - (Optional) The settings passed to the extension, these are
     specified as a JSON object in a string.
 
 ~> **Please Note:** Certain VM Extensions require that the keys in the `settings` block are case sensitive. If you're seeing unhelpful errors, please ensure the keys are consistent with how Azure is expecting them (for instance, for the `JsonADDomainExtension` extension, the keys are expected to be in `TitleCase`.)


### PR DESCRIPTION
Fix #17788
`settings` is Optional in code
https://github.com/hashicorp/terraform-provider-azurerm/blob/5cbafc5ce27aaf909b80a126380869049639efa7/internal/services/compute/virtual_machine_extension_resource.go#L78-L80