### PR TITLE
Fix test `TestAccIotHubDPS_linkedHubs`

### DIFF
--- a/internal/services/iothub/iothub_dps_resource_test.go
+++ b/internal/services/iothub/iothub_dps_resource_test.go
@@ -360,8 +360,9 @@ resource "azurerm_iothub_shared_access_policy" "test" {
   iothub_name         = azurerm_iothub.test.name
   name                = "acctest"
 
-  registry_read  = true
-  registry_write = true
+  registry_read   = true
+  registry_write  = true
+  service_connect = true
 }
 
 resource "azurerm_iothub" "test2" {
@@ -384,8 +385,9 @@ resource "azurerm_iothub_shared_access_policy" "test2" {
   iothub_name         = azurerm_iothub.test2.name
   name                = "acctest2"
 
-  registry_read  = true
-  registry_write = true
+  registry_read   = true
+  registry_write  = true
+  service_connect = true
 }
 `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/iothub/iothub_dps_resource_test.go
+++ b/internal/services/iothub/iothub_dps_resource_test.go
@@ -272,16 +272,13 @@ resource "azurerm_iothub_dps" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (IotHubDPSResource) linkedHubs(data acceptance.TestData) string {
+func (r IotHubDPSResource) linkedHubs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+%s
 
 resource "azurerm_iothub_dps" "test" {
   name                = "acctestIoTDPS-%d"
@@ -294,30 +291,27 @@ resource "azurerm_iothub_dps" "test" {
   }
 
   linked_hub {
-    connection_string       = "HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=booo"
+    connection_string       = azurerm_iothub_shared_access_policy.test.primary_connection_string
     location                = azurerm_resource_group.test.location
     allocation_weight       = 15
     apply_allocation_policy = true
   }
 
   linked_hub {
-    connection_string = "HostName=test2.azure-devices.net;SharedAccessKeyName=iothubowner2;SharedAccessKey=key2"
+    connection_string = azurerm_iothub_shared_access_policy.test2.primary_connection_string
     location          = azurerm_resource_group.test.location
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, r.linkedHubsDependencies(data), data.RandomInteger)
 }
 
-func (IotHubDPSResource) linkedHubsUpdated(data acceptance.TestData) string {
+func (r IotHubDPSResource) linkedHubsUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+%s
 
 resource "azurerm_iothub_dps" "test" {
   name                = "acctestIoTDPS-%d"
@@ -330,13 +324,70 @@ resource "azurerm_iothub_dps" "test" {
   }
 
   linked_hub {
-    connection_string       = "HostName=test3.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=booo"
+    connection_string       = azurerm_iothub_shared_access_policy.test.primary_connection_string
     location                = azurerm_resource_group.test.location
     allocation_weight       = 150
     apply_allocation_policy = true
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, r.linkedHubsDependencies(data), data.RandomInteger)
+}
+
+func (IotHubDPSResource) linkedHubsDependencies(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_shared_access_policy" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  name                = "acctest"
+
+  registry_read  = true
+  registry_write = true
+}
+
+resource "azurerm_iothub" "test2" {
+  name                = "acctestIoTHub2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_shared_access_policy" "test2" {
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test2.name
+  name                = "acctest2"
+
+  registry_read  = true
+  registry_write = true
+}
+`, data.Locations.Primary, data.RandomInteger)
 }
 
 func (IotHubDPSResource) ipFilterRules(data acceptance.TestData) string {


### PR DESCRIPTION
`connection_string` is not referencing existing IoT Hubs, causing error "Unable to find the IoThub ...", fixing it by using existing reference.