### PR TITLE
`azurerm_mssql_database` - `license_type ` is now also Computed

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -774,6 +774,7 @@ func resourceMsSqlDatabaseSchema() map[string]*pluginsdk.Schema {
 		"license_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
+			Computed: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				string(sql.DatabaseLicenseTypeBasePrice),
 				string(sql.DatabaseLicenseTypeLicenseIncluded),


### PR DESCRIPTION
Some tests of resource `azurerm_mssql_database` failed with "After applying this test step, the plan was not empty."

The tests fail because in some cases the property `LicenseType` is set to default value `LicenseIncluded`. Checking the current API behavior as follows:

1.  When the value of [createMode](https://github.com/Azure/azure-rest-api-specs/blob/eb3d746872e49c9839cfdeff349a52638e4e6f5c/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Databases.json#L1239) is set to `Default` and the value of [LicenseType ](https://github.com/Azure/azure-rest-api-specs/blob/eb3d746872e49c9839cfdeff349a52638e4e6f5c/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/Databases.json#L1069)is not set, the API returns the value of `LicenseType` as `LicenseIncluded`.

2. When the value of `createMode` is set to `Copy`, the value of `LicenseType` is not set and the `LicenseType` of the source database is set to `BasePrice`, the API returns the value of `LicenseType` as `BasePrice`.

3. When the value of `createMode` is set to `Copy`,  the value of `LicenseType` is set to `LicenseIncluded` and the `LicenseType` of the source database is set to `BasePrice` , the API returns the value of `LicenseType` as `LicenseIncluded`.

Per the above API behavior, I submitted this PR to add `Computed = true` for property `license_type` to fix the tests failure.