### PR TITLE
azurerm_windows_web_app_slot - fix zip_deploy_file on Update

### DIFF
--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -684,7 +684,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("zip_deploy_file") || metadata.ResourceData.HasChange("zip_deploy_file") {
-				if err = helpers.GetCredentialsAndPublish(ctx, client, id.ResourceGroup, id.SiteName, state.ZipDeployFile); err != nil {
+				if err = helpers.GetCredentialsAndPublishSlot(ctx, client, id.ResourceGroup, id.SiteName, state.ZipDeployFile, id.SlotName); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Bugfix to correct updating the `zip_deploy_file` for a slot. Currently, it will update the main windows app service with the contents of the `zip_deploy_file` that should be going to the specified slot.

fixes #18001 