### PR TITLE
Corrected role assignment example usage for metric forwarding

### DIFF
--- a/website/docs/r/datadog_monitors.html.markdown
+++ b/website/docs/r/datadog_monitors.html.markdown
@@ -118,9 +118,15 @@ To enable metrics flow, perform role assignment on the identity created above. `
 
 ### Role assignment on the monitor created
 ```hcl
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_role_definition" "monitoring_reader" {
+  name = "Monitoring Reader"
+}
+
 resource "azurerm_role_assignment" "example" {
   scope              = data.azurerm_subscription.primary.id
-  role_definition_id = "/subscriptions/XXXX-XXXX-XXXX/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05"
+  role_definition_id = data.azurerm_role_definition.monitoring_reader.role_definition_id
   principal_id       = azurerm_datadog_monitor.example.identity.0.principal_id
 }
 ```


### PR DESCRIPTION
I found an opportunity to update the documented usage for the azurerm_role_assignment for the "Monitoring Reader" azurerm_role_definition and the principle created with azurerm_datadog_monitor.