### PR TITLE
Fix name check in windows web app

### DIFF
--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -278,7 +278,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 						}
 					}
 				}
-				availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s.%s", webApp.Name, servicePlanId.ServerfarmName, nameSuffix))
+				availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s", webApp.Name, nameSuffix))
 				availabilityRequest.IsFqdn = utils.Bool(true)
 			}
 


### PR DESCRIPTION
The name check when using an ASE was inserting the app service plan name, which is incorrect. (The Linux resource uses the correct name already)