### PR TITLE
`azurerm_role_definition` - Increase the continuous count of post delete checks

### DIFF
--- a/internal/services/authorization/role_definition_resource.go
+++ b/internal/services/authorization/role_definition_resource.go
@@ -340,7 +340,7 @@ func resourceArmRoleDefinitionDelete(d *pluginsdk.ResourceData, meta interface{}
 		},
 		Refresh:                   roleDefinitionDeleteStateRefreshFunc(ctx, client, id.ResourceID),
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 6,
+		ContinuousTargetOccurence: 10,
 		Timeout:                   d.Timeout(pluginsdk.TimeoutDelete),
 	}
 


### PR DESCRIPTION
There are still a couple of test failures for the `azurerm_role_definition` on TC with following error message:

```
=== RUN   TestAccRoleDefinition_basic
=== PAUSE TestAccRoleDefinition_basic
=== CONT  TestAccRoleDefinition_basic
testing_new.go:84: Error running post-test destroy, there may be dangling resources: "azurerm_role_definition.test" still exists
--- FAIL: TestAccRoleDefinition_basic (131.26s)
FAIL
```

From the API sequence, it appears that even though the GET API returns 404 for 6 times (each time has a 10s delay), the last check on its existance is still possible to return a 200. The underlying reason behind this might due to the ARM cache, but increasing the check during might still help?