### PR TITLE
Fix use of versioned source_image_id from gallery

### DIFF
--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -403,7 +403,7 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) (*
 	if imageId != "" {
 		// With Version            : "/CommunityGalleries/publicGalleryName/Images/myGalleryImageName/Versions/(major.minor.patch | latest)"
 		// Versionless(e.g. latest): "/CommunityGalleries/publicGalleryName/Images/myGalleryImageName"
-		if _, err := validate.CommunityGalleryImageID(imageId, "source_image_id"); err == nil {
+		if _, errors := validation.Any(validate.CommunityGalleryImageID, validate.CommunityGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
 			return &compute.ImageReference{
 				CommunityGalleryImageID: utils.String(imageId),
 			}, nil
@@ -411,7 +411,7 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) (*
 
 		// With Version            : "/SharedGalleries/galleryUniqueName/Images/myGalleryImageName/Versions/(major.minor.patch | latest)"
 		// Versionless(e.g. latest): "/SharedGalleries/galleryUniqueName/Images/myGalleryImageName"
-		if _, err := validate.SharedGalleryImageID(imageId, "source_image_id"); err == nil {
+		if _, errors := validation.Any(validate.SharedGalleryImageID, validate.SharedGalleryImageVersionID)(imageId, "source_image_id"); len(errors) == 0 {
 			return &compute.ImageReference{
 				SharedGalleryImageID: utils.String(imageId),
 			}, nil


### PR DESCRIPTION
Support for "community gallery" & "shared gallery" source_image_ids was added in https://github.com/hashicorp/terraform-provider-azurerm/pull/17571 for virtual machines and virtual machine scale sets.

The schema correctly allows both versioned and non-versioned gallery source_image_ids:

https://github.com/hashicorp/terraform-provider-azurerm/blob/38df6ad73f26cad8c6c7bec10e5c7f3ad9aaab72/internal/services/compute/linux_virtual_machine_resource.go#L277-L290

but the implementation of `resourceLinuxVirtualMachineCreate` does not correctly expand source_image_ids that have a version.

This pull request fixes this by checking if either of the versionless or with-version validators match.

(fixes #18304)