### PR TITLE
Linux/Windows VM store ID to state if partially created

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -650,6 +650,10 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		// Check whether the error occurs after the VM is created, if so, we shall store it to state.
+		if _, err := client.Get(ctx, id.ResourceGroup, id.Name, compute.InstanceViewTypesUserData); err == nil {
+			d.SetId(id.ID())
+		}
 		return fmt.Errorf("waiting for creation of Linux %s: %+v", id, err)
 	}
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -707,6 +707,10 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		// Check whether the error occurs after the VM is created, if so, we shall store it to state.
+		if _, err := client.Get(ctx, id.ResourceGroup, id.Name, compute.InstanceViewTypesUserData); err == nil {
+			d.SetId(id.ID())
+		}
 		return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
 	}
 


### PR DESCRIPTION
Fix #17728.

Partially created resource might be a fit to be stored in the state, as long as the Create returns error. In which case, Terraform will mark these resources as tainted, which will triger a replace in the next apply. This saves user's effor to manually clean that resource up.