### PR TITLE
`azurerm_storage_account` - support for the `public_network_access_enabled` property

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -733,11 +733,11 @@ resource "azurerm_windows_virtual_machine" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   # Message="OS disk of Ephemeral VM with size greater than 32 GB is not allowed for VM size Standard_F2s_v2"
-  size           = "Standard_DS3_v2"
-  admin_username = "adminuser"
-  admin_password = "P@$$w0rd1234!"
-  priority            = "Spot"
-  eviction_policy     = "Delete"
+  size            = "Standard_DS3_v2"
+  admin_username  = "adminuser"
+  admin_password  = "P@$$w0rd1234!"
+  priority        = "Spot"
+  eviction_policy = "Delete"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1312,9 +1312,9 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  location                      = azurerm_resource_group.test.location
+  account_tier                  = "Standard"
+  account_replication_type      = "LRS"
   public_network_access_enabled = %t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -468,6 +468,28 @@ func TestAccStorageAccount_updateResourceByEnablingIdentity(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_publicNetworkAccess(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.publicNetworkAccess(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccount_networkRules(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -1243,6 +1265,29 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) publicNetworkAccess(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  public_network_access_enabled = %t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)
 }
 
 func (r StorageAccountResource) noCrossTenantReplication(data acceptance.TestData) string {

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -115,6 +115,8 @@ The following arguments are supported:
 
 ~> **Note:** Terraform uses Shared Key Authorisation to provision Storage Containers, Blobs and other items - when Shared Key Access is disabled, you will need to enable [the `storage_use_azuread` flag in the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to use Azure AD for authentication, however not all Azure Storage services support Active Directory authentication.
 
+* `public_network_access_enabled` - (Optional) Whether the public network access is enabled? Defaults to `true`.
+
 * `default_to_oauth_authentication` - (Optional) Default to Azure Active Directory authorization in the Azure portal when accessing the Storage Account. The default value is `false`
 
 * `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created.


### PR DESCRIPTION
Fix #17976

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_publicNetworkAccess'
=== RUN   TestAccStorageAccount_publicNetworkAccess
=== PAUSE TestAccStorageAccount_publicNetworkAccess
=== CONT  TestAccStorageAccount_publicNetworkAccess
--- PASS: TestAccStorageAccount_publicNetworkAccess (192.58s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       192.588s
```