### PR TITLE
`azurerm_stream_analytics_output_powerbi` - support for `token_user_principal_name` and `token_user_display_name` properties

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_powerbi_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_powerbi_resource_test.go
@@ -67,6 +67,20 @@ func TestAccStreamAnalyticsOutputPowerBI_update(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsOutputPowerBI_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_powerbi", "test")
+	r := StreamAnalyticsOutputPowerBIResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (r StreamAnalyticsOutputPowerBIResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
@@ -95,6 +109,24 @@ resource "azurerm_stream_analytics_output_powerbi" "test" {
   table                   = "updated-table"
   group_id                = "e18ff5df-fb66-4f6d-8f27-88c4dcbfc002"
   group_name              = "some-updated-group-id"
+}
+`, template, data.RandomInteger)
+}
+
+func (r StreamAnalyticsOutputPowerBIResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_output_powerbi" "test" {
+  name                      = "acctestoutput-%d"
+  stream_analytics_job_id   = azurerm_stream_analytics_job.test.id
+  dataset                   = "complete-dataset"
+  table                     = "complete-table"
+  group_id                  = "e18ff5df-fb66-4f6d-8f27-88c4dcbfc002"
+  group_name                = "some-test-group-name"
+  token_user_principal_name = "bobsmith@contoso.com"
+  token_user_display_name   = "Bob Smith"
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/stream_analytics_output_powerbi.html.markdown
+++ b/website/docs/r/stream_analytics_output_powerbi.html.markdown
@@ -48,6 +48,10 @@ The following arguments are supported:
 
 * `group_name` - (Required) The name of the Power BI group. Use this property to help remember which specific Power BI group id was used.
 
+* `token_user_principal_name` - (Optional) The user principal name (UPN) of the user that was used to obtain the refresh token. 
+
+* `token_user_display_name` - (Optional) The user display name of the user that was used to obtain the refresh token.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
* All test cases passed. 

```
--- PASS: TestAccStreamAnalyticsOutputPowerBI_basic (174.57s)
--- PASS: TestAccStreamAnalyticsOutputPowerBI_complete (223.87s)
--- PASS: TestAccStreamAnalyticsOutputPowerBI_update (330.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       347.818s
```