### PR TITLE
`r\virtual_machine_extension` `r\virtual_machine_scale_set_extension`: Fix validation of `name`

### DIFF
--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -40,6 +40,10 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringDoesNotContainAny("/"),
+				),
 			},
 
 			"virtual_machine_id": {

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -39,10 +39,13 @@ func resourceVirtualMachineScaleSetExtension() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringDoesNotContainAny("/"),
+				),
 			},
 
 			"virtual_machine_scale_set_id": {


### PR DESCRIPTION
Fix #17911
The `/` is not valid for the name, it causes error with REST API, as well as the ID parsing