### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert` - Add `query_type` Enums

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -131,6 +131,7 @@ func resourceMonitorScheduledQueryRulesAlert() *pluginsdk.Resource {
 				Default:  "ResultCount",
 				ValidateFunc: validation.StringInSlice([]string{
 					"ResultCount",
+					"Number",
 				}, false),
 			},
 			"severity": {


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17806

The `query_type` can be `Number` which dismatches the Swagger, I have submitted a REST API issue, see https://github.com/Azure/azure-rest-api-specs/issues/20123