### PR TITLE
`azurerm_batch_pool` - support for the `mount` property

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -284,6 +284,95 @@ func findBatchPoolContainerRegistryPassword(d *pluginsdk.ResourceData, armServer
 	return ""
 }
 
+func findSensitiveInfoForMountConfig(targetType string, sourceType string, sourceValue string, mountType string, d *pluginsdk.ResourceData) string {
+	if num, ok := d.GetOk("mount_configuration.#"); ok {
+		n := num.(int)
+		for i := 0; i < n; i++ {
+			if src, ok := d.GetOk(fmt.Sprintf("mount_configuration.%d.%v.0.%v", i, mountType, sourceType)); ok && src == sourceValue {
+				return d.Get(fmt.Sprintf("mount_configuration.%d.%v.0.%v", i, mountType, targetType)).(string)
+			}
+		}
+	}
+	return ""
+}
+
+func flattenBatchPoolMountConfig(d *pluginsdk.ResourceData, config *batch.MountConfiguration) map[string]interface{} {
+	mountConfig := make(map[string]interface{})
+
+	switch {
+	case config.AzureBlobFileSystemConfiguration != nil:
+		azureBlobFileSysConfigList := make([]interface{}, 0)
+		azureBlobFileSysConfig := make(map[string]interface{})
+		azureBlobFileSysConfig["account_name"] = *config.AzureBlobFileSystemConfiguration.AccountName
+		azureBlobFileSysConfig["container_name"] = *config.AzureBlobFileSystemConfiguration.ContainerName
+		azureBlobFileSysConfig["relative_mount_path"] = *config.AzureBlobFileSystemConfiguration.RelativeMountPath
+		azureBlobFileSysConfig["account_key"] = findSensitiveInfoForMountConfig("account_key", "account_name", *config.AzureBlobFileSystemConfiguration.AccountName, "azure_blob_file_system_configuration", d)
+		azureBlobFileSysConfig["sas_key"] = findSensitiveInfoForMountConfig("sas_key", "account_name", *config.AzureBlobFileSystemConfiguration.AccountName, "azure_blob_file_system_configuration", d)
+		if config.AzureBlobFileSystemConfiguration.IdentityReference != nil {
+			azureBlobFileSysConfig["identity_id"] = flattenBatchPoolIdentityReferenceToIdentityID(config.AzureBlobFileSystemConfiguration.IdentityReference)
+		}
+		if config.AzureBlobFileSystemConfiguration.BlobfuseOptions != nil {
+			azureBlobFileSysConfig["blobfuse_options"] = *config.AzureBlobFileSystemConfiguration.BlobfuseOptions
+		}
+		azureBlobFileSysConfigList = append(azureBlobFileSysConfigList, azureBlobFileSysConfig)
+		mountConfig["azure_blob_file_system_configuration"] = azureBlobFileSysConfigList
+	case config.AzureFileShareConfiguration != nil:
+		azureFileShareConfigList := make([]interface{}, 0)
+		azureFileShareConfig := make(map[string]interface{})
+		azureFileShareConfig["account_name"] = *config.AzureFileShareConfiguration.AccountName
+		azureFileShareConfig["azure_file_url"] = *config.AzureFileShareConfiguration.AzureFileURL
+		azureFileShareConfig["account_key"] = findSensitiveInfoForMountConfig("account_key", "account_name", *config.AzureFileShareConfiguration.AccountName, "azure_file_share_configuration", d)
+		azureFileShareConfig["relative_mount_path"] = *config.AzureFileShareConfiguration.RelativeMountPath
+
+		if config.AzureFileShareConfiguration.MountOptions != nil {
+			azureFileShareConfig["mount_options"] = *config.AzureFileShareConfiguration.MountOptions
+		}
+
+		azureFileShareConfigList = append(azureFileShareConfigList, azureFileShareConfig)
+		mountConfig["azure_file_share_configuration"] = azureFileShareConfigList
+
+	case config.CifsMountConfiguration != nil:
+		cifsMountConfigList := make([]interface{}, 0)
+		cifsMountConfig := make(map[string]interface{})
+
+		cifsMountConfig["user_name"] = *config.CifsMountConfiguration.Username
+		cifsMountConfig["password"] = findSensitiveInfoForMountConfig("password", "user_name", *config.CifsMountConfiguration.Username, "cifs_mount_configuration", d)
+		cifsMountConfig["source"] = *config.CifsMountConfiguration.Source
+		cifsMountConfig["relative_mount_path"] = *config.CifsMountConfiguration.RelativeMountPath
+
+		if config.CifsMountConfiguration.MountOptions != nil {
+			cifsMountConfig["mount_options"] = *config.CifsMountConfiguration.MountOptions
+		}
+
+		cifsMountConfigList = append(cifsMountConfigList, cifsMountConfig)
+		mountConfig["cifs_mount_configuration"] = cifsMountConfigList
+	case config.NfsMountConfiguration != nil:
+		nfsMountConfigList := make([]interface{}, 0)
+		nfsMountConfig := make(map[string]interface{})
+
+		nfsMountConfig["source"] = *config.NfsMountConfiguration.Source
+		nfsMountConfig["relative_mount_path"] = *config.NfsMountConfiguration.RelativeMountPath
+
+		if config.NfsMountConfiguration.MountOptions != nil {
+			nfsMountConfig["mount_options"] = *config.NfsMountConfiguration.MountOptions
+		}
+
+		nfsMountConfigList = append(nfsMountConfigList, nfsMountConfig)
+		mountConfig["nfs_mount_configuration"] = nfsMountConfigList
+	default:
+		return nil
+	}
+
+	return mountConfig
+}
+
+func flattenBatchPoolIdentityReferenceToIdentityID(ref *batch.ComputeNodeIdentityReference) string {
+	if ref != nil && ref.ResourceID != nil {
+		return *ref.ResourceID
+	}
+	return ""
+}
+
 // ExpandBatchPoolImageReference expands Batch pool image reference
 func ExpandBatchPoolImageReference(list []interface{}) (*batch.ImageReference, error) {
 	if len(list) == 0 {
@@ -576,6 +665,121 @@ func FlattenBatchMetaData(metadatas *[]batch.MetadataItem) map[string]interface{
 	}
 
 	return output
+}
+
+func ExpandBatchPoolMountConfigurations(d *pluginsdk.ResourceData) (*[]batch.MountConfiguration, error) {
+	var result []batch.MountConfiguration
+
+	if mountConfigs, ok := d.GetOk("mount_configuration"); ok {
+		mountConfigList := mountConfigs.([]interface{})
+		for _, tempItem := range mountConfigList {
+			item := tempItem.(map[string]interface{})
+			if mountConfig, err := expandBatchPoolMountConfiguration(item); err == nil {
+				result = append(result, mountConfig)
+			}
+		}
+		return &result, nil
+	}
+	return nil, fmt.Errorf("mount_configuration either is empty or contains parsing errors")
+}
+
+func expandBatchPoolMountConfiguration(ref map[string]interface{}) (batch.MountConfiguration, error) {
+	var result batch.MountConfiguration
+	if azureBlobFileSystemConfiguration, err := expandBatchPoolAzureBlobFileSystemConfiguration(ref["azure_blob_file_system_configuration"].([]interface{})); err == nil {
+		result.AzureBlobFileSystemConfiguration = azureBlobFileSystemConfiguration
+	}
+	if azureFileShareConfiguration, err := expandBatchPoolAzureFileShareConfiguration(ref["azure_file_share_configuration"].([]interface{})); err == nil {
+		result.AzureFileShareConfiguration = azureFileShareConfiguration
+	}
+	if cifsMountConfiguration, err := expandBatchPoolCIFSMountConfiguration(ref["cifs_mount_configuration"].([]interface{})); err == nil {
+		result.CifsMountConfiguration = cifsMountConfiguration
+	}
+	if nfsMountConfiguration, err := expandBatchPoolNFSMountConfiguration(ref["nfs_mount_configuration"].([]interface{})); err == nil {
+		result.NfsMountConfiguration = nfsMountConfiguration
+	}
+	return result, nil
+}
+
+func expandBatchPoolAzureBlobFileSystemConfiguration(list []interface{}) (*batch.AzureBlobFileSystemConfiguration, interface{}) {
+	if list == nil || len(list) == 0 || list[0] == nil {
+		return nil, fmt.Errorf("azure_blob_file_system_configuration is empty")
+	}
+	configMap := list[0].(map[string]interface{})
+	result := batch.AzureBlobFileSystemConfiguration{
+		AccountName:       utils.String(configMap["account_name"].(string)),
+		ContainerName:     utils.String(configMap["container_name"].(string)),
+		RelativeMountPath: utils.String(configMap["relative_mount_path"].(string)),
+	}
+	if accountKey, ok := configMap["account_key"]; ok {
+		result.AccountKey = utils.String(accountKey.(string))
+	} else if sasKey, ok := configMap["sas_key"]; ok {
+		result.SasKey = utils.String(sasKey.(string))
+	} else if computedIDRef, err := expandBatchPoolIdentityReference(configMap); err == nil {
+		result.IdentityReference = computedIDRef
+	}
+
+	if blobfuseOptions, ok := configMap["blobfuse_options"]; ok {
+		result.BlobfuseOptions = utils.String(blobfuseOptions.(string))
+	}
+	return &result, nil
+}
+
+func expandBatchPoolAzureFileShareConfiguration(list []interface{}) (*batch.AzureFileShareConfiguration, interface{}) {
+	if list == nil || len(list) == 0 || list[0] == nil {
+		return nil, fmt.Errorf("azure_file_share_configuration is empty")
+	}
+	configMap := list[0].(map[string]interface{})
+	result := batch.AzureFileShareConfiguration{
+		AccountName:       utils.String(configMap["account_name"].(string)),
+		AccountKey:        utils.String(configMap["account_key"].(string)),
+		AzureFileURL:      utils.String(configMap["azure_file_url"].(string)),
+		RelativeMountPath: utils.String(configMap["relative_mount_path"].(string)),
+	}
+	if mountOptions, ok := configMap["mount_options"]; ok {
+		result.MountOptions = utils.String(mountOptions.(string))
+	}
+	return &result, nil
+}
+
+func expandBatchPoolCIFSMountConfiguration(list []interface{}) (*batch.CIFSMountConfiguration, interface{}) {
+	if list == nil || len(list) == 0 || list[0] == nil {
+		return nil, fmt.Errorf("cifs_mount_configuration is empty")
+	}
+	configMap := list[0].(map[string]interface{})
+	result := batch.CIFSMountConfiguration{
+		Username:          utils.String(configMap["user_name"].(string)),
+		Source:            utils.String(configMap["source"].(string)),
+		Password:          utils.String(configMap["password"].(string)),
+		RelativeMountPath: utils.String(configMap["relative_mount_path"].(string)),
+	}
+	if mountOptions, ok := configMap["mount_options"]; ok {
+		result.MountOptions = utils.String(mountOptions.(string))
+	}
+	return &result, nil
+}
+
+func expandBatchPoolNFSMountConfiguration(list []interface{}) (*batch.NFSMountConfiguration, interface{}) {
+	if list == nil || len(list) == 0 || list[0] == nil {
+		return nil, fmt.Errorf("nfs_mount_configuration is empty")
+	}
+	configMap := list[0].(map[string]interface{})
+	result := batch.NFSMountConfiguration{
+		Source:            utils.String(configMap["source"].(string)),
+		RelativeMountPath: utils.String(configMap["relative_mount_path"].(string)),
+	}
+	if mountOptions, ok := configMap["mount_options"]; ok {
+		result.MountOptions = utils.String(mountOptions.(string))
+	}
+	return &result, nil
+}
+
+func expandBatchPoolIdentityReference(ref map[string]interface{}) (*batch.ComputeNodeIdentityReference, error) {
+	var result batch.ComputeNodeIdentityReference
+	if iid, ok := ref["identity_id"]; ok && iid != "" {
+		result.ResourceID = utils.String(iid.(string))
+		return &result, nil
+	}
+	return nil, fmt.Errorf("identity_id is empty")
 }
 
 // ExpandBatchPoolNetworkConfiguration expands Batch pool network configuration

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -204,12 +204,12 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
-			"mount_configuration": {
+			"mount": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"azure_blob_file_system_configuration": {
+						"azure_blob_file_system": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -245,7 +245,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"azure_file_share_configuration": {
+						"azure_file_share": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -273,7 +273,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"cifs_mount_configuration": {
+						"cifs_mount": {
 							Type:     pluginsdk.TypeList,
 							Computed: true,
 							Elem: &pluginsdk.Resource{
@@ -301,7 +301,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"nfs_mount_configuration": {
+						"nfs_mount": {
 							Type:     pluginsdk.TypeList,
 							Computed: true,
 							Elem: &pluginsdk.Resource{

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -204,6 +204,126 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
+			"mount_configuration": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"azure_blob_file_system_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"account_name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"container_name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"relative_mount_path": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"account_key": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"sas_key": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"identity_id": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"blobfuse_options": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"azure_file_share_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"account_name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"azure_file_url": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"account_key": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"relative_mount_path": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"mount_options": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cifs_mount_configuration": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"user_name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"source": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"relative_mount_path": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"mount_options": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"password": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"nfs_mount_configuration": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"source": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"relative_mount_path": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+									"mount_options": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"network_configuration": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -309,6 +309,151 @@ func resourceBatchPool() *pluginsdk.Resource {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
+			"mount_configuration": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"azure_blob_file_system_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"account_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"container_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"relative_mount_path": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"account_key": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"sas_key": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"identity_id": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+									},
+									"blobfuse_options": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+						"azure_file_share_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"account_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"azure_file_url": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.IsURLWithHTTPS,
+									},
+									"account_key": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"relative_mount_path": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"mount_options": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+						"cifs_mount_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"user_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"source": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"relative_mount_path": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"mount_options": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"password": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+						"nfs_mount_configuration": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"source": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"relative_mount_path": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"mount_options": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"network_configuration": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -521,6 +666,12 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	parameters.PoolProperties.Metadata = ExpandBatchMetaData(metaDataRaw)
 
+	mountConfiguration, err := ExpandBatchPoolMountConfigurations(d)
+	if err != nil {
+		log.Printf(`[DEBUG] expanding "mount_configuration": %v`, err)
+	}
+	parameters.PoolProperties.MountConfiguration = mountConfiguration
+
 	networkConfiguration := d.Get("network_configuration").([]interface{})
 	parameters.PoolProperties.NetworkConfiguration, err = ExpandBatchPoolNetworkConfiguration(networkConfiguration)
 	if err != nil {
@@ -633,6 +784,12 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 		parameters.PoolProperties.Metadata = ExpandBatchMetaData(metaDataRaw)
 	}
 
+	mountConfiguration, err := ExpandBatchPoolMountConfigurations(d)
+	if err != nil {
+		log.Printf(`[DEBUG] expanding "mount_configuration": %v`, err)
+	}
+	parameters.PoolProperties.MountConfiguration = mountConfiguration
+
 	result, err := client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.Name, parameters, "")
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
@@ -714,6 +871,14 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		d.Set("start_task", flattenBatchPoolStartTask(props.StartTask))
 		d.Set("metadata", FlattenBatchMetaData(props.Metadata))
+
+		if props.MountConfiguration != nil {
+			mountConfigs := make([]interface{}, 0)
+			for _, mountConfig := range *props.MountConfiguration {
+				mountConfigs = append(mountConfigs, flattenBatchPoolMountConfig(d, &mountConfig))
+			}
+			d.Set("mount_configuration", mountConfigs)
+		}
 
 		if err := d.Set("network_configuration", flattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {
 			return fmt.Errorf("setting `network_configuration`: %v", err)

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -309,12 +309,12 @@ func resourceBatchPool() *pluginsdk.Resource {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
-			"mount_configuration": {
+			"mount": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"azure_blob_file_system_configuration": {
+						"azure_blob_file_system": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							MaxItems: 1,
@@ -360,7 +360,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"azure_file_share_configuration": {
+						"azure_file_share": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -394,7 +394,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"cifs_mount_configuration": {
+						"cifs_mount": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -428,7 +428,7 @@ func resourceBatchPool() *pluginsdk.Resource {
 								},
 							},
 						},
-						"nfs_mount_configuration": {
+						"nfs_mount": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -668,7 +668,7 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	mountConfiguration, err := ExpandBatchPoolMountConfigurations(d)
 	if err != nil {
-		log.Printf(`[DEBUG] expanding "mount_configuration": %v`, err)
+		log.Printf(`[DEBUG] expanding "mount": %v`, err)
 	}
 	parameters.PoolProperties.MountConfiguration = mountConfiguration
 
@@ -786,7 +786,7 @@ func resourceBatchPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	mountConfiguration, err := ExpandBatchPoolMountConfigurations(d)
 	if err != nil {
-		log.Printf(`[DEBUG] expanding "mount_configuration": %v`, err)
+		log.Printf(`[DEBUG] expanding "mount": %v`, err)
 	}
 	parameters.PoolProperties.MountConfiguration = mountConfiguration
 
@@ -877,7 +877,7 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			for _, mountConfig := range *props.MountConfiguration {
 				mountConfigs = append(mountConfigs, flattenBatchPoolMountConfig(d, &mountConfig))
 			}
-			d.Set("mount_configuration", mountConfigs)
+			d.Set("mount", mountConfigs)
 		}
 
 		if err := d.Set("network_configuration", flattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -501,13 +501,13 @@ func TestAccBatchPool_mountConfigurationAzureBlobFileSystem(t *testing.T) {
 			Config: r.mountConfigurationAzureBlobFileSystem(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("mount_configuration.0.azure_blob_file_system_configuration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("mount_configuration.0.azure_blob_file_system_configuration.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount.0.azure_blob_file_system.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount.0.azure_blob_file_system.0.relative_mount_path").HasValue("/mnt/"),
 			),
 		},
 		data.ImportStep(
 			"stop_pending_resize_operation",
-			"mount_configuration.0.azure_blob_file_system_configuration.0.account_key",
+			"mount.0.azure_blob_file_system.0.account_key",
 		),
 	})
 }
@@ -521,13 +521,13 @@ func TestAccBatchPool_mountConfigurationAzureFileShare(t *testing.T) {
 			Config: r.mountConfigurationAzureFileShare(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("mount_configuration.0.azure_file_share_configuration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("mount_configuration.0.azure_file_share_configuration.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount.0.azure_file_share.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount.0.azure_file_share.0.relative_mount_path").HasValue("/mnt/"),
 			),
 		},
 		data.ImportStep(
 			"stop_pending_resize_operation",
-			"mount_configuration.0.azure_file_share_configuration.0.account_key",
+			"mount.0.azure_file_share.0.account_key",
 		),
 	})
 }
@@ -541,17 +541,17 @@ func TestAccBatchPool_mountConfigurationCIFS(t *testing.T) {
 			Config: r.mountConfigurationCIFS(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.user_name").HasValue("myUserName"),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.password").HasValue("myPassword"),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.source").HasValue("https://testaccount.file.core.windows.net/"),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.relative_mount_path").HasValue("/mnt/"),
-				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.mount_options").HasValue("sampleops"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.0.user_name").HasValue("myUserName"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.0.password").HasValue("myPassword"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.0.source").HasValue("https://testaccount.file.core.windows.net/"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount.0.cifs_mount.0.mount_options").HasValue("sampleops"),
 			),
 		},
 		data.ImportStep(
 			"stop_pending_resize_operation",
-			"mount_configuration.0.cifs_mount_configuration.0.password",
+			"mount.0.cifs_mount.0.password",
 		),
 	})
 }
@@ -565,10 +565,10 @@ func TestAccBatchPool_mountConfigurationNFS(t *testing.T) {
 			Config: r.mountConfigurationNFS(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.source").HasValue("https://testaccount.file.core.windows.net/"),
-				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.relative_mount_path").HasValue("/mnt/"),
-				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.mount_options").HasValue("sampleops"),
+				check.That(data.ResourceName).Key("mount.0.nfs_mount.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount.0.nfs_mount.0.source").HasValue("https://testaccount.file.core.windows.net/"),
+				check.That(data.ResourceName).Key("mount.0.nfs_mount.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount.0.nfs_mount.0.mount_options").HasValue("sampleops"),
 			),
 		},
 		data.ImportStep(
@@ -1779,8 +1779,8 @@ resource "azurerm_batch_pool" "test" {
   account_name        = azurerm_batch_account.test.name
   node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
-  mount_configuration {
-    azure_blob_file_system_configuration {
+  mount {
+    azure_blob_file_system {
       account_name        = azurerm_storage_account.test.name
       container_name      = azurerm_storage_container.test.name
       account_key         = azurerm_storage_account.test.primary_access_key
@@ -1827,8 +1827,8 @@ resource "azurerm_batch_pool" "test" {
   account_name        = azurerm_batch_account.test.name
   node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
-  mount_configuration {
-    azure_file_share_configuration {
+  mount {
+    azure_file_share {
       account_name        = azurerm_storage_account.test.name
       account_key         = azurerm_storage_account.test.primary_access_key
       azure_file_url      = "https://testaccount.file.core.windows.net/"
@@ -1863,8 +1863,8 @@ resource "azurerm_batch_pool" "test" {
   account_name        = azurerm_batch_account.test.name
   node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
-  mount_configuration {
-    cifs_mount_configuration {
+  mount {
+    cifs_mount {
       user_name           = "myUserName"
       password            = "myPassword"
       source              = "https://testaccount.file.core.windows.net/"
@@ -1900,8 +1900,8 @@ resource "azurerm_batch_pool" "test" {
   account_name        = azurerm_batch_account.test.name
   node_agent_sku_id   = "batch.node.ubuntu 18.04"
   vm_size             = "Standard_A1"
-  mount_configuration {
-    nfs_mount_configuration {
+  mount {
+    nfs_mount {
       source              = "https://testaccount.file.core.windows.net/"
       relative_mount_path = "/mnt/"
       mount_options       = "sampleops"

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -492,6 +492,91 @@ func TestAccBatchPool_fixedScaleUpdate(t *testing.T) {
 	})
 }
 
+func TestAccBatchPool_mountConfigurationAzureBlobFileSystem(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mountConfigurationAzureBlobFileSystem(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_configuration.0.azure_blob_file_system_configuration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_configuration.0.azure_blob_file_system_configuration.0.relative_mount_path").HasValue("/mnt/"),
+			),
+		},
+		data.ImportStep(
+			"stop_pending_resize_operation",
+			"mount_configuration.0.azure_blob_file_system_configuration.0.account_key",
+		),
+	})
+}
+
+func TestAccBatchPool_mountConfigurationAzureFileShare(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mountConfigurationAzureFileShare(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_configuration.0.azure_file_share_configuration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_configuration.0.azure_file_share_configuration.0.relative_mount_path").HasValue("/mnt/"),
+			),
+		},
+		data.ImportStep(
+			"stop_pending_resize_operation",
+			"mount_configuration.0.azure_file_share_configuration.0.account_key",
+		),
+	})
+}
+
+func TestAccBatchPool_mountConfigurationCIFS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mountConfigurationCIFS(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.user_name").HasValue("myUserName"),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.password").HasValue("myPassword"),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.source").HasValue("https://testaccount.file.core.windows.net/"),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount_configuration.0.cifs_mount_configuration.0.mount_options").HasValue("sampleops"),
+			),
+		},
+		data.ImportStep(
+			"stop_pending_resize_operation",
+			"mount_configuration.0.cifs_mount_configuration.0.password",
+		),
+	})
+}
+
+func TestAccBatchPool_mountConfigurationNFS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mountConfigurationNFS(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.source").HasValue("https://testaccount.file.core.windows.net/"),
+				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.relative_mount_path").HasValue("/mnt/"),
+				check.That(data.ResourceName).Key("mount_configuration.0.nfs_mount_configuration.0.mount_options").HasValue("sampleops"),
+			),
+		},
+		data.ImportStep(
+			"stop_pending_resize_operation",
+		),
+	})
+}
+
 func (t BatchPoolResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.PoolID(state.ID)
 	if err != nil {
@@ -1665,4 +1750,206 @@ resource "azurerm_batch_pool" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (BatchPoolResource) mountConfigurationAzureBlobFileSystem(data acceptance.TestData) string {
+	template := BatchPoolResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_storage_account" "test" {
+  name                     = "accbatchsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+resource "azurerm_storage_container" "test" {
+  name                  = "accbatchsc%s"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  vm_size             = "Standard_A1"
+  mount_configuration {
+    azure_blob_file_system_configuration {
+      account_name        = azurerm_storage_account.test.name
+      container_name      = azurerm_storage_container.test.name
+      account_key         = azurerm_storage_account.test.primary_access_key
+      relative_mount_path = "/mnt/"
+    }
+  }
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-lts"
+    version   = "latest"
+  }
+}
+`, template, data.RandomString, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) mountConfigurationAzureFileShare(data acceptance.TestData) string {
+	template := BatchPoolResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_storage_account" "test" {
+  name                     = "accbatchsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+resource "azurerm_storage_container" "test" {
+  name                  = "accbatchsc%s"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  vm_size             = "Standard_A1"
+  mount_configuration {
+    azure_file_share_configuration {
+      account_name        = azurerm_storage_account.test.name
+      account_key         = azurerm_storage_account.test.primary_access_key
+      azure_file_url      = "https://testaccount.file.core.windows.net/"
+      relative_mount_path = "/mnt/"
+    }
+  }
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-lts"
+    version   = "latest"
+  }
+}
+`, template, data.RandomString, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) mountConfigurationCIFS(data acceptance.TestData) string {
+	template := BatchPoolResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  vm_size             = "Standard_A1"
+  mount_configuration {
+    cifs_mount_configuration {
+      user_name           = "myUserName"
+      password            = "myPassword"
+      source              = "https://testaccount.file.core.windows.net/"
+      relative_mount_path = "/mnt/"
+      mount_options       = "sampleops"
+    }
+  }
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-lts"
+    version   = "latest"
+  }
+}
+`, template, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) mountConfigurationNFS(data acceptance.TestData) string {
+	template := BatchPoolResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.ubuntu 18.04"
+  vm_size             = "Standard_A1"
+  mount_configuration {
+    nfs_mount_configuration {
+      source              = "https://testaccount.file.core.windows.net/"
+      relative_mount_path = "/mnt/"
+      mount_options       = "sampleops"
+    }
+  }
+  fixed_scale {
+    target_dedicated_nodes = 1
+  }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-lts"
+    version   = "latest"
+  }
+}
+`, template, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+resource "azurerm_network_security_group" "test" {
+  name                = "testnsg-batch-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+resource "azurerm_virtual_network" "test" {
+  name                = "testvn-batch-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+  dns_servers         = ["10.0.0.4", "10.0.0.5"]
+}
+resource "azurerm_subnet" "testsubnet" {
+  name                 = "testsn-%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+resource "azurerm_subnet_network_security_group_association" "test" {
+  subnet_id                 = azurerm_subnet.testsubnet.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
 }

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -45,6 +45,8 @@ The following attributes are exported:
 
 * `max_tasks_per_node` - The maximum number of tasks that can run concurrently on a single compute node in the pool.
 
+* `mount_configuration` - A `mount_configuration` block that describes mount configuration.
+
 * `certificate` - One or more `certificate` blocks that describe the certificates installed on each compute node in the pool.
 
 * `container_configuration` - The container configuration used in the pool's VMs.
@@ -152,6 +154,78 @@ A `container_registries` block exports the following:
 * `password` - The password to log into the registry server.
 
 * `user_assigned_identity_id` - The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password.
+
+---
+
+An `mount_configuration` exports the following:
+
+Any property below is mutually exclusive with all other properties.
+
+* `azure_blob_file_system_configuration` - A `azure_blob_file_system_configuration` block defined as below.
+
+* `azure_file_share_configuration` - A `azure_file_share_configuration` block defined as below.
+
+* `cifs_mount_configuration` - A `cifs_mount_configuration` block defined as below.
+
+* `nfs_mount_configuration` - A `nfs_mount_configuration` block defined as below.
+
+---
+
+An `azure_blob_file_system_configuration` block exports the following:
+
+* `account_name` - The Azure Storage Account name.
+
+* `container_name` - The Azure Blob Storage Container name.
+
+* `relative_mount_path` - The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `account_key` - The Azure Storage Account key. This property is mutually exclusive with both `sas_key` and `identity_id`; exactly one must be specified.
+
+* `sas_key` - The Azure Storage SAS token. This property is mutually exclusive with both `account_key` and `identity_id`; exactly one must be specified.
+
+* `identity_id` - The ARM resource id of the user assigned identity. This property is mutually exclusive with both `account_key` and `sas_key`; exactly one must be specified.
+
+* `blobfuse_options` - Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+An `azure_file_share_configuration` block exports the following:
+
+* `account_name` - The Azure Storage Account name.
+
+* `account_key` - The Azure Storage Account key.
+
+* `azure_file_url` - The Azure Files URL. This is of the form 'https://{account}.file.core.windows.net/'.
+
+* `relative_mount_path` - The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+A `cifs_mount_configuration` block exports the following:
+
+* `user_name` - The user to use for authentication against the CIFS file system.
+
+* `password` - The password to use for authentication against the CIFS file system.
+
+* `source` - The URI of the file system to mount.
+
+* `relative_mount_path` - The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+A `nfs_mount_configuration` block exports the following:
+
+* `source` - The URI of the file system to mount.
+
+* `relative_mount_path` - The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
 
 ---
 

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -45,7 +45,7 @@ The following attributes are exported:
 
 * `max_tasks_per_node` - The maximum number of tasks that can run concurrently on a single compute node in the pool.
 
-* `mount_configuration` - A `mount_configuration` block that describes mount configuration.
+* `mount` - A `mount` block that describes mount configuration.
 
 * `certificate` - One or more `certificate` blocks that describe the certificates installed on each compute node in the pool.
 
@@ -157,21 +157,21 @@ A `container_registries` block exports the following:
 
 ---
 
-An `mount_configuration` exports the following:
+An `mount` exports the following:
 
 Any property below is mutually exclusive with all other properties.
 
-* `azure_blob_file_system_configuration` - A `azure_blob_file_system_configuration` block defined as below.
+* `azure_blob_file_system` - A `azure_blob_file_system` block defined as below.
 
-* `azure_file_share_configuration` - A `azure_file_share_configuration` block defined as below.
+* `azure_file_share` - A `azure_file_share` block defined as below.
 
-* `cifs_mount_configuration` - A `cifs_mount_configuration` block defined as below.
+* `cifs_mount` - A `cifs_mount` block defined as below.
 
-* `nfs_mount_configuration` - A `nfs_mount_configuration` block defined as below.
+* `nfs_mount` - A `nfs_mount` block defined as below.
 
 ---
 
-An `azure_blob_file_system_configuration` block exports the following:
+An `azure_blob_file_system` block exports the following:
 
 * `account_name` - The Azure Storage Account name.
 
@@ -189,7 +189,7 @@ An `azure_blob_file_system_configuration` block exports the following:
 
 ---
 
-An `azure_file_share_configuration` block exports the following:
+An `azure_file_share` block exports the following:
 
 * `account_name` - The Azure Storage Account name.
 
@@ -203,7 +203,7 @@ An `azure_file_share_configuration` block exports the following:
 
 ---
 
-A `cifs_mount_configuration` block exports the following:
+A `cifs_mount` block exports the following:
 
 * `user_name` - The user to use for authentication against the CIFS file system.
 
@@ -217,7 +217,7 @@ A `cifs_mount_configuration` block exports the following:
 
 ---
 
-A `nfs_mount_configuration` block exports the following:
+A `nfs_mount` block exports the following:
 
 * `source` - The URI of the file system to mount.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -144,6 +144,8 @@ The following arguments are supported:
 
 * `metadata` - (Optional) A map of custom batch pool metadata.
 
+* `mount_configuration` - (Optional) A `mount_configuration` block defined as below.
+
 * `network_configuration` - (Optional) A `network_configuration` block that describes the network configurations for the Batch pool.
 
 -> **NOTE:** For Windows compute nodes, the Batch service installs the certificates to the specified certificate store and location. For Linux compute nodes, the certificates are stored in a directory inside the task working directory and an environment variable `AZ_BATCH_CERTIFICATES_DIR` is supplied to the task to query for this location. For certificates with visibility of `remoteUser`, a `certs` directory is created in the user's home directory (e.g., `/home/{user-name}/certs`) and certificates are placed in that directory.
@@ -282,6 +284,77 @@ A `container_registries` block supports the following:
 * `password` - (Optional) The password to log into the registry server. Changing this forces a new resource to be created.
 
 * `user_assigned_identity_id` - (Optional) The reference to the user assigned identity to use to access an Azure Container Registry instead of username and password. Changing this forces a new resource to be created.
+
+---
+
+An `mount_configuration` block supports the following:
+
+Any property below is mutually exclusive with all other properties.
+
+* `azure_blob_file_system_configuration` - (Optional) A `azure_blob_file_system_configuration` block defined as below.
+
+* `azure_file_share_configuration` - (Optional) A `azure_file_share_configuration` block defined as below.
+
+* `cifs_mount_configuration` - (Optional) A `cifs_mount_configuration` block defined as below.
+
+* `nfs_mount_configuration` - (Optional) A `nfs_mount_configuration` block defined as below.
+
+---
+
+An `azure_blob_file_system_configuration` block supports the following:
+
+* `account_name` - (Required) The Azure Storage Account name.
+
+* `container_name` - (Required) The Azure Blob Storage Container name.
+
+* `relative_mount_path` - (Required) The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `account_key` - (Optional) The Azure Storage Account key. This property is mutually exclusive with both `sas_key` and `identity_id`; exactly one must be specified.
+
+* `sas_key` - (Optional) The Azure Storage SAS token. This property is mutually exclusive with both `account_key` and `identity_id`; exactly one must be specified.
+
+* `identity_id` - (Optional) The ARM resource id of the user assigned identity. This property is mutually exclusive with both `account_key` and `sas_key`; exactly one must be specified.
+
+* `blobfuse_options` - (Optional) Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+An `azure_file_share_configuration` block supports the following:
+
+* `account_name` - (Required) The Azure Storage Account name.
+
+* `account_key` - (Required) The Azure Storage Account key.
+
+* `azure_file_url` - (Required) The Azure Files URL. This is of the form 'https://{account}.file.core.windows.net/'.
+
+* `relative_mount_path` - (Required) The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - (Optional) Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+A `cifs_mount_configuration` block supports the following:
+
+* `user_name` - (Required) The user to use for authentication against the CIFS file system.
+
+* `password` - (Required) The password to use for authentication against the CIFS file system.
+
+* `source` - (Required) The URI of the file system to mount.
+
+* `relative_mount_path` - (Required) The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - (Optional) Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
+---
+
+A `nfs_mount_configuration` block supports the following:
+
+* `source` - (Required) The URI of the file system to mount.
+
+* `relative_mount_path` - (Required) The relative path on compute node where the file system will be mounted All file systems are mounted relative to the Batch mounts directory, accessible via the `AZ_BATCH_NODE_MOUNTS_DIR` environment variable.
+
+* `mount_options` - (Optional) Additional command line options to pass to the mount command. These are 'net use' options in Windows and 'mount' options in Linux.
+
 ---
 
 A `network_configuration` block supports the following:

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) A map of custom batch pool metadata.
 
-* `mount_configuration` - (Optional) A `mount_configuration` block defined as below.
+* `mount` - (Optional) A `mount` block defined as below.
 
 * `network_configuration` - (Optional) A `network_configuration` block that describes the network configurations for the Batch pool.
 
@@ -287,21 +287,21 @@ A `container_registries` block supports the following:
 
 ---
 
-An `mount_configuration` block supports the following:
+An `mount` block supports the following:
 
 Any property below is mutually exclusive with all other properties.
 
-* `azure_blob_file_system_configuration` - (Optional) A `azure_blob_file_system_configuration` block defined as below.
+* `azure_blob_file_system` - (Optional) A `azure_blob_file_system` block defined as below.
 
-* `azure_file_share_configuration` - (Optional) A `azure_file_share_configuration` block defined as below.
+* `azure_file_share` - (Optional) A `azure_file_share` block defined as below.
 
-* `cifs_mount_configuration` - (Optional) A `cifs_mount_configuration` block defined as below.
+* `cifs_mount` - (Optional) A `cifs_mount` block defined as below.
 
-* `nfs_mount_configuration` - (Optional) A `nfs_mount_configuration` block defined as below.
+* `nfs_mount` - (Optional) A `nfs_mount` block defined as below.
 
 ---
 
-An `azure_blob_file_system_configuration` block supports the following:
+An `azure_blob_file_system` block supports the following:
 
 * `account_name` - (Required) The Azure Storage Account name.
 
@@ -319,7 +319,7 @@ An `azure_blob_file_system_configuration` block supports the following:
 
 ---
 
-An `azure_file_share_configuration` block supports the following:
+An `azure_file_share` block supports the following:
 
 * `account_name` - (Required) The Azure Storage Account name.
 
@@ -333,7 +333,7 @@ An `azure_file_share_configuration` block supports the following:
 
 ---
 
-A `cifs_mount_configuration` block supports the following:
+A `cifs_mount` block supports the following:
 
 * `user_name` - (Required) The user to use for authentication against the CIFS file system.
 
@@ -347,7 +347,7 @@ A `cifs_mount_configuration` block supports the following:
 
 ---
 
-A `nfs_mount_configuration` block supports the following:
+A `nfs_mount` block supports the following:
 
 * `source` - (Required) The URI of the file system to mount.
 


### PR DESCRIPTION
Add support for `mount_configuration` property. This is the first PR to cover all batch pool properties. Testing evidence will be provided shortly.