### PR TITLE
Fixed basic batch account example.

### DIFF
--- a/examples/batch/basic/main.tf
+++ b/examples/batch/basic/main.tf
@@ -16,10 +16,11 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_batch_account" "example" {
-  name                = "${var.prefix}batch"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
-  storage_account_id  = azurerm_storage_account.example.id
+  name                                = "${var.prefix}batch"
+  resource_group_name                 = azurerm_resource_group.example.name
+  location                            = azurerm_resource_group.example.location
+  storage_account_id                  = azurerm_storage_account.example.id
+  storage_account_authentication_mode = "StorageKeys"
 }
 
 resource "azurerm_batch_pool" "fixed" {


### PR DESCRIPTION
There was a change in `azurerm_batch_account` resource in #16758. 
It was changing  resource, without fixing examples.

Now main branch fails to check `make validate-examples` for any PR that touches examples directly.

IMO, examples validation check should be also ran if resource is changed, even if examples were not modified in that PR.