### PR TITLE
`azurerm_data_factory_flowlet_data_flow` `azurerm_data_factory_data_flow` - support for the `rejected_linked_service` property

### DIFF
--- a/internal/services/datafactory/data_factory_data_flow.go
+++ b/internal/services/datafactory/data_factory_data_flow.go
@@ -100,6 +100,29 @@ func SchemaForDataFlowSourceAndSink() *pluginsdk.Schema {
 					},
 				},
 
+				"rejected_linked_service": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"name": {
+								Type:         pluginsdk.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+
+							"parameters": {
+								Type:     pluginsdk.TypeMap,
+								Optional: true,
+								Elem: &pluginsdk.Schema{
+									Type: pluginsdk.TypeString,
+								},
+							},
+						},
+					},
+				},
+
 				"schema_linked_service": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
@@ -253,12 +276,13 @@ func expandDataFactoryDataFlowSink(input []interface{}) *[]datafactory.DataFlowS
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 		result = append(result, datafactory.DataFlowSink{
-			Description:         utils.String(raw["description"].(string)),
-			Name:                utils.String(raw["name"].(string)),
-			Dataset:             expandDataFactoryDatasetReference(raw["dataset"].([]interface{})),
-			LinkedService:       expandDataFactoryLinkedServiceReference(raw["linked_service"].([]interface{})),
-			SchemaLinkedService: expandDataFactoryLinkedServiceReference(raw["schema_linked_service"].([]interface{})),
-			Flowlet:             expandDataFactoryDataFlowReference(raw["flowlet"].([]interface{})),
+			Description:               utils.String(raw["description"].(string)),
+			Name:                      utils.String(raw["name"].(string)),
+			Dataset:                   expandDataFactoryDatasetReference(raw["dataset"].([]interface{})),
+			LinkedService:             expandDataFactoryLinkedServiceReference(raw["linked_service"].([]interface{})),
+			SchemaLinkedService:       expandDataFactoryLinkedServiceReference(raw["schema_linked_service"].([]interface{})),
+			RejectedDataLinkedService: expandDataFactoryLinkedServiceReference(raw["rejected_linked_service"].([]interface{})),
+			Flowlet:                   expandDataFactoryDataFlowReference(raw["flowlet"].([]interface{})),
 		})
 	}
 	return &result
@@ -366,12 +390,13 @@ func flattenDataFactoryDataFlowSink(input *[]datafactory.DataFlowSink) []interfa
 			description = *v.Description
 		}
 		result = append(result, map[string]interface{}{
-			"name":                  name,
-			"description":           description,
-			"dataset":               flattenDataFactoryDatasetReference(v.Dataset),
-			"linked_service":        flattenDataFactoryLinkedServiceReference(v.LinkedService),
-			"schema_linked_service": flattenDataFactoryLinkedServiceReference(v.SchemaLinkedService),
-			"flowlet":               flattenDataFactoryDataFlowReference(v.Flowlet),
+			"name":                    name,
+			"description":             description,
+			"dataset":                 flattenDataFactoryDatasetReference(v.Dataset),
+			"linked_service":          flattenDataFactoryLinkedServiceReference(v.LinkedService),
+			"rejected_linked_service": flattenDataFactoryLinkedServiceReference(v.RejectedDataLinkedService),
+			"schema_linked_service":   flattenDataFactoryLinkedServiceReference(v.SchemaLinkedService),
+			"flowlet":                 flattenDataFactoryDataFlowReference(v.Flowlet),
 		})
 	}
 	return result

--- a/internal/services/datafactory/data_factory_data_flow_resource_test.go
+++ b/internal/services/datafactory/data_factory_data_flow_resource_test.go
@@ -224,6 +224,13 @@ resource "azurerm_data_factory_data_flow" "test" {
       }
     }
 
+    rejected_linked_service {
+      name = azurerm_data_factory_linked_custom_service.test.name
+      parameters = {
+        "Key1" = "value1"
+      }
+    }
+
     schema_linked_service {
       name = azurerm_data_factory_linked_custom_service.test.name
       parameters = {

--- a/internal/services/datafactory/data_factory_flowlet_data_flow_resource_test.go
+++ b/internal/services/datafactory/data_factory_flowlet_data_flow_resource_test.go
@@ -195,6 +195,13 @@ resource "azurerm_data_factory_flowlet_data_flow" "test" {
       }
     }
 
+    rejected_linked_service {
+      name = azurerm_data_factory_linked_custom_service.test.name
+      parameters = {
+        "Key1" = "value1"
+      }
+    }
+
     schema_linked_service {
       name = azurerm_data_factory_linked_custom_service.test.name
       parameters = {

--- a/website/docs/r/data_factory_data_flow.html.markdown
+++ b/website/docs/r/data_factory_data_flow.html.markdown
@@ -245,6 +245,8 @@ A `sink` block supports the following:
 
 * `linked_service` - (Optional) A `linked_service` block as defined below.
 
+* `rejected_linked_service` - (Optional) A `rejected_linked_service` block as defined below.
+
 * `schema_linked_service` - (Optional) A `schema_linked_service` block as defined below.
 
 ---
@@ -268,6 +270,14 @@ A `flowlet` block supports the following:
 A `linked_service` block supports the following:
 
 * `name` - (Required) The name for the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
+
+---
+
+A `rejected_linked_service` block supports the following:
+
+* `name` - (Required) The name for the Data Factory Linked Service with schema.
 
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
 

--- a/website/docs/r/data_factory_flowlet_data_flow.html.markdown
+++ b/website/docs/r/data_factory_flowlet_data_flow.html.markdown
@@ -264,7 +264,17 @@ A `sink` block supports the following:
 
 * `name` - (Required) The name for the Data Flow Source.
 
+* `rejected_linked_service` - (Optional) A `rejected_linked_service` block as defined below.
+
 * `schema_linked_service` - (Optional) A `schema_linked_service` block as defined below.
+
+---
+
+A `rejected_linked_service` block supports the following:
+
+* `name` - (Required) The name for the Data Factory Linked Service with schema.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
 
 ---
 


### PR DESCRIPTION
`azurerm_data_factory_flowlet_data_flow` `azurerm_data_factory_data_flow` - `rejected_linked_service`