### PR TITLE
`azurerm_application_insights_api_key` - fix failed test case `TestAccApplicationInsightsAPIKey_no_permission`

### DIFF
--- a/internal/services/applicationinsights/application_insights_api_key_resource.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource.go
@@ -136,10 +136,15 @@ func resourceApplicationInsightsAPIKeyCreate(d *pluginsdk.ResourceData, meta int
 		return tf.ImportAsExistsError("azurerm_application_insights_api_key", existingAPIKeyId.ID())
 	}
 
+	linkedReadProperties := expandApplicationInsightsAPIKeyLinkedProperties(d.Get("read_permissions").(*pluginsdk.Set), appInsightsId.ID())
+	linkedWriteProperties := expandApplicationInsightsAPIKeyLinkedProperties(d.Get("write_permissions").(*pluginsdk.Set), appInsightsId.ID())
+	if len(*linkedReadProperties) == 0 && len(*linkedWriteProperties) == 0 {
+		return fmt.Errorf("at least one read or write permission must be defined")
+	}
 	apiKeyProperties := insights.APIKeyRequest{
 		Name:                  &name,
-		LinkedReadProperties:  expandApplicationInsightsAPIKeyLinkedProperties(d.Get("read_permissions").(*pluginsdk.Set), appInsightsId.ID()),
-		LinkedWriteProperties: expandApplicationInsightsAPIKeyLinkedProperties(d.Get("write_permissions").(*pluginsdk.Set), appInsightsId.ID()),
+		LinkedReadProperties:  linkedReadProperties,
+		LinkedWriteProperties: linkedWriteProperties,
 	}
 
 	result, err := client.Create(ctx, appInsightsId.ResourceGroup, appInsightsId.Name, apiKeyProperties)

--- a/internal/services/applicationinsights/application_insights_api_key_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource_test.go
@@ -24,7 +24,7 @@ func TestAccApplicationInsightsAPIKey_no_permission(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.basic(data, "[]", "[]"),
-			ExpectError: regexp.MustCompile("At least one read or write permission must be defined"),
+			ExpectError: regexp.MustCompile("at least one read or write permission must be defined"),
 		},
 	})
 }

--- a/internal/services/applicationinsights/application_insights_api_key_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource_test.go
@@ -24,7 +24,7 @@ func TestAccApplicationInsightsAPIKey_no_permission(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.basic(data, "[]", "[]"),
-			ExpectError: regexp.MustCompile("The API Key needs to have a Role"),
+			ExpectError: regexp.MustCompile("At least one read or write permission must be defined"),
 		},
 	})
 }


### PR DESCRIPTION
Related to https://github.com/Azure/azure-rest-api-specs/issues/20690

Test Result:
![image](https://user-images.githubusercontent.com/104055472/189867070-726289c4-c517-48c7-8424-10d51541906b.png)

Original failure:
```
------- Stdout: -------
=== RUN   TestAccApplicationInsightsAPIKey_no_permission
=== PAUSE TestAccApplicationInsightsAPIKey_no_permission
=== CONT  TestAccApplicationInsightsAPIKey_no_permission
testcase.go:110: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1
Error: creating Application Insights API key "acctestappinsightsapikey-220912011823516251" (Component: (Name "acctestappinsights-220912011823516251" / Resource Group "acctestRG-220912011823516251")): insights.APIKeysClient#Create: Failure responding to request: StatusCode=500 -- Original Error: autorest/azure: Service returned an error. Status=500 Code="" Message="An error has occurred."
with azurerm_application_insights_api_key.test,
on terraform_plugin_test.tf line 18, in resource "azurerm_application_insights_api_key" "test":
18: resource "azurerm_application_insights_api_key" "test" {
--- FAIL: TestAccApplicationInsightsAPIKey_no_permission (567.04s)
FAIL
```
