### PR TITLE
feat: AKS add support for spot node pool upgrades

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -3,7 +3,6 @@ package containers
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/containerservice/mgmt/2022-03-02-preview/containerservice"
@@ -616,16 +615,6 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if d.HasChange("orchestrator_version") {
-		// Spot Node pool's can't be updated - Azure Docs: https://docs.microsoft.com/en-us/azure/aks/spot-node-pool
-		//   > You can't upgrade a spot node pool since spot node pools can't guarantee cordon and drain.
-		//   > You must replace your existing spot node pool with a new one to do operations such as upgrading
-		//   > the Kubernetes version. To replace a spot node pool, create a new spot node pool with a different
-		//   > version of Kubernetes, wait until its status is Ready, then remove the old node pool.
-		if strings.EqualFold(string(props.ScaleSetPriority), string(containerservice.ScaleSetPrioritySpot)) {
-			// ^ the Scale Set Priority isn't returned when Regular
-			return fmt.Errorf("the Orchestrator Version cannot be updated when using a Spot Node Pool")
-		}
-
 		existingNodePool, err := client.Get(ctx, id.ResourceGroup, id.ManagedClusterName, id.AgentPoolName)
 		if err != nil {
 			return fmt.Errorf("retrieving Node Pool %s: %+v", *id, err)

--- a/internal/services/containers/kubernetes_cluster_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_upgrade_test.go
@@ -239,6 +239,37 @@ func TestAccKubernetesCluster_upgradeControlPlaneAndAllPoolsTogetherVersionAlias
 	})
 }
 
+func TestAccKubernetesCluster_upgradeControlPlaneAndAllPoolsTogetherSpot(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+	nodePoolName := "azurerm_kubernetes_cluster_node_pool.test"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// all on the older version
+			Config: r.upgradeVersionsConfigSpot(data, olderKubernetesVersion, olderKubernetesVersion, olderKubernetesVersion),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kubernetes_version").HasValue(olderKubernetesVersion),
+				check.That(data.ResourceName).Key("default_node_pool.0.orchestrator_version").HasValue(olderKubernetesVersion),
+				check.That(nodePoolName).Key("orchestrator_version").HasValue(olderKubernetesVersion),
+			),
+		},
+		data.ImportStep(),
+		{
+			// upgrade control plane, default and custom node pools
+			Config: r.upgradeVersionsConfigSpot(data, currentKubernetesVersion, currentKubernetesVersion, currentKubernetesVersion),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kubernetes_version").HasValue(currentKubernetesVersion),
+				check.That(data.ResourceName).Key("default_node_pool.0.orchestrator_version").HasValue(currentKubernetesVersion),
+				check.That(nodePoolName).Key("orchestrator_version").HasValue(currentKubernetesVersion),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -346,6 +377,29 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   orchestrator_version  = %q
+}
+`, r.upgradeControlPlaneDefaultNodePoolConfig(data, controlPlaneVersion, defaultNodePoolVersion), customNodePoolVersion)
+}
+
+func (r KubernetesClusterResource) upgradeVersionsConfigSpot(data acceptance.TestData, controlPlaneVersion, defaultNodePoolVersion, customNodePoolVersion string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  orchestrator_version  = %q
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = 0.5 # high, but this is a maximum (we pay less) so ensures this won't fail
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
+  ]
 }
 `, r.upgradeControlPlaneDefaultNodePoolConfig(data, controlPlaneVersion, defaultNodePoolVersion), customNodePoolVersion)
 }


### PR DESCRIPTION
Starting from June, AKS supports spot node pool upgrades:
- https://github.com/Azure/AKS/blob/master/CHANGELOG.md#release-2022-06-12
- https://docs.microsoft.com/en-gb/azure/aks/spot-node-pool#upgrade-a-spot-node-pool

This PR removes the respective restriction from the provider code. No library updates are needed. 

Fixes: #14786 