### PR TITLE
New Data Source: `azurerm_monitor_data_collection_endpoint`

### DIFF
--- a/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
@@ -1,0 +1,135 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-04-01/datacollectionendpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type DataCollectionEndpointDataSource struct{}
+
+var _ sdk.DataSource = DataCollectionEndpointDataSource{}
+
+func (d DataCollectionEndpointDataSource) ModelObject() interface{} {
+	return &DataCollectionEndpoint{}
+}
+
+func (d DataCollectionEndpointDataSource) ResourceType() string {
+	return "azurerm_monitor_data_collection_endpoint"
+}
+
+func (d DataCollectionEndpointDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (d DataCollectionEndpointDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"configuration_access_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"location": commonschema.LocationComputed(),
+
+		"logs_ingestion_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"kind": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (d DataCollectionEndpointDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Monitor.DataCollectionEndpointsClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state DataCollectionEndpoint
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := datacollectionendpoints.NewDataCollectionEndpointID(subscriptionId, state.ResourceGroupName, state.Name)
+			metadata.Logger.Infof("retrieving %s", id)
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					metadata.Logger.Infof("%s was not found - removing from state!", id)
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			var enablePublicNetWorkAccess bool
+			var description, kind, location, configurationAccessEndpoint, logsIngestionEndpoint string
+			var tag map[string]interface{}
+			if model := resp.Model; model != nil {
+				kind = flattenDataCollectionEndpointKind(model.Kind)
+				location = azure.NormalizeLocation(model.Location)
+				tag = tags.Flatten(model.Tags)
+				if prop := model.Properties; prop != nil {
+					description = flattenDataCollectionEndpointDescription(prop.Description)
+					if networkAcls := prop.NetworkAcls; networkAcls != nil {
+						enablePublicNetWorkAccess = flattenDataCollectionEndpointPublicNetworkAccess(networkAcls.PublicNetworkAccess)
+					}
+
+					if prop.ConfigurationAccess != nil && prop.ConfigurationAccess.Endpoint != nil {
+						configurationAccessEndpoint = *prop.ConfigurationAccess.Endpoint
+					}
+
+					if prop.LogsIngestion != nil && prop.LogsIngestion.Endpoint != nil {
+						logsIngestionEndpoint = *prop.LogsIngestion.Endpoint
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&DataCollectionEndpoint{
+				ConfigurationAccessEndpoint: configurationAccessEndpoint,
+				Description:                 description,
+				Kind:                        kind,
+				Location:                    location,
+				LogsIngestionEndpoint:       logsIngestionEndpoint,
+				Name:                        id.DataCollectionEndpointName,
+				EnablePublicNetworkAccess:   enablePublicNetWorkAccess,
+				ResourceGroupName:           id.ResourceGroupName,
+				Tags:                        tag,
+			})
+		},
+		Timeout: 5 * time.Minute,
+	}
+}

--- a/internal/services/monitor/monitor_data_collection_endpoint_data_source_test.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_data_source_test.go
@@ -1,0 +1,39 @@
+package monitor_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type MonitorDataCollectionEndpointDataSource struct{}
+
+func TestAccMonitorDataCollectionEndpointDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_monitor_data_collection_endpoint", "test")
+	d := MonitorDataCollectionEndpointDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("kind").HasValue("Windows"),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("configuration_access_endpoint").Exists(),
+				check.That(data.ResourceName).Key("logs_ingestion_endpoint").Exists(),
+			),
+		},
+	})
+}
+
+func (d MonitorDataCollectionEndpointDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_monitor_data_collection_endpoint" "test" {
+  name                = azurerm_monitor_data_collection_endpoint.test.name
+  resource_group_name = azurerm_monitor_data_collection_endpoint.test.resource_group_name
+}
+`, MonitorDataCollectionEndpointResource{}.complete(data))
+}

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -83,8 +83,7 @@ type LogAnalytic struct {
 	WorkspaceResourceId string `tfschema:"workspace_resource_id"`
 }
 
-type DataCollectionRuleResource struct {
-}
+type DataCollectionRuleResource struct{}
 
 func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{

--- a/internal/services/monitor/registration.go
+++ b/internal/services/monitor/registration.go
@@ -17,7 +17,9 @@ func (r Registration) AssociatedGitHubLabel() string {
 }
 
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		DataCollectionEndpointDataSource{},
+	}
 }
 
 func (r Registration) Resources() []sdk.Resource {

--- a/website/docs/d/monitor_data_collection_endpoint.html.markdown
+++ b/website/docs/d/monitor_data_collection_endpoint.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Monitor"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_monitor_data_collection_endpoint"
+description: |-
+  Get information about the specified Data Collection Endpoint.
+
+---
+
+# Data Source: azurerm_monitor_data_collection_endpoint
+
+Use this data source to access information about an existing Data Collection Endpoint.
+
+## Example Usage
+
+```hcl
+data "azurerm_data_collection_endpoint" "example" {
+  name                = "example-mdce"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+output "endpoint_id" {
+  value = data.azurerm_monitor_data_collection_endpoint.example.id
+}
+```
+
+## Argument Reference
+
+* `name` - Specifies the name of the Data Collection Endpoint.
+
+* `resource_group_name` - Specifies the name of the resource group the Data Collection Endpoint is located in.
+
+## Attributes Reference
+
+* `id` - The ID of the Resource.
+
+* `configuration_access_endpoint` - The endpoint used for accessing configuration, e.g., `https://mydce-abcd.eastus-1.control.monitor.azure.com`.
+
+* `description` - Specifies a description for the Data Collection Endpoint.
+
+* `kind` - The kind of the Data Collection Endpoint. Possible values are `Linux` and `Windows`.
+
+* `location` - The Azure Region where the Data Collection Endpoint should exist.
+
+* `logs_ingestion_endpoint` - The endpoint used for ingesting logs, e.g., `https://mydce-abcd.eastus-1.ingest.monitor.azure.com`.
+
+* `public_network_access_enabled` - Whether network access from public internet to the Data Collection Endpoint are allowed. Possible values are `true` and `false`.
+
+* `tags` - A mapping of tags which should be assigned to the Data Collection Endpoint.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Collection Endpoint.

--- a/website/docs/r/monitor_data_collection_endpoint.html.markdown
+++ b/website/docs/r/monitor_data_collection_endpoint.html.markdown
@@ -13,14 +13,15 @@ Manages a Data Collection Endpoint.
 ## Example Usage
 
 ```hcl
-# Generated from AccTest TestAccMonitorDataCollectionEndpoint_complete
 provider "azurerm" {
   features {}
 }
+
 resource "azurerm_resource_group" "example" {
   name     = "example-rg"
   location = "West Europe"
 }
+
 resource "azurerm_monitor_data_collection_endpoint" "example" {
   name                          = "example-mdce"
   resource_group_name           = azurerm_resource_group.example.name
@@ -60,9 +61,13 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Data Collection Endpoint.
 
+* `configuration_access_endpoint` - The endpoint used for accessing configuration, e.g., `https://mydce-abcd.eastus-1.control.monitor.azure.com`.
+
+* `logs_ingestion_endpoint` - The endpoint used for ingesting logs, e.g., `https://mydce-abcd.eastus-1.ingest.monitor.azure.com`.
+
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Collection Endpoint.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Data Collection Endpoint.


### PR DESCRIPTION
## New Data Source: `azurerm_monitor_data_collection_endpoint`
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17956
Reference:
1. [Microsoft doc](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-endpoint-overview)
2. [REST API specification 2021-04-01](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-04-01/dataCollectionEndpoints_API.json)

<details>
<summary>Test Result</summary>

```
make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorDataCollectionEndpointDataSource_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccMonitorDataCollectionEndpointDataSource_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDataCollectionEndpointDataSource_complete
=== PAUSE TestAccMonitorDataCollectionEndpointDataSource_complete
=== CONT  TestAccMonitorDataCollectionEndpointDataSource_complete
--- PASS: TestAccMonitorDataCollectionEndpointDataSource_complete (171.45s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       171.485s

```
</details>
