### PR TITLE
[Document]`azurerm_kubernetes_cluster_node_pool` - Add `host_group_id` information to the document.

### DIFF
--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
 
 ~> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot` and will default to `Delete` unless otherwise specified.
 
+* `host_group_id` - (Optional) The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from. Changing this forces a new resource to be created.
+
 * `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below.


### PR DESCRIPTION
The [`host_group_id`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/containers/kubernetes_cluster_node_pool_resource.go#L83) argument is not in the document now, and this patch fixes this issue.