### PR TITLE
`azurerm_policy_set_definition`/`azurerm_policy_definition` - Reverse the order of policies lookup to favour builtin

### DIFF
--- a/internal/services/policy/policy.go
+++ b/internal/services/policy/policy.go
@@ -50,9 +50,9 @@ func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.Defini
 
 func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsClient, name, managementGroupName string) (res policy.Definition, err error) {
 	if managementGroupName == "" {
-		res, err = client.Get(ctx, name)
+		res, err = client.GetBuiltIn(ctx, name)
 		if utils.ResponseWasNotFound(res.Response) {
-			res, err = client.GetBuiltIn(ctx, name)
+			res, err = client.Get(ctx, name)
 		}
 	} else {
 		res, err = client.GetAtManagementGroup(ctx, name, managementGroupName)
@@ -63,9 +63,9 @@ func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsCl
 
 func getPolicySetDefinitionByName(ctx context.Context, client *policy.SetDefinitionsClient, name, managementGroupID string) (res policy.SetDefinition, err error) {
 	if managementGroupID == "" {
-		res, err = client.Get(ctx, name)
+		res, err = client.GetBuiltIn(ctx, name)
 		if utils.ResponseWasNotFound(res.Response) {
-			res, err = client.GetBuiltIn(ctx, name)
+			res, err = client.Get(ctx, name)
 		}
 	} else {
 		res, err = client.GetAtManagementGroup(ctx, name, managementGroupID)


### PR DESCRIPTION
This one would solve #18337 

It changed the plan time from over 2 minutes to less than 40 seconds fot the sample case

```hcl
terraform {
}

provider "azurerm" {
  features {}
}

data "azurerm_policy_set_definition" "policy_set" {
  name = "179d1daa-458f-4e47-8086-2a68d0d6c38f"
}

data "azurerm_policy_definition" "for_each_pol" {
    count = length(data.azurerm_policy_set_definition.policy_set.policy_definition_reference)
    name = data.azurerm_policy_set_definition.policy_set.policy_definition_reference[0].reference_id
}
```

There could be a solution long term for you to sepecify the policy type when creating a data block but those would probablt be corner cases.
