### PR TITLE
Fix doc of `mointor_schduled_query_rule_alert`: import command case sensitivity

### DIFF
--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -167,5 +167,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Scheduled Query Rule Alerts can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_monitor_scheduled_query_rules_alert.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Insights/scheduledqueryrules/myrulename
+terraform import azurerm_monitor_scheduled_query_rules_alert.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/myrulename
 ```


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17890
This place has been changed in PR https://github.com/hashicorp/terraform-provider-azurerm/pull/14649 brefore.
After PR https://github.com/hashicorp/terraform-provider-azurerm/pull/13644, `scheduledqueryrules` in the import command should be fix to case-sensitive form as `scheduledQueryRules`