### PR TITLE
For azurerm_static_site, documentation does not mention identity and principal_id access

### DIFF
--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -58,6 +58,18 @@ In addition to the Arguments listed above - the following Attributes are exporte
   
 * `default_host_name` - The default host name of the Static Web App.
 
+* `identity` - (Optional) An `identity` block as defined below which contains the Managed Service Identity information for this resource.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - The Type of Managed Identity assigned to this resource. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+
+* `principal_id` - (Optional) The Principal ID associated with this Managed Service Identity.
+
+-> You can access the Principal ID via `azurerm_static_site.example.identity.0.principal_id`
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
As per test cases [link](https://github.com/hashicorp/terraform-provider-azurerm/blob/6613b0d791ed576c7b6bd7e7529c1b9c8e7d9508/internal/services/web/static_site_resource_test.go#L47), identity block and principal_id is exported. But not added to documentation.