### PR TITLE
azurerm_postgresql_server : Fix issue about azurerm_postgressql_server requires ssl_enforcement_enabled but documentation says it's optional 

### DIFF
--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -220,7 +220,7 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 
 			"ssl_enforcement_enabled": {
 				Type:     pluginsdk.TypeBool,
-				Required: true,
+				Optional: true,
 			},
 
 			"threat_detection_policy": {


### PR DESCRIPTION
Fix[ #17877](https://github.com/hashicorp/terraform-provider-azurerm/issues/17877).