### PR TITLE
`azurerm_disk_pool_iscsi_target_lun_resource` `azurerm_disk_pool_iscsi_target_resource` `azurerm_disk_pool_managed_disk_attachment_resource` - Extend create and delete timeouts

### DIFF
--- a/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
+++ b/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
@@ -75,7 +75,7 @@ func (d DiskPoolIscsiTargetLunModel) ResourceType() string {
 
 func (d DiskPoolIscsiTargetLunModel) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			m := DiskPoolIscsiTargetLunModel{}
 			err := metadata.Decode(&m)
@@ -195,7 +195,7 @@ func (d DiskPoolIscsiTargetLunModel) Read() sdk.ResourceFunc {
 
 func (d DiskPoolIscsiTargetLunModel) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			m := DiskPoolIscsiTargetLunModel{}
 			err := metadata.Decode(&m)

--- a/internal/services/disks/disk_pool_iscsi_target_lun_resource_test.go
+++ b/internal/services/disks/disk_pool_iscsi_target_lun_resource_test.go
@@ -124,6 +124,8 @@ func (r DisksPoolIscsiTargetLunResource) Exists(ctx context.Context, clients *cl
 }
 
 func (r DisksPoolIscsiTargetLunResource) Destroy(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+	defer cancel()
 	id, err := iscsitargets.ParseIscsiTargetLunID(state.ID)
 	if err != nil {
 		return nil, err
@@ -165,7 +167,7 @@ func (r DisksPoolIscsiTargetLunResource) Destroy(ctx context.Context, clients *c
 
 	m := disks.DiskPoolIscsiTargetLunModel{}
 
-	err = m.RetryError(30*time.Minute, "waiting for delete DisksPool iscsi target", id.ID(), func() error {
+	err = m.RetryError(60*time.Minute, "waiting for delete DisksPool iscsi target", id.ID(), func() error {
 		return client.UpdateThenPoll(ctx, iscsiTargetId, patch)
 	})
 	if err != nil {

--- a/internal/services/disks/disk_pool_iscsi_target_lun_resource_test.go
+++ b/internal/services/disks/disk_pool_iscsi_target_lun_resource_test.go
@@ -220,6 +220,11 @@ resource "azurerm_disk_pool_iscsi_target_lun" "test%[2]d" {
   iscsi_target_id                      = azurerm_disk_pool_iscsi_target.test.id
   disk_pool_managed_disk_attachment_id = azurerm_disk_pool_managed_disk_attachment.test[%[2]d].id
   name                                 = "test-%[2]d"
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
 }
 `, tfCode, i)
 	}
@@ -314,6 +319,11 @@ resource "azurerm_disk_pool_managed_disk_attachment" "test" {
   depends_on      = [azurerm_role_assignment.disk_pool_operator, azurerm_role_assignment.vm_contributor]
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.test[count.index].id
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
 }
 
 resource "azurerm_disk_pool_iscsi_target" "test" {

--- a/internal/services/disks/disk_pool_iscsi_target_resource.go
+++ b/internal/services/disks/disk_pool_iscsi_target_resource.go
@@ -98,7 +98,7 @@ func (d DisksPoolIscsiTargetResource) ResourceType() string {
 
 func (d DisksPoolIscsiTargetResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			m := DiskPoolIscsiTargetModel{}
 			err := metadata.Decode(&m)
@@ -194,7 +194,7 @@ func (d DisksPoolIscsiTargetResource) Read() sdk.ResourceFunc {
 
 func (d DisksPoolIscsiTargetResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			id, err := iscsitargets.ParseIscsiTargetID(metadata.ResourceData.Id())
 			if err != nil {

--- a/internal/services/disks/disk_pool_managed_disk_attachment_resource.go
+++ b/internal/services/disks/disk_pool_managed_disk_attachment_resource.go
@@ -56,7 +56,7 @@ func (d DiskPoolManagedDiskAttachmentResource) ResourceType() string {
 
 func (d DiskPoolManagedDiskAttachmentResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			attachment := DiskPoolManagedDiskAttachmentModel{}
 			err := metadata.Decode(&attachment)
@@ -157,7 +157,7 @@ func (d DiskPoolManagedDiskAttachmentResource) Read() sdk.ResourceFunc {
 
 func (d DiskPoolManagedDiskAttachmentResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			diskToDetach := &DiskPoolManagedDiskAttachmentModel{}
 			err := metadata.Decode(diskToDetach)

--- a/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
+++ b/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -107,6 +108,8 @@ func (a DisksPoolManagedDiskAttachmentResource) Exists(ctx context.Context, clie
 }
 
 func (a DisksPoolManagedDiskAttachmentResource) Destroy(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+	defer cancel()
 	id, err := diskpools.DiskPoolManagedDiskAttachmentID(state.ID)
 	if err != nil {
 		return nil, err

--- a/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
+++ b/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
@@ -149,11 +149,6 @@ resource "azurerm_disk_pool_managed_disk_attachment" "test" {
   depends_on      = [azurerm_role_assignment.test]
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.test.id
-
-  timeouts {
-    create = "60m"
-    delete = "60m"
-  }
 }
 `, a.template(data))
 }
@@ -238,11 +233,6 @@ func (a DisksPoolManagedDiskAttachmentResource) requiresImport(data acceptance.T
 resource "azurerm_disk_pool_managed_disk_attachment" "import" {
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.test.id
-
-  timeouts {
-    create = "60m"
-    delete = "60m"
-  }
 }
 `, a.basic(data))
 }
@@ -273,11 +263,6 @@ resource "azurerm_disk_pool_managed_disk_attachment" "second" {
   depends_on      = [azurerm_role_assignment.second]
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.second.id
-
-  timeouts {
-    create = "60m"
-    delete = "60m"
-  }
 }
 `, a.basic(data), data.RandomInteger)
 }

--- a/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
+++ b/internal/services/disks/disk_pool_managed_disk_attachment_resource_test.go
@@ -146,6 +146,11 @@ resource "azurerm_disk_pool_managed_disk_attachment" "test" {
   depends_on      = [azurerm_role_assignment.test]
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.test.id
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
 }
 `, a.template(data))
 }
@@ -230,6 +235,11 @@ func (a DisksPoolManagedDiskAttachmentResource) requiresImport(data acceptance.T
 resource "azurerm_disk_pool_managed_disk_attachment" "import" {
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.test.id
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
 }
 `, a.basic(data))
 }
@@ -260,6 +270,11 @@ resource "azurerm_disk_pool_managed_disk_attachment" "second" {
   depends_on      = [azurerm_role_assignment.second]
   disk_pool_id    = azurerm_disk_pool.test.id
   managed_disk_id = azurerm_managed_disk.second.id
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
 }
 `, a.basic(data), data.RandomInteger)
 }


### PR DESCRIPTION
`azurerm_disk_pool_managed_disk_attachment` locks the disk pool, thus creating multiple instances increase the creation time. Besides this, sometimes destroy take longer time to finish. These two issues cause `Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded` in test case, which means the create/delete timesout at Terraform side before the API finishes. Similar issue happens also for `azurerm_disk_pool_iscsi_target_lun` which locks `azurerm_disk_pool_iscsi_target`.
Extending the timeouts to allow more time for the operations to finish