### PR TITLE
`azurerm_eventhub_namespace`: update public_network_access settings

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -168,6 +168,18 @@ func TestAccEventHubNamespace_networkrule_iprule(t *testing.T) {
 	})
 }
 
+func TestAccEventHubNamespace_networkrule_publicNetworkAccessDiff(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+	r := EventHubNamespaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.networkrule_publicNetworkAccessDiff(data),
+			ExpectError: regexp.MustCompile("the value of public network access of namespace should be the same as of the network rulesets"),
+		},
+	})
+}
+
 func TestAccEventHubNamespace_networkrule_vnet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 	r := EventHubNamespaceResource{}
@@ -709,6 +721,37 @@ resource "azurerm_eventhub_namespace" "test" {
 
   network_rulesets {
     default_action = "Deny"
+    ip_rule {
+      ip_mask = "10.0.0.0/16"
+      action  = "Allow"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (EventHubNamespaceResource) networkrule_publicNetworkAccessDiff(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eh-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                          = "acctesteventhubnamespace-%d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  sku                           = "Standard"
+  capacity                      = "2"
+  public_network_access_enabled = true
+
+  network_rulesets {
+    default_action                = "Deny"
+    public_network_access_enabled = false
     ip_rule {
       ip_mask = "10.0.0.0/16"
       action  = "Allow"

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -79,6 +79,10 @@ A `network_rulesets` block supports the following:
 
 * `default_action` - (Required) The default action to take when a rule is not matched. Possible values are `Allow` and `Deny`.
 
+* `public_network_access` - (Optional)  Is public network access enabled for the EventHub Namespace? Defaults to `true`.
+
+* ~> **Note:** The public network access setting at the network rule sets level should be the same as it's at the namespace level.
+
 * `trusted_service_access_enabled` - (Optional) Whether Trusted Microsoft Services are allowed to bypass firewall.
 
 * `virtual_network_rule` - (Optional) One or more `virtual_network_rule` blocks as defined below.


### PR DESCRIPTION
Fix:https://github.com/hashicorp/terraform-provider-azurerm/issues/18054

There are two places to set `public_network_access` for an eventhub namespace. If the values are different, one overrides the other. For example, if the public network access is turned off at the namespace level, while is turned on in the network rulesets block. The namespace setting will be override.