### PR TITLE
`azurerm_stream_analytics_reference_input_mssql`: add support for `table` property

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
@@ -105,6 +105,12 @@ func resourceStreamAnalyticsReferenceMsSql() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+
+			"table": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -156,6 +162,10 @@ func resourceStreamAnalyticsReferenceInputMsSqlCreateUpdate(d *pluginsdk.Resourc
 
 	if v, ok := d.GetOk("delta_snapshot_query"); ok {
 		properties.DeltaSnapshotQuery = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("table"); ok {
+		properties.Table = utils.String(v.(string))
 	}
 
 	props := streamanalytics.Input{
@@ -221,6 +231,7 @@ func resourceStreamAnalyticsReferenceInputMsSqlRead(d *pluginsdk.ResourceData, m
 		d.Set("refresh_interval_duration", inputDataSource.AzureSQLReferenceInputDataSourceProperties.RefreshRate)
 		d.Set("full_snapshot_query", inputDataSource.AzureSQLReferenceInputDataSourceProperties.FullSnapshotQuery)
 		d.Set("delta_snapshot_query", inputDataSource.AzureSQLReferenceInputDataSourceProperties.DeltaSnapshotQuery)
+		d.Set("table", inputDataSource.AzureSQLReferenceInputDataSourceProperties.Table)
 	}
 	return nil
 }

--- a/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `delta_snapshot_query` - (Optional) The query used to retrieve incremental changes in the reference data from the MS SQL database. Cannot be set when `refresh_type` is `Static`.
 
+* `table` - (Optional) The name of the table in the Azure SQL database.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 


### PR DESCRIPTION
* All tests passed.

```
--- PASS: TestAccStreamAnalyticsReferenceInputMsSql_basic (523.41s)
--- PASS: TestAccStreamAnalyticsReferenceInputMsSql_complete (526.03s)
--- PASS: TestAccStreamAnalyticsReferenceInputMsSql_requiresImport (562.17s)
--- PASS: TestAccStreamAnalyticsReferenceInputMsSql_update (610.77s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       627.588s
```