### PR TITLE
`r\network_interface_network_security_group_association`: Ignore case of `network_security_group_id`

### DIFF
--- a/internal/services/network/network_interface_network_security_group_association_resource.go
+++ b/internal/services/network/network_interface_network_security_group_association_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -53,10 +54,12 @@ func resourceNetworkInterfaceSecurityGroupAssociation() *pluginsdk.Resource {
 			},
 
 			"network_security_group_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				// Casing issue is tracked by https://github.com/Azure/azure-rest-api-specs/issues/20131
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     azure.ValidateResourceID,
 			},
 		},
 	}

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -66,8 +66,9 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 						},
 
 						"subnet_id": {
-							Type:             pluginsdk.TypeString,
-							Optional:         true,
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							// Casing issue is tracked by https://github.com/Azure/azure-rest-api-specs/issues/20131
 							DiffSuppressFunc: suppress.CaseDifference,
 							ValidateFunc:     azure.ValidateResourceID,
 						},


### PR DESCRIPTION
Same as `subnet_id`, `network_security_group_id` is also having the casing issue for Network Interface, ignoring the case per https://github.com/Azure/azure-rest-api-specs/issues/20131