### PR TITLE
`azurerm_kubernetes_cluster` - `kube_config` is now set when AAD is enabled for a v1.24 cluster

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1925,7 +1925,7 @@ func flattenKubernetesClusterAccessProfile(profile containerservice.ManagedClust
 			rawConfig := string(*kubeConfigRaw)
 			var flattenedKubeConfig []interface{}
 
-			if strings.Contains(rawConfig, "apiserver-id:") {
+			if strings.Contains(rawConfig, "apiserver-id:") || strings.Contains(rawConfig, "exec") {
 				kubeConfigAAD, err := kubernetes.ParseKubeConfigAAD(rawConfig)
 				if err != nil {
 					return utils.String(rawConfig), []interface{}{}

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -286,3 +286,18 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, maxSurge)
 }
+
+func TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
+				check.That(data.ResourceName).Key("kube_config.0.host").IsSet(),
+			),
+		},
+	})
+}


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/18139

```
--- PASS: TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree (588.47s)
PASS
```