### PR TITLE
Removed typo space in README.md hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ resource "azurerm_virtual_network" "example" {
 
 ## Developing & Contributing to the Provider
 
-The [DEVELOPER.md](DEVELOPER.md) file is a basic outline on how to build and develop the provider while more detailed guides geared towards contributors can be found in the [`/contributing`] (https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing) directory of this repository.
+The [DEVELOPER.md](DEVELOPER.md) file is a basic outline on how to build and develop the provider while more detailed guides geared towards contributors can be found in the [`/contributing`](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing) directory of this repository.


### PR DESCRIPTION

Removed extra space in markdown hyperlink resulting into improper display.

File changed: [README.md](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/README.md)
**before changes:**
[`/contributing`] (https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing) directory of this repository

**after changes:** 
[`/contributing`](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing) directory of this repository