### PR TITLE
`azurerm_linux_function_app` - fix `linuxFxVersion` for docker runtime

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1590,13 +1590,15 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 
 		if linuxAppStack.Docker != nil && len(linuxAppStack.Docker) == 1 {
 			dockerConfig := linuxAppStack.Docker[0]
-			dockerUrl := dockerConfig.RegistryURL
-			httpPrefixes := []string{"https://", "http://"}
-			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_URL", dockerUrl, false)
+			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_URL", dockerConfig.RegistryURL, false)
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_USERNAME", dockerConfig.RegistryUsername, false)
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_PASSWORD", dockerConfig.RegistryPassword, false)
-			for _, prefix := range httpPrefixes {
-				dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+			var dockerUrl string
+			for _, prefix := range urlSchemes {
+				if strings.HasPrefix(dockerConfig.RegistryURL, prefix) {
+					dockerUrl = strings.TrimPrefix(dockerConfig.RegistryURL, prefix)
+					continue
+				}
 			}
 			expanded.LinuxFxVersion = utils.String(fmt.Sprintf("DOCKER|%s/%s:%s", dockerUrl, dockerConfig.ImageName, dockerConfig.ImageTag))
 		}

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	apimValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -1132,15 +1131,10 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*schema.Schema{
 							"registry_url": {
-								Type:     pluginsdk.TypeString,
-								Required: true,
-								ValidateFunc: func() pluginsdk.SchemaValidateFunc {
-									if !features.FourPointOh() {
-										return validation.StringIsNotEmpty
-									}
-									return validation.IsURLWithHTTPorHTTPS
-								}(),
-								Description: "The URL of the docker registry.",
+								Type:         pluginsdk.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+								Description:  "The URL of the docker registry.",
 							},
 
 							"registry_username": {

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -2,13 +2,13 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	apimValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -8,6 +8,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var urlSchemes = []string{
+	"https://",
+	"HTTPS://",
+	"http://",
+	"HTTP://",
+}
+
 func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 	parts := strings.Split(fxString, "|")
 	result := ApplicationStackLinux{}
@@ -189,9 +196,11 @@ func DecodeFunctionAppDockerFxString(input string, partial ApplicationStackDocke
 	}
 
 	dockerUrl := partial.RegistryURL
-	urlPrefix := []string{"https://", "http://"}
-	for _, prefix := range urlPrefix {
-		dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+	for _, prefix := range urlSchemes {
+		if strings.HasPrefix(dockerUrl, prefix) {
+			dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+			continue
+		}
 	}
 	dockerParts := strings.Split(strings.TrimPrefix(parts[1], dockerUrl), ":")
 	if len(dockerParts) != 2 {

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -114,7 +114,12 @@ func EncodeFunctionAppLinuxFxVersion(input []ApplicationStackLinuxFunctionApp) *
 		appType = "DOCKER"
 		dockerCfg := appStack.Docker[0]
 		if dockerCfg.RegistryURL != "" {
-			appString = fmt.Sprintf("%s/%s:%s", strings.Trim(dockerCfg.RegistryURL, "/"), dockerCfg.ImageName, dockerCfg.ImageTag)
+			dockerUrl := dockerCfg.RegistryURL
+			httpPrefixes := []string{"https://", "http://"}
+			for _, prefix := range httpPrefixes {
+				dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+			}
+			appString = fmt.Sprintf("%s/%s:%s", dockerUrl, dockerCfg.ImageName, dockerCfg.ImageTag)
 		} else {
 			appString = fmt.Sprintf("%s:%s", dockerCfg.ImageName, dockerCfg.ImageTag)
 		}
@@ -183,7 +188,12 @@ func DecodeFunctionAppDockerFxString(input string, partial ApplicationStackDocke
 		return nil, fmt.Errorf("expected a docker FX version, got %q", parts[0])
 	}
 
-	dockerParts := strings.Split(strings.TrimPrefix(parts[1], partial.RegistryURL), ":")
+	dockerUrl := partial.RegistryURL
+	urlPrefix := []string{"https://", "http://"}
+	for _, prefix := range urlPrefix {
+		dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+	}
+	dockerParts := strings.Split(strings.TrimPrefix(parts[1], dockerUrl), ":")
 	if len(dockerParts) != 2 {
 		return nil, fmt.Errorf("invalid docker image reference %q", parts[1])
 	}

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -2334,11 +2334,13 @@ resource "azurerm_linux_function_app" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
+    always_on = true
+
     application_stack {
       docker {
         registry_url = "https://mcr.microsoft.com"
-        image_name   = "azure-app-service/samples/aspnethelloworld"
-        image_tag    = "latest"
+        image_name   = "azure-functions/dotnet"
+        image_tag    = "3.0-appservice-quickstart"
       }
     }
   }

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -244,7 +244,7 @@ A `cors` block supports the following:
 
 A `docker` block supports the following:
 
-* `registry_url` - (Required) The URL of the docker registry.
+* `registry_url` - (Required) The URL of the docker registry. Please provide the full registry URL, including http:// or https://.
 
 * `image_name` - (Required) The name of the Docker image to use.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -244,7 +244,7 @@ A `cors` block supports the following:
 
 A `docker` block supports the following:
 
-* `registry_url` - (Required) The URL of the docker registry. Please provide the full registry URL, including http:// or https://.
+* `registry_url` - (Required) The URL of the docker registry.
 
 * `image_name` - (Required) The name of the Docker image to use.
 


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/16483
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18236

1.The app cannot be started if linuxFxVersion has "https://" or "http://" included like `DOCKER|https://registry.hub.docker.com/test/dotnet/samples:aspnetapp`
2. we need to validate the format of the registry url to align with official guidance:https://docs.microsoft.com/en-us/troubleshoot/azure/app-service/faqs-app-service-linux#what-is-the-format-for-the-private-registry-server-url-
