### PR TITLE
`azurerm_data_factory_dataset_json` - `filename` and `path` in `azure_blob_storage_location` block can now be empty

### DIFF
--- a/internal/services/datafactory/data_factory_dataset_json_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_json_resource.go
@@ -114,9 +114,8 @@ func resourceDataFactoryDatasetJSON() *pluginsdk.Resource {
 							Default:  false,
 						},
 						"path": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Required: true,
 						},
 						"dynamic_path_enabled": {
 							Type:     pluginsdk.TypeBool,
@@ -124,9 +123,8 @@ func resourceDataFactoryDatasetJSON() *pluginsdk.Resource {
 							Default:  false,
 						},
 						"filename": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Required: true,
 						},
 						"dynamic_filename_enabled": {
 							Type:     pluginsdk.TypeBool,

--- a/internal/services/datafactory/data_factory_dataset_json_resource_test.go
+++ b/internal/services/datafactory/data_factory_dataset_json_resource_test.go
@@ -77,6 +77,21 @@ func TestAccDataFactoryDatasetJSON_blob(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryDatasetJSON_blobWithoutFileName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_dataset_json", "test")
+	r := DatasetJSONResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.blobWithEmptyFileNameAndPath(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataFactoryDatasetJSON_blobDynamicContainer(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_dataset_json", "test")
 	r := DatasetJSONResource{}
@@ -396,6 +411,63 @@ resource "azurerm_data_factory_dataset_json" "test" {
     filename                  = "foo.json"
     dynamic_filename_enabled  = false
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (DatasetJSONResource) blobWithEmptyFileNameAndPath(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestdf%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "content"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
+  name              = "acctestlsblob%d"
+  data_factory_id   = azurerm_data_factory.test.id
+  connection_string = azurerm_storage_account.test.primary_connection_string
+}
+
+resource "azurerm_data_factory_dataset_json" "test" {
+  name                = "acctestds%d"
+  data_factory_id     = azurerm_data_factory.test.id
+  linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.test.name
+
+  azure_blob_storage_location {
+    container                = azurerm_storage_container.test.name
+    path                     = ""
+    dynamic_path_enabled     = true
+    filename                 = ""
+    dynamic_filename_enabled = false
+  }
+
+  encoding = "UTF-8"
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
As #17972 described we can pass empty string as `filename` and `path` an `azure_blob_storage_location` block. This patch removes `ValidateFunc` on these two arguments to loose the constraints.