### PR TITLE
Fix Cosmos SQL DB Resource name

### DIFF
--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_cosmosdb_account" "example" {
 }
 
 resource "azurerm_cosmosdb_sql_database" "example" {
-  name                = "tfex-cosmos-mongo-db"
+  name                = "tfex-cosmos-sql-db"
   resource_group_name = data.azurerm_cosmosdb_account.example.resource_group_name
   account_name        = data.azurerm_cosmosdb_account.example.name
   throughput          = 400


### PR DESCRIPTION
Looks like this was copied from the Cosmos Mongo Doc but the name wasnt changed from Mongo to SQL