### PR TITLE
`azurerm_firewall` - fix AccTest `TestAccFirewall_withZones`

### DIFF
--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -173,7 +173,7 @@ func TestAccFirewall_withZones(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
 	r := FirewallResource{}
 	zones := []string{"1"}
-	zonesUpdate := []string{"1", "3"}
+	zonesUpdate := []string{"1", "2", "3"}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -189,9 +189,7 @@ func TestAccFirewall_withZones(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("zones.#").HasValue("2"),
-				check.That(data.ResourceName).Key("zones.0").HasValue("1"),
-				check.That(data.ResourceName).Key("zones.1").HasValue("3"),
+				check.That(data.ResourceName).Key("zones.#").HasValue("3"),
 			),
 		},
 	})


### PR DESCRIPTION
Public IP Address creating API add skipped zone number in response, described in this issue: https://github.com/Azure/azure-rest-api-specs/issues/20691


TeamCity test passed now: 
![image](https://user-images.githubusercontent.com/2633022/190103939-e28f6997-f68d-4a7a-8d47-84824105bfed.png)


origin test failure error message:

```
------- Stdout: -------
=== RUN   TestAccFirewall_withZones
=== PAUSE TestAccFirewall_withZones
=== CONT  TestAccFirewall_withZones
    testcase.go:110: Step 2/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # azurerm_firewall.test will be updated in-place
          ~ resource "azurerm_firewall" "test" {
                id                  = "/subscriptions/*******/resourceGroups/acctestRG-fw-220914021507693024/providers/Microsoft.Network/azureFirewalls/acctestfirewall220914021507693024"
                name                = "acctestfirewall220914021507693024"
                tags                = {}
                # (8 unchanged attributes hidden)
        
              ~ ip_configuration {
                    name                 = "configuration"
                  ~ public_ip_address_id = "/subscriptions/*******/resourceGroups/acctestRG-fw-220914021507693024/providers/Microsoft.Network/publicIPAddresses/acctestpip220914021507693024" -> (known after apply)
                    # (2 unchanged attributes hidden)
                }
            }
        
          # azurerm_public_ip.test must be replaced
        -/+ resource "azurerm_public_ip" "test" {
              + fqdn                    = (known after apply)
              ~ id                      = "/subscriptions/*******/resourceGroups/acctestRG-fw-220914021507693024/providers/Microsoft.Network/publicIPAddresses/acctestpip220914021507693024" -> (known after apply)
              ~ ip_address              = "20.252.2.88" -> (known after apply)
              - ip_tags                 = {} -> null
                name                    = "acctestpip220914021507693024"
              - tags                    = {} -> null
              ~ zones                   = [ # forces replacement
                  - "2",
                    # (2 unchanged elements hidden)
                ]
                # (7 unchanged attributes hidden)
            }
        
        Plan: 1 to add, 1 to change, 1 to destroy.
--- FAIL: TestAccFirewall_withZones (1717.58s)
FAIL
```