### PR TITLE
Update naming validation to allow length to be 1 - 128

### DIFF
--- a/internal/services/policy/assignment_management_group_resource.go
+++ b/internal/services/policy/assignment_management_group_resource.go
@@ -28,7 +28,7 @@ func (r ManagementGroupAssignmentResource) Arguments() map[string]*pluginsdk.Sch
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				// The policy assignment name length must not exceed '24' characters.
+				// The policy assignment name length must not exceed '128' characters.
 				validation.StringLenBetween(1, 128),
 				validation.StringDoesNotContainAny("/"),
 			),

--- a/internal/services/policy/assignment_management_group_resource.go
+++ b/internal/services/policy/assignment_management_group_resource.go
@@ -29,7 +29,7 @@ func (r ManagementGroupAssignmentResource) Arguments() map[string]*pluginsdk.Sch
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
 				// The policy assignment name length must not exceed '24' characters.
-				validation.StringLenBetween(3, 24),
+				validation.StringLenBetween(1, 128),
 				validation.StringDoesNotContainAny("/"),
 			),
 		},


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftauthorization
length of a definitionname is 1 - 128 and not 3 - 24