### PR TITLE
`azurerm_service_plan` - update the limitation of `maximum_elastic_worker_count`

### DIFF
--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -185,7 +185,7 @@ func (r ServicePlanResource) Create() sdk.ResourceFunc {
 			}
 
 			if servicePlan.MaximumElasticWorkerCount > 0 {
-				if !strings.HasPrefix(servicePlan.Sku, "EP") && !strings.HasPrefix(servicePlan.Sku, "PC") {
+				if !isServicePlanSupportScaleOut(servicePlan.Sku) {
 					return fmt.Errorf("`maximum_elastic_worker_count` can only be specified with Elastic Premium Skus")
 				}
 				appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(servicePlan.MaximumElasticWorkerCount))
@@ -338,7 +338,7 @@ func (r ServicePlanResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("maximum_elastic_worker_count") {
-				if metadata.ResourceData.HasChange("maximum_elastic_worker_count") && !strings.HasPrefix(state.Sku, "EP") && !strings.HasPrefix(state.Sku, "PC") {
+				if metadata.ResourceData.HasChange("maximum_elastic_worker_count") && !isServicePlanSupportScaleOut(state.Sku) {
 					return fmt.Errorf("`maximum_elastic_worker_count` can only be specified with Elastic Premium Skus")
 				}
 				existing.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(state.MaximumElasticWorkerCount))
@@ -356,4 +356,12 @@ func (r ServicePlanResource) Update() sdk.ResourceFunc {
 			return nil
 		},
 	}
+}
+
+func isServicePlanSupportScaleOut(plan string) bool {
+	support := false
+	support = support || strings.HasPrefix(plan, "EP")
+	support = support || strings.HasPrefix(plan, "PC")
+	support = support || strings.HasPrefix(plan, "WS")
+	return support
 }

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -97,6 +97,32 @@ func TestAccServicePlan_completeUpdate(t *testing.T) {
 	})
 }
 
+func TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku(t *testing.T) {
+	for _, sku := range []string{"WS1","EP1"} {
+		t.Run(sku, func(t *testing.T) {
+			data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
+			r := ServicePlanResource{}
+
+			data.ResourceTest(t, r, []acceptance.TestStep{
+				{
+					Config: r.maxElasticWorkerCountWithSku(data, 5, sku),
+					Check: acceptance.ComposeTestCheckFunc(
+						check.That(data.ResourceName).ExistsInAzure(r),
+					),
+				},
+				data.ImportStep(),
+				{
+					Config: r.maxElasticWorkerCountWithSku(data, 10, sku),
+					Check: acceptance.ComposeTestCheckFunc(
+						check.That(data.ResourceName).ExistsInAzure(r),
+					),
+				},
+				data.ImportStep(),
+			})
+		})
+	}
+}
+
 func TestAccServicePlan_maxElasticWorkerCount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
 	r := ServicePlanResource{}
@@ -324,6 +350,33 @@ resource "azurerm_service_plan" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, count)
+}
+
+func (r ServicePlanResource) maxElasticWorkerCountWithSku(data acceptance.TestData, count int, sku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appserviceplan-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                         = "acctest-SP-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  sku_name                     = "%[3]s"
+  os_type                      = "Linux"
+  maximum_elastic_worker_count = %[4]d
+
+  tags = {
+    environment = "AccTest"
+    Foo         = "bar"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, sku, count)
 }
 
 func (r ServicePlanResource) aseV2(data acceptance.TestData) string {

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -98,7 +98,7 @@ func TestAccServicePlan_completeUpdate(t *testing.T) {
 }
 
 func TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku(t *testing.T) {
-	for _, sku := range []string{"WS1","EP1"} {
+	for _, sku := range []string{"WS1", "EP1"} {
 		t.Run(sku, func(t *testing.T) {
 			data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
 			r := ServicePlanResource{}


### PR DESCRIPTION
Update the limitation of `maximum_elastic_worker_count ` in `azurerm_service_plan` according to the [document ](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans) to fix #18128

Test
---
```
TF_ACC=1 go test -v  ./internal/services/appservice -run=TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku -timeout=60m

=== RUN   TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku
=== RUN   TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/WS1
=== PAUSE TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/WS1
=== RUN   TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/EP1
=== PAUSE TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/EP1
=== CONT  TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/WS1
=== CONT  TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/EP1
--- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku (0.00s)
    --- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/WS1 (293.23s)
    --- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/EP1 (301.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    301.193s
```