### PR TITLE
`azurerm_monitor_autoscale_setting` - fix failed test case

### DIFF
--- a/internal/services/monitor/monitor_autoscale_setting_resource_test.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource_test.go
@@ -251,7 +251,7 @@ func TestAccMonitorAutoScaleSetting_fixedDate(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMMonitorAutoScaleSetting_multipleRulesDimensions(t *testing.T) {
+func TestAccMonitorAutoScaleSetting_multipleRulesDimensions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_autoscale_setting", "test")
 	r := MonitorAutoScaleSettingResource{}
 
@@ -310,7 +310,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "metricRules"
@@ -324,7 +324,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name              = "Percentage CPU"
-        metric_resource_id       = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id       = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain               = "PT1M"
         statistic                = "Average"
         time_window              = "PT5M"
@@ -369,7 +369,7 @@ resource "azurerm_monitor_autoscale_setting" "import" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -399,7 +399,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "primary"
@@ -413,7 +413,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -433,7 +433,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -486,7 +486,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
   enabled             = false
 
   profile {
@@ -501,7 +501,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -531,7 +531,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
   enabled             = true
 
   profile {
@@ -546,7 +546,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -567,7 +567,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -598,7 +598,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "metricRules"
@@ -612,7 +612,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -650,7 +650,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "metricRules"
@@ -664,7 +664,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -702,7 +702,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "recurrence"
@@ -746,7 +746,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "recurrence"
@@ -790,7 +790,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
 
   profile {
     name = "fixedDate"
@@ -820,7 +820,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
   enabled             = true
 
   profile {
@@ -835,7 +835,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -862,7 +862,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -893,7 +893,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
   name                = "acctestautoscale-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.test.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.test.id
   enabled             = true
 
   profile {
@@ -908,7 +908,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -940,7 +940,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.test.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.test.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -987,34 +987,24 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.2.0/24"]
 }
 
-resource "azurerm_virtual_machine_scale_set" "test" {
-  name                = "acctvmss-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  upgrade_policy_mode = "Manual"
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                            = "acctvmss-%d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  upgrade_mode                    = "Manual"
+  sku                             = "Standard_F2"
+  instances                       = 2
+  disable_password_authentication = false
+  computer_name_prefix            = "testvm-%d"
+  admin_username                  = "myadmin"
+  admin_password                  = "Passwword1234"
 
-  sku {
-    name     = "Standard_F2"
-    tier     = "Standard"
-    capacity = 2
+  admin_ssh_key {
+    username   = "myadmin"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
   }
 
-  os_profile {
-    computer_name_prefix = "testvm-%d"
-    admin_username       = "myadmin"
-    admin_password       = "Passwword1234"
-  }
-
-  os_profile_linux_config {
-    disable_password_authentication = true
-
-    ssh_keys {
-      path     = "/home/myadmin/.ssh/authorized_keys"
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
-    }
-  }
-
-  network_profile {
+  network_interface {
     name    = "TestNetworkProfile-%d"
     primary = true
 
@@ -1025,18 +1015,22 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     }
   }
 
-  storage_profile_os_disk {
-    name              = ""
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "StandardSSD_LRS"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
   }
 
-  storage_profile_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
     sku       = "16.04-LTS"
     version   = "latest"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "instances",
+    ]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -32,17 +32,21 @@ resource "azurerm_subnet" "example" {
   address_prefixes     = ["10.0.2.0/24"]
 }
 
-resource "azurerm_virtual_machine_scale_set" "example" {
-  name                = "example"
+resource "azurerm_linux_virtual_machine_scale_set" "example" {
+  name                = "exampleset"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  upgrade_policy_mode = "Manual"
+  upgrade_mode        = "Manual"
+  sku                 = "Standard_F2"
+  instances           = 2
+  admin_username      = "myadmin"
 
-  storage_profile_os_disk {
-    create_option = "FromImage"
+  admin_ssh_key {
+    username   = "myadmin"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
   }
 
-  network_profile {
+  network_interface {
     name    = "TestNetworkProfile"
     primary = true
 
@@ -53,14 +57,20 @@ resource "azurerm_virtual_machine_scale_set" "example" {
     }
   }
 
-  os_profile {
-    computer_name_prefix = "testvm"
-    admin_username       = "myadmin"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
   }
 
-  sku {
-    name     = "Standard_F2"
-    capacity = 2
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  lifecycle {
+    ignore_changes = ["instances"]
   }
 }
 
@@ -68,7 +78,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
   name                = "myAutoscaleSetting"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.example.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.example.id
 
   profile {
     name = "defaultProfile"
@@ -82,7 +92,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -108,7 +118,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -158,17 +168,21 @@ resource "azurerm_subnet" "example" {
   address_prefixes     = ["10.0.2.0/24"]
 }
 
-resource "azurerm_virtual_machine_scale_set" "example" {
-  name                = "example"
+resource "azurerm_linux_virtual_machine_scale_set" "example" {
+  name                = "exampleset"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  upgrade_policy_mode = "Manual"
+  upgrade_mode        = "Manual"
+  sku                 = "Standard_F2"
+  instances           = 2
+  admin_username      = "myadmin"
 
-  storage_profile_os_disk {
-    create_option = "FromImage"
+  admin_ssh_key {
+    username   = "myadmin"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
   }
 
-  network_profile {
+  network_interface {
     name    = "TestNetworkProfile"
     primary = true
 
@@ -179,14 +193,20 @@ resource "azurerm_virtual_machine_scale_set" "example" {
     }
   }
 
-  os_profile {
-    computer_name_prefix = "testvm"
-    admin_username       = "myadmin"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
   }
 
-  sku {
-    name     = "Standard_F2"
-    capacity = 2
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  lifecycle {
+    ignore_changes = ["instances"]
   }
 }
 
@@ -194,7 +214,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
   name                = "myAutoscaleSetting"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.example.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.example.id
 
   profile {
     name = "Weekends"
@@ -208,7 +228,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -228,7 +248,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -285,17 +305,21 @@ resource "azurerm_subnet" "example" {
   address_prefixes     = ["10.0.2.0/24"]
 }
 
-resource "azurerm_virtual_machine_scale_set" "example" {
-  name                = "example"
+resource "azurerm_linux_virtual_machine_scale_set" "example" {
+  name                = "exampleset"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  upgrade_policy_mode = "Manual"
+  upgrade_mode        = "Manual"
+  sku                 = "Standard_F2"
+  instances           = 2
+  admin_username      = "myadmin"
 
-  storage_profile_os_disk {
-    create_option = "FromImage"
+  admin_ssh_key {
+    username   = "myadmin"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
   }
 
-  network_profile {
+  network_interface {
     name    = "TestNetworkProfile"
     primary = true
 
@@ -306,14 +330,20 @@ resource "azurerm_virtual_machine_scale_set" "example" {
     }
   }
 
-  os_profile {
-    computer_name_prefix = "testvm"
-    admin_username       = "myadmin"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
   }
 
-  sku {
-    name     = "Standard_F2"
-    capacity = 2
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  lifecycle {
+    ignore_changes = ["instances"]
   }
 }
 
@@ -322,7 +352,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
   enabled             = true
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  target_resource_id  = azurerm_virtual_machine_scale_set.example.id
+  target_resource_id  = azurerm_linux_virtual_machine_scale_set.example.id
 
   profile {
     name = "forJuly"
@@ -336,7 +366,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -356,7 +386,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
+        metric_resource_id = azurerm_linux_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"


### PR DESCRIPTION
switch dependency `azurerm_virtual_machine_scale_set` to `azurerm_linux_virtual_machine_scale_set` and use `ignore_changes` for [scale set `instances`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#instances).


![image](https://user-images.githubusercontent.com/104055472/189075130-a6c6495c-0f73-43a1-af34-5be90f0d7325.png)

<details>

<summary>original failure</summary>

```
------- Stdout: -------
=== RUN   TestAccAzureRMMonitorAutoScaleSetting_multipleRulesDimensions
=== PAUSE TestAccAzureRMMonitorAutoScaleSetting_multipleRulesDimensions
=== CONT  TestAccAzureRMMonitorAutoScaleSetting_multipleRulesDimensions
testcase.go:110: Step 5/8 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_virtual_machine_scale_set.test will be updated in-place
~ resource "azurerm_virtual_machine_scale_set" "test" {
id                     = "/subscriptions/*******/resourceGroups/acctestRG-220908001610639333/providers/Microsoft.Compute/virtualMachineScaleSets/acctvmss-220908001610639333"
name                   = "acctvmss-220908001610639333"
tags                   = {}
# (7 unchanged attributes hidden)
~ sku {
~ capacity = 1 -> 2
name     = "Standard_F2"
# (1 unchanged attribute hidden)
}
# (5 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAzureRMMonitorAutoScaleSetting_multipleRulesDimensions (471.25s)
FAIL
```

</details>