### PR TITLE
Docs: fix wrong title for azurerm_mssql_failover_group 

### DIFF
--- a/website/docs/r/mssql_failover_group.html.markdown
+++ b/website/docs/r/mssql_failover_group.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 ---
 
-# azurerm_mssql_server
+# azurerm_mssql_failover_group
 
 Manages a Microsoft Azure SQL Failover Group.
 


### PR DESCRIPTION
This PR fixes a typo in documentation for the `azurerm_mssql_failover_group` resource.

It replaces `azurerm_mssql_server` with `azurerm_mssql_failover_group`
 