### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - fix failed test

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -222,11 +222,11 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {}
   }
   log {
-	category = "B2CRequestLogs"
-	enabled  = true
-	retention_policy {
+    category = "B2CRequestLogs"
+    enabled  = true
+    retention_policy {
       enabled = true
-	  days    = 1
+      days    = 1
     }
   }
 }
@@ -342,11 +342,11 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {}
   }
   log {
-	category = "B2CRequestLogs"
-	enabled  = true
-	retention_policy {
+    category = "B2CRequestLogs"
+    enabled  = true
+    retention_policy {
       enabled = true
-	  days    = 1
+      days    = 1
     }
   }
 }
@@ -487,11 +487,11 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {}
   }
   log {
-	category = "B2CRequestLogs"
-	enabled  = true
-	retention_policy {
+    category = "B2CRequestLogs"
+    enabled  = true
+    retention_policy {
       enabled = true
-	  days    = 1
+      days    = 1
     }
   }
 }
@@ -600,11 +600,11 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {}
   }
   log {
-	category = "B2CRequestLogs"
-	enabled  = true
-	retention_policy {
+    category = "B2CRequestLogs"
+    enabled  = true
+    retention_policy {
       enabled = true
-	  days    = 1
+      days    = 1
     }
   }
 }

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -221,6 +221,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     enabled  = false
     retention_policy {}
   }
+  log {
+	category = "B2CRequestLogs"
+	enabled  = true
+	retention_policy {
+      enabled = true
+	  days    = 1
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -332,6 +340,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     category = "ServicePrincipalRiskEvents"
     enabled  = false
     retention_policy {}
+  }
+  log {
+	category = "B2CRequestLogs"
+	enabled  = true
+	retention_policy {
+      enabled = true
+	  days    = 1
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
@@ -470,6 +486,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     enabled  = false
     retention_policy {}
   }
+  log {
+	category = "B2CRequestLogs"
+	enabled  = true
+	retention_policy {
+      enabled = true
+	  days    = 1
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -574,6 +598,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     category = "ServicePrincipalRiskEvents"
     enabled  = false
     retention_policy {}
+  }
+  log {
+	category = "B2CRequestLogs"
+	enabled  = true
+	retention_policy {
+      enabled = true
+	  days    = 1
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomStringOfLength(5))


### PR DESCRIPTION
Fix by adding new log category:
```
  log {
    category = "B2CRequestLogs"
    enabled  = true
    retention_policy {
      enabled = true
      days    = 1
    }
  }
```

There is a quota limit allows only 5 `azurerm_monitor_aad_diagnostic_setting` in the test subscription. The tests may failed due to existance other resources of the same type , I can successfully pass the test by setting `PARALLELISM=1`, the test result is below:
![image](https://user-images.githubusercontent.com/104055472/187843410-5a6e43e4-0efb-466f-97ff-5aca2723948a.png)
