### PR TITLE
`azurerm_stream_analytics_output_cosmosdb` - support for `partition_key` property

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
@@ -29,6 +29,7 @@ type OutputCosmosDBResourceModel struct {
 	Database           string `tfschema:"cosmosdb_sql_database_id"`
 	ContainerName      string `tfschema:"container_name"`
 	DocumentID         string `tfschema:"document_id"`
+	PartitionKey       string `tfschema:"partition_key"`
 }
 
 func (r OutputCosmosDBResource) Arguments() map[string]*pluginsdk.Schema {
@@ -67,6 +68,12 @@ func (r OutputCosmosDBResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"document_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"partition_key": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
@@ -124,6 +131,7 @@ func (r OutputCosmosDBResource) Create() sdk.ResourceFunc {
 				Database:              utils.String(databaseId.Name),
 				CollectionNamePattern: utils.String(model.ContainerName),
 				DocumentID:            utils.String(model.DocumentID),
+				PartitionKey:          utils.String(model.PartitionKey),
 			}
 
 			props := streamanalytics.Output{
@@ -190,6 +198,10 @@ func (r OutputCosmosDBResource) Read() sdk.ResourceFunc {
 					state.DocumentID = *v.DocumentID
 				}
 
+				if v.PartitionKey != nil {
+					state.PartitionKey = *v.PartitionKey
+				}
+
 				return metadata.Encode(&state)
 			}
 			return nil
@@ -253,6 +265,7 @@ func (r OutputCosmosDBResource) Update() sdk.ResourceFunc {
 								Database:              &databaseId.Name,
 								CollectionNamePattern: &state.ContainerName,
 								DocumentID:            &state.DocumentID,
+								PartitionKey:          &state.PartitionKey,
 							},
 						},
 					},

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
@@ -153,6 +153,7 @@ resource "azurerm_stream_analytics_output_cosmosdb" "test" {
   cosmosdb_sql_database_id = azurerm_cosmosdb_sql_database.test.id
   container_name           = azurerm_cosmosdb_sql_container.test.name
   document_id              = "exampledocumentid"
+  partition_key            = "exmaplekey"
 }
 `, template, data.RandomString, data.RandomInteger)
 }

--- a/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
+++ b/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `document_id` - (Optional) The name of the field in output events used to specify the primary key which insert or update operations are based on.
 
+* `partition_key` - (Optional) The name of the field in output events used to specify the key for partitioning output across collections. If `container_name` contains `{partition}` token, this property is required to be specified.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
* All tests passed.

```
--- PASS: TestAccStreamAnalyticsOutputCosmosDB_complete (968.30s)
--- PASS: TestAccStreamAnalyticsOutputCosmosDB_basic (989.61s)
--- PASS: TestAccStreamAnalyticsOutputCosmosDB_requiresImport (1060.37s)
--- PASS: TestAccStreamAnalyticsOutputCosmosDB_update (1160.29s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics      1176.085s
```