### PR TITLE
Make `instances` optional since the API doesn't require this parameter.

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -1059,7 +1059,8 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 
 		"instances": {
 			Type:         pluginsdk.TypeInt,
-			Required:     true,
+			Optional:     true,
+			Default:      0,
 			ValidateFunc: validation.IntAtLeast(0),
 		},
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `admin_username` - (Required) The username of the local administrator on each Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
 
-* `instances` - (Required) The number of Virtual Machines in the Scale Set.
+* `instances` - (Optional) The number of Virtual Machines in the Scale Set. Defaults to `0`.
 
 -> **NOTE:** If you're using AutoScaling, you may wish to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) to ignore changes to this field.
 


### PR DESCRIPTION
Make `instances` optional since the API doesn't require this parameter.
If we leave this parameter `nil` in creation, the API will respond `0` when we read, so I add a default value to this argument.
This pr will fix #17821 .

The new added acc test:

=== RUN   TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
=== PAUSE TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
=== CONT  TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
--- PASS: TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount (306.18s)
PASS
