### PR TITLE
`azurerm_kubernetes_cluster` - fix failed tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -166,7 +166,7 @@ func TestAccKubernetesCluster_nodeLabels(t *testing.T) {
 			Config: r.nodeLabelsConfig(data, labels3),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				acceptance.TestCheckNoResourceAttr(data.ResourceName, "default_node_pool.0.node_labels"),
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.%").HasValue("0"),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -17,8 +17,8 @@ import (
 type KubernetesClusterResource struct{}
 
 var (
-	olderKubernetesVersion        = "1.21.7"
-	currentKubernetesVersion      = "1.22.4"
+	olderKubernetesVersion        = "1.22.11"
+	currentKubernetesVersion      = "1.23.5"
 	olderKubernetesVersionAlias   = "1.22"
 	currentKubernetesVersionAlias = "1.23"
 )


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesCluster_upgrade
=== PAUSE TestAccKubernetesCluster_upgrade
=== CONT  TestAccKubernetesCluster_upgrade
--- PASS: TestAccKubernetesCluster_upgrade (840.98s)

=== RUN   TestAccKubernetesCluster_nodeLabels
=== PAUSE TestAccKubernetesCluster_nodeLabels
=== CONT  TestAccKubernetesCluster_nodeLabels
--- PASS: TestAccKubernetesCluster_nodeLabels (864.17s)
PASS
```