### PR TITLE
`azurerm_logic_app_standard` - add default values to worker runtime

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1430,7 +1430,7 @@ func addDefaultWorkerRuntime(d *pluginsdk.ResourceData, appSettings []web.NameVa
 func appendIfNotExist(appSettings []web.NameValuePair, toAddSettings web.NameValuePair) []web.NameValuePair {
 	exist := false
 	for _, pair := range appSettings {
-		if strings.EqualFold(*pair.Name, *toAddSettings.Name) {
+		if pair != nil && *pair.Name == *toAddSettings.Name {
 			exist = true
 		}
 	}

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -101,6 +101,23 @@ func TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_appSettingsWorkerRuntime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("app_settings.FUNCTIONS_WORKER_RUNTIME").HasValue("node"),
+				check.That(data.ResourceName).Key("app_settings.WEBSITE_NODE_DEFAULT_VERSION").HasValue("~14"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppStandard_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -118,7 +118,9 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **NOTE:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
+~> **NOTE:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below..
+
+~> **NOTE:** There are a number of application settings wil be set to default value if not specified. `FUNCTIONS_WORKER_RUNTIME` is set to `node`, `WEBSITE_NODE_DEFAULT_VERSION` application settings will be set to default value based on `version` if not specified.
 
 * `use_extension_bundle` - (Optional) Should the logic app use the bundled extension package? If true, then application settings for `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` will be created. Default true
 


### PR DESCRIPTION
add default values to worker runtime to fixes #18123, #18017 and #16292

It seems to be a **breaking change**.

test
---
```
TF_ACC=1 go test -v  ./internal/services/logic -run=TestAccLogicAppStandard_appSettingsWorkerRuntime -timeout=60m
=== RUN   TestAccLogicAppStandard_appSettingsWorkerRuntime
=== PAUSE TestAccLogicAppStandard_appSettingsWorkerRuntime
=== CONT  TestAccLogicAppStandard_appSettingsWorkerRuntime
--- PASS: TestAccLogicAppStandard_appSettingsWorkerRuntime (299.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 299.774s
```