### PR TITLE
azurerm_postgresql_flexible_server: use time format RFC3339 for PointInTimeUTC parameter

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -315,7 +315,7 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 		if err != nil {
 			return fmt.Errorf("unable to parse `point_in_time_restore_time_in_utc` value")
 		}
-		parameters.Properties.PointInTimeUTC = utils.String(v.String())
+		parameters.Properties.PointInTimeUTC = utils.String(v.Format(time.RFC3339))
 	}
 
 	if err = client.CreateThenPoll(ctx, id, parameters); err != nil {


### PR DESCRIPTION
This PR fixes the issue with restoring a Flexible Postgres Server based on a point in time. If `point_in_time_restore_time_in_utc` parameter is specified, the formatted value make the restore crash.

```
Error: creating Flexible Server (Subscription: "xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
│ Resource Group Name: "test-db-group"
│ Server Name: "testdb-db"): performing Create: servers.ServersClient#Create: Failure sending request: StatusCode=0 -- Original Error: Code="InternalServerError" Message="An unexpected error occured while processing the request. Tracking ID: 'xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'"
│
│   with module.test_module.azurerm_postgresql_flexible_server.this,
│   on postgres/postgres.tf line 46, in resource "azurerm_postgresql_flexible_server" "this":
│   46: resource "azurerm_postgresql_flexible_server" "this" {
```

With the patched provider, I did manage to create the DB.

fixes #18082