### PR TITLE
`azurerm_storage_management_policy` - Relieve the rule name validation

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
@@ -49,12 +48,9 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringMatch(
-								regexp.MustCompile(`^[a-zA-Z0-9-]*$`),
-								"A rule name can contain any combination of alpha numeric characters.",
-							),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"enabled": {
 							Type:     pluginsdk.TypeBool,

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 * `rule` supports the following:
 
-* `name` - (Required) A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy.
+* `name` - (Required) The name of the rule. Rule name is case-sensitive. It must be unique within a policy.
 * `enabled` - (Required)  Boolean to specify whether the rule is enabled.
 * `filters` - A `filter` block as documented below.
 * `actions` - An `actions` block as documented below.


### PR DESCRIPTION
Locally tested on names like " rule.*^&!@#$%^&*(){}:>< 1", the API still works.

Fix #17969.