### PR TITLE
`legacy` - Fix tests

### DIFF
--- a/internal/services/legacy/virtual_machine_resource_test.go
+++ b/internal/services/legacy/virtual_machine_resource_test.go
@@ -110,6 +110,34 @@ func (VirtualMachineResource) Exists(ctx context.Context, clients *clients.Clien
 	return utils.Bool(resp.ID != nil), nil
 }
 
+func (VirtualMachineResource) managedDiskDelete(diskId *string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		id, err := parse.ManagedDiskID(*diskId)
+		if err != nil {
+			return err
+		}
+
+		disk, err := clients.Legacy.DisksClient.Get(ctx, id.ResourceGroup, id.DiskName)
+		if err != nil {
+			if utils.ResponseWasNotFound(disk.Response) {
+				return fmt.Errorf("disk %s does not exist", *id)
+			}
+			return err
+		}
+
+		future, err := clients.Legacy.DisksClient.Delete(ctx, id.ResourceGroup, id.DiskName)
+		if err != nil {
+			return fmt.Errorf("deleting disk %q: %s", id.String(), err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, clients.Legacy.DisksClient.Client); err != nil {
+			return fmt.Errorf("waiting for deletion of disk %q: %s", id.String(), err)
+		}
+
+		return nil
+	}
+}
+
 func (VirtualMachineResource) managedDiskExists(diskId *string, shouldExist bool) acceptance.ClientCheckFunc {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
 		id, err := parse.ManagedDiskID(*diskId)

--- a/internal/services/legacy/virtual_machine_unmanaged_disks_resource_test.go
+++ b/internal/services/legacy/virtual_machine_unmanaged_disks_resource_test.go
@@ -387,9 +387,7 @@ func TestAccVirtualMachine_optionalOSProfile(t *testing.T) {
 		{
 			Destroy: false,
 			Config:  r.basicLinuxMachine_destroy(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).DoesNotExistInAzure(r),
-			),
+			Check:   acceptance.ComposeTestCheckFunc(),
 		},
 		{
 			Config: r.basicLinuxMachine_attach_without_osProfile(data),
@@ -1705,7 +1703,7 @@ resource "azurerm_virtual_machine" "test" {
 
   os_profile_windows_config {
     winrm {
-      protocol = "http"
+      protocol = "HTTP"
     }
   }
 }
@@ -1796,7 +1794,7 @@ resource "azurerm_virtual_machine" "test" {
 
   os_profile_windows_config {
     winrm {
-      protocol = "http"
+      protocol = "HTTP"
     }
   }
 }
@@ -2688,7 +2686,7 @@ resource "azurerm_virtual_machine" "test" {
   storage_os_disk {
     name          = "myosdisk1"
     vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-    os_type       = "linux"
+    os_type       = "Linux"
     caching       = "ReadWrite"
     create_option = "Attach"
   }


### PR DESCRIPTION
Although `legacy` is in feature frozen state, the acc tests could help finding the future regression, fixing the failing tests there.
Fixes done in this change:
- Update enum value `http`/`https` to `HTTP`/`HTTPS`
- Update enum value `linux` to `Linux`
- Set `delete_os_disk_on_termination` and `delete_data_disks_on_termination` to `true` to resolve dangling disk during resource group clean up
- Update `TestAccVirtualMachine_deleteManagedDiskOptOut` to use API to delete the remaining disks after testing. This test is to explicitly test setting `delete_os_disk_on_termination` and `delete_data_disks_on_termination` to `false` to validate that the disks are not deleted after deleting the VM. So have to use API to delete it