### PR TITLE
`iotcentral` - Fix test locations

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -75,6 +75,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // HSM has low quota and potentially slow recycle time, Only run on Mondays
         "hsm" to testConfiguration(parallelism = 1, daysOfWeek = "1"),
 
+        // IoT Central is only available in certain locations
+        "iotcentral" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "southeastasia", "eastus2", false)),
+
         // Log Analytics Clusters have a max deployments of 2 - parallelism set to 1 or `importTest` fails
         "loganalytics" to testConfiguration(parallelism = 1),
 


### PR DESCRIPTION
`westus2` is not supported, change it to another location
```
The provided location 'westus2' is not available for resource type 'Microsoft.IoTCentral/IoTApps'.
List of available regions for the resource type is
'australiaeast,canadacentral,centralus,eastus,eastus2,japaneast,northeurope,southeastasia,southcentralus,uksouth,westcentralus,westeurope,westus'."
```