### PR TITLE
fix: azurerm_virtual_network fails to detect in-line subnets removal

### DIFF
--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -125,7 +125,6 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		"subnet": {
 			Type:       pluginsdk.TypeSet,
 			Optional:   true,
-			Computed:   true,
 			ConfigMode: pluginsdk.SchemaConfigModeAttr,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -198,6 +198,7 @@ func TestAccVirtualNetwork_deleteSubnet(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("subnet.0.id").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -205,7 +206,7 @@ func TestAccVirtualNetwork_deleteSubnet(t *testing.T) {
 			Config: r.noSubnet(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("subnet.#").HasValue("0"),
+				check.That(data.ResourceName).Key("subnet.0.id").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -527,7 +528,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  subnet              = []
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
## Description

As described in #18107, azurerm-provider `v3.19.1` (terraform `1.2.7`) fails to detect in-line subnets removal unless an empty array is passed (`subnets = []`) or another subnet is added to terraform config.

The PR is meant to address that.
Closes: #18107 

## Implementation details

### Subnet removal detection

To fix the issue, we just need to remove `Computed: true,` from `subnet` schema.

Please, let me know if you can foresee any negative implications as a result of the change.

### Adjustments in TestAccVirtualNetwork_deleteSubnet

Firstly, I think the test should be adjusted:
- to explicitly check for the presence of a subnet after its creation;
- to make sure that the subnet is gone once the config without the subnet is applied.

Secondly, I've noticed that these two cases are treated differently:

```hcl
resource "azurerm_virtual_network" "example" {
  name                = "example-vnet"
  address_space       = ["10.5.0.0/16"]
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  subnet              = [] # if this line is present, everything works just fine
}
```

```hcl
resource "azurerm_virtual_network" "example" {
  name                = "example-vnet"
  address_space       = ["10.5.0.0/16"]
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  # when the list of subnets is not explicitly nullified, the provider fails to detect that the subnet is gone 
}
```

If we make the changes suggested above, but leave `Computed: true,` in the code, the test would catch the issue:

```shell
$ make acctests SERVICE='network' TESTARGS='-run=TestAccVirtualNetwork_deleteSubnet' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccVirtualNetwork_deleteSubnet -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualNetwork_deleteSubnet
=== PAUSE TestAccVirtualNetwork_deleteSubnet
=== CONT  TestAccVirtualNetwork_deleteSubnet
    testcase.go:110: Step 3/4 error: Check failed: Check 2/2 error: azurerm_virtual_network.test: Attribute 'subnet.0.id' expected to be set
--- FAIL: TestAccVirtualNetwork_deleteSubnet (132.47s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/network       133.567s
FAIL 
```

With all the changes added in the PR, everything seems to be fine:

```shell
$ make acctests SERVICE='network' TESTARGS='-run=TestAccVirtualNetwork_deleteSubnet' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccVirtualNetwork_deleteSubnet -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualNetwork_deleteSubnet
=== PAUSE TestAccVirtualNetwork_deleteSubnet
=== CONT  TestAccVirtualNetwork_deleteSubnet
--- PASS: TestAccVirtualNetwork_deleteSubnet (160.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       161.281s
```