### PR TITLE
New Datasource: `azurerm_monitor_data_collection_rule`

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source.go
@@ -1,0 +1,303 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-04-01/datacollectionrules"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type DataCollectionRuleDataSource struct{}
+
+var _ sdk.DataSource = DataCollectionRuleDataSource{}
+
+func (d DataCollectionRuleDataSource) ModelObject() interface{} {
+	return &DataCollectionRule{}
+}
+
+func (d DataCollectionRuleDataSource) ResourceType() string {
+	return "azurerm_monitor_data_collection_rule"
+}
+
+func (d DataCollectionRuleDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+
+		"location": commonschema.LocationComputed(),
+
+		"data_flow": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"destinations": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"streams": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"destinations": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"azure_monitor_metrics": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+					"log_analytics": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"workspace_resource_id": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"data_sources": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"extension": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"extension_name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"streams": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"extension_json": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"input_data_sources": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"performance_counter": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"sampling_frequency_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Computed: true,
+								},
+								"streams": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"counter_specifiers": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"syslog": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"facility_names": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"log_levels": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"windows_event_log": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"streams": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"x_path_queries": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"kind": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Monitor.DataCollectionRulesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state DataCollectionRule
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := datacollectionrules.NewDataCollectionRuleID(subscriptionId, state.ResourceGroupName, state.Name)
+			metadata.Logger.Infof("retrieving %s", id)
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					metadata.Logger.Infof("%s was not found - removing from state!", id)
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			var description, kind, location string
+			var tag map[string]interface{}
+			var dataFlows []DataFlow
+			var dataSources []DataSource
+			var destinations []Destination
+
+			if model := resp.Model; model != nil {
+				kind = flattenDataCollectionRuleKind(model.Kind)
+				location = azure.NormalizeLocation(model.Location)
+				tag = tags.Flatten(model.Tags)
+				if prop := model.Properties; prop != nil {
+					description = flattenStringPtr(prop.Description)
+					dataFlows = flattenDataCollectionRuleDataFlows(prop.DataFlows)
+					dataSources = flattenDataCollectionRuleDataSources(prop.DataSources)
+					destinations = flattenDataCollectionRuleDestinations(prop.Destinations)
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&DataCollectionRule{
+				Name:              id.DataCollectionRuleName,
+				ResourceGroupName: id.ResourceGroupName,
+				DataFlows:         dataFlows,
+				DataSources:       dataSources,
+				Description:       description,
+				Destinations:      destinations,
+				Kind:              kind,
+				Location:          location,
+				Tags:              tag,
+			})
+		},
+		Timeout: 5 * time.Minute,
+	}
+}

--- a/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
@@ -1,0 +1,50 @@
+package monitor_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type MonitorDataCollectionRuleDataSource struct{}
+
+func TestAccMonitorDataCollectionRuleDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_monitor_data_collection_rule", "test")
+	d := MonitorDataCollectionRuleDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("destinations.0.log_analytics.0.workspace_resource_id").Exists(),
+				check.That(data.ResourceName).Key("destinations.0.log_analytics.0.name").HasValue("test-destination-log1"),
+				check.That(data.ResourceName).Key("destinations.0.log_analytics.1.workspace_resource_id").Exists(),
+				check.That(data.ResourceName).Key("destinations.0.log_analytics.1.name").HasValue("test-destination-log2"),
+				check.That(data.ResourceName).Key("data_flow.#").HasValue("3"),
+				check.That(data.ResourceName).Key("data_flow.1.streams.#").HasValue("3"),
+				check.That(data.ResourceName).Key("data_flow.1.destinations.#").HasValue("1"),
+				check.That(data.ResourceName).Key("data_flow.2.streams.0").HasValue("Microsoft-Event"),
+				check.That(data.ResourceName).Key("data_flow.2.destinations.0").HasValue("test-destination-log1"),
+				check.That(data.ResourceName).Key("data_sources.0.syslog.0.facility_names.#").HasValue("5"),
+				check.That(data.ResourceName).Key("data_sources.0.performance_counter.#").HasValue("2"),
+				check.That(data.ResourceName).Key("data_sources.0.performance_counter.1.sampling_frequency_in_seconds").HasValue("20"),
+				check.That(data.ResourceName).Key("data_sources.0.performance_counter.1.name").HasValue("test-datasource-perfcounter2"),
+				check.That(data.ResourceName).Key("data_sources.0.windows_event_log.0.x_path_queries.0").HasValue("*[System/Level=1]"),
+				check.That(data.ResourceName).Key("data_sources.0.extension.0.extension_json").Exists(),
+			),
+		},
+	})
+}
+
+func (d MonitorDataCollectionRuleDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_monitor_data_collection_rule" "test" {
+  name                = azurerm_monitor_data_collection_rule.test.name
+  resource_group_name = azurerm_monitor_data_collection_rule.test.resource_group_name
+}
+`, MonitorDataCollectionRuleResource{}.complete(data))
+}

--- a/internal/services/monitor/registration.go
+++ b/internal/services/monitor/registration.go
@@ -19,6 +19,7 @@ func (r Registration) AssociatedGitHubLabel() string {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		DataCollectionEndpointDataSource{},
+		DataCollectionRuleDataSource{},
 	}
 }
 

--- a/website/docs/d/monitor_data_collection_endpoint.html.markdown
+++ b/website/docs/d/monitor_data_collection_endpoint.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Data Collection End
 ## Example Usage
 
 ```hcl
-data "azurerm_data_collection_endpoint" "example" {
+data "azurerm_monitor_data_collection_endpoint" "example" {
   name                = "example-mdce"
   resource_group_name = azurerm_resource_group.example.name
 }

--- a/website/docs/d/monitor_data_collection_rule.html.markdown
+++ b/website/docs/d/monitor_data_collection_rule.html.markdown
@@ -1,0 +1,145 @@
+---
+subcategory: "Monitor"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_monitor_data_collection_rule"
+description: |-
+  Get information about the specified Data Collection Rule.
+
+---
+
+# Data Source: azurerm_monitor_data_collection_rule
+
+Use this data source to access information about an existing Data Collection Rule.
+
+## Example Usage
+
+```hcl
+data "azurerm_monitor_data_collection_rule" "example" {
+  name                = "example-rule"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+output "rule_id" {
+  value = data.azurerm_monitor_data_collection_rule.example.id
+}
+```
+
+## Argument Reference
+
+* `name` - Specifies the name of the Data Collection Rule.
+
+* `resource_group_name` - Specifies the name of the resource group the Data Collection Rule is located in.
+
+## Attributes Reference
+
+* `id` - The ID of the Resource.
+ 
+* `data_flow` - One or more `data_flow` blocks as defined below.
+
+* `destinations` - A `destinations` block as defined below.
+
+* `location` - The Azure Region where the Data Collection Rule should exist. Changing this forces a new Data Collection Rule to be created.
+
+* `data_sources` - A `data_sources` block as defined below. This property is optional and can be omitted if the rule is meant to be used via direct calls to the provisioned endpoint.
+
+* `description` - The description of the Data Collection Rule.
+
+* `kind` - The kind of the Data Collection Rule. Possible values are `Linux` and `Windows`. A rule of kind `Linux` does not allow for `windows_event_log` data sources. And a rule of kind `Windows` does not allow for `syslog` data sources. If kind is not specified, all kinds of data sources are allowed.
+
+* `tags` - A mapping of tags which should be assigned to the Data Collection Rule.
+
+---
+
+A `azure_monitor_metrics` block supports the following:
+
+* `name` - The name which should be used for this destination. This name should be unique across all destinations regardless of type within the Data Collection Rule.
+
+---
+
+A `data_flow` block supports the following:
+
+* `destinations` - Specifies a list of destination names. A `azure_monitor_metrics` data source only allows for stream of kind `Microsoft-InsightsMetrics`.
+
+* `streams` - Specifies a list of streams. Possible values are `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`,and `Microsoft-WindowsEvent`.
+
+---
+
+A `data_sources` block supports the following:
+
+* `extension` - One or more `extension` blocks as defined below.
+
+* `performance_counter` - One or more `performance_counter` blocks as defined below.
+
+* `syslog` - One or more `syslog` blocks as defined below.
+
+* `windows_event_log` - One or more `windows_event_log` blocks as defined below.
+
+---
+
+A `destinations` block supports the following:
+
+* `azure_monitor_metrics` - A `azure_monitor_metrics` block as defined above.
+
+* `log_analytics` - One or more `log_analytics` blocks as defined below.
+
+---
+
+A `extension` block supports the following:
+
+* `extension_name` - The name of the VM extension.
+
+* `name` - The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
+
+* `streams` - Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`,and `Microsoft-WindowsEvent`.
+
+* `extension_json` - A JSON String which specifies the extension setting.
+
+* `input_data_sources` - Specifies a list of data sources this extension needs data from. An item should be a name of a supported data source which produces only one stream. Supported data sources type: `performance_counter`, `windows_event_log`,and `syslog`.
+
+---
+
+A `log_analytics` block supports the following:
+
+* `name` - The name which should be used for this destination. This name should be unique across all destinations regardless of type within the Data Collection Rule.
+
+* `workspace_resource_id` - The ID of a Log Analytic Workspace resource.
+
+---
+
+A `performance_counter` block supports the following:
+
+* `counter_specifiers` - Specifies a list of specifier names of the performance counters you want to collect. Use a wildcard `*` to collect counters for all instances. To get a list of performance counters on Windows, run the command `typeperf`.
+
+* `name` - The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
+
+* `sampling_frequency_in_seconds` - The number of seconds between consecutive counter measurements (samples). The value should be integer between `1` and `300` inclusive.
+
+* `streams` - Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-InsightsMetrics`,and `Microsoft-Perf`.
+
+---
+
+A `syslog` block supports the following:
+
+* `facility_names` - Specifies a list of facility names. Use a wildcard `*` to collect logs for all facility names. Possible values are `auth`, `authpriv`, `cron`, `daemon`, `kern`, `lpr`, `mail`, `mark`, `news`, `syslog`, `user`, `uucp`, `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`,and `*`.
+
+* `log_levels` - Specifies a list of log levels. Use a wildcard `*` to collect logs for all log levels. Possible values are `Debug`,  `Info`, `Notice`, `Warning`, `Error`, `Critical`, `Alert`, `Emergency`,and `*`.
+
+* `name` - The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
+
+-> **Note:** Syslog data source has only one possible streams value which is `Microsoft-Syslog`.
+
+---
+
+A `windows_event_log` block supports the following:
+
+* `name` - The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
+
+* `streams` - Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-Event`,and `Microsoft-WindowsEvent`.
+
+* `x_path_queries` - Specifies a list of Windows Event Log queries in XPath expression.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Collection Rule.

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -194,7 +194,7 @@ A `performance_counter` block supports the following:
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 
-* `sampling_frequency_in_seconds` - (Required) The number of seconds between consecutive counter measurements (samples). The value should be integer between 1 and 300 inclusive.
+* `sampling_frequency_in_seconds` - (Required) The number of seconds between consecutive counter measurements (samples). The value should be integer between `1` and `300` inclusive.
 
 * `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-InsightsMetrics`,and `Microsoft-Perf`.
 
@@ -208,7 +208,7 @@ A `syslog` block supports the following:
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 
--> **Note:** Syslog data source has only one possible streams value which is "Microsoft-Syslog".
+-> **Note:** Syslog data source has only one possible streams value which is `Microsoft-Syslog`.
 
 ---
 


### PR DESCRIPTION
### New datasource `azurerm_monitor_data_collection_rule`

resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18187

```
make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorDataCollectionRuleDataSource' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccMonitorDataCollectionRuleDataSource -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDataCollectionRuleDataSource_complete
=== PAUSE TestAccMonitorDataCollectionRuleDataSource_complete
=== CONT  TestAccMonitorDataCollectionRuleDataSource_complete
--- PASS: TestAccMonitorDataCollectionRuleDataSource_complete (211.41s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       211.448s

```