### PR TITLE
gha - fix and improvements to waiting-response

### DIFF
--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -22,9 +22,11 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           labels: waiting-response
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
         if: ${{ endsWith(github.event.comment.body, '/wr') }}
         with:
           labels: waiting-response
           github_token: "${{ secrets.GITHUB_TOKEN }}"
+          number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}
 

--- a/.github/workflows/pull-request-reviewed.yaml
+++ b/.github/workflows/pull-request-reviewed.yaml
@@ -7,10 +7,20 @@ on:
 
 jobs:
   add-waiting-response:
-    if: github.event.review.state != 'approved'
+    if: github.event.review.state != 'approved' && github.actor != github.event.pull_request.user.login
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: waiting-response
           github_token: "${{ secrets.GITHUB_TOKEN }}"
+          number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}
+  remove-waiting-response:
+    if: github.actor == github.event.pull_request.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: waiting-response


### PR DESCRIPTION
- include PR number and repo details in action
- do not add "waiting-response" when PR owner responds with review comment
- remove "waiting-response" when PR owner replies on review comment