### PR TITLE
`azurerm_stream_analytics_reference_input_blob` - support for `authentication_mode`

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
@@ -91,6 +91,16 @@ func resourceStreamAnalyticsReferenceInputBlob() *pluginsdk.Resource {
 			},
 
 			"serialization": schemaStreamAnalyticsStreamInputSerialization(),
+
+			"authentication_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(streamanalytics.AuthenticationModeConnectionString),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(streamanalytics.AuthenticationModeConnectionString),
+					string(streamanalytics.AuthenticationModeMsi),
+				}, false),
+			},
 		},
 	}
 }
@@ -192,6 +202,7 @@ func resourceStreamAnalyticsReferenceInputBlobRead(d *pluginsdk.ResourceData, me
 		d.Set("path_pattern", blobInputDataSource.PathPattern)
 		d.Set("storage_container_name", blobInputDataSource.Container)
 		d.Set("time_format", blobInputDataSource.TimeFormat)
+		d.Set("authentication_mode", blobInputDataSource.AuthenticationMode)
 
 		if accounts := blobInputDataSource.StorageAccounts; accounts != nil && len(*accounts) > 0 {
 			account := (*accounts)[0]
@@ -233,6 +244,7 @@ func getBlobReferenceInputProps(d *pluginsdk.ResourceData) (streamanalytics.Inpu
 	storageAccountKey := d.Get("storage_account_key").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 	timeFormat := d.Get("time_format").(string)
+	authenticationMode := d.Get("authentication_mode").(string)
 
 	serializationRaw := d.Get("serialization").([]interface{})
 	serialization, err := expandStreamAnalyticsStreamInputSerialization(serializationRaw)
@@ -257,6 +269,7 @@ func getBlobReferenceInputProps(d *pluginsdk.ResourceData) (streamanalytics.Inpu
 							AccountKey:  utils.String(storageAccountKey),
 						},
 					},
+					AuthenticationMode: streamanalytics.AuthenticationMode(authenticationMode),
 				},
 			},
 			Serialization: serialization,

--- a/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource_test.go
@@ -81,6 +81,21 @@ func TestAccStreamAnalyticsReferenceInputBlob_update(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsReferenceInputBlob_authenticationMode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_reference_input_blob", "test")
+	r := StreamAnalyticsReferenceInputBlobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authenticationMode(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_key"),
+	})
+}
+
 func TestAccStreamAnalyticsReferenceInputBlob_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_reference_input_blob", "test")
 	r := StreamAnalyticsReferenceInputBlobResource{}
@@ -219,6 +234,31 @@ resource "azurerm_stream_analytics_reference_input_blob" "test" {
   }
 }
 `, template, data.RandomString, data.RandomInteger)
+}
+
+func (r StreamAnalyticsReferenceInputBlobResource) authenticationMode(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
+  name                      = "acctestinput-%d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+  storage_account_name      = azurerm_storage_account.test.name
+  storage_account_key       = azurerm_storage_account.test.primary_access_key
+  storage_container_name    = azurerm_storage_container.test.name
+  path_pattern              = "some-random-pattern"
+  date_format               = "yyyy/MM/dd"
+  time_format               = "HH"
+  authentication_mode       = "Msi"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+  }
+}
+`, template, data.RandomInteger)
 }
 
 func (r StreamAnalyticsReferenceInputBlobResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -93,6 +93,8 @@ A `serialization` block supports the following:
 
 -> **NOTE:** This is required when `type` is set to `Csv`.
 
+* `authentication_mode` - (Optional) The authentication mode for the Stream Analytics Reference Input. Possible values are `Msi` and `ConnectionString`. Defaults to `ConnectionString`.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:


### PR DESCRIPTION
* All related tests passed.

```
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_authenticationMode (264.33s)
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_json (269.27s)
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_avro (274.05s)
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_csv (276.76s)
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_requiresImport (308.68s)
--- PASS: TestAccStreamAnalyticsReferenceInputBlob_update (401.92s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       417.708s
```