### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - nil check first element when expanding upgrade settings

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -918,7 +918,7 @@ func upgradeSettingsForDataSourceSchema() *pluginsdk.Schema {
 
 func expandUpgradeSettings(input []interface{}) *containerservice.AgentPoolUpgradeSettings {
 	setting := &containerservice.AgentPoolUpgradeSettings{}
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return setting
 	}
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-azurerm/issues/18066#issuecomment-1223308764