### PR TITLE
Added Resource naming restrictions to docs

### DIFF
--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_analysis_services_server" "server" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Analysis Services Server. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Analysis Services Server. Only lowercase Alphanumeric characters allowed, starting with a letter. Changing this forces a new resource to be created.
 
 * `location` - (Required) The Azure location where the Analysis Services Server exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_batch_account" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Batch account. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Batch account. Only lowercase Alphanumeric characters allowed. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Batch account. Changing this forces a new resource to be created.
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -135,7 +135,7 @@ resource "azurerm_role_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Container Registry. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Container Registry. Only Alphanumeric characters allowed. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created.
 

--- a/website/docs/r/container_registry_webhook.html.markdown
+++ b/website/docs/r/container_registry_webhook.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_container_registry_webhook" "webhook" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Container Registry Webhook. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Container Registry Webhook. Only Alphanumeric characters allowed. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Container Registry Webhook. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_kusto_cluster" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Kusto Cluster to create. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Kusto Cluster to create. Only lowercase Alphanumeric characters allowed, starting with a letter. Changing this forces a new resource to be created.
 
 * `location` - (Required) The location where the Kusto Cluster should be created. Changing this forces a new resource to be created.
 

--- a/website/docs/r/logic_app_integration_account_batch_configuration.html.markdown
+++ b/website/docs/r/logic_app_integration_account_batch_configuration.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_logic_app_integration_account_batch_configuration" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Logic App Integration Account Batch Configuration. Changing this forces a new resource to be created.
+* `name` - (Required) The name which should be used for this Logic App Integration Account Batch Configuration. Only Alphanumeric characters allowed. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Logic App Integration Account Batch Configuration should exist. Changing this forces a new resource to be created.
 

--- a/website/docs/r/media_services_account.html.markdown
+++ b/website/docs/r/media_services_account.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_media_services_account" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Media Services Account. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Media Services Account. Only lowercase Alphanumeric characters allowed. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Media Services Account. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -78,7 +78,7 @@ resource "azurerm_storage_account" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the storage account. Changing this forces a new resource to be created. This must be unique across the entire Azure service, not just within the resource group.
+* `name` - (Required) Specifies the name of the storage account. Only lowercase Alphanumeric characters allowed. Changing this forces a new resource to be created. This must be unique across the entire Azure service, not just within the resource group.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the storage account. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_storage_table" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the storage table. Must be unique within the storage account the table is located.
+* `name` - (Required) The name of the storage table. Only Alphanumeric characters allowed, starting with a letter. Must be unique within the storage account the table is located.
 
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage table.
  Changing this forces a new resource to be created.


### PR DESCRIPTION
Azure has certain restrictions on naming resources which are not obvious from the Terraform documentation. A user would have to go to [Microsoft documentation](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules) or try implementing a resource and receiving an error to see these restrictions. It would be much more useful knowing this while writing down the configuration itself, plus it can be standardized that way.

Source for naming restrictions: [Microsoft documentation](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)