### PR TITLE
fix(AKS): use currentOrchestratorVersion if orchestratorVersion is absent

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -817,7 +817,13 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
 
-		d.Set("orchestrator_version", props.OrchestratorVersion)
+		// NOTE: workaround for migration from 2022-01-02-preview (<3.12.0) to 2022-03-02-preview (>=3.12.0). Before terraform apply is run against the new API, Azure will respond only with currentOrchestratorVersion, orchestratorVersion will be absent. More details: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353
+		if props.OrchestratorVersion != nil {
+			d.Set("orchestrator_version", props.OrchestratorVersion)
+		} else {
+			d.Set("orchestrator_version", props.CurrentOrchestratorVersion)
+		}
+
 		osDiskSizeGB := 0
 		if props.OsDiskSizeGB != nil {
 			osDiskSizeGB = int(*props.OsDiskSizeGB)

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -1071,8 +1071,11 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 	}
 
 	orchestratorVersion := ""
+	// NOTE: workaround for migration from 2022-01-02-preview (<3.12.0) to 2022-03-02-preview (>=3.12.0). Before terraform apply is run against the new API, Azure will respond only with currentOrchestratorVersion, orchestratorVersion will be absent. More details: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353
 	if agentPool.OrchestratorVersion != nil {
 		orchestratorVersion = *agentPool.OrchestratorVersion
+	} else if agentPool.CurrentOrchestratorVersion != nil {
+		orchestratorVersion = *agentPool.CurrentOrchestratorVersion
 	}
 
 	proximityPlacementGroupId := ""


### PR DESCRIPTION
As it was surfaced in #17833 and #17518, migration of AKS API from `2022-01-02-preview` to `2022-03-02-preview` under https://github.com/hashicorp/terraform-provider-azurerm/pull/17084 did not go flawless. - There's an edge case in which there's a state drift of `orchestratorVersion` (node pool's property) due to peculiarities of Azure API.

- `2022-01-02-preview` returns only `orchestratorVersion`;
- `2022-03-02-preview` is supposed to return both `orchestratorVersion` and `currentOrchestratorVersion`. But if a node pool is created against `2022-01-02-preview` (provider `<3.12.0`), `2022-03-02-preview` API (provider `>=3.12.0`) would be returning only `currentOrchestratorVersion` until `terraform apply` is executed (=PUT call is made). Once that is done, both properties would be present.

Since `orchestratorVersion` is absent from Azure response, terraform refresh phase would set `orchestrator_version` in tfstate-file to an empty value (`""`).
With standard node pools, it's enough to run `terraform apply` to overcome the state drift. - No actual changes will be done to nodes inside a node pool, API endpoint will start returning both `orchestratorVersion` and `currentOrchestratorVersion`.
Spot node pools cannot be upgraded due to the restriction in provider code that I suggested to lift in PR https://github.com/hashicorp/terraform-provider-azurerm/pull/18124, so they have to be deleted through an older provider version and recreated with the newer.

The PR tries to mitigate the whole issue by forcing provider to fallback to `currentOrchestratorVersion` if `orchestratorVersion` is absent in Azure API responses.

More technical details can be found here: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353

Fixes: #17833
Fixes: #17518
