### PR TITLE
fix doc of Schduled Query Rule: add `tags`

### DIFF
--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -59,6 +59,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "example" {
     operator  = "GreaterThan"
     threshold = 3
   }
+  tags = {
+    foo = "bar"
+  }
 }
 
 # Example: Alerting Action Cross-Resource
@@ -92,6 +95,9 @@ QUERY
     operator  = "GreaterThan"
     threshold = 3
   }
+  tags = {
+    foo = "bar"
+  }
 }
 ```
 
@@ -114,6 +120,7 @@ The following arguments are supported:
 * `enabled` - (Optional) Whether this scheduled query rule is enabled.  Default is `true`.
 * `severity` - (Optional) Severity of the alert. Possible values include: 0, 1, 2, 3, or 4.
 * `throttling` - (Optional) Time (in minutes) for which Alerts should be throttled or suppressed.  Values must be between 0 and 10000 (inclusive).
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 

--- a/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
@@ -76,6 +76,9 @@ resource "azurerm_monitor_scheduled_query_rules_log" "example" {
   data_source_id = azurerm_log_analytics_workspace.example.id
   description    = "Scheduled query rule LogToMetric example"
   enabled        = true
+  tags = {
+    foo = "bar"
+  }
 }
 ```
 
@@ -89,6 +92,7 @@ The following arguments are supported:
 * `data_source_id` - (Required) The resource URI over which log search query is to be run.
 * `description` - (Optional) The description of the scheduled query rule.
 * `enabled` - (Optional) Whether this scheduled query rule is enabled.  Default is `true`.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17891
`tags` block has already supported in [`azurerm_monitor_scheduled_query_rules_alert`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go#L216) and [`azurerm_monitor_scheduled_query_rules_log`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/monitor/monitor_scheduled_query_rules_log_resource.go#L126) but it is omitted in the doc.