### PR TITLE
docs: mariadb_database: use utf8mb4_unicode_520_ci

### DIFF
--- a/website/docs/r/mariadb_database.html.markdown
+++ b/website/docs/r/mariadb_database.html.markdown
@@ -39,8 +39,8 @@ resource "azurerm_mariadb_database" "example" {
   name                = "mariadb_database"
   resource_group_name = azurerm_resource_group.example.name
   server_name         = azurerm_mariadb_server.example.name
-  charset             = "utf8"
-  collation           = "utf8_general_ci"
+  charset             = "utf8mb4"
+  collation           = "utf8mb4_unicode_520_ci"
 }
 ```
 


### PR DESCRIPTION
utf8 and general should not be used as explained here: https://stackoverflow.com/a/766996/15290244
At least `utf8_unicode_ci` would be appropriate.
I find it important to have good examples where many people will just copy and paste them.

`utf8mb4_unicode_520_ci` is the better collation. Not only does it use the non-deprecated mb4 variant
but also it uses Unicode 5.2 instead of 4.0 (as indicated by the 520 part).

Test: created database with these options on Azure and it worked