### PR TITLE
Make each geo_location in example usage unique

### DIFF
--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -60,7 +60,7 @@ resource "azurerm_cosmosdb_account" "db" {
   }
 
   geo_location {
-    location          = "eastus"
+    location          = "westus"
     failover_priority = 0
   }
 }


### PR DESCRIPTION
With the original config Terraform will error. Each `geo_location` needs to be in unique location. Multiple instances of 'eastus' found.

The 2nd geo_location changed to westus so both unique.