### PR TITLE
Add generic OIDC authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
-	github.com/hashicorp/go-azure-helpers v0.39.1
+	github.com/hashicorp/go-azure-helpers v0.40.0
 	github.com/hashicorp/go-azure-sdk v0.20220824.1090858
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.39.1 h1:f5zkbJccz9Zbgx1qiI1ssMh8jpPubT3cyPRpKuM9WfQ=
-github.com/hashicorp/go-azure-helpers v0.39.1/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
+github.com/hashicorp/go-azure-helpers v0.40.0 h1:NjiyF+jN+0mRdFBU894yzZSxu1SNrbvj8l4rEDpCB0A=
+github.com/hashicorp/go-azure-helpers v0.40.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
 github.com/hashicorp/go-azure-sdk v0.20220824.1090858 h1:OPdyEfc24JtC4fhYChE6vC7meCAMbPkgyWZ5ZYPC1W8=
 github.com/hashicorp/go-azure-sdk v0.20220824.1090858/go.mod h1:jOhjVttoXh2We/glz4BC/0t0Lo8+M9WQBA4sbAPQPMY=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -171,13 +171,20 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}, ""),
-				Description: "The bearer token for the request to the OIDC provider. For use When authenticating as a Service Principal using OpenID Connect.",
+				Description: "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.",
 			},
 			"oidc_request_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}, ""),
-				Description: "The URL for the OIDC provider from which to request an ID token. For use When authenticating as a Service Principal using OpenID Connect.",
+				Description: "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.",
+			},
+
+			"oidc_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_TOKEN"}, ""),
+				Description: "The OIDC ID token for use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
 			"use_oidc": {
@@ -279,6 +286,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			ClientCertPath:      d.Get("client_certificate_path").(string),
 			IDTokenRequestToken: d.Get("oidc_request_token").(string),
 			IDTokenRequestURL:   d.Get("oidc_request_url").(string),
+			IDToken:             d.Get("oidc_token").(string),
 
 			// Feature Toggles
 			SupportsClientCertAuth:         true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -183,7 +183,7 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 			"oidc_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_TOKEN"}, ""),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN", ""),
 				Description: "The OIDC ID token for use when authenticating as a Service Principal using OpenID Connect.",
 			},
 

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
@@ -46,6 +46,7 @@ type Builder struct {
 
 	// OIDC Auth
 	SupportsOIDCAuth    bool
+	IDToken             string
 	IDTokenRequestURL   string
 	IDTokenRequestToken string
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,7 +166,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.39.1
+# github.com/hashicorp/go-azure-helpers v0.40.0
 ## explicit; go 1.17
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates

--- a/website/docs/guides/service_principal_oidc.html.markdown
+++ b/website/docs/guides/service_principal_oidc.html.markdown
@@ -92,15 +92,7 @@ Secondly, search for and select the name of the Service Principal created in Azu
 
 On the Azure Active Directory application page, go to **Certificates and secrets**.
 
-In the Federated credentials tab, select Add credential. The Add a credential blade opens. In the **Federated credential scenario** drop-down box select **Other issuer**.
-
-Specify the **Issuer URL** and **Subject Identifier** for your OIDC provider. For GitLab use your GitLab instance URL and the project/branch specifier as defined in the [GitLab OIDC documentation](https://docs.gitlab.com/ee/ci/cloud_services/) (e.g. `"project_path:user/my-repo:ref_type:branch:ref:main"`).
-
-Add a **Name** for the federated credential.
-
-For GitLab you will need to set the value for **Audience** to your GitLab instance ("https://gitlab.com" or "https://gitlab.example.com").
-
-Click **Add** to configure the federated credential.
+In the Federated credentials tab, select **Add credential**. The 'Add a credential' blade opens. Refer to the instructions from your OIDC provider for completing the form, before choosing a **Name** for the federated credential and clicking the **Add** button.
 
 ## Configuring the Service Principal in Terraform
 
@@ -116,16 +108,9 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The provider will use the `ARM_OIDC_TOKEN` environment variable as an OIDC token. 
+The provider will use the `ARM_OIDC_TOKEN` environment variable as an OIDC token. You can use this variable to specify the token provided by your OIDC provider.
 
-GitLab CI provides a valid OIDC token as an environment variable with the name `CI_JOB_JWT_V2` - you will have to set the ARM_OIDC_TOKEN in the GitLab CI variables:
-
-```yaml
-variables:
-  ARM_OIDC_TOKEN: $CI_JOB_JWT_V2
-```
-
-For GitHub provider will detect the `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables set by the GitHub Actions runtim. You can also specify the `ARM_OIDC_REQUEST_TOKEN` and `ARM_OIDC_REQUEST_URL` environment variables. 
+When running Terraform in GitHub Actions, the provider will detect the `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables set by the GitHub Actions runtime. You can also specify the `ARM_OIDC_REQUEST_TOKEN` and `ARM_OIDC_REQUEST_URL` environment variables.
 
 For GitHub Actions workflows, you'll need to ensure the workflow has `write` permissions for the `id-token`.
 
@@ -195,10 +180,12 @@ provider "azurerm" {
   subscription_id = "00000000-0000-0000-0000-000000000000"
   client_id       = "00000000-0000-0000-0000-000000000000"
   use_oidc        = true
-  # for GitHub actions
+
+  # for GitHub Actions
   oidc_request_token = var.oidc_request_token
   oidc_request_url   = var.oidc_request_url
-  # for GitLab or generic OIDC
+
+  # for other generic OIDC providers
   oidc_token = var.oidc_token
   tenant_id  = "00000000-0000-0000-0000-000000000000"
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -136,6 +136,8 @@ When authenticating as a Service Principal using Open ID Connect, the following 
 
 * `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_URL` Environment Variables.
 
+* `oidc_token` - (Optional) The OIDC ID token. This can also be sourced from the `ARM_OIDC_TOKEN` environment Variable.
+
 * `use_oidc` - (Optional) Should OIDC be used for Authentication? This can also be sourced from the `ARM_USE_OIDC` Environment Variable. Defaults to `false`.
 
 More information on [how to configure a Service Principal using OpenID Connect can be found in this guide](guides/service_principal_oidc.html).

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -136,7 +136,7 @@ When authenticating as a Service Principal using Open ID Connect, the following 
 
 * `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_URL` Environment Variables.
 
-* `oidc_token` - (Optional) The OIDC ID token. This can also be sourced from the `ARM_OIDC_TOKEN` environment Variable.
+* `oidc_token` - (Optional) The ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN` environment Variable.
 
 * `use_oidc` - (Optional) Should OIDC be used for Authentication? This can also be sourced from the `ARM_USE_OIDC` Environment Variable. Defaults to `false`.
 


### PR DESCRIPTION
Adds a way to provide the OIDC token directly to the provider.

This enables to use the provider without tokens/passwords in GitLab CI
See: https://docs.gitlab.com/ee/ci/cloud_services/

Closes #16901