### PR TITLE
`azurerm_firewall_nat_rule_collection` - fix AccTest `TestAccFirewallNatRuleCollection_multipleRules`

### DIFF
--- a/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
@@ -573,7 +573,6 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
 
     destination_ports = [
       "53",
-      "64",
     ]
 
     destination_addresses = [
@@ -599,7 +598,6 @@ resource "azurerm_firewall_nat_rule_collection" "test" {
 
     destination_ports = [
       "8888",
-      "9999",
     ]
 
     destination_addresses = [


### PR DESCRIPTION
fix acc test failure. Origin failure infomation:

```
------- Stdout: -------
=== RUN   TestAccFirewallNatRuleCollection_multipleRules
=== PAUSE TestAccFirewallNatRuleCollection_multipleRules
=== CONT  TestAccFirewallNatRuleCollection_multipleRules
    testcase.go:110: Step 3/6 error: Error running apply: exit status 1
        
        Error: creating/updating NAT Rule Collection "acctestnrc-220912013842479048" in Firewall "acctestfirewall220912013842479048" (Resource Group "acctestRG-fw-220912013842479048"): network.AzureFirewallsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AzureFirewallRuleInvalidDnatPortOrRangeFormat" Message="AzureFirewallRule acctestrule: Invalid DNat port value or range. Multiple values, * and ranges are not supported for DNAT translated port." Details=[]
        
          with azurerm_firewall_nat_rule_collection.test,
          on terraform_plugin_test.tf line 50, in resource "azurerm_firewall_nat_rule_collection" "test":
          50: resource "azurerm_firewall_nat_rule_collection" "test" {
        
--- FAIL: TestAccFirewallNatRuleCollection_multipleRules (1228.51s)
FAIL
```

Passed screen:

![image](https://user-images.githubusercontent.com/2633022/189820436-1236171f-1245-4f27-b860-208a57b342f8.png)
