### PR TITLE
`data.azurerm_kubernetes_cluster` - `kube_config` is now set when AAD is enabled for a v1.24 cluster #17182

### DIFF
--- a/internal/services/containers/kubernetes_cluster_auth_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_auth_resource_test.go
@@ -810,6 +810,51 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, tenantId, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
+func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data acceptance.TestData, tenantId string) string {
+	return fmt.Sprintf(`
+variable "tenant_id" {
+  default = "%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = "1.24.3"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  azure_active_directory_role_based_access_control {
+    tenant_id          = var.tenant_id
+    managed            = true
+    azure_rbac_enabled = false
+  }
+}
+`, tenantId, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
 func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigWithLocalAccountDisabled(data acceptance.TestData, tenantId string) string {
 	return fmt.Sprintf(`
 variable "tenant_id" {

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -789,7 +789,7 @@ func flattenKubernetesClusterDataSourceAccessProfile(profile containerservice.Ma
 		rawConfig := string(*kubeConfigRaw)
 		var flattenedKubeConfig []interface{}
 
-		if strings.Contains(rawConfig, "apiserver-id:") {
+		if strings.Contains(rawConfig, "apiserver-id:") || strings.Contains(rawConfig, "exec") {
 			kubeConfigAAD, err := kubernetes.ParseKubeConfigAAD(rawConfig)
 			if err != nil {
 				return utils.String(rawConfig), []interface{}{}

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -70,6 +70,21 @@ func TestAccDataSourceKubernetesCluster_roleBasedAccessControl(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
+				check.That(data.ResourceName).Key("kube_config.0.host").IsSet(),
+			),
+		},
+	})
+}
+
 func TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
@@ -566,6 +581,17 @@ data "azurerm_kubernetes_cluster" "test" {
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
 `, KubernetesClusterResource{}.roleBasedAccessControlConfig(data))
+}
+
+func (KubernetesClusterDataSource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data, ""))
 }
 
 func (KubernetesClusterDataSource) localAccountDisabled(data acceptance.TestData, tenantId string) string {


### PR DESCRIPTION
Fixes #17182 
```
--- PASS: TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree (693.30s)
```