### PR TITLE
Fix `TestAccManagedDisk_import`

### DIFF
--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -68,19 +68,8 @@ func TestAccManagedDisk_zeroGbFromPlatformImage(t *testing.T) {
 func TestAccManagedDisk_import(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
-	vm := LinuxVirtualMachineResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			// need to create a vm and then delete it so we can use the vhd to test import
-			Config:             vm.authSSH(data),
-			Destroy:            false,
-			ExpectNonEmptyPlan: true,
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That("azurerm_linux_virtual_machine.test").ExistsInAzure(vm),
-				data.CheckWithClientForResource(r.destroyVirtualMachine, "azurerm_linux_virtual_machine.test"),
-			),
-		},
 		{
 			Config: r.importConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -777,12 +766,76 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+# NOTE: using the legacy vm resource since this test requires an unmanaged disk
+resource "azurerm_virtual_machine" "test" {
+  name                          = "acctestvm-%[1]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  network_interface_ids         = [azurerm_network_interface.test.id]
+  vm_size                       = "Standard_F2"
+  delete_os_disk_on_termination = true
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "acctestvm-%[1]d"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  tags = {
+    environment = "staging"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "accsa%d"
+  name                     = "accsa%[1]d"
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
@@ -800,7 +853,7 @@ resource "azurerm_storage_container" "test" {
 }
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "acctestd-%d"
+  name                 = "acctestd-%[1]d"
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   storage_account_type = "Standard_LRS"
@@ -812,8 +865,12 @@ resource "azurerm_managed_disk" "test" {
   tags = {
     environment = "acctest"
   }
+
+  depends_on = [
+    azurerm_virtual_machine.test,
+  ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (ManagedDiskResource) copy(data acceptance.TestData) string {


### PR DESCRIPTION
to import disk from a storage container, the legacy vm `azurerm_virtual_machine` is required as the dependency like what we did in `TestAccSnapshot_fromUnmanagedDisk` in below link. The previous test config uses `azurerm_linux_virtual_machine` which is not able to export the disk vhd to the storage container https://github.com/hashicorp/terraform-provider-azurerm/blob/220af7ef87e245ababea5e34dec2d25d10a44cbd/internal/services/compute/snapshot_resource_test.go#L466