### PR TITLE
WIP `azurerm_active_directory_domain_service` - Update acctest to use existing aad SP

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -133,7 +133,7 @@ func (td TestData) providers() map[string]func() (*schema.Provider, error) {
 func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"azuread": {
-			VersionConstraint: "=2.28.1",
+			VersionConstraint: "=2.8.0",
 			Source:            "registry.terraform.io/hashicorp/azuread",
 		},
 	}

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -133,7 +133,7 @@ func (td TestData) providers() map[string]func() (*schema.Provider, error) {
 func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"azuread": {
-			VersionConstraint: "=2.8.0",
+			VersionConstraint: "=2.28.1",
 			Source:            "registry.terraform.io/hashicorp/azuread",
 		},
 	}

--- a/internal/services/domainservices/active_directory_domain_service_test.go
+++ b/internal/services/domainservices/active_directory_domain_service_test.go
@@ -309,6 +309,7 @@ data "azuread_domains" "test" {
 
 resource "azuread_service_principal" "test" {
   application_id = "2565bd9d-da50-47d4-8b85-4c97f669dc36" // published app for domain services
+  use_existing   = true
 }
 
 resource "azuread_group" "test" {


### PR DESCRIPTION
This PR is trying to fix the acctest for `azurerm_active_directory_domain_service` by updating the acctest to useing the existing aad SP (as otherwise it failed in TC).