### PR TITLE
`azurerm_policy_definition` - expose `role_definition_ids` property if exists

### DIFF
--- a/internal/services/policy/policy.go
+++ b/internal/services/policy/policy.go
@@ -163,3 +163,17 @@ func flattenParameterValuesValueToString(input map[string]*policy.ParameterValue
 
 	return compactJson.String(), nil
 }
+
+func getPolicyRoleDefinitionIDs(ruleStr string) (res []string, err error) {
+	type policyRule struct {
+		Then struct {
+			Details struct {
+				RoleDefinitionIds []string `json:"roleDefinitionIds"`
+			} `json:"details"`
+		} `json:"then"`
+	}
+	var ins policyRule
+	err = json.Unmarshal([]byte(ruleStr), &ins)
+	res = ins.Then.Details.RoleDefinitionIds
+	return
+}

--- a/internal/services/policy/policy_definition_data_source.go
+++ b/internal/services/policy/policy_definition_data_source.go
@@ -71,6 +71,14 @@ func dataSourceArmPolicyDefinition() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"role_definition_ids": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -118,6 +126,9 @@ func dataSourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface
 	policyRule := policyDefinition.PolicyRule.(map[string]interface{})
 	if policyRuleStr := flattenJSON(policyRule); policyRuleStr != "" {
 		d.Set("policy_rule", policyRuleStr)
+		if roleIDs, err := getPolicyRoleDefinitionIDs(policyRuleStr); err == nil {
+			d.Set("role_definition_ids", roleIDs)
+		}
 	} else {
 		return fmt.Errorf("flattening Policy Definition Rule %q: %+v", name, err)
 	}

--- a/internal/services/policy/policy_definition_data_source.go
+++ b/internal/services/policy/policy_definition_data_source.go
@@ -126,9 +126,8 @@ func dataSourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface
 	policyRule := policyDefinition.PolicyRule.(map[string]interface{})
 	if policyRuleStr := flattenJSON(policyRule); policyRuleStr != "" {
 		d.Set("policy_rule", policyRuleStr)
-		if roleIDs, err := getPolicyRoleDefinitionIDs(policyRuleStr); err == nil {
-			d.Set("role_definition_ids", roleIDs)
-		}
+		roleIDs, _ := getPolicyRoleDefinitionIDs(policyRuleStr)
+		d.Set("role_definition_ids", roleIDs)
 	} else {
 		return fmt.Errorf("flattening Policy Definition Rule %q: %+v", name, err)
 	}

--- a/internal/services/policy/policy_definition_data_source_test.go
+++ b/internal/services/policy/policy_definition_data_source_test.go
@@ -28,6 +28,21 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtIn(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+	d := PolicyDefinitionDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.builtInByName("04d53d87-841c-4f23-8a5b-21564380b55e"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/policyDefinitions/04d53d87-841c-4f23-8a5b-21564380b55e"),
+				check.That(data.ResourceName).Key("role_definition_ids.0").Exists(),
+			),
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMPolicyDefinition_builtInByName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
 	d := PolicyDefinitionDataSource{}

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -205,6 +205,9 @@ func resourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface{}
 
 		if policyRuleStr := flattenJSON(props.PolicyRule); policyRuleStr != "" {
 			d.Set("policy_rule", policyRuleStr)
+			if roleIDs, err := getPolicyRoleDefinitionIDs(policyRuleStr); err == nil {
+				d.Set("role_definition_ids", roleIDs)
+			}
 		}
 
 		if metadataStr := flattenJSON(props.Metadata); metadataStr != "" {
@@ -345,6 +348,14 @@ func resourceArmPolicyDefinitionSchema() map[string]*pluginsdk.Schema {
 			Optional:         true,
 			ValidateFunc:     validation.StringIsJSON,
 			DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+		},
+
+		"role_definition_ids": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
 		},
 
 		"metadata": metadataSchema(),

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -205,9 +205,8 @@ func resourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface{}
 
 		if policyRuleStr := flattenJSON(props.PolicyRule); policyRuleStr != "" {
 			d.Set("policy_rule", policyRuleStr)
-			if roleIDs, err := getPolicyRoleDefinitionIDs(policyRuleStr); err == nil {
-				d.Set("role_definition_ids", roleIDs)
-			}
+			roleIDs, _ := getPolicyRoleDefinitionIDs(policyRuleStr)
+			d.Set("role_definition_ids", roleIDs)
 		}
 
 		if metadataStr := flattenJSON(props.Metadata); metadataStr != "" {

--- a/internal/services/policy/policy_definition_resource_test.go
+++ b/internal/services/policy/policy_definition_resource_test.go
@@ -31,6 +31,22 @@ func TestAccAzureRMPolicyDefinition_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPolicyDefinition_basicWithDetail(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_policy_definition", "test")
+	r := PolicyDefinitionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithDetail(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_definition_ids.0").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAzureRMPolicyDefinition_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_definition", "test")
 	r := PolicyDefinitionResource{}
@@ -184,6 +200,51 @@ POLICY_RULE
     }
   }
 PARAMETERS
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (r PolicyDefinitionResource) basicWithDetail(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_policy_definition" "test" {
+  name         = "acctestpol-%d"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "acctestpol-%d"
+
+  policy_rule = <<POLICY_RULE
+{
+  "if": {
+    "field": "type",
+    "equals": "Microsoft.ServiceBus/namespaces"
+  },
+  "then": {
+    "effect": "DeployIfNotExists",
+    "details": {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "name": "acctest",
+      "roleDefinitionIds": [
+        "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+        "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {}
+          }
+        }
+      }
+    }
+  }
+}
+POLICY_RULE
 }
 `, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -44,6 +44,8 @@ output "id" {
 
 * `policy_rule` - The Rule as defined (in JSON) in the Policy.
 
+* `role_definition_ids` - A list of role definition id extracted from `policy_rule` required for remediation.
+
 * `parameters` - Any Parameters defined in the Policy.
 
 * `metadata` - Any Metadata defined in the Policy.

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -95,6 +95,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Policy Definition.
 
+* `role_definition_ids` - A list of role definition id extracted from `policy_rule` required for remediation.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
for issue #18018 and will simplify customers with role assignment in policy_assigment.

fixes #18018 

--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtIn (28.21s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics (9.91s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtInByName (11.97s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup (26.63s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName (126.06s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_customByName (106.59s)
--- PASS: TestAccAzureRMPolicyDefinition_basic (107.76s)
--- PASS: TestAccAzureRMPolicyDefinition_basicWithDetail (107.67s)
--- PASS: TestAccAzureRMPolicyDefinition_requiresImport (110.10s)
--- PASS: TestAccAzureRMPolicyDefinition_computedMetadata (106.50s)
--- PASS: TestAccAzureRMPolicyDefinition_metadata (107.92s)
--- PASS: TestAccAzureRMPolicyDefinition_modeUpdate (308.42s)
PASS
