### PR TITLE
`azurerm_hdinsight_kafka_cluster`, `azurerm_hdinsight_spark_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_hadoop_cluster` - Add support for `extension` property

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -448,6 +448,98 @@ func TestAccHDInsightHadoopCluster_monitor(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHadoopCluster_azureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	r := HDInsightHadoopClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccHDInsightHadoopCluster_updateAzureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	r := HDInsightHadoopClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			PreConfig: func() {
+				data.RandomString += "new"
+			},
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightHadoopCluster_updateGateway(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
 	r := HDInsightHadoopClusterResource{}
@@ -1969,6 +2061,68 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   monitor {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
     primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
+  }
+}
+`, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightHadoopClusterResource) azureMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name = "acctestLAW-%s-%d"
+  location = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_hdinsight_hadoop_cluster" "test" {
+  name = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location = azurerm_resource_group.test.location
+  cluster_version = "4.0"
+  tier = "Standard"
+  
+  component_version {
+    hadoop = "3.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size                  = "Standard_D4_V2"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+
+  extension {
+	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -2071,19 +2071,19 @@ func (r HDInsightHadoopClusterResource) azureMonitor(data acceptance.TestData) s
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW-%s-%d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW-%s-%d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku = "PerGB2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_hdinsight_hadoop_cluster" "test" {
-  name = "acctesthdi-%d"
+  name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location = azurerm_resource_group.test.location
-  cluster_version = "4.0"
-  tier = "Standard"
-  
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
   component_version {
     hadoop = "3.1"
   }
@@ -2107,10 +2107,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
     }
 
     worker_node {
-      vm_size                  = "Standard_D4_V2"
-      username                 = "acctestusrvm"
-      password                 = "AccTestvdSC4daf986!"
-      target_instance_count    = 3
+      vm_size               = "Standard_D4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
     }
 
     zookeeper_node {
@@ -2121,8 +2121,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   extension {
-	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
-	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+    primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -131,6 +131,8 @@ func resourceHDInsightHBaseCluster() *pluginsdk.Resource {
 			},
 
 			"monitor": SchemaHDInsightsMonitor(),
+
+			"extension": SchemaHDInsightsExtension(),
 		},
 	}
 }
@@ -267,6 +269,13 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if v, ok := d.GetOk("extension"); ok {
+		extensionRaw := v.([]interface{})
+		if err := enableHDInsightAzureMonitor(ctx, extensionsClient, resourceGroup, name, extensionRaw); err != nil {
+			return err
+		}
+	}
+
 	return resourceHDInsightHBaseClusterRead(d, meta)
 }
 
@@ -375,6 +384,13 @@ func resourceHDInsightHBaseClusterRead(d *pluginsdk.ResourceData, meta interface
 		}
 
 		d.Set("monitor", flattenHDInsightMonitoring(monitor))
+
+		extension, err := extensionsClient.GetAzureMonitorStatus(ctx, resourceGroup, name)
+		if err != nil {
+			return fmt.Errorf("reading extension configuration for HDInsight Hadoop Cluster %q (Resource Group %q) %+v", name, resourceGroup, err)
+		}
+
+		d.Set("extension", flattenHDInsightAzureMonitor(extension))
 
 		if err := d.Set("security_profile", flattenHDInsightSecurityProfile(props.SecurityProfile, d)); err != nil {
 			return fmt.Errorf("setting `security_profile`: %+v", err)

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -420,6 +420,135 @@ func TestAccHDInsightHBaseCluster_updateMonitor(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHBaseCluster_azureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
+	r := HDInsightHBaseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccHDInsightHBaseCluster_updateAzureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
+	r := HDInsightHBaseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			PreConfig: func() {
+				data.RandomString += "new"
+			},
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccAzureRMHDInsightHBaseCluster_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
+	r := HDInsightHBaseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscale_schedule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func testAccHDInsightHBaseCluster_securityProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
 	r := HDInsightHBaseClusterResource{}
@@ -1639,6 +1768,133 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightHBaseClusterResource) azureMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name = "acctestLAW-%s-%d"
+  location = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_hdinsight_hbase_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    hbase = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D3_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+
+  extension {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+    primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
+  }
+}
+`, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightHBaseClusterResource) autoscale_schedule(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hbase_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    hbase = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D3_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+      autoscale {
+        recurrence {
+          timezone = "Pacific Standard Time"
+          schedule {
+            days                  = ["Monday"]
+            time                  = "10:00"
+            target_instance_count = 5
+          }
+          schedule {
+            days                  = ["Saturday", "Sunday"]
+            time                  = "10:00"
+            target_instance_count = 3
+          }
+        }
+      }
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r HDInsightHBaseClusterResource) securityProfile(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1775,10 +1775,10 @@ func (r HDInsightHBaseClusterResource) azureMonitor(data acceptance.TestData) st
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW-%s-%d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW-%s-%d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku = "PerGB2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_hdinsight_hbase_cluster" "test" {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -443,6 +443,83 @@ func TestAccHDInsightInteractiveQueryCluster_updateMonitor(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightInteractiveQueryCluster_azureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
+	r := HDInsightInteractiveQueryClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.monitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccHDInsightInteractiveQueryCluster_updateAzureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
+	r := HDInsightInteractiveQueryClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			PreConfig: func() {
+				data.RandomString += "new"
+			},
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
 	r := HDInsightInteractiveQueryClusterResource{}
@@ -1764,6 +1841,68 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   monitor {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
     primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
+  }
+}
+`, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightInteractiveQueryClusterResource) azureMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name = "acctestLAW-%s-%d"
+  location = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_hdinsight_interactive_query_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    interactive_hive = "3.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D13_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D14_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+
+  extension {
+	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1851,10 +1851,10 @@ func (r HDInsightInteractiveQueryClusterResource) azureMonitor(data acceptance.T
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW-%s-%d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW-%s-%d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku = "PerGB2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_hdinsight_interactive_query_cluster" "test" {
@@ -1901,8 +1901,8 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   extension {
-	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
-	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+    primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -383,6 +383,98 @@ func TestAccHDInsightKafkaCluster_updateMonitor(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightKafkaCluster_azureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	r := HDInsightKafkaClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccHDInsightKafkaCluster_updateAzureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	r := HDInsightKafkaClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			PreConfig: func() {
+				data.RandomString += "new"
+			},
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightKafkaCluster_restProxy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
 	r := HDInsightKafkaClusterResource{}
@@ -1292,6 +1384,69 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   monitor {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
     primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
+  }
+}
+`, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightKafkaClusterResource) azureMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name = "acctestLAW-%s-%d"
+  location = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_hdinsight_kafka_cluster" "test" {
+  name = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location = azurerm_resource_group.test.location
+  cluster_version = "4.0"
+  tier = "Standard"
+  
+  component_version {
+    kafka = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size                  = "Standard_D3_V2"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+      number_of_disks_per_node = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+
+  extension {
+	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1394,19 +1394,19 @@ func (r HDInsightKafkaClusterResource) azureMonitor(data acceptance.TestData) st
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW-%s-%d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW-%s-%d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku = "PerGB2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_hdinsight_kafka_cluster" "test" {
-  name = "acctesthdi-%d"
+  name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location = azurerm_resource_group.test.location
-  cluster_version = "4.0"
-  tier = "Standard"
-  
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
   component_version {
     kafka = "2.1"
   }
@@ -1445,8 +1445,8 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   extension {
-	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
-	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+    primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -443,6 +443,98 @@ func TestAccHDInsightSparkCluster_updateMonitor(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightSparkCluster_azureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	r := HDInsightSparkClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
+func TestAccHDInsightSparkCluster_updateAzureMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	r := HDInsightSparkClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			PreConfig: func() {
+				data.RandomString += "new"
+			},
+			Config: r.azureMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccAzureRMHDInsightSparkCluster_autoscaleWithSchedule(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
 	r := HDInsightSparkClusterResource{}
@@ -1788,6 +1880,68 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   monitor {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
     primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
+  }
+}
+`, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightSparkClusterResource) azureMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name = "acctestLAW-%s-%d"
+  location = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_hdinsight_spark_cluster" "test" {
+  name = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location = azurerm_resource_group.test.location
+  cluster_version = "4.0"
+  tier = "Standard"
+
+  component_version {
+	spark = "2.4"
+  }
+
+  gateway {
+	username = "acctestusrgw"
+	password = "TerrAform123!"
+  }
+
+  storage_account {
+	storage_container_id = azurerm_storage_container.test.id
+	storage_account_key = azurerm_storage_account.test.primary_access_key
+	is_default = true
+  }
+
+  roles {
+	head_node {
+	  vm_size = "Standard_A4_V2"
+	  username = "acctestusrvm"
+	  password = "AccTestvdSC4daf986!"
+	}
+
+	worker_node {
+	  vm_size = "Standard_A4_V2"
+	  username = "acctestusrvm"
+	  password = "AccTestvdSC4daf986!"
+	  target_instance_count = 3
+	}
+
+    zookeeper_node {
+      vm_size  = "Medium"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+
+  extension {
+	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1890,47 +1890,47 @@ func (r HDInsightSparkClusterResource) azureMonitor(data acceptance.TestData) st
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW-%s-%d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW-%s-%d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku = "PerGB2018"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_hdinsight_spark_cluster" "test" {
-  name = "acctesthdi-%d"
+  name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location = azurerm_resource_group.test.location
-  cluster_version = "4.0"
-  tier = "Standard"
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
 
   component_version {
-	spark = "2.4"
+    spark = "2.4"
   }
 
   gateway {
-	username = "acctestusrgw"
-	password = "TerrAform123!"
+    username = "acctestusrgw"
+    password = "TerrAform123!"
   }
 
   storage_account {
-	storage_container_id = azurerm_storage_container.test.id
-	storage_account_key = azurerm_storage_account.test.primary_access_key
-	is_default = true
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
   }
 
   roles {
-	head_node {
-	  vm_size = "Standard_A4_V2"
-	  username = "acctestusrvm"
-	  password = "AccTestvdSC4daf986!"
-	}
+    head_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
 
-	worker_node {
-	  vm_size = "Standard_A4_V2"
-	  username = "acctestusrvm"
-	  password = "AccTestvdSC4daf986!"
-	  target_instance_count = 3
-	}
+    worker_node {
+      vm_size               = "Standard_A4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+    }
 
     zookeeper_node {
       vm_size  = "Medium"
@@ -1940,8 +1940,8 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   extension {
-	log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
-	primary_key = azurerm_log_analytics_workspace.test.primary_shared_key
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.test.workspace_id
+    primary_key                = azurerm_log_analytics_workspace.test.primary_shared_key
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -2,6 +2,7 @@ package hdinsight
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net/url"
 	"regexp"
 	"strings"
@@ -187,6 +188,32 @@ func SchemaHDInsightsMonitor() *pluginsdk.Schema {
 					ValidateFunc: validation.StringIsNotEmpty,
 					// Azure doesn't return the key
 					DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
+						return (new == d.Get(k).(string)) && (old == "*****")
+					},
+				},
+			},
+		},
+	}
+}
+
+func SchemaHDInsightsExtension() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"log_analytics_workspace_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsUUID,
+				},
+				"primary_key": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 						return (new == d.Get(k).(string)) && (old == "*****")
 					},
 				},

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -2,13 +2,13 @@ package hdinsight
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/hdinsight/mgmt/2018-06-01/hdinsight"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hdinsight/validate"

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -114,6 +114,8 @@ The following arguments are supported:
 * `metastores` - (Optional) A `metastores` block as defined below.
 
 * `monitor` - (Optional) A `monitor` block as defined below.
+
+* `extension` - (Optional) An `extension` block as defined below.
   
 * `security_profile` - (Optional) A `security_profile` block as defined below.
 
@@ -359,6 +361,14 @@ A `monitor` block supports the following:
 * `log_analytics_workspace_id` - (Required) The Operations Management Suite (OMS) workspace ID.
 
 * `primary_key` - (Required) The Operations Management Suite (OMS) workspace key.
+
+---
+
+A `extension` block supports the following:
+
+* `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
+
+* `primary_key` - (Required) The workspace key of the log analytics extension.
 
 ---
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -115,6 +115,8 @@ The following arguments are supported:
 
 * `monitor` - (Optional) A `monitor` block as defined below.
 
+* `extension` - (Optional) An `extension` block as defined below.
+
 * `security_profile` - (Optional) A `security_profile` block as defined below.
 
 ---
@@ -315,6 +317,14 @@ A `monitor` block supports the following:
 * `log_analytics_workspace_id` - (Required) The Operations Management Suite (OMS) workspace ID.
 
 * `primary_key` - (Required) The Operations Management Suite (OMS) workspace key.
+
+---
+
+A `extension` block supports the following:
+
+* `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
+
+* `primary_key` - (Required) The workspace key of the log analytics extension.
 
 ---
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -116,6 +116,8 @@ The following arguments are supported:
 
 * `monitor` - (Optional) A `monitor` block as defined below.
 
+* `extension` - (Optional) An `extension` block as defined below.
+
 * `security_profile` - (Optional) A `security_profile` block as defined below.
 
 ---
@@ -320,6 +322,14 @@ A `monitor` block supports the following:
 * `log_analytics_workspace_id` - (Required) The Operations Management Suite (OMS) workspace ID.
 
 * `primary_key` - (Required) The Operations Management Suite (OMS) workspace key.
+
+---
+
+A `extension` block supports the following:
+
+* `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
+
+* `primary_key` - (Required) The workspace key of the log analytics extension.
 
 ---
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -118,6 +118,8 @@ The following arguments are supported:
 
 * `monitor` - (Optional) A `monitor` block as defined below.
 
+* `extension` - (Optional) An `extension` block as defined below.
+
 * `rest_proxy` - (Optional) A `rest_proxy` block as defined below.
 
 * `security_profile` - (Optional) A `security_profile` block as defined below.
@@ -340,6 +342,14 @@ A `monitor` block supports the following:
 * `log_analytics_workspace_id` - (Required) The Operations Management Suite (OMS) workspace ID.
 
 * `primary_key` - (Required) The Operations Management Suite (OMS) workspace key.
+
+---
+
+A `extension` block supports the following:
+
+* `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
+
+* `primary_key` - (Required) The workspace key of the log analytics extension.
 
 ---
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -117,6 +117,8 @@ The following arguments are supported:
 
 * `monitor` - (Optional) A `monitor` block as defined below.
 
+* `extension` - (Optional) An `extension` block as defined below.
+
 * `security_profile` - (Optional) A `security_profile` block as defined below.
 
 ---
@@ -317,6 +319,14 @@ A `monitor` block supports the following:
 * `log_analytics_workspace_id` - (Required) The Operations Management Suite (OMS) workspace ID.
 
 * `primary_key` - (Required) The Operations Management Suite (OMS) workspace key.
+
+---
+
+A `extension` block supports the following:
+
+* `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
+
+* `primary_key` - (Required) The workspace key of the log analytics extension.
 
 ---
 


### PR DESCRIPTION
* All test cases passed.