### PR TITLE
#17425 — use dot operator for `principal_id`.

### DIFF
--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_role_assignment" "example" {
   name               = azurerm_virtual_machine.example.name
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.subscription.id}${data.azurerm_role_definition.contributor.id}"
-  principal_id       = azurerm_virtual_machine.example.identity[0]["principal_id"]
+  principal_id       = azurerm_virtual_machine.example.identity[0].principal_id
 }
 ```
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -371,7 +371,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 }
 
 output "principal_id" {
-  value = azurerm_virtual_machine_scale_set.example.identity[0]["principal_id"]
+  value = azurerm_virtual_machine_scale_set.example.identity[0].principal_id
 }
 ```
 


### PR DESCRIPTION
Fix documentation error (see #17425).