### PR TITLE
Correct the sample import resource path for azurerm_servicebus_namespace_authorization_rule

### DIFF
--- a/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
@@ -87,5 +87,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 ServiceBus Namespace authorization rules can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_servicebus_namespace_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ServiceBus/namespaces/namespace1/AuthorizationRules/rule1
+terraform import azurerm_servicebus_namespace_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ServiceBus/namespaces/namespace1/authorizationRules/rule1
 ```


### PR DESCRIPTION
```
Error:
    parsing Resource ID "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/sbn/AuthorizationRules/rule1":
    parsing "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/sbn/AuthorizationRules/rule1":
    parsing segment "staticAuthorizationRules": expected the segment "AuthorizationRules" to be "authorizationRules"
```