### PR TITLE
Revert "Update naming validation to allow length to be 1 - 128 (#17965)"

### DIFF
--- a/internal/services/policy/assignment_management_group_resource.go
+++ b/internal/services/policy/assignment_management_group_resource.go
@@ -28,8 +28,8 @@ func (r ManagementGroupAssignmentResource) Arguments() map[string]*pluginsdk.Sch
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				// The policy assignment name length must not exceed '128' characters.
-				validation.StringLenBetween(1, 128),
+				// The policy assignment name length must not exceed '24' characters.
+				validation.StringLenBetween(3, 24),
 				validation.StringDoesNotContainAny("/"),
 			),
 		},


### PR DESCRIPTION
This reverts commit e31b6febe9c5cc7d37dc5ae93b77ee49a52fdf7c.

I'm sorry but the "name" property does have this constraint. I was mistaken by the "Display Name" property.

Please revert this commit