### PR TITLE
Correct resource name references in documentation

### DIFF
--- a/website/docs/d/logic_app_workflow.html.markdown
+++ b/website/docs/d/logic_app_workflow.html.markdown
@@ -65,13 +65,13 @@ The following attributes are exported:
 
 An `identity` block exports the following:
 
-* `type` - The type of Managed Service Identity that is configured on this API Management Service.
+* `type` - The type of Managed Service Identity that is configured on this Logic App Workflow.
 
-* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Logic App Workflow.
 
-* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Logic App Workflow.
 
-* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this API Management Service.
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Logic App Workflow.
 
 ## Timeouts
 

--- a/website/docs/r/machine_learning_compute_cluster.html.markdown
+++ b/website/docs/r/machine_learning_compute_cluster.html.markdown
@@ -131,9 +131,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this API Management Service. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Compute Cluster. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this API Management Service.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Compute Cluster.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -41,6 +41,7 @@ resource "azurerm_mssql_server" "example" {
   }
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -71,7 +72,7 @@ The following arguments are supported:
 
 * `outbound_network_restriction_enabled` - (Optional) Whether outbound network traffic is restricted for this server. Defaults to `false`.
 
-* `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id. Required if `type` is `UserAssigned` and should be combined with `user_assigned_identity_ids`.
+* `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id. Required if `type` is `UserAssigned` and should be combined with `identity_ids`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -79,9 +80,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this API Management Service. Possible values are `SystemAssigned`, `UserAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this SQL Server. Possible values are `SystemAssigned`, `UserAssigned`.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this API Management Service.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this SQL Server.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`
 

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -66,7 +66,7 @@ An `identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this ServiceBus Namespace. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this API Management Service.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this ServiceBus namespace.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/web_pubsub.html.markdown
+++ b/website/docs/r/web_pubsub.html.markdown
@@ -90,7 +90,7 @@ An `identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Web PubSub. Possible values are `SystemAssigned`, `UserAssigned`.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this API Management Service.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Web PubSub.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`
 


### PR DESCRIPTION
- I assume these were originally copy/pasted from API Management
- Also correct reference to 'user_assigned_identity_ids' which I think was changed in v3