### PR TITLE
Fix Import As Exists Error Message of`azurerm_monitor_diagnostic_setting` 

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -195,7 +195,7 @@ func resourceMonitorDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, met
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_monitor_diagnostic_setting", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_monitor_diagnostic_setting", fmt.Sprintf("%s|%s", actualResourceId, name))
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17263
The error messge should return an ID with format `{resourceId}|{diagnosticSettingName}`. 
Reference: 
1. [Import Doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting#import)

2. [Source Code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/monitor/monitor_diagnostic_setting_resource.go#L287)