### PR TITLE
User-assigned managed identity support for Logic Apps Standard

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -106,7 +106,7 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
+			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"site_config": schemaLogicAppStandardSiteConfig(),
 
@@ -232,7 +232,11 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	log.Printf("[INFO] preparing arguments for AzureRM Logic App Standard creation.")
 
-	id := parse.NewLogicAppStandardID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := parse.NewLogicAppStandardID(
+		subscriptionId,
+		d.Get("resource_group_name").(string),
+		d.Get("name").(string),
+	)
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
@@ -254,7 +258,11 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if !*available.NameAvailable {
-		return fmt.Errorf("the name %q used for the Logic App Standard needs to be globally unique and isn't available: %+v", id.SiteName, *available.Message)
+		return fmt.Errorf(
+			"the name %q used for the Logic App Standard needs to be globally unique and isn't available: %+v",
+			id.SiteName,
+			*available.Message,
+		)
 	}
 
 	appServicePlanID := d.Get("app_service_plan_id").(string)
@@ -610,7 +618,10 @@ func resourceLogicAppStandardDelete(d *pluginsdk.ResourceData, meta interface{})
 	return nil
 }
 
-func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) ([]web.NameValuePair, error) {
+func getBasicLogicAppSettings(
+	d *pluginsdk.ResourceData,
+	endpointSuffix string,
+) ([]web.NameValuePair, error) {
 	storagePropName := "AzureWebJobsStorage"
 	functionVersionPropName := "FUNCTIONS_EXTENSION_VERSION"
 	contentSharePropName := "WEBSITE_CONTENTSHARE"
@@ -620,7 +631,12 @@ func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) 
 
 	storageAccount := d.Get("storage_account_name").(string)
 	accountKey := d.Get("storage_account_access_key").(string)
-	storageConnection := fmt.Sprintf("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s", storageAccount, accountKey, endpointSuffix)
+	storageConnection := fmt.Sprintf(
+		"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
+		storageAccount,
+		accountKey,
+		endpointSuffix,
+	)
 	functionVersion := d.Get("version").(string)
 
 	contentShare := strings.ToLower(d.Get("name").(string)) + "-content"
@@ -644,7 +660,9 @@ func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) 
 		extensionBundleVersion := d.Get("bundle_version").(string)
 
 		if extensionBundleVersion == "" {
-			return nil, fmt.Errorf("when `use_extension_bundle` is true, `bundle_version` must be specified")
+			return nil, fmt.Errorf(
+				"when `use_extension_bundle` is true, `bundle_version` must be specified",
+			)
 		}
 
 		bundleSettings := []web.NameValuePair{
@@ -848,7 +866,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 					}, false),
 				},
 
-				//lintignore:XS003
+				// lintignore:XS003
 				"headers": {
 					Type:       pluginsdk.TypeList,
 					Optional:   true,
@@ -857,7 +875,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 					ConfigMode: pluginsdk.SchemaConfigModeAttr,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
-							//lintignore:S018
+							// lintignore:S018
 							"x_forwarded_host": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
@@ -867,7 +885,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 								},
 							},
 
-							//lintignore:S018
+							// lintignore:S018
 							"x_forwarded_for": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
@@ -878,7 +896,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 								},
 							},
 
-							//lintignore:S018
+							// lintignore:S018
 							"x_azure_fdid": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
@@ -889,7 +907,7 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 								},
 							},
 
-							//lintignore:S018
+							// lintignore:S018
 							"x_fd_health_probe": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
@@ -918,7 +936,9 @@ func flattenLogicAppStandardAppSettings(input map[string]*string) map[string]str
 	return output
 }
 
-func flattenLogicAppStandardConnectionStrings(input map[string]*web.ConnStringValueTypePair) interface{} {
+func flattenLogicAppStandardConnectionStrings(
+	input map[string]*web.ConnStringValueTypePair,
+) interface{} {
 	results := make([]interface{}, 0)
 
 	for k, v := range input {
@@ -1239,7 +1259,10 @@ func flattenLogicAppStandardIdentity(input *web.ManagedServiceIdentity) []interf
 	return identity.FlattenSystemAssigned(transform)
 }
 
-func expandLogicAppStandardSettings(d *pluginsdk.ResourceData, endpointSuffix string) (map[string]*string, error) {
+func expandLogicAppStandardSettings(
+	d *pluginsdk.ResourceData,
+	endpointSuffix string,
+) (map[string]*string, error) {
 	output := make(map[string]*string)
 	appSettings := expandAppSettings(d)
 	basicAppSettings, err := getBasicLogicAppSettings(d, endpointSuffix)
@@ -1268,7 +1291,9 @@ func expandAppSettings(d *pluginsdk.ResourceData) []web.NameValuePair {
 	return output
 }
 
-func expandLogicAppStandardConnectionStrings(d *pluginsdk.ResourceData) map[string]*web.ConnStringValueTypePair {
+func expandLogicAppStandardConnectionStrings(
+	d *pluginsdk.ResourceData,
+) map[string]*web.ConnStringValueTypePair {
 	input := d.Get("connection_string").(*pluginsdk.Set).List()
 	output := make(map[string]*web.ConnStringValueTypePair, len(input))
 
@@ -1340,11 +1365,15 @@ func expandLogicAppStandardIpRestriction(input interface{}) ([]web.IPSecurityRes
 		action := restriction["action"].(string)
 
 		if vNetSubnetID != "" && ipAddress != "" && serviceTag != "" {
-			return nil, fmt.Errorf("only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` can be set for an IP restriction")
+			return nil, fmt.Errorf(
+				"only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` can be set for an IP restriction",
+			)
 		}
 
 		if vNetSubnetID == "" && ipAddress == "" && serviceTag == "" {
-			return nil, fmt.Errorf("one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be set for an IP restriction")
+			return nil, fmt.Errorf(
+				"one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be set for an IP restriction",
+			)
 		}
 
 		ipSecurityRestriction := web.IPSecurityRestriction{}

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -106,8 +106,7 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			// TODO: API supports UserAssigned & SystemAssignedUserAssigned too?
-			"identity": commonschema.SystemAssignedIdentityOptional(),
+			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
 			"site_config": schemaLogicAppStandardSiteConfig(),
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -48,10 +48,6 @@ resource "azurerm_logic_app_standard" "example" {
   app_service_plan_id        = azurerm_app_service_plan.example.id
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
-
-  identity {
-    type = "SystemAssigned"
-  }
 }
 ```
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -48,6 +48,10 @@ resource "azurerm_logic_app_standard" "example" {
   app_service_plan_id        = azurerm_app_service_plan.example.id
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 ```
 
@@ -214,10 +218,12 @@ A `cors` block supports the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Logic App Standard. The only possible value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Logic App Standard. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned` (to enable both).
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
 
 ~> **NOTE:** When `type` is set to `SystemAssigned`, The assigned `principal_id` and `tenant_id` can be retrieved after the Logic App has been created. More details are available below.
 
+~> **NOTE:** The `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 
 ---
 


### PR DESCRIPTION
Currently the `azurerm_logic_app_standard` resource only supports system-assigned managed identity, although the service supports user-assigned identity on the [ManagedServiceIdentity](https://docs.microsoft.com/en-us/azure/templates/microsoft.logic/workflows?pivots=deployment-language-bicep#managedserviceidentity) property for ARM Template an Bicep.

Additionally, the official [Azure documentation](https://docs.microsoft.com/en-us/azure/logic-apps/create-managed-service-identity?tabs=consumption) points out that *You can enable both the system-assigned identity type, which is enabled by default, and the user-assigned identity type at the same time.*

This PR introduces changes on the resource to support both identity types and updates on the documentation.