### PR TITLE
`automation_dsc_nodeconfiguration` - support for the `content_version`, `hash` and `increment_build_enabled` properties

### DIFF
--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
@@ -228,14 +228,3 @@ func expandContentHash(input []interface{}) *automation.ContentHash {
 	hash.Value = utils.String(meta["value"].(string))
 	return &hash
 }
-
-func flattenContentHash(input *automation.ContentHash) (res []interface{}) {
-	if input == nil {
-		return
-	}
-	res = append(res, map[string]interface{}{
-		"algorithm": utils.NormalizeNilableString(input.Algorithm),
-		"value":     utils.NormalizeNilableString(input.Value),
-	})
-	return res
-}

--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
@@ -27,7 +27,7 @@ func TestAccAutomationDscNodeConfiguration_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("configuration_name").HasValue("acctest"),
 			),
 		},
-		data.ImportStep("content_embedded"),
+		data.ImportStep("content_embedded", "content_hash", "tags", "content_version", "increment_build_enabled"),
 	})
 }
 
@@ -91,6 +91,15 @@ resource "azurerm_automation_dsc_nodeconfiguration" "test" {
   resource_group_name     = azurerm_resource_group.test.name
   automation_account_name = azurerm_automation_account.test.name
   depends_on              = [azurerm_automation_dsc_configuration.test]
+  content_hash {
+    algorithm = "sha256"
+    value     = "c10eef522ab9759496831c26087ad4b83cac47f3fc6ac4355d55fe8fdd518514"
+  }
+  content_version = "1.1.1"
+  tags = {
+    foo = "bar"
+  }
+  increment_build_enabled = true
 
   content_embedded = <<mofcontent
 instance of MSFT_FileDirectoryConfiguration as $MSFT_FileDirectoryConfiguration1ref

--- a/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
+++ b/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
@@ -78,6 +78,22 @@ The following arguments are supported:
 
 * `content_embedded` - (Required) The PowerShell DSC Node Configuration (mof content).
 
+* `content_version` - (Optional) The version of the content.
+
+* `content_hash` - (Optional) A `content_hash` block as defined below.
+ 
+* `increment_build_enabled` - (Optional) Whether a new build version of NodeConfiguration is required
+
+* `tags` - (Optional) A mapping of tags assigned to the resource.
+
+---
+
+A `content_hash` block supports the following:
+
+* `algorithm` - (Required) The algorithm used to hash the content.
+
+* `value` - (Required) The expected hash value of the content.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
acctest pass only when dsc_configuration read function fixed in #17804  , cause it will cause this pr's resource acc test to fail

--- PASS: TestAccAutomationDscNodeConfiguration_basic (169.09s)
PASS