### PR TITLE
`azurerm_windows_web_app` - correct parsing of docker configuration from WindowsFxVersion

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -3629,11 +3629,12 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 		if len(parts) == 2 {
 			winAppStack.DockerContainerTag = parts[1]
 			path := strings.Split(parts[0], "/")
-			if len(path) > 2 {
+			if len(path) > 1 {
 				winAppStack.DockerContainerRegistry = path[0]
 				winAppStack.DockerContainerName = strings.TrimPrefix(parts[0], fmt.Sprintf("%s/", path[0]))
+			} else {
+				winAppStack.DockerContainerName = path[0]
 			}
-			winAppStack.DockerContainerName = path[0]
 		}
 	}
 	winAppStack.CurrentStack = currentStack


### PR DESCRIPTION
```hcl
resource "azurerm_windows_web_app" "example" {
  site_config {
    application_stack {
      docker_container_name = "myname"
      docker_container_registry = "myregistry"
      docker_container_tag  = "latest"
    }
  }
}
```

'terraform plan' command indicates false changes on existing infrastructure:
```hcl
~ site_config {
      # (25 unchanged attributes hidden)

    ~ application_stack {
        ~ docker_container_name     = "myregistry" -> "myname"
        + docker_container_registry = "myregistry"
          # (1 unchanged attribute hidden)
      }
  }
```