### PR TITLE
chore: Auto update github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a dependabot file to update the versions of the Github Actions used for CI jobs.
This requires to create a dependabot.yml file and to enable dependabot version updates in the settings of the repository

I applied this to my fork and it proposed the correct updates.
https://github.com/iemejia/terraform-provider-azurerm/pulls