### PR TITLE
fix KeyVault test: `TestAccKeyVault_softDeleteRecoveryDisabled`

### DIFF
--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -983,6 +983,7 @@ func (KeyVaultResource) softDeleteAbsent(data acceptance.TestData) string {
 provider "azurerm" {
   features {
     key_vault {
+      purge_soft_delete_on_destroy    = false
       recover_soft_deleted_key_vaults = false
     }
   }


### PR DESCRIPTION
This `TestAccKeyVault_softDeleteRecoveryDisabled` test failed every time before.

---
Test result:
```
make acctests SERVICE='keyvault' TESTARGS='-run=TestAccKeyVault_softDelete' TESTTIMEOUT='60m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault -run=TestAccKeyVault_softDelete -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVault_softDelete
=== PAUSE TestAccKeyVault_softDelete
=== RUN   TestAccKeyVault_softDeleteRecovery
=== PAUSE TestAccKeyVault_softDeleteRecovery
=== RUN   TestAccKeyVault_softDeleteRecoveryDisabled
=== PAUSE TestAccKeyVault_softDeleteRecoveryDisabled
=== CONT  TestAccKeyVault_softDelete
=== CONT  TestAccKeyVault_softDeleteRecoveryDisabled
=== CONT  TestAccKeyVault_softDeleteRecovery
--- PASS: TestAccKeyVault_softDelete (266.57s)
--- PASS: TestAccKeyVault_softDeleteRecoveryDisabled (333.73s)
--- PASS: TestAccKeyVault_softDeleteRecovery (517.37s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      517.403s
```