### PR TITLE
`azurerm_container_registry` - Doc: mention the expected order of `georeplications`

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -153,6 +153,8 @@ The following arguments are supported:
 
 ~> **NOTE:** The `georeplications` list cannot contain the location where the Container Registry exists.
 
+~> **NOTE:** If more than one `georeplications` block is specified, they are expected to follow the alphabetic order on the `location` property.
+
 * `network_rule_set` - (Optional) A `network_rule_set` block as documented below.
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for the container registry. Defaults to `true`.


### PR DESCRIPTION
Fix #17987

The reason of it can be found in https://github.com/hashicorp/terraform-provider-azurerm/pull/16678