### PR TITLE
`azurerm_web_pubsub`, `azurerm_web_pubsub_hub` resource: Migrating `id` and `web_pubsub_id`

### DIFF
--- a/internal/services/signalr/migration/web_pubsub_hub_v0_to_v1.go
+++ b/internal/services/signalr/migration/web_pubsub_hub_v0_to_v1.go
@@ -1,0 +1,98 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = WebPubsubHubV0ToV1{}
+
+type WebPubsubHubV0ToV1 struct{}
+
+func (WebPubsubHubV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"web_pubsub_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"event_handler": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"url_template": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"user_event_pattern": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"system_events": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"auth": {
+						Type:     pluginsdk.TypeList,
+						MaxItems: 1,
+						MinItems: 1,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"managed_identity_id": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"anonymous_connections_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+	}
+	return s
+}
+
+func (WebPubsubHubV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// the old segment is `WebPubsub` but should be `webPubsub`
+		oldID := rawState["id"].(string)
+		newID, err := parse.WebPubsubHubIDInsensitively(oldID)
+		if err != nil {
+			return nil, err
+		}
+		rawState["id"] = newID.ID()
+
+		// parent webPubsub ID should also has the segment `webPubsub`
+		oldWebPubSubID := rawState["web_pubsub_id"].(string)
+		newWebPubsubID, err := parse.WebPubsubIDInsensitively(oldWebPubSubID)
+		if err != nil {
+			return nil, err
+		}
+		rawState["web_pubsub_id"] = newWebPubsubID.ID()
+
+		return rawState, nil
+	}
+}

--- a/internal/services/signalr/migration/web_pubsub_v0_to_v1.go
+++ b/internal/services/signalr/migration/web_pubsub_v0_to_v1.go
@@ -1,0 +1,200 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = WebPubsubV0ToV1{}
+
+type WebPubsubV0ToV1 struct{}
+
+func (WebPubsubV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"sku": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"capacity": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"live_trace": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
+					"connectivity_logs_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
+					"messaging_logs_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
+					"http_request_logs_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"local_auth_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"aad_auth_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"tls_client_cert_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"identity": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"identity_ids": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+
+					"principal_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"tenant_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"public_port": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"server_port": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"external_ip": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"hostname": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"version": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"primary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"primary_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_access_key": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"secondary_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+	return s
+}
+
+func (WebPubsubV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// the old segment is `WebPubsub` but should be `webPubsub`
+		oldID := rawState["id"].(string)
+
+		newID, err := parse.WebPubsubIDInsensitively(oldID)
+		if err != nil {
+			return nil, err
+		}
+
+		rawState["id"] = newID.ID()
+
+		return rawState, nil
+	}
+}

--- a/internal/services/signalr/parse/web_pubsub.go
+++ b/internal/services/signalr/parse/web_pubsub.go
@@ -67,3 +67,47 @@ func WebPubsubID(input string) (*WebPubsubId, error) {
 
 	return &resourceId, nil
 }
+
+// WebPubsubIDInsensitively parses an WebPubsub ID into an WebPubsubId struct, insensitively
+// This should only be used to parse an ID for rewriting, the WebPubsubID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func WebPubsubIDInsensitively(input string) (*WebPubsubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := WebPubsubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'webPubSub' segment
+	webPubSubKey := "webPubSub"
+	for key := range id.Path {
+		if strings.EqualFold(key, webPubSubKey) {
+			webPubSubKey = key
+			break
+		}
+	}
+	if resourceId.WebPubSubName, err = id.PopSegment(webPubSubKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/signalr/parse/web_pubsub_hub.go
+++ b/internal/services/signalr/parse/web_pubsub_hub.go
@@ -73,3 +73,59 @@ func WebPubsubHubID(input string) (*WebPubsubHubId, error) {
 
 	return &resourceId, nil
 }
+
+// WebPubsubHubIDInsensitively parses an WebPubsubHub ID into an WebPubsubHubId struct, insensitively
+// This should only be used to parse an ID for rewriting, the WebPubsubHubID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func WebPubsubHubIDInsensitively(input string) (*WebPubsubHubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := WebPubsubHubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'webPubSub' segment
+	webPubSubKey := "webPubSub"
+	for key := range id.Path {
+		if strings.EqualFold(key, webPubSubKey) {
+			webPubSubKey = key
+			break
+		}
+	}
+	if resourceId.WebPubSubName, err = id.PopSegment(webPubSubKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'hubs' segment
+	hubsKey := "hubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, hubsKey) {
+			hubsKey = key
+			break
+		}
+	}
+	if resourceId.HubName, err = id.PopSegment(hubsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/signalr/parse/web_pubsub_hub_test.go
+++ b/internal/services/signalr/parse/web_pubsub_hub_test.go
@@ -126,3 +126,139 @@ func TestWebPubsubHubID(t *testing.T) {
 		}
 	}
 }
+
+func TestWebPubsubHubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *WebPubsubHubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing WebPubSubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/",
+			Error: true,
+		},
+
+		{
+			// missing value for WebPubSubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/",
+			Error: true,
+		},
+
+		{
+			// missing HubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/",
+			Error: true,
+		},
+
+		{
+			// missing value for HubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/hubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/hubs/Webpubsubhub1",
+			Expected: &WebPubsubHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+				HubName:        "Webpubsubhub1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webpubsub/Webpubsub1/hubs/Webpubsubhub1",
+			Expected: &WebPubsubHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+				HubName:        "Webpubsubhub1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/WEBPUBSUB/Webpubsub1/HUBS/Webpubsubhub1",
+			Expected: &WebPubsubHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+				HubName:        "Webpubsubhub1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/WeBpUbSuB/Webpubsub1/HuBs/Webpubsubhub1",
+			Expected: &WebPubsubHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+				HubName:        "Webpubsubhub1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := WebPubsubHubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.WebPubSubName != v.Expected.WebPubSubName {
+			t.Fatalf("Expected %q but got %q for WebPubSubName", v.Expected.WebPubSubName, actual.WebPubSubName)
+		}
+		if actual.HubName != v.Expected.HubName {
+			t.Fatalf("Expected %q but got %q for HubName", v.Expected.HubName, actual.HubName)
+		}
+	}
+}

--- a/internal/services/signalr/parse/web_pubsub_test.go
+++ b/internal/services/signalr/parse/web_pubsub_test.go
@@ -110,3 +110,120 @@ func TestWebPubsubID(t *testing.T) {
 		}
 	}
 }
+
+func TestWebPubsubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *WebPubsubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing WebPubSubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/",
+			Error: true,
+		},
+
+		{
+			// missing value for WebPubSubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1",
+			Expected: &WebPubsubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webpubsub/Webpubsub1",
+			Expected: &WebPubsubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/WEBPUBSUB/Webpubsub1",
+			Expected: &WebPubsubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/WeBpUbSuB/Webpubsub1",
+			Expected: &WebPubsubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				WebPubSubName:  "Webpubsub1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := WebPubsubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.WebPubSubName != v.Expected.WebPubSubName {
+			t.Fatalf("Expected %q but got %q for WebPubSubName", v.Expected.WebPubSubName, actual.WebPubSubName)
+		}
+	}
+}

--- a/internal/services/signalr/resourceids.go
+++ b/internal/services/signalr/resourceids.go
@@ -1,5 +1,5 @@
 package signalr
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebPubsub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebPubsubHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/hubs/Webpubsubhub1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebPubsub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1 -rewrite=true
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebPubsubHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/hubs/Webpubsubhub1 -rewrite=true
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebPubsubSharedPrivateLinkResource -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.SignalRService/webPubSub/Webpubsub1/sharedPrivateLinkResources/resource1

--- a/internal/services/signalr/web_pubsub_hub_resource.go
+++ b/internal/services/signalr/web_pubsub_hub_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -29,6 +30,11 @@ func resourceWebPubsubHub() *pluginsdk.Resource {
 			_, err := parse.WebPubsubHubID(id)
 			return err
 		}),
+
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WebPubsubHubV0ToV1{},
+		}),
+		SchemaVersion: 1,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -37,6 +38,11 @@ func resourceWebPubSub() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WebPubsubV0ToV1{},
+		}),
+		SchemaVersion: 1,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.WebPubsubID(id)


### PR DESCRIPTION
The old segment is `WebPubsub` but should be `webPubsub`

fixing the issue https://github.com/hashicorp/terraform-provider-azurerm/issues/17784