### PR TITLE
fix: AKS state drift for some optional fields in spot node pools (eviction_policy, node_taints)

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -115,6 +115,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			"eviction_policy": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.ScaleSetEvictionPolicyDelete),
@@ -188,11 +189,10 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				RequiredWith: []string{"enable_node_public_ip"},
 			},
 
-			// Node Taints control the behaviour of the Node Pool, as such they should not be computed and
-			// must be specified/reconciled as required
 			"node_taints": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group where the Virtual Machine Scale Set that powers this Node Pool will be placed. Changing this forces a new resource to be created.
 
--> **Note:** When setting `priority` to Spot - you must configure an `eviction_policy`, `spot_max_price` and add the applicable `node_labels` and `node_taints` [as per the Azure Documentation](https://docs.microsoft.com/azure/aks/spot-node-pool).
+-> **Note:** When setting `priority` to Spot - you should consider also adjusting `eviction_policy`, `spot_max_price`, `node_labels` and `node_taints` according to your needs [as per the Azure Documentation](https://docs.microsoft.com/azure/aks/spot-node-pool).
 
 * `spot_max_price` - (Optional) The maximum price you're willing to pay in USD per Virtual Machine. Valid values are `-1` (the current on-demand price for a Virtual Machine) or a positive value with up to five decimal places. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Based on the official AKS documentation (https://docs.microsoft.com/azure/aks/spot-node-pool), `eviction_policy` and `node_taints` are optional fields which default to `Delete` and `kubernetes.azure.com/scalesetpriority=spot:NoSchedule` respectively if not specified explicitly.

azurerm provider, on the other hand, implicitly expects you to always define those attributes, but doesn't really enforce that.
As a result, you can end up with a state drift for spot node pools like described in #18237 - the provider would try to nullify them upon each `terraform plan/apply` instead of reflecting the default value returned by Azure API.

The PR is intended to address the issues described above through the following changes:
- `eviction_policy` and `node_taints` should be marked as `Computed`, so there's no state drift even if the values are not specified by a user;
- The provider documentation should reflect the fact that `eviction_policy`, `spot_max_price`, `node_labels` and `node_taints` in the context of spot node pools are not mandatory, it's just a recommendation to have those set to non-default values.

Fixes: #18237