### PR TITLE
TestCase: Fix TCs for CosmosDB Cassandra Table

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -60,11 +60,13 @@ func resourceCosmosDbCassandraTable() *pluginsdk.Resource {
 			},
 
 			"analytical_storage_ttl": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      -2,
-				ValidateFunc: validation.IntAtLeast(-1),
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.IntBetween(-1, 2147483647),
+					validation.IntNotInSlice([]int{0}),
+				),
 			},
 
 			"schema": common.CassandraTableSchemaPropertySchema(),
@@ -123,8 +125,8 @@ func resourceCosmosDbCassandraTableCreate(d *pluginsdk.ResourceData, meta interf
 		table.CassandraTableCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
 	}
 
-	if analyticalTTL := d.Get("analytical_storage_ttl").(int); analyticalTTL != -2 {
-		table.CassandraTableCreateUpdateProperties.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalTTL))
+	if analyticalTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
+		table.CassandraTableCreateUpdateProperties.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalTTL.(int)))
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -237,16 +237,11 @@ func resourceCosmosDbCassandraTableRead(d *pluginsdk.ResourceData, meta interfac
 	if props := resp.CassandraTableGetProperties; props != nil {
 		if res := props.Resource; res != nil {
 			d.Set("name", res.ID)
+			d.Set("analytical_storage_ttl", res.AnalyticalStorageTTL)
 
 			if defaultTTL := res.DefaultTTL; defaultTTL != nil {
 				d.Set("default_ttl", defaultTTL)
 			}
-
-			analyticalTTL := -2
-			if res.AnalyticalStorageTTL != nil {
-				analyticalTTL = int(*res.AnalyticalStorageTTL)
-			}
-			d.Set("analytical_storage_ttl", analyticalTTL)
 
 			if schema := res.Schema; schema != nil {
 				d.Set("schema", flattenTableSchema(schema))

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -237,11 +237,16 @@ func resourceCosmosDbCassandraTableRead(d *pluginsdk.ResourceData, meta interfac
 	if props := resp.CassandraTableGetProperties; props != nil {
 		if res := props.Resource; res != nil {
 			d.Set("name", res.ID)
-			d.Set("analytical_storage_ttl", res.AnalyticalStorageTTL)
 
 			if defaultTTL := res.DefaultTTL; defaultTTL != nil {
 				d.Set("default_ttl", defaultTTL)
 			}
+
+			var analyticalTTL int
+			if res.AnalyticalStorageTTL != nil {
+				analyticalTTL = int(*res.AnalyticalStorageTTL)
+			}
+			d.Set("analytical_storage_ttl", analyticalTTL)
 
 			if schema := res.Schema; schema != nil {
 				d.Set("schema", flattenTableSchema(schema))

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -238,7 +238,7 @@ func (r CosmosDBCassandraTableResource) analyticalStorageTTL(data acceptance.Tes
 resource "azurerm_cosmosdb_cassandra_table" "test" {
   name                   = "acctest-CCASST-%[2]d"
   cassandra_keyspace_id  = azurerm_cosmosdb_cassandra_keyspace.test.id
-  analytical_storage_ttl = 0
+  analytical_storage_ttl = 1
 
   schema {
     column {

--- a/website/docs/r/cosmosdb_cassandra_table.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_table.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `default_ttl` - (Optional) Time to live of the Cosmos DB Cassandra table. Possible values are at least `-1`. `-1` means the Cassandra table never expires.
 
-* `analytical_storage_ttl` - (Optional) Time to live of the Analytical Storage. Possible values are at least `-1`. `-1` means the Analytical Storage never expires. Changing this forces a new resource to be created.
+* `analytical_storage_ttl` - (Optional) Time to live of the Analytical Storage. Possible values are between `-1` and `2147483647` except `0`. `-1` means the Analytical Storage never expires. Changing this forces a new resource to be created.
 
 ~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
 


### PR DESCRIPTION
The TCs for CosmosDB Cassandra Table are failed. The root cause is that there is tf diff on `AnalyticalStorageTTL`. So submitted this PR to fix the TCs.

While not setting `AnalyticalStorageTTL`, API returns `nil` for this property.
While setting `AnalyticalStorageTTL` to `0`, API returns `nil` for this property.
While setting `AnalyticalStorageTTL` to other values, API returns the corresponding value for this property.
While setting `AnalyticalStorageTTL` to `-2`, API returns below error message.

The error message returned by API:
```
Message: {"code":"BadRequest","message":"Message: {"Errors":["The input 'analyticalStorageTtl' '-2' is invalid. Ensure to provide a nonzero positive integer less than or equal to '2147483647', or '-1' which means never expire.
```
