### PR TITLE
`azurerm_monitor_action_group` - fix tests and doc of `itsm_receiver` 

### DIFF
--- a/internal/services/monitor/monitor_action_group_data_source_test.go
+++ b/internal/services/monitor/monitor_action_group_data_source_test.go
@@ -90,7 +90,7 @@ func TestAccDataSourceMonitorActionGroup_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("email_receiver.1.email_address").HasValue("devops@contoso.com"),
 				check.That(data.ResourceName).Key("email_receiver.1.use_common_alert_schema").HasValue("false"),
 				check.That(data.ResourceName).Key("itsm_receiver.#").HasValue("1"),
-				check.That(data.ResourceName).Key("itsm_receiver.0.workspace_id").HasValue("6eee3a18-aac3-40e4-b98e-1f309f329816"),
+				check.That(data.ResourceName).Key("itsm_receiver.0.workspace_id").HasValue("5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.connection_id").HasValue("53de6956-42b4-41ba-be3c-b154cdf17b13"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.ticket_configuration").HasValue("{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.region").HasValue("southcentralus"),
@@ -217,7 +217,7 @@ resource "azurerm_monitor_action_group" "test" {
 
   itsm_receiver {
     name                 = "createorupdateticket"
-    workspace_id         = "6eee3a18-aac3-40e4-b98e-1f309f329816"
+    workspace_id         = "5def922a-3ed4-49c1-b9fd-05ec533819a3|55dfd1f8-7e59-4f89-bf56-4c82f5ace23c"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
     ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "southcentralus"

--- a/internal/services/monitor/monitor_action_group_data_source_test.go
+++ b/internal/services/monitor/monitor_action_group_data_source_test.go
@@ -92,7 +92,7 @@ func TestAccDataSourceMonitorActionGroup_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("itsm_receiver.#").HasValue("1"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.workspace_id").HasValue("6eee3a18-aac3-40e4-b98e-1f309f329816"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.connection_id").HasValue("53de6956-42b4-41ba-be3c-b154cdf17b13"),
-				check.That(data.ResourceName).Key("itsm_receiver.0.ticket_configuration").HasValue("{}"),
+				check.That(data.ResourceName).Key("itsm_receiver.0.ticket_configuration").HasValue("{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"),
 				check.That(data.ResourceName).Key("itsm_receiver.0.region").HasValue("southcentralus"),
 				check.That(data.ResourceName).Key("azure_app_push_receiver.#").HasValue("1"),
 				check.That(data.ResourceName).Key("azure_app_push_receiver.0.email_address").HasValue("admin@contoso.com"),
@@ -219,7 +219,7 @@ resource "azurerm_monitor_action_group" "test" {
     name                 = "createorupdateticket"
     workspace_id         = "6eee3a18-aac3-40e4-b98e-1f309f329816"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    ticket_configuration = "{}"
+    ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "southcentralus"
   }
 

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -496,10 +496,9 @@ resource "azurerm_monitor_action_group" "test" {
   short_name          = "acctestag"
 
   itsm_receiver {
-    name          = "createorupdateticket"
-    workspace_id  = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
-    connection_id = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    # https://github.com/Azure/azure-rest-api-specs/issues/20488
+    name                 = "createorupdateticket"
+    workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
+    connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
     ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "eastus"
   }

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -496,9 +496,10 @@ resource "azurerm_monitor_action_group" "test" {
   short_name          = "acctestag"
 
   itsm_receiver {
-    name                 = "createorupdateticket"
-    workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
-    connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
+    name          = "createorupdateticket"
+    workspace_id  = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
+    connection_id = "53de6956-42b4-41ba-be3c-b154cdf17b13"
+    # https://github.com/Azure/azure-rest-api-specs/issues/20488
     ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "eastus"
   }

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -499,7 +499,7 @@ resource "azurerm_monitor_action_group" "test" {
     name                 = "createorupdateticket"
     workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    ticket_configuration = "{}"
+    ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "eastus"
   }
 }
@@ -912,7 +912,7 @@ resource "azurerm_monitor_action_group" "test" {
     name                 = "createorupdateticket"
     workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.test.workspace_id}"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    ticket_configuration = "{}"
+    ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "eastus"
   }
 

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -199,6 +199,8 @@ The following arguments are supported:
 * `ticket_configuration` - (Required) A JSON blob for the configurations of the ITSM action. CreateMultipleWorkItems option will be part of this blob as well.
 * `region` - (Required) The region of the workspace.
 
+-> **NOTE** `ticket_configuration` should be JSON blob with `PayloadRevision` and `WorkItemType` keys (e.g., `ticket_configuration="{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\"}"`), and `ticket_configuration="{}"` will return an error, see more at this [REST API issue](https://github.com/Azure/azure-rest-api-specs/issues/20488) 
+
 ---
 
 `logic_app_receiver` supports the following:

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -83,7 +83,7 @@ resource "azurerm_monitor_action_group" "example" {
     name                 = "createorupdateticket"
     workspace_id         = "${data.azurerm_client_config.current.subscription_id}|${azurerm_log_analytics_workspace.example.workspace_id}"
     connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    ticket_configuration = "{}"
+    ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
     region               = "southcentralus"
   }
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18144

Service returns 500 with `ticket_configuration = "{}"`, see https://github.com/Azure/azure-rest-api-specs/issues/20488
A workaround is to use 
```hcl
ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
```

![image](https://user-images.githubusercontent.com/104055472/187816552-23a7795e-6c75-4839-b318-dbbd1d3b1a7c.png)

<details>

<summary>Test Result</summary>

```
make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorActionGroup_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccMonitorActionGroup_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorActionGroup_basic
=== PAUSE TestAccMonitorActionGroup_basic
=== RUN   TestAccMonitorActionGroup_requiresImport
=== PAUSE TestAccMonitorActionGroup_requiresImport
=== RUN   TestAccMonitorActionGroup_emailReceiver
=== PAUSE TestAccMonitorActionGroup_emailReceiver
=== RUN   TestAccMonitorActionGroup_itsmReceiver
=== PAUSE TestAccMonitorActionGroup_itsmReceiver
=== RUN   TestAccMonitorActionGroup_azureAppPushReceiver
=== PAUSE TestAccMonitorActionGroup_azureAppPushReceiver
=== RUN   TestAccMonitorActionGroup_smsReceiver
=== PAUSE TestAccMonitorActionGroup_smsReceiver
=== RUN   TestAccMonitorActionGroup_webhookReceiver
=== PAUSE TestAccMonitorActionGroup_webhookReceiver
=== RUN   TestAccMonitorActionGroup_automationRunbookReceiver
=== PAUSE TestAccMonitorActionGroup_automationRunbookReceiver
=== RUN   TestAccMonitorActionGroup_voiceReceiver
=== PAUSE TestAccMonitorActionGroup_voiceReceiver
=== RUN   TestAccMonitorActionGroup_logicAppReceiver
=== PAUSE TestAccMonitorActionGroup_logicAppReceiver
=== RUN   TestAccMonitorActionGroup_azureFunctionReceiver
=== PAUSE TestAccMonitorActionGroup_azureFunctionReceiver
=== RUN   TestAccMonitorActionGroup_armRoleReceiver
=== PAUSE TestAccMonitorActionGroup_armRoleReceiver
=== RUN   TestAccMonitorActionGroup_eventHubReceiver
=== PAUSE TestAccMonitorActionGroup_eventHubReceiver
=== RUN   TestAccMonitorActionGroup_complete
=== PAUSE TestAccMonitorActionGroup_complete
=== RUN   TestAccMonitorActionGroup_disabledUpdate
=== PAUSE TestAccMonitorActionGroup_disabledUpdate
=== RUN   TestAccMonitorActionGroup_singleReceiverUpdate
=== PAUSE TestAccMonitorActionGroup_singleReceiverUpdate
=== RUN   TestAccMonitorActionGroup_multipleReceiversUpdate
=== PAUSE TestAccMonitorActionGroup_multipleReceiversUpdate
=== CONT  TestAccMonitorActionGroup_basic
=== CONT  TestAccMonitorActionGroup_multipleReceiversUpdate
=== CONT  TestAccMonitorActionGroup_voiceReceiver
=== CONT  TestAccMonitorActionGroup_singleReceiverUpdate
=== CONT  TestAccMonitorActionGroup_disabledUpdate
=== CONT  TestAccMonitorActionGroup_complete
=== CONT  TestAccMonitorActionGroup_eventHubReceiver
=== CONT  TestAccMonitorActionGroup_armRoleReceiver
--- PASS: TestAccMonitorActionGroup_voiceReceiver (177.92s)
=== CONT  TestAccMonitorActionGroup_azureFunctionReceiver
--- PASS: TestAccMonitorActionGroup_basic (178.04s)
=== CONT  TestAccMonitorActionGroup_logicAppReceiver
--- PASS: TestAccMonitorActionGroup_armRoleReceiver (183.51s)
=== CONT  TestAccMonitorActionGroup_webhookReceiver
--- PASS: TestAccMonitorActionGroup_disabledUpdate (290.80s)
=== CONT  TestAccMonitorActionGroup_automationRunbookReceiver
--- PASS: TestAccMonitorActionGroup_eventHubReceiver (339.25s)
=== CONT  TestAccMonitorActionGroup_emailReceiver
--- PASS: TestAccMonitorActionGroup_webhookReceiver (159.19s)
=== CONT  TestAccMonitorActionGroup_itsmReceiver
--- PASS: TestAccMonitorActionGroup_complete (369.99s)
=== CONT  TestAccMonitorActionGroup_requiresImport
--- PASS: TestAccMonitorActionGroup_logicAppReceiver (200.56s)
=== CONT  TestAccMonitorActionGroup_smsReceiver
--- PASS: TestAccMonitorActionGroup_azureFunctionReceiver (283.17s)
=== CONT  TestAccMonitorActionGroup_azureAppPushReceiver
--- PASS: TestAccMonitorActionGroup_multipleReceiversUpdate (461.60s)
--- PASS: TestAccMonitorActionGroup_smsReceiver (97.69s)
--- PASS: TestAccMonitorActionGroup_emailReceiver (157.47s)
--- PASS: TestAccMonitorActionGroup_automationRunbookReceiver (215.74s)
--- PASS: TestAccMonitorActionGroup_itsmReceiver (184.60s)
--- PASS: TestAccMonitorActionGroup_requiresImport (174.72s)
--- PASS: TestAccMonitorActionGroup_azureAppPushReceiver (165.17s)
--- PASS: TestAccMonitorActionGroup_singleReceiverUpdate (1130.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       1130.378s


```
</details>
<details>

<summary>Test Result(DataSource)</summary>

```
make acctests SERVICE='monitor' TESTARGS='-run=TestAccDataSourceMonitorActionGroup_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccDataSourceMonitorActionGroup_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceMonitorActionGroup_basic
=== PAUSE TestAccDataSourceMonitorActionGroup_basic
=== RUN   TestAccDataSourceMonitorActionGroup_disabledBasic
=== PAUSE TestAccDataSourceMonitorActionGroup_disabledBasic
=== RUN   TestAccDataSourceMonitorActionGroup_complete
=== PAUSE TestAccDataSourceMonitorActionGroup_complete
=== CONT  TestAccDataSourceMonitorActionGroup_basic
=== CONT  TestAccDataSourceMonitorActionGroup_complete
=== CONT  TestAccDataSourceMonitorActionGroup_disabledBasic
--- PASS: TestAccDataSourceMonitorActionGroup_disabledBasic (168.27s)
--- PASS: TestAccDataSourceMonitorActionGroup_basic (172.52s)
--- PASS: TestAccDataSourceMonitorActionGroup_complete (358.86s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       358.883s

```
</details>