### PR TITLE
`azurerm_automation_account` - support for the `private_endpoint_connection` property

### DIFF
--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -41,6 +41,22 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+			"private_endpoint_connection": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -76,5 +92,21 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("secondary_key", iresp.Keys.Secondary)
 	}
 	d.Set("endpoint", iresp.Endpoint)
+	if resp.Model != nil && resp.Model.Properties != nil {
+		d.Set("private_endpoint_connection", flattenPrivateEndpointConnections(resp.Model.Properties.PrivateEndpointConnections))
+	}
 	return nil
+}
+
+func flattenPrivateEndpointConnections(conns *[]automationaccount.PrivateEndpointConnection) (res []interface{}) {
+	if conns == nil || len(*conns) == 0 {
+		return
+	}
+	for _, con := range *conns {
+		res = append(res, map[string]interface{}{
+			"id":   con.Id,
+			"name": con.Name,
+		})
+	}
+	return res
 }

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -79,6 +79,22 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"private_endpoint_connection": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -229,6 +245,10 @@ func resourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 	if err := d.Set("identity", identity); err != nil {
 		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
+	if resp.Model != nil && resp.Model.Properties != nil {
+		d.Set("private_endpoint_connection", flattenPrivateEndpointConnections(resp.Model.Properties.PrivateEndpointConnections))
 	}
 
 	if resp.Model.Tags != nil {


### PR DESCRIPTION
which is needed by automation_private_endpoint_connectioin resource, to Approve/Reject this connection


--- PASS: TestAccAutomationAccount_systemAssignedIdentity (137.62s)
--- PASS: TestAccDataSourceAutomationAccount (147.93s)
--- PASS: TestAccAutomationAccount_complete (149.37s)
--- PASS: TestAccAutomationAccount_basic (150.23s)
--- PASS: TestAccAutomationAccount_systemAssignedUserAssignedIdentity (210.22s)
--- PASS: TestAccAutomationAccount_requiresImport (303.13s)
