### PR TITLE
`azurerm_mssql_managed_instance` - Fix the sku.name returned from API has changed

### DIFF
--- a/internal/services/mssql/mssql_managed_instance_resource.go
+++ b/internal/services/mssql/mssql_managed_instance_resource.go
@@ -579,13 +579,13 @@ func (r MsSqlManagedInstanceResource) expandSkuName(skuName string) (*sql.Sku, e
 
 func (r MsSqlManagedInstanceResource) normalizeSku(sku string) string {
 	switch sku {
-	case "MIBC64G8IH":
+	case "MIBC64G8IH", "BC_G8IH":
 		return "BC_Gen8IH"
-	case "MIBC64G8IM":
+	case "MIBC64G8IM", "BC_G8IM":
 		return "BC_Gen8IM"
-	case "MIGP4G8IH":
+	case "MIGP4G8IH", "GP_G8IH":
 		return "GP_Gen8IH"
-	case "MIGP4G8IM":
+	case "MIGP4G8IM", "GP_G8IM":
 		return "GP_Gen8IM"
 	}
 


### PR DESCRIPTION
Test case `TestAccMsSqlManagedInstance_premium` failing as "After applying this test step, the plan was not empty.", details:
```
~ update in-place
Terraform will perform the following actions:
# azurerm_mssql_managed_instance.test will be updated in-place
~ resource "azurerm_mssql_managed_instance" "test" {
id                             = "/subscriptions/*******/resourceGroups/acctestRG1-sql-220906085147020933/providers/Microsoft.Sql/managedInstances/acctestsqlserver220906085147020933"
name                           = "acctestsqlserver220906085147020933"
~ sku_name                       = **"GP_G8IM" -> "GP_Gen8IM"**
```
Per the [API Doc ](https://github.com/Azure/azure-rest-api-specs/blob/bc2806dd48491e4ad0bf5796bedd985c8591969a/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ManagedInstances.json#L660), allowed values for sku.name are GP_G8IM, GP_G8IH, BC_G8IM, BC_G8IH, etc. So submitted this PR to fix the test failure. 

Test Result:
![image](https://user-images.githubusercontent.com/39109137/189011943-5be97c89-7eac-4f96-a385-859e996f44a4.png)

