### PR TITLE
internal/services/cognitive: add kind = "OpenAI"

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -89,6 +89,7 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 					"LUIS",
 					"LUIS.Authoring",
 					"MetricsAdvisor",
+					"OpenAI",
 					"Personalizer",
 					"QnAMaker",
 					"Recommendations",


### PR DESCRIPTION
Azure Cognitive Services supports models of kind = "OpenAI". Add this
kind to the validation list to permit the provider to create and manage
cog services resources of this kind.