### PR TITLE
`Consumption` - fix failed tests

### DIFF
--- a/internal/services/consumption/consumption_budget_base.go
+++ b/internal/services/consumption/consumption_budget_base.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
@@ -127,78 +129,6 @@ func (br consumptionBudgetBaseResource) arguments(fields map[string]*pluginsdk.S
 							},
 						},
 					},
-					"not": {
-						Type:         pluginsdk.TypeList,
-						Optional:     true,
-						MaxItems:     1,
-						AtLeastOneOf: []string{"filter.0.dimension", "filter.0.tag", "filter.0.not"},
-						Elem: &pluginsdk.Resource{
-							Schema: map[string]*pluginsdk.Schema{
-								"dimension": {
-									Type:         pluginsdk.TypeList,
-									MaxItems:     1,
-									Optional:     true,
-									ExactlyOneOf: []string{"filter.0.not.0.tag"},
-									Elem: &pluginsdk.Resource{
-										Schema: map[string]*pluginsdk.Schema{
-											"name": {
-												Type:         pluginsdk.TypeString,
-												Required:     true,
-												ValidateFunc: validation.StringInSlice(getDimensionNames(), false),
-											},
-											"operator": {
-												Type:     pluginsdk.TypeString,
-												Optional: true,
-												Default:  "In",
-												ValidateFunc: validation.StringInSlice([]string{
-													"In",
-												}, false),
-											},
-											"values": {
-												Type:     pluginsdk.TypeList,
-												MinItems: 1,
-												Required: true,
-												Elem: &pluginsdk.Schema{
-													Type:         pluginsdk.TypeString,
-													ValidateFunc: validation.StringIsNotEmpty,
-												},
-											},
-										},
-									},
-								},
-								"tag": {
-									Type:         pluginsdk.TypeList,
-									MaxItems:     1,
-									Optional:     true,
-									ExactlyOneOf: []string{"filter.0.not.0.dimension"},
-									Elem: &pluginsdk.Resource{
-										Schema: map[string]*pluginsdk.Schema{
-											"name": {
-												Type:     pluginsdk.TypeString,
-												Required: true,
-											},
-											"operator": {
-												Type:     pluginsdk.TypeString,
-												Optional: true,
-												Default:  "In",
-												ValidateFunc: validation.StringInSlice([]string{
-													"In",
-												}, false),
-											},
-											"values": {
-												Type:     pluginsdk.TypeList,
-												Required: true,
-												Elem: &pluginsdk.Schema{
-													Type:         pluginsdk.TypeString,
-													ValidateFunc: validation.StringIsNotEmpty,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 		},
@@ -311,6 +241,83 @@ func (br consumptionBudgetBaseResource) arguments(fields map[string]*pluginsdk.S
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		output["filter"].Elem.(*pluginsdk.Resource).Schema["not"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeList,
+			Optional:     true,
+			MaxItems:     1,
+			Deprecated:   "This property has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.",
+			AtLeastOneOf: []string{"filter.0.dimension", "filter.0.tag", "filter.0.not"},
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"dimension": {
+						Type:         pluginsdk.TypeList,
+						MaxItems:     1,
+						Optional:     true,
+						ExactlyOneOf: []string{"filter.0.not.0.tag"},
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice(getDimensionNames(), false),
+								},
+								"operator": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Default:  "In",
+									ValidateFunc: validation.StringInSlice([]string{
+										"In",
+									}, false),
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									MinItems: 1,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+					"tag": {
+						Type:         pluginsdk.TypeList,
+						MaxItems:     1,
+						Optional:     true,
+						ExactlyOneOf: []string{"filter.0.not.0.dimension"},
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"operator": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Default:  "In",
+									ValidateFunc: validation.StringInSlice([]string{
+										"In",
+									}, false),
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	// Consumption Budgets for Management Groups have a different notification schema,
 	// here we override the notification schema in the base resource
 	for k, v := range fields {

--- a/internal/services/consumption/consumption_budget_management_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource_test.go
@@ -299,16 +299,6 @@ resource "azurerm_consumption_budget_management_group" "test" {
         "baz",
       ]
     }
-
-    not {
-      tag {
-        name = "zip"
-        values = [
-          "zap",
-          "zop"
-        ]
-      }
-    }
   }
 
   notification {

--- a/internal/services/consumption/consumption_budget_resource_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_resource_group_resource_test.go
@@ -309,16 +309,6 @@ resource "azurerm_consumption_budget_resource_group" "test" {
         "baz",
       ]
     }
-
-    not {
-      tag {
-        name = "zip"
-        values = [
-          "zap",
-          "zop"
-        ]
-      }
-    }
   }
 
   notification {

--- a/internal/services/consumption/consumption_budget_subscription_resource_test.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource_test.go
@@ -294,16 +294,6 @@ resource "azurerm_consumption_budget_subscription" "test" {
         "baz",
       ]
     }
-
-    not {
-      tag {
-        name = "zip"
-        values = [
-          "zap",
-          "zop"
-        ]
-      }
-    }
   }
 
   notification {

--- a/website/docs/r/consumption_budget_management_group.html.markdown
+++ b/website/docs/r/consumption_budget_management_group.html.markdown
@@ -102,7 +102,7 @@ A `filter` block supports the following:
 
 * `tag` - (Optional) One or more `tag` blocks as defined below to filter the budget on.
 
-* `not` - (Optional) A `not` block as defined below to filter the budget on.
+* `not` - (Optional) A `not` block as defined below to filter the budget on. This is deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.
 
 ---
 

--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -112,7 +112,7 @@ A `filter` block supports the following:
 
 * `tag` - (Optional) One or more `tag` blocks as defined below to filter the budget on.
 
-* `not` - (Optional) A `not` block as defined below to filter the budget on.
+* `not` - (Optional) A `not` block as defined below to filter the budget on. This is deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.
 
 ---
 

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -116,7 +116,7 @@ A `filter` block supports the following:
 
 * `tag` - (Optional) One or more `tag` blocks as defined below to filter the budget on.
 
-* `not` - (Optional) A `not` block as defined below to filter the budget on.
+* `not` - (Optional) A `not` block as defined below to filter the budget on. This is deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.
 
 ---
 


### PR DESCRIPTION
Notes: Confirmed with Azure Service that the `not` property was never supported by `Consumption Budget` so that it should be removed from the testcases.
![image](https://user-images.githubusercontent.com/76987228/190373613-e9b53558-39b3-4887-9003-39a126ac1387.png)
