### PR TITLE
Event Hub namespace identity attribute description update to include the support for `UserAssigned` type

### DIFF
--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -69,8 +69,7 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Event Hub Namespace. The only possible value is `SystemAssigned`.
-
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Event Hub Namespace. Possible values are `SystemAssigned` or `UserAssigned`.
 ~> **Note:** Due to the limitation of the current Azure API, once an EventHub Namespace has been assigned an identity, it cannot be removed.
 
 ---

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 A `identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Event Hub Namespace. Possible values are `SystemAssigned` or `UserAssigned`.
+
 ~> **Note:** Due to the limitation of the current Azure API, once an EventHub Namespace has been assigned an identity, it cannot be removed.
 
 ---


### PR DESCRIPTION
Although the `azurerm_eventhub_namespace` resource supports `SystemAssigned` or `UserAssigned` identity types (see [here](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/eventhub/eventhub_namespace_resource.go#L106)), the current documentation describes only the support for `SystemAssigned`.

This PR introduces an update on the `identity` attribute description to include the support for the `UserAssigned` type.