### PR TITLE
`azurerm_netapp_volume`: add extra validation when `data_protection_snapshot_policy.0. snapshot_policy_id` is empty

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -1117,11 +1117,7 @@ func flattenNetAppVolumeDataProtectionReplication(input *volumes.VolumePropertie
 }
 
 func flattenNetAppVolumeDataProtectionSnapshotPolicy(input *volumes.VolumePropertiesDataProtection) []interface{} {
-	if input == nil || input.Snapshot == nil {
-		return []interface{}{}
-	}
-
-	if input.Snapshot != nil && *input.Snapshot.SnapshotPolicyId == "" {
+	if input == nil || input.Snapshot == nil || *input.Snapshot.SnapshotPolicyId == "" {
 		return []interface{}{}
 	}
 

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -1121,6 +1121,10 @@ func flattenNetAppVolumeDataProtectionSnapshotPolicy(input *volumes.VolumeProper
 		return []interface{}{}
 	}
 
+	if input.Snapshot != nil && *input.Snapshot.SnapshotPolicyId == "" {
+		return []interface{}{}
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"snapshot_policy_id": input.Snapshot.SnapshotPolicyId,


### PR DESCRIPTION
In at least one circumstance, described in issue #18284, the azure backend is set the SnapshotPolicyId to an empty string.    

This proposed change checks if the string is empty, and then ignoring the block.   

fixes: #18284
