### PR TITLE
Typo in the docs:

### DIFF
--- a/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `username` - (Required) The username to connect to the MS SQL database.
 
-* `password` - (Required) The username to connect to the MS SQL database.
+* `password` - (Required) The password to connect to the MS SQL database.
 
 * `refresh_type` - (Required) Defines whether and how the reference data should be refreshed. Accepted values are `Static`, `RefreshPeriodicallyWithFull` and `RefreshPeriodicallyWithDelta`.
 


### PR DESCRIPTION
"username" was written instead of "password" in the argument reference of resource "azurerm_stream_analytics_reference_input_mssql"