### PR TITLE
Fix function app examples

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -43,9 +43,9 @@ resource "azurerm_linux_function_app" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  storage_account_name = azurerm_storage_account.example.name
+  storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
-  service_plan_id      = azurerm_service_plan.example.id
+  service_plan_id            = azurerm_service_plan.example.id
 
   site_config {}
 }

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -44,6 +44,7 @@ resource "azurerm_linux_function_app" "example" {
   location            = azurerm_resource_group.example.location
 
   storage_account_name = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
   service_plan_id      = azurerm_service_plan.example.id
 
   site_config {}

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -43,9 +43,9 @@ resource "azurerm_windows_function_app" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  storage_account_name = azurerm_storage_account.example.name
+  storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
-  service_plan_id      = azurerm_service_plan.example.id
+  service_plan_id            = azurerm_service_plan.example.id
 
   site_config {}
 }

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -44,6 +44,7 @@ resource "azurerm_windows_function_app" "example" {
   location            = azurerm_resource_group.example.location
 
   storage_account_name = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
   service_plan_id      = azurerm_service_plan.example.id
 
   site_config {}


### PR DESCRIPTION
Current examples of the function app are not working because of missing primary access key. 

The documentation states that:

~> **NOTE:** One of `storage_account_access_key` or `storage_uses_managed_identity` must be specified when using `storage_account_name`.

I fixed it in the linux and windows function app, by adding the primary key. 