### PR TITLE
New resources: `azurerm_dynatrace_monitors`, `azurerm_dynatrace_tag_rules`

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -111,6 +111,9 @@ service/dns:
 service/domain-services:
   - internal/services/domainservices/**/*
 
+service/dynatrace:
+  - internal/services/dynatrace/**/*
+
 service/elastic:
   - internal/services/elastic/**/*
 

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -41,6 +41,7 @@ var services = mapOf(
         "digitaltwins" to "Digital Twins",
         "disks" to "Disks",
         "domainservices" to "DomainServices",
+        "dynatrace" to "Dynatrace",
         "elastic" to "Elastic",
         "eventgrid" to "EventGrid",
         "eventhub" to "EventHub",

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -52,6 +52,7 @@ import (
 	disks "github.com/hashicorp/terraform-provider-azurerm/internal/services/disks/client"
 	dns "github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/client"
 	domainservices "github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/client"
+	dynatrace "github.com/hashicorp/terraform-provider-azurerm/internal/services/dynatrace/client"
 	elastic "github.com/hashicorp/terraform-provider-azurerm/internal/services/elastic/client"
 	eventgrid "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid/client"
 	eventhub "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/client"
@@ -170,6 +171,7 @@ type Client struct {
 	Disks                 *disks.Client
 	Dns                   *dns_v2018_05_01.Client
 	DomainServices        *domainservices.Client
+	Dynatrace             *dynatrace.Client
 	Elastic               *elastic.Client
 	EventGrid             *eventgrid.Client
 	Eventhub              *eventhub.Client
@@ -292,6 +294,7 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	client.Disks = disks.NewClient(o)
 	client.Dns = dns.NewClient(o)
 	client.DomainServices = domainservices.NewClient(o)
+	client.Dynatrace = dynatrace.NewClient(o)
 	client.Elastic = elastic.NewClient(o)
 	client.EventGrid = eventgrid.NewClient(o)
 	client.Eventhub = eventhub.NewClient(o)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -42,6 +42,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/disks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dynatrace"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/elastic"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub"
@@ -132,6 +133,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		databricks.Registration{},
 		disks.Registration{},
 		domainservices.Registration{},
+		dynatrace.Registration{},
 		eventhub.Registration{},
 		fluidrelay.Registration{},
 		iothub.Registration{},

--- a/internal/services/dynatrace/client/client.go
+++ b/internal/services/dynatrace/client/client.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+type Client struct {
+	MonitorClient  *monitors.MonitorsClient
+	TagRulesClient *tagrules.TagRulesClient
+}
+
+func NewClient(o *common.ClientOptions) *Client {
+	monitorClient := monitors.NewMonitorsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&monitorClient.Client, o.ResourceManagerAuthorizer)
+
+	tagRulesClient := tagrules.NewTagRulesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&tagRulesClient.Client, o.ResourceManagerAuthorizer)
+
+	return &Client{
+		MonitorClient:  &monitorClient,
+		TagRulesClient: &tagRulesClient,
+	}
+}

--- a/internal/services/dynatrace/dynatrace_monitors_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource.go
@@ -26,8 +26,8 @@ type MonitorsResourceModel struct {
 	MonitoringStatus              bool              `tfschema:"monitoring_enabled"`
 	MarketplaceSubscriptionStatus string            `tfschema:"marketplace_subscription"`
 	IdentityType                  string            `tfschema:"identity_type"`
-	PlanData                      []PlanData        `tfschema:"plan_data"`
-	UserInfo                      []UserInfo        `tfschema:"user_info"`
+	PlanData                      []PlanData        `tfschema:"plan"`
+	UserInfo                      []UserInfo        `tfschema:"user"`
 	Tags                          map[string]string `tfschema:"tags"`
 }
 
@@ -87,9 +87,9 @@ func (r MonitorsResource) Arguments() map[string]*schema.Schema {
 			}, false),
 		},
 
-		"plan_data": SchemaPlanData(),
+		"plan": SchemaPlanData(),
 
-		"user_info": SchemaUserInfo(),
+		"user": SchemaUserInfo(),
 
 		"tags": tags.Schema(),
 	}
@@ -152,7 +152,7 @@ func (r MonitorsResource) Create() sdk.ResourceFunc {
 				Tags:       &model.Tags,
 			}
 
-			if _, err := client.CreateOrUpdate(ctx, id, monitor); err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, id, monitor); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -183,7 +183,7 @@ func (r MonitorsResource) Read() sdk.ResourceFunc {
 			if model := resp.Model; model != nil {
 				props := model.Properties
 				identityProps := model.Identity
-				userInfo := metadata.ResourceData.Get("user_info").([]interface{})
+				userInfo := metadata.ResourceData.Get("user").([]interface{})
 				monitoringStatus := true
 				if *props.MonitoringStatus == monitors.MonitoringStatusDisabled {
 					monitoringStatus = false

--- a/internal/services/dynatrace/dynatrace_monitors_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource.go
@@ -3,6 +3,7 @@ package dynatrace
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -63,10 +64,10 @@ func (r MonitorsResource) Arguments() map[string]*schema.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
-			Default:  "SystemAssigned",
+			Default:  string(identity.TypeSystemAssigned),
 			ValidateFunc: validation.StringInSlice([]string{
-				"SystemAssigned",
-				"UserAssigned",
+				string(identity.TypeSystemAssigned),
+				string(identity.TypeUserAssigned),
 			}, false),
 		},
 

--- a/internal/services/dynatrace/dynatrace_monitors_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource.go
@@ -3,10 +3,10 @@ package dynatrace
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"

--- a/internal/services/dynatrace/dynatrace_monitors_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource.go
@@ -1,0 +1,264 @@
+package dynatrace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type MonitorsResource struct{}
+
+var _ sdk.ResourceWithUpdate = MonitorsResource{}
+
+type MonitorsResourceModel struct {
+	Name                          string            `tfschema:"name"`
+	ResourceGroup                 string            `tfschema:"resource_group_name"`
+	Location                      string            `tfschema:"location"`
+	MonitoringStatus              string            `tfschema:"monitoring_status"`
+	MarketplaceSubscriptionStatus string            `tfschema:"marketplace_subscription_status"`
+	IdentityType                  string            `tfschema:"identity_type"`
+	PlanData                      []PlanData        `tfschema:"plan_data"`
+	UserInfo                      []UserInfo        `tfschema:"user_info"`
+	Tags                          map[string]string `tfschema:"tags"`
+}
+
+type PlanData struct {
+	BillingCycle  string `tfschema:"billing_cycle"`
+	EffectiveDate string `tfschema:"effective_date"`
+	PlanDetails   string `tfschema:"plan_details"`
+	UsageType     string `tfschema:"usage_type"`
+}
+
+type UserInfo struct {
+	Country      string `tfschema:"country"`
+	EmailAddress string `tfschema:"email_address"`
+	FirstName    string `tfschema:"first_name"`
+	LastName     string `tfschema:"last_name"`
+	PhoneNumber  string `tfschema:"phone_number"`
+}
+
+func (r MonitorsResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"location": azure.SchemaLocation(),
+
+		"identity_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "SystemAssigned",
+			ValidateFunc: validation.StringInSlice([]string{
+				"SystemAssigned",
+				"UserAssigned",
+			}, false),
+		},
+
+		"monitoring_status": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Enabled",
+				"Disabled",
+			}, false),
+		},
+
+		"marketplace_subscription_status": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Active",
+				"Suspended",
+			}, false),
+		},
+
+		"plan_data": SchemaPlanData(),
+
+		"user_info": SchemaUserInfo(),
+
+		"tags": tags.Schema(),
+	}
+}
+
+func (r MonitorsResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (r MonitorsResource) ModelObject() interface{} {
+	return &MonitorsResourceModel{}
+}
+
+func (r MonitorsResource) ResourceType() string {
+	return "azurerm_dynatrace_monitors"
+}
+
+func (r MonitorsResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model MonitorsResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			client := metadata.Client.Dynatrace.MonitorClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := monitors.NewMonitorID(subscriptionId, model.ResourceGroup, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			marketplaceSubscriptionServiceStatus := monitors.MarketplaceSubscriptionStatus(model.MarketplaceSubscriptionStatus)
+			monitoringStatus := monitors.MonitoringStatus(model.MonitoringStatus)
+			monitorsProps := monitors.MonitorProperties{
+				MarketplaceSubscriptionStatus: &marketplaceSubscriptionServiceStatus,
+				MonitoringStatus:              &monitoringStatus,
+				PlanData:                      ExpandDynatracePlanData(model.PlanData),
+				UserInfo:                      ExpandDynatraceUserInfo(model.UserInfo),
+			}
+
+			identity := monitors.IdentityProperties{
+				Type: monitors.ManagedIdentityType(model.IdentityType),
+			}
+
+			monitor := monitors.MonitorResource{
+				Identity:   &identity,
+				Location:   model.Location,
+				Name:       &model.Name,
+				Properties: monitorsProps,
+				Tags:       &model.Tags,
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, monitor); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r MonitorsResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Dynatrace.MonitorClient
+			id, err := monitors.ParseMonitorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+			if model := resp.Model; model != nil {
+				props := model.Properties
+				identityProps := model.Identity
+				userInfo := metadata.ResourceData.Get("user_info").([]interface{})
+
+				state := MonitorsResourceModel{
+					Name:                          id.MonitorName,
+					ResourceGroup:                 id.ResourceGroupName,
+					Location:                      model.Location,
+					MonitoringStatus:              string(*props.MonitoringStatus),
+					MarketplaceSubscriptionStatus: string(*props.MarketplaceSubscriptionStatus),
+					IdentityType:                  string(identityProps.Type),
+					PlanData:                      FlattenDynatracePlanData(props.PlanData),
+					UserInfo:                      FlattenDynatraceUserInfo(userInfo),
+				}
+
+				if model.Tags != nil {
+					state.Tags = *model.Tags
+				}
+
+				return metadata.Encode(&state)
+			}
+			return nil
+		},
+	}
+}
+
+func (r MonitorsResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Dynatrace.MonitorClient
+			id, err := monitors.ParseMonitorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s", *id)
+
+			if resp, err := client.Delete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", *id, err)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (r MonitorsResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return monitors.ValidateMonitorID
+}
+
+func (r MonitorsResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Dynatrace.MonitorClient
+			id, err := monitors.ParseMonitorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var state MonitorsResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				props := monitors.MonitorResourceUpdate{
+					Tags: &state.Tags,
+				}
+
+				if _, err := client.Update(ctx, *id, props); err != nil {
+					return fmt.Errorf("updating %s: %+v", *id, err)
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/dynatrace/dynatrace_monitors_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource_test.go
@@ -1,0 +1,181 @@
+package dynatrace_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type MonitorsResource struct{}
+
+func TestAccDynatraceMonitors_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitors", "test")
+	r := MonitorsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+
+		data.ImportStep("user_info"),
+	})
+}
+
+func TestAccDynatraceMonitors_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitors", "test")
+	r := MonitorsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("user_info"),
+	})
+}
+
+func TestAccDynatraceMonitors_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitors", "test")
+	r := MonitorsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r MonitorsResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := monitors.ParseMonitorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Dynatrace.MonitorClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r MonitorsResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_dynatrace_monitors" "test" {
+  name                            = "acctestacc%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = "SystemAssigned"
+  monitoring_status               = "Enabled"
+  marketplace_subscription_status = "Active"
+
+  user_info {
+    first_name    = "Alice"
+    last_name     = "Bobab"
+    email_address = "alice@microsoft.com"
+    phone_number  = "123456"
+    country       = "westus"
+  }
+
+  plan_data {
+    usage_type     = "COMMITTED"
+    billing_cycle  = "MONTHLY"
+    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    effective_date = "2019-08-30T15:14:33Z"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r MonitorsResource) updated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_dynatrace_monitors" "test" {
+  name                            = "acctestacc%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = "SystemAssigned"
+  monitoring_status               = "Enabled"
+  marketplace_subscription_status = "Active"
+
+  user_info {
+    first_name    = "Alice"
+    last_name     = "Bobab"
+    email_address = "alice@microsoft.com"
+    phone_number  = "123456"
+    country       = "westus"
+  }
+
+  plan_data {
+    usage_type     = "COMMITTED"
+    billing_cycle  = "MONTHLY"
+    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    effective_date = "2019-08-30T15:14:33Z"
+  }
+
+  tags = {
+    environment = "Prod"
+    test        = "Patch"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r MonitorsResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dynatrace_monitors" "import" {
+  name                            = azurerm_dynatrace_monitors.test.name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = azurerm_dynatrace_monitors.test.identity_type
+  monitoring_status               = azurerm_dynatrace_monitors.test.monitoring_status
+  marketplace_subscription_status = azurerm_dynatrace_monitors.test.marketplace_subscription_status
+}
+`, template)
+}
+
+func (r MonitorsResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/dynatrace/dynatrace_monitors_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource_test.go
@@ -28,7 +28,7 @@ func TestAccDynatraceMonitors_basic(t *testing.T) {
 			),
 		},
 
-		data.ImportStep("user_info"),
+		data.ImportStep("user"),
 	})
 }
 
@@ -49,7 +49,7 @@ func TestAccDynatraceMonitors_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("user_info"),
+		data.ImportStep("user"),
 	})
 }
 
@@ -97,7 +97,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   monitoring_enabled       = true
   marketplace_subscription = "Active"
 
-  user_info {
+  user {
     first_name   = "Alice"
     last_name    = "Bobab"
     email        = "alice@microsoft.com"
@@ -105,7 +105,7 @@ resource "azurerm_dynatrace_monitors" "test" {
     country      = "westus"
   }
 
-  plan_data {
+  plan {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
     plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
@@ -128,7 +128,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   monitoring_enabled       = true
   marketplace_subscription = "Active"
 
-  user_info {
+  user {
     first_name   = "Alice"
     last_name    = "Bobab"
     email        = "alice@microsoft.com"
@@ -136,7 +136,7 @@ resource "azurerm_dynatrace_monitors" "test" {
     country      = "westus"
   }
 
-  plan_data {
+  plan {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
     plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"

--- a/internal/services/dynatrace/dynatrace_monitors_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource_test.go
@@ -94,7 +94,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = "SystemAssigned"
-  monitoring_status        = "Enabled"
+  monitoring_enabled        = true
   marketplace_subscription = "Active"
 
   user_info {
@@ -125,7 +125,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = "SystemAssigned"
-  monitoring_status        = "Enabled"
+  monitoring_enabled        = true
   marketplace_subscription = "Active"
 
   user_info {
@@ -161,7 +161,7 @@ resource "azurerm_dynatrace_monitors" "import" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = azurerm_dynatrace_monitors.test.identity_type
-  monitoring_status        = azurerm_dynatrace_monitors.test.monitoring_status
+  monitoring_enabled        = azurerm_dynatrace_monitors.test.monitoring_enabled
   marketplace_subscription = azurerm_dynatrace_monitors.test.marketplace_subscription_status
 }
 `, template)

--- a/internal/services/dynatrace/dynatrace_monitors_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource_test.go
@@ -90,25 +90,25 @@ func (r MonitorsResource) basic(data acceptance.TestData) string {
 %[1]s
 
 resource "azurerm_dynatrace_monitors" "test" {
-  name                            = "acctestacc%[2]d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  identity_type                   = "SystemAssigned"
-  monitoring_status               = "Enabled"
-  marketplace_subscription_status = "Active"
+  name                     = "acctestacc%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  identity_type            = "SystemAssigned"
+  monitoring_status        = "Enabled"
+  marketplace_subscription = "Active"
 
   user_info {
-    first_name    = "Alice"
-    last_name     = "Bobab"
-    email_address = "alice@microsoft.com"
-    phone_number  = "123456"
-    country       = "westus"
+    first_name   = "Alice"
+    last_name    = "Bobab"
+    email        = "alice@microsoft.com"
+    phone_number = "123456"
+    country      = "westus"
   }
 
   plan_data {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
-    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
     effective_date = "2019-08-30T15:14:33Z"
   }
 }
@@ -121,25 +121,25 @@ func (r MonitorsResource) updated(data acceptance.TestData) string {
 %[1]s
 
 resource "azurerm_dynatrace_monitors" "test" {
-  name                            = "acctestacc%[2]d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  identity_type                   = "SystemAssigned"
-  monitoring_status               = "Enabled"
-  marketplace_subscription_status = "Active"
+  name                     = "acctestacc%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  identity_type            = "SystemAssigned"
+  monitoring_status        = "Enabled"
+  marketplace_subscription = "Active"
 
   user_info {
-    first_name    = "Alice"
-    last_name     = "Bobab"
-    email_address = "alice@microsoft.com"
-    phone_number  = "123456"
-    country       = "westus"
+    first_name   = "Alice"
+    last_name    = "Bobab"
+    email        = "alice@microsoft.com"
+    phone_number = "123456"
+    country      = "westus"
   }
 
   plan_data {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
-    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
     effective_date = "2019-08-30T15:14:33Z"
   }
 
@@ -157,12 +157,12 @@ func (r MonitorsResource) requiresImport(data acceptance.TestData) string {
 %s
 
 resource "azurerm_dynatrace_monitors" "import" {
-  name                            = azurerm_dynatrace_monitors.test.name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  identity_type                   = azurerm_dynatrace_monitors.test.identity_type
-  monitoring_status               = azurerm_dynatrace_monitors.test.monitoring_status
-  marketplace_subscription_status = azurerm_dynatrace_monitors.test.marketplace_subscription_status
+  name                     = azurerm_dynatrace_monitors.test.name
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  identity_type            = azurerm_dynatrace_monitors.test.identity_type
+  monitoring_status        = azurerm_dynatrace_monitors.test.monitoring_status
+  marketplace_subscription = azurerm_dynatrace_monitors.test.marketplace_subscription_status
 }
 `, template)
 }

--- a/internal/services/dynatrace/dynatrace_monitors_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitors_resource_test.go
@@ -94,7 +94,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = "SystemAssigned"
-  monitoring_enabled        = true
+  monitoring_enabled       = true
   marketplace_subscription = "Active"
 
   user_info {
@@ -125,7 +125,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = "SystemAssigned"
-  monitoring_enabled        = true
+  monitoring_enabled       = true
   marketplace_subscription = "Active"
 
   user_info {
@@ -161,8 +161,8 @@ resource "azurerm_dynatrace_monitors" "import" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = azurerm_dynatrace_monitors.test.identity_type
-  monitoring_enabled        = azurerm_dynatrace_monitors.test.monitoring_enabled
-  marketplace_subscription = azurerm_dynatrace_monitors.test.marketplace_subscription_status
+  monitoring_enabled       = azurerm_dynatrace_monitors.test.monitoring_enabled
+  marketplace_subscription = azurerm_dynatrace_monitors.test.marketplace_subscription
 }
 `, template)
 }

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource.go
@@ -1,0 +1,184 @@
+package dynatrace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type TagRulesResource struct{}
+
+type TagRulesResourceModel struct {
+	Name        string       `tfschema:"name"`
+	Monitor     string       `tfschema:"monitor_id"`
+	LogRules    []LogRule    `tfschema:"log_rules"`
+	MetricRules []MetricRule `tfschema:"metric_rules"`
+}
+
+type MetricRule struct {
+	FilteringTags []FilteringTag `tfschema:"filtering_tag"`
+}
+
+type LogRule struct {
+	FilteringTags        []FilteringTag `tfschema:"filtering_tag"`
+	SendAadLogs          string         `tfschema:"send_aad_logs"`
+	SendActivityLogs     string         `tfschema:"send_activity_logs"`
+	SendSubscriptionLogs string         `tfschema:"send_subscription_logs"`
+}
+
+type FilteringTag struct {
+	Name   string `tfschema:"name"`
+	Value  string `tfschema:"value"`
+	Action string `tfschema:"action"`
+}
+
+func (r TagRulesResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"monitor_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: monitors.ValidateMonitorID,
+		},
+
+		"log_rules": SchemaLogRule(),
+
+		"metric_rules": SchemaMetricRules(),
+	}
+}
+
+func (r TagRulesResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (r TagRulesResource) ModelObject() interface{} {
+	return &TagRulesResourceModel{}
+}
+
+func (r TagRulesResource) ResourceType() string {
+	return "azurerm_dynatrace_tag_rules"
+}
+
+func (r TagRulesResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model TagRulesResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			client := metadata.Client.Dynatrace.TagRulesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			monitorsId, err := monitors.ParseMonitorID(model.Monitor)
+			id := tagrules.NewTagRuleID(subscriptionId, monitorsId.ResourceGroupName, monitorsId.MonitorName, model.Name)
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			tagRulesProps := tagrules.MonitoringTagRulesProperties{
+				LogRules:    ExpandLogRule(model.LogRules),
+				MetricRules: ExpandMetricRules(model.MetricRules),
+			}
+			tagRules := tagrules.TagRule{
+				Name:       &model.Name,
+				Properties: tagRulesProps,
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, tagRules); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r TagRulesResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Dynatrace.TagRulesClient
+			id, err := tagrules.ParseTagRuleID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+			if model := resp.Model; model != nil {
+				props := model.Properties
+				monitorId := monitors.NewMonitorID(id.SubscriptionId, id.ResourceGroupName, id.MonitorName)
+
+				state := TagRulesResourceModel{
+					Name:        id.RuleSetName,
+					Monitor:     monitorId.ID(),
+					LogRules:    FlattenLogRules(props.LogRules),
+					MetricRules: FlattenMetricRules(props.MetricRules),
+				}
+
+				return metadata.Encode(&state)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r TagRulesResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Dynatrace.TagRulesClient
+			id, err := tagrules.ParseTagRuleID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s", *id)
+
+			if resp, err := client.Delete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", *id, err)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (r TagRulesResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return tagrules.ValidateTagRuleID
+}

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource.go
@@ -29,9 +29,9 @@ type MetricRule struct {
 
 type LogRule struct {
 	FilteringTags        []FilteringTag `tfschema:"filtering_tag"`
-	SendAadLogs          string         `tfschema:"send_aad_logs"`
-	SendActivityLogs     string         `tfschema:"send_activity_logs"`
-	SendSubscriptionLogs string         `tfschema:"send_subscription_logs"`
+	SendAadLogs          string         `tfschema:"send_aad_logs_enabled"`
+	SendActivityLogs     string         `tfschema:"send_activity_logs_enabled"`
+	SendSubscriptionLogs string         `tfschema:"send_subscription_logs_enabled"`
 }
 
 type FilteringTag struct {

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource.go
@@ -19,8 +19,8 @@ type TagRulesResource struct{}
 type TagRulesResourceModel struct {
 	Name        string       `tfschema:"name"`
 	Monitor     string       `tfschema:"monitor_id"`
-	LogRules    []LogRule    `tfschema:"log_rules"`
-	MetricRules []MetricRule `tfschema:"metric_rules"`
+	LogRules    []LogRule    `tfschema:"log_rule"`
+	MetricRules []MetricRule `tfschema:"metric_rule"`
 }
 
 type MetricRule struct {
@@ -29,9 +29,9 @@ type MetricRule struct {
 
 type LogRule struct {
 	FilteringTags        []FilteringTag `tfschema:"filtering_tag"`
-	SendAadLogs          string         `tfschema:"send_aad_logs_enabled"`
-	SendActivityLogs     string         `tfschema:"send_activity_logs_enabled"`
-	SendSubscriptionLogs string         `tfschema:"send_subscription_logs_enabled"`
+	SendAadLogs          bool           `tfschema:"send_aad_logs"`
+	SendActivityLogs     bool           `tfschema:"send_activity_logs"`
+	SendSubscriptionLogs bool           `tfschema:"send_subscription_logs"`
 }
 
 type FilteringTag struct {
@@ -56,9 +56,9 @@ func (r TagRulesResource) Arguments() map[string]*schema.Schema {
 			ValidateFunc: monitors.ValidateMonitorID,
 		},
 
-		"log_rules": SchemaLogRule(),
+		"log_rule": SchemaLogRule(),
 
-		"metric_rules": SchemaMetricRules(),
+		"metric_rule": SchemaMetricRules(),
 	}
 }
 

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -121,7 +121,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   identity_type            = "SystemAssigned"
-  monitoring_status        = "Enabled"
+  monitoring_enabled       = true
   marketplace_subscription = "Active"
 
   user_info {

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -77,9 +77,9 @@ resource "azurerm_dynatrace_tag_rules" "test" {
       value  = "Prod"
       action = "Include"
     }
-    send_aad_logs          = "Enabled"
-    send_activity_logs     = "Enabled"
-    send_subscription_logs = "Enabled"
+    send_aad_logs_enabled          = "Enabled"
+    send_activity_logs_enabled     = "Enabled"
+    send_subscription_logs_enabled = "Enabled"
   }
 
   metric_rules {
@@ -117,25 +117,25 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dynatrace_monitors" "test" {
-  name                            = "acctestacc%[2]s"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  identity_type                   = "SystemAssigned"
-  monitoring_status               = "Enabled"
-  marketplace_subscription_status = "Active"
+  name                     = "acctestacc%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  identity_type            = "SystemAssigned"
+  monitoring_status        = "Enabled"
+  marketplace_subscription = "Active"
 
   user_info {
-    first_name    = "Alice"
-    last_name     = "Bobab"
-    email_address = "alice@microsoft.com"
-    phone_number  = "123456"
-    country       = "westus"
+    first_name   = "Alice"
+    last_name    = "Bobab"
+    email        = "alice@microsoft.com"
+    phone_number = "123456"
+    country      = "westus"
   }
 
   plan_data {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
-    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
     effective_date = "2019-08-30T15:14:33Z"
   }
 }

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -71,18 +71,17 @@ resource "azurerm_dynatrace_tag_rules" "test" {
   name       = "default"
   monitor_id = azurerm_dynatrace_monitors.test.id
 
-  log_rules {
+  log_rule {
     filtering_tag {
       name   = "Environment"
       value  = "Prod"
       action = "Include"
     }
-    send_aad_logs_enabled          = "Enabled"
-    send_activity_logs_enabled     = "Enabled"
-    send_subscription_logs_enabled = "Enabled"
+    send_aad_logs      = true
+    send_activity_logs = true
   }
 
-  metric_rules {
+  metric_rule {
     filtering_tag {
       name   = "Environment"
       value  = "Prod"
@@ -124,7 +123,7 @@ resource "azurerm_dynatrace_monitors" "test" {
   monitoring_enabled       = true
   marketplace_subscription = "Active"
 
-  user_info {
+  user {
     first_name   = "Alice"
     last_name    = "Bobab"
     email        = "alice@microsoft.com"
@@ -132,7 +131,7 @@ resource "azurerm_dynatrace_monitors" "test" {
     country      = "westus"
   }
 
-  plan_data {
+  plan {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
     plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -1,0 +1,143 @@
+package dynatrace_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type TagRulesResource struct{}
+
+func TestAccDynatraceTagRules_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dynatrace_tag_rules", "test")
+	r := TagRulesResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDynatraceTagRules_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dynatrace_tag_rules", "test")
+	r := TagRulesResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r TagRulesResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := tagrules.ParseTagRuleID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Dynatrace.TagRulesClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r TagRulesResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_dynatrace_tag_rules" "test" {
+  name       = "default"
+  monitor_id = azurerm_dynatrace_monitors.test.id
+
+  log_rules {
+    filtering_tag {
+      name   = "Environment"
+      value  = "Prod"
+      action = "Include"
+    }
+    send_aad_logs          = "Enabled"
+    send_activity_logs     = "Enabled"
+    send_subscription_logs = "Enabled"
+  }
+
+  metric_rules {
+    filtering_tag {
+      name   = "Environment"
+      value  = "Prod"
+      action = "Include"
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r TagRulesResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dynatrace_tag_rules" "import" {
+  name       = azurerm_dynatrace_tag_rules.test.name
+  monitor_id = azurerm_dynatrace_tag_rules.test.monitor_id
+}
+`, template)
+}
+
+func (r TagRulesResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_dynatrace_monitors" "test" {
+  name                            = "acctestacc%[2]s"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = "SystemAssigned"
+  monitoring_status               = "Enabled"
+  marketplace_subscription_status = "Active"
+
+  user_info {
+    first_name    = "Alice"
+    last_name     = "Bobab"
+    email_address = "alice@microsoft.com"
+    phone_number  = "123456"
+    country       = "westus"
+  }
+
+  plan_data {
+    usage_type     = "COMMITTED"
+    billing_cycle  = "MONTHLY"
+    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    effective_date = "2019-08-30T15:14:33Z"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/dynatrace/helper.go
+++ b/internal/services/dynatrace/helper.go
@@ -31,7 +31,7 @@ func SchemaPlanData() *pluginsdk.Schema {
 					ValidateFunc: validation.IsRFC3339Time,
 				},
 
-				"plan_details": {
+				"plan": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
@@ -64,7 +64,7 @@ func SchemaUserInfo() *pluginsdk.Schema {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
-				"email_address": {
+				"email": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
@@ -133,7 +133,7 @@ func SchemaLogRule() *pluginsdk.Schema {
 			Schema: map[string]*schema.Schema{
 				"filtering_tag": SchemaFilteringTag(),
 
-				"send_aad_logs": {
+				"send_aad_logs_enabled": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -142,7 +142,7 @@ func SchemaLogRule() *pluginsdk.Schema {
 					}, false),
 				},
 
-				"send_activity_logs": {
+				"send_activity_logs_enabled": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -151,7 +151,7 @@ func SchemaLogRule() *pluginsdk.Schema {
 					}, false),
 				},
 
-				"send_subscription_logs": {
+				"send_subscription_logs_enabled": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -295,7 +295,7 @@ func FlattenDynatraceUserInfo(input []interface{}) []UserInfo {
 	v := input[0].(map[string]interface{})
 
 	country := v["country"].(string)
-	emailAddress := v["email_address"].(string)
+	emailAddress := v["email"].(string)
 	firstName := v["first_name"].(string)
 	lastName := v["last_name"].(string)
 	phoneNumber := v["phone_number"].(string)

--- a/internal/services/dynatrace/helper.go
+++ b/internal/services/dynatrace/helper.go
@@ -1,0 +1,398 @@
+package dynatrace
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func SchemaPlanData() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"billing_cycle": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"MONTHLY",
+						"WEEKLY",
+					}, false),
+				},
+
+				"effective_date": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.IsRFC3339Time,
+				},
+
+				"plan_details": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"usage_type": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"PAYG",
+						"COMMITTED",
+					}, false),
+				},
+			},
+		},
+	}
+}
+
+func SchemaUserInfo() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"country": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"email_address": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"first_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"last_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"phone_number": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func SchemaFilteringTag() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Include",
+						"Exclude",
+					}, false),
+				},
+
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"value": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func SchemaLogRule() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"filtering_tag": SchemaFilteringTag(),
+
+				"send_aad_logs": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Enabled",
+						"Disabled",
+					}, false),
+				},
+
+				"send_activity_logs": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Enabled",
+						"Disabled",
+					}, false),
+				},
+
+				"send_subscription_logs": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Enabled",
+						"Disabled",
+					}, false),
+				},
+			},
+		},
+	}
+}
+
+func SchemaMetricRules() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"filtering_tag": SchemaFilteringTag(),
+			},
+		},
+	}
+}
+
+func ExpandFilteringTag(input []FilteringTag) *[]tagrules.FilteringTag {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+	action := tagrules.TagAction(v.Action)
+
+	return &[]tagrules.FilteringTag{
+		{
+			Action: &action,
+			Name:   &v.Name,
+			Value:  &v.Value,
+		},
+	}
+}
+
+func ExpandLogRule(input []LogRule) *tagrules.LogRules {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+	sendAadLogs := tagrules.SendAadLogsStatus(v.SendAadLogs)
+	sendActivityLogs := tagrules.SendActivityLogsStatus(v.SendActivityLogs)
+	sendSubscriptionLogs := tagrules.SendSubscriptionLogsStatus(v.SendSubscriptionLogs)
+
+	return &tagrules.LogRules{
+		FilteringTags:        ExpandFilteringTag(v.FilteringTags),
+		SendAadLogs:          &sendAadLogs,
+		SendActivityLogs:     &sendActivityLogs,
+		SendSubscriptionLogs: &sendSubscriptionLogs,
+	}
+}
+
+func ExpandMetricRules(input []MetricRule) *tagrules.MetricRules {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+
+	return &tagrules.MetricRules{
+		FilteringTags: ExpandFilteringTag(v.FilteringTags),
+	}
+}
+
+func ExpandDynatracePlanData(input []PlanData) *monitors.PlanData {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+
+	return &monitors.PlanData{
+		BillingCycle:  &v.BillingCycle,
+		EffectiveDate: &v.EffectiveDate,
+		PlanDetails:   &v.PlanDetails,
+		UsageType:     &v.UsageType,
+	}
+}
+
+func ExpandDynatraceUserInfo(input []UserInfo) *monitors.UserInfo {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+
+	return &monitors.UserInfo{
+		Country:      &v.Country,
+		EmailAddress: &v.EmailAddress,
+		FirstName:    &v.FirstName,
+		LastName:     &v.LastName,
+		PhoneNumber:  &v.PhoneNumber,
+	}
+}
+
+func FlattenDynatracePlanData(input *monitors.PlanData) []PlanData {
+	if input == nil {
+		return []PlanData{}
+	}
+
+	var billingCycle string
+	var effectiveDate string
+	var planDetails string
+	var usageType string
+
+	if input.BillingCycle != nil {
+		billingCycle = *input.BillingCycle
+	}
+
+	if input.EffectiveDate != nil {
+		effectiveDate = *input.EffectiveDate
+	}
+
+	if input.PlanDetails != nil {
+		planDetails = *input.PlanDetails
+	}
+
+	if input.UsageType != nil {
+		usageType = *input.UsageType
+	}
+
+	return []PlanData{
+		{
+			BillingCycle:  billingCycle,
+			EffectiveDate: effectiveDate,
+			PlanDetails:   planDetails,
+			UsageType:     usageType,
+		},
+	}
+}
+
+func FlattenDynatraceUserInfo(input []interface{}) []UserInfo {
+	if input == nil || len(input) == 0 {
+		return []UserInfo{}
+	}
+
+	v := input[0].(map[string]interface{})
+
+	country := v["country"].(string)
+	emailAddress := v["email_address"].(string)
+	firstName := v["first_name"].(string)
+	lastName := v["last_name"].(string)
+	phoneNumber := v["phone_number"].(string)
+
+	return []UserInfo{
+		{
+			Country:      country,
+			EmailAddress: emailAddress,
+			FirstName:    firstName,
+			LastName:     lastName,
+			PhoneNumber:  phoneNumber,
+		},
+	}
+}
+
+func FlattenFilteringTags(input *[]tagrules.FilteringTag) []FilteringTag {
+	if input == nil || len(*input) == 0 {
+		return []FilteringTag{}
+	}
+
+	var name string
+	var value string
+	var action string
+	tags := *input
+	v := tags[0]
+
+	if v.Name != nil {
+		name = *v.Name
+	}
+
+	if v.Value != nil {
+		value = *v.Value
+	}
+
+	if v.Action != nil {
+		action = string(*v.Action)
+	}
+
+	return []FilteringTag{
+		{
+			Name:   name,
+			Value:  value,
+			Action: action,
+		},
+	}
+}
+
+func FlattenLogRules(input *tagrules.LogRules) []LogRule {
+	if input == nil {
+		return []LogRule{}
+	}
+
+	var filteringTags []FilteringTag
+	var sendAadLogs string
+	var sendActivityLogs string
+	var sendSubscriptionLogs string
+
+	if input.FilteringTags != nil {
+		filteringTags = FlattenFilteringTags(input.FilteringTags)
+	}
+
+	if input.SendActivityLogs != nil {
+		sendActivityLogs = string(*input.SendActivityLogs)
+	}
+
+	if input.SendAadLogs != nil {
+		sendAadLogs = string(*input.SendAadLogs)
+	}
+
+	if input.SendSubscriptionLogs != nil {
+		sendSubscriptionLogs = string(*input.SendSubscriptionLogs)
+	}
+
+	return []LogRule{
+		{
+			FilteringTags:        filteringTags,
+			SendAadLogs:          sendAadLogs,
+			SendActivityLogs:     sendActivityLogs,
+			SendSubscriptionLogs: sendSubscriptionLogs,
+		},
+	}
+}
+
+func FlattenMetricRules(input *tagrules.MetricRules) []MetricRule {
+	if input == nil {
+		return []MetricRule{}
+	}
+
+	var filteringTags []FilteringTag
+
+	if input.FilteringTags != nil {
+		filteringTags = FlattenFilteringTags(input.FilteringTags)
+	}
+
+	return []MetricRule{
+		{
+			FilteringTags: filteringTags,
+		},
+	}
+}

--- a/internal/services/dynatrace/registration.go
+++ b/internal/services/dynatrace/registration.go
@@ -1,0 +1,32 @@
+package dynatrace
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type Registration struct{}
+
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/dynatrace"
+}
+
+func (r Registration) Name() string {
+	return "Dynatrace"
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		MonitorsResource{},
+		TagRulesResource{},
+	}
+}
+
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Dynatrace",
+	}
+}

--- a/internal/services/serviceconnector/service_connector_app_service_resource_test.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource_test.go
@@ -29,6 +29,7 @@ func (r ServiceConnectorAppServiceResource) Exists(ctx context.Context, client *
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
+
 	return utils.Bool(true), nil
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/README.md
@@ -1,0 +1,246 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors` Documentation
+
+The `monitors` SDK allows for interaction with the Azure Resource Manager Service `dynatrace` (API Version `2021-09-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors"
+```
+
+
+### Client Initialization
+
+```go
+client := monitors.NewMonitorsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `MonitorsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+payload := monitors.MonitorResource{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `MonitorsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `MonitorsClient.Get`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MonitorsClient.GetAccountCredentials`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+read, err := client.GetAccountCredentials(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MonitorsClient.GetSSODetails`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+payload := monitors.SSODetailsRequest{
+	// ...
+}
+
+
+read, err := client.GetSSODetails(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MonitorsClient.GetVMHostPayload`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+read, err := client.GetVMHostPayload(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListAppServices`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+// alternatively `client.ListAppServices(ctx, id)` can be used to do batched pagination
+items, err := client.ListAppServicesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := monitors.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListBySubscriptionId`
+
+```go
+ctx := context.TODO()
+id := monitors.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscriptionId(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionIdComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListHosts`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+// alternatively `client.ListHosts(ctx, id)` can be used to do batched pagination
+items, err := client.ListHostsComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListLinkableEnvironments`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+payload := monitors.LinkableEnvironmentRequest{
+	// ...
+}
+
+
+// alternatively `client.ListLinkableEnvironments(ctx, id, payload)` can be used to do batched pagination
+items, err := client.ListLinkableEnvironmentsComplete(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.ListMonitoredResources`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+// alternatively `client.ListMonitoredResources(ctx, id)` can be used to do batched pagination
+items, err := client.ListMonitoredResourcesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MonitorsClient.Update`
+
+```go
+ctx := context.TODO()
+id := monitors.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+payload := monitors.MonitorResourceUpdate{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/client.go
@@ -1,0 +1,18 @@
+package monitors
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitorsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewMonitorsClientWithBaseURI(endpoint string) MonitorsClient {
+	return MonitorsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/constants.go
@@ -1,0 +1,467 @@
+package monitors
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutoUpdateSetting string
+
+const (
+	AutoUpdateSettingDISABLED AutoUpdateSetting = "DISABLED"
+	AutoUpdateSettingENABLED  AutoUpdateSetting = "ENABLED"
+)
+
+func PossibleValuesForAutoUpdateSetting() []string {
+	return []string{
+		string(AutoUpdateSettingDISABLED),
+		string(AutoUpdateSettingENABLED),
+	}
+}
+
+func parseAutoUpdateSetting(input string) (*AutoUpdateSetting, error) {
+	vals := map[string]AutoUpdateSetting{
+		"disabled": AutoUpdateSettingDISABLED,
+		"enabled":  AutoUpdateSettingENABLED,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutoUpdateSetting(input)
+	return &out, nil
+}
+
+type AvailabilityState string
+
+const (
+	AvailabilityStateCRASHED            AvailabilityState = "CRASHED"
+	AvailabilityStateLOST               AvailabilityState = "LOST"
+	AvailabilityStateMONITORED          AvailabilityState = "MONITORED"
+	AvailabilityStatePREMONITORED       AvailabilityState = "PRE_MONITORED"
+	AvailabilityStateSHUTDOWN           AvailabilityState = "SHUTDOWN"
+	AvailabilityStateUNEXPECTEDSHUTDOWN AvailabilityState = "UNEXPECTED_SHUTDOWN"
+	AvailabilityStateUNKNOWN            AvailabilityState = "UNKNOWN"
+	AvailabilityStateUNMONITORED        AvailabilityState = "UNMONITORED"
+)
+
+func PossibleValuesForAvailabilityState() []string {
+	return []string{
+		string(AvailabilityStateCRASHED),
+		string(AvailabilityStateLOST),
+		string(AvailabilityStateMONITORED),
+		string(AvailabilityStatePREMONITORED),
+		string(AvailabilityStateSHUTDOWN),
+		string(AvailabilityStateUNEXPECTEDSHUTDOWN),
+		string(AvailabilityStateUNKNOWN),
+		string(AvailabilityStateUNMONITORED),
+	}
+}
+
+func parseAvailabilityState(input string) (*AvailabilityState, error) {
+	vals := map[string]AvailabilityState{
+		"crashed":             AvailabilityStateCRASHED,
+		"lost":                AvailabilityStateLOST,
+		"monitored":           AvailabilityStateMONITORED,
+		"pre_monitored":       AvailabilityStatePREMONITORED,
+		"shutdown":            AvailabilityStateSHUTDOWN,
+		"unexpected_shutdown": AvailabilityStateUNEXPECTEDSHUTDOWN,
+		"unknown":             AvailabilityStateUNKNOWN,
+		"unmonitored":         AvailabilityStateUNMONITORED,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AvailabilityState(input)
+	return &out, nil
+}
+
+type LiftrResourceCategories string
+
+const (
+	LiftrResourceCategoriesMonitorLogs LiftrResourceCategories = "MonitorLogs"
+	LiftrResourceCategoriesUnknown     LiftrResourceCategories = "Unknown"
+)
+
+func PossibleValuesForLiftrResourceCategories() []string {
+	return []string{
+		string(LiftrResourceCategoriesMonitorLogs),
+		string(LiftrResourceCategoriesUnknown),
+	}
+}
+
+func parseLiftrResourceCategories(input string) (*LiftrResourceCategories, error) {
+	vals := map[string]LiftrResourceCategories{
+		"monitorlogs": LiftrResourceCategoriesMonitorLogs,
+		"unknown":     LiftrResourceCategoriesUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LiftrResourceCategories(input)
+	return &out, nil
+}
+
+type LogModule string
+
+const (
+	LogModuleDISABLED LogModule = "DISABLED"
+	LogModuleENABLED  LogModule = "ENABLED"
+)
+
+func PossibleValuesForLogModule() []string {
+	return []string{
+		string(LogModuleDISABLED),
+		string(LogModuleENABLED),
+	}
+}
+
+func parseLogModule(input string) (*LogModule, error) {
+	vals := map[string]LogModule{
+		"disabled": LogModuleDISABLED,
+		"enabled":  LogModuleENABLED,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LogModule(input)
+	return &out, nil
+}
+
+type ManagedIdentityType string
+
+const (
+	ManagedIdentityTypeSystemAndUserAssigned ManagedIdentityType = "SystemAndUserAssigned"
+	ManagedIdentityTypeSystemAssigned        ManagedIdentityType = "SystemAssigned"
+	ManagedIdentityTypeUserAssigned          ManagedIdentityType = "UserAssigned"
+)
+
+func PossibleValuesForManagedIdentityType() []string {
+	return []string{
+		string(ManagedIdentityTypeSystemAndUserAssigned),
+		string(ManagedIdentityTypeSystemAssigned),
+		string(ManagedIdentityTypeUserAssigned),
+	}
+}
+
+func parseManagedIdentityType(input string) (*ManagedIdentityType, error) {
+	vals := map[string]ManagedIdentityType{
+		"systemanduserassigned": ManagedIdentityTypeSystemAndUserAssigned,
+		"systemassigned":        ManagedIdentityTypeSystemAssigned,
+		"userassigned":          ManagedIdentityTypeUserAssigned,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedIdentityType(input)
+	return &out, nil
+}
+
+type MarketplaceSubscriptionStatus string
+
+const (
+	MarketplaceSubscriptionStatusActive    MarketplaceSubscriptionStatus = "Active"
+	MarketplaceSubscriptionStatusSuspended MarketplaceSubscriptionStatus = "Suspended"
+)
+
+func PossibleValuesForMarketplaceSubscriptionStatus() []string {
+	return []string{
+		string(MarketplaceSubscriptionStatusActive),
+		string(MarketplaceSubscriptionStatusSuspended),
+	}
+}
+
+func parseMarketplaceSubscriptionStatus(input string) (*MarketplaceSubscriptionStatus, error) {
+	vals := map[string]MarketplaceSubscriptionStatus{
+		"active":    MarketplaceSubscriptionStatusActive,
+		"suspended": MarketplaceSubscriptionStatusSuspended,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MarketplaceSubscriptionStatus(input)
+	return &out, nil
+}
+
+type MonitoringStatus string
+
+const (
+	MonitoringStatusDisabled MonitoringStatus = "Disabled"
+	MonitoringStatusEnabled  MonitoringStatus = "Enabled"
+)
+
+func PossibleValuesForMonitoringStatus() []string {
+	return []string{
+		string(MonitoringStatusDisabled),
+		string(MonitoringStatusEnabled),
+	}
+}
+
+func parseMonitoringStatus(input string) (*MonitoringStatus, error) {
+	vals := map[string]MonitoringStatus{
+		"disabled": MonitoringStatusDisabled,
+		"enabled":  MonitoringStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MonitoringStatus(input)
+	return &out, nil
+}
+
+type MonitoringType string
+
+const (
+	MonitoringTypeCLOUDINFRASTRUCTURE MonitoringType = "CLOUD_INFRASTRUCTURE"
+	MonitoringTypeFULLSTACK           MonitoringType = "FULL_STACK"
+)
+
+func PossibleValuesForMonitoringType() []string {
+	return []string{
+		string(MonitoringTypeCLOUDINFRASTRUCTURE),
+		string(MonitoringTypeFULLSTACK),
+	}
+}
+
+func parseMonitoringType(input string) (*MonitoringType, error) {
+	vals := map[string]MonitoringType{
+		"cloud_infrastructure": MonitoringTypeCLOUDINFRASTRUCTURE,
+		"full_stack":           MonitoringTypeFULLSTACK,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MonitoringType(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateAccepted     ProvisioningState = "Accepted"
+	ProvisioningStateCanceled     ProvisioningState = "Canceled"
+	ProvisioningStateCreating     ProvisioningState = "Creating"
+	ProvisioningStateDeleted      ProvisioningState = "Deleted"
+	ProvisioningStateDeleting     ProvisioningState = "Deleting"
+	ProvisioningStateFailed       ProvisioningState = "Failed"
+	ProvisioningStateNotSpecified ProvisioningState = "NotSpecified"
+	ProvisioningStateSucceeded    ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating     ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateAccepted),
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleted),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateNotSpecified),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"accepted":     ProvisioningStateAccepted,
+		"canceled":     ProvisioningStateCanceled,
+		"creating":     ProvisioningStateCreating,
+		"deleted":      ProvisioningStateDeleted,
+		"deleting":     ProvisioningStateDeleting,
+		"failed":       ProvisioningStateFailed,
+		"notspecified": ProvisioningStateNotSpecified,
+		"succeeded":    ProvisioningStateSucceeded,
+		"updating":     ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type SSOStatus string
+
+const (
+	SSOStatusDisabled SSOStatus = "Disabled"
+	SSOStatusEnabled  SSOStatus = "Enabled"
+)
+
+func PossibleValuesForSSOStatus() []string {
+	return []string{
+		string(SSOStatusDisabled),
+		string(SSOStatusEnabled),
+	}
+}
+
+func parseSSOStatus(input string) (*SSOStatus, error) {
+	vals := map[string]SSOStatus{
+		"disabled": SSOStatusDisabled,
+		"enabled":  SSOStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SSOStatus(input)
+	return &out, nil
+}
+
+type SendingLogsStatus string
+
+const (
+	SendingLogsStatusDisabled SendingLogsStatus = "Disabled"
+	SendingLogsStatusEnabled  SendingLogsStatus = "Enabled"
+)
+
+func PossibleValuesForSendingLogsStatus() []string {
+	return []string{
+		string(SendingLogsStatusDisabled),
+		string(SendingLogsStatusEnabled),
+	}
+}
+
+func parseSendingLogsStatus(input string) (*SendingLogsStatus, error) {
+	vals := map[string]SendingLogsStatus{
+		"disabled": SendingLogsStatusDisabled,
+		"enabled":  SendingLogsStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SendingLogsStatus(input)
+	return &out, nil
+}
+
+type SendingMetricsStatus string
+
+const (
+	SendingMetricsStatusDisabled SendingMetricsStatus = "Disabled"
+	SendingMetricsStatusEnabled  SendingMetricsStatus = "Enabled"
+)
+
+func PossibleValuesForSendingMetricsStatus() []string {
+	return []string{
+		string(SendingMetricsStatusDisabled),
+		string(SendingMetricsStatusEnabled),
+	}
+}
+
+func parseSendingMetricsStatus(input string) (*SendingMetricsStatus, error) {
+	vals := map[string]SendingMetricsStatus{
+		"disabled": SendingMetricsStatusDisabled,
+		"enabled":  SendingMetricsStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SendingMetricsStatus(input)
+	return &out, nil
+}
+
+type SingleSignOnStates string
+
+const (
+	SingleSignOnStatesDisable  SingleSignOnStates = "Disable"
+	SingleSignOnStatesEnable   SingleSignOnStates = "Enable"
+	SingleSignOnStatesExisting SingleSignOnStates = "Existing"
+	SingleSignOnStatesInitial  SingleSignOnStates = "Initial"
+)
+
+func PossibleValuesForSingleSignOnStates() []string {
+	return []string{
+		string(SingleSignOnStatesDisable),
+		string(SingleSignOnStatesEnable),
+		string(SingleSignOnStatesExisting),
+		string(SingleSignOnStatesInitial),
+	}
+}
+
+func parseSingleSignOnStates(input string) (*SingleSignOnStates, error) {
+	vals := map[string]SingleSignOnStates{
+		"disable":  SingleSignOnStatesDisable,
+		"enable":   SingleSignOnStatesEnable,
+		"existing": SingleSignOnStatesExisting,
+		"initial":  SingleSignOnStatesInitial,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SingleSignOnStates(input)
+	return &out, nil
+}
+
+type UpdateStatus string
+
+const (
+	UpdateStatusINCOMPATIBLE     UpdateStatus = "INCOMPATIBLE"
+	UpdateStatusOUTDATED         UpdateStatus = "OUTDATED"
+	UpdateStatusSCHEDULED        UpdateStatus = "SCHEDULED"
+	UpdateStatusSUPPRESSED       UpdateStatus = "SUPPRESSED"
+	UpdateStatusUNKNOWN          UpdateStatus = "UNKNOWN"
+	UpdateStatusUPDATEINPROGRESS UpdateStatus = "UPDATE_IN_PROGRESS"
+	UpdateStatusUPDATEPENDING    UpdateStatus = "UPDATE_PENDING"
+	UpdateStatusUPDATEPROBLEM    UpdateStatus = "UPDATE_PROBLEM"
+	UpdateStatusUPTwoDATE        UpdateStatus = "UP2DATE"
+)
+
+func PossibleValuesForUpdateStatus() []string {
+	return []string{
+		string(UpdateStatusINCOMPATIBLE),
+		string(UpdateStatusOUTDATED),
+		string(UpdateStatusSCHEDULED),
+		string(UpdateStatusSUPPRESSED),
+		string(UpdateStatusUNKNOWN),
+		string(UpdateStatusUPDATEINPROGRESS),
+		string(UpdateStatusUPDATEPENDING),
+		string(UpdateStatusUPDATEPROBLEM),
+		string(UpdateStatusUPTwoDATE),
+	}
+}
+
+func parseUpdateStatus(input string) (*UpdateStatus, error) {
+	vals := map[string]UpdateStatus{
+		"incompatible":       UpdateStatusINCOMPATIBLE,
+		"outdated":           UpdateStatusOUTDATED,
+		"scheduled":          UpdateStatusSCHEDULED,
+		"suppressed":         UpdateStatusSUPPRESSED,
+		"unknown":            UpdateStatusUNKNOWN,
+		"update_in_progress": UpdateStatusUPDATEINPROGRESS,
+		"update_pending":     UpdateStatusUPDATEPENDING,
+		"update_problem":     UpdateStatusUPDATEPROBLEM,
+		"up2date":            UpdateStatusUPTwoDATE,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UpdateStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/id_monitor.go
@@ -1,0 +1,124 @@
+package monitors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = MonitorId{}
+
+// MonitorId is a struct representing the Resource ID for a Monitor
+type MonitorId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	MonitorName       string
+}
+
+// NewMonitorID returns a new MonitorId struct
+func NewMonitorID(subscriptionId string, resourceGroupName string, monitorName string) MonitorId {
+	return MonitorId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		MonitorName:       monitorName,
+	}
+}
+
+// ParseMonitorID parses 'input' into a MonitorId
+func ParseMonitorID(input string) (*MonitorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MonitorId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MonitorId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseMonitorIDInsensitively parses 'input' case-insensitively into a MonitorId
+// note: this method should only be used for API response data and not user input
+func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MonitorId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MonitorId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateMonitorID checks that 'input' can be parsed as a Monitor ID
+func ValidateMonitorID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMonitorID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Monitor ID
+func (id MonitorId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Dynatrace.Observability/monitors/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.MonitorName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Monitor ID
+func (id MonitorId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticDynatraceObservability", "Dynatrace.Observability", "Dynatrace.Observability"),
+		resourceids.StaticSegment("staticMonitors", "monitors", "monitors"),
+		resourceids.UserSpecifiedSegment("monitorName", "monitorValue"),
+	}
+}
+
+// String returns a human-readable description of this Monitor ID
+func (id MonitorId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Monitor Name: %q", id.MonitorName),
+	}
+	return fmt.Sprintf("Monitor (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_createorupdate_autorest.go
@@ -1,0 +1,79 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c MonitorsClient) CreateOrUpdate(ctx context.Context, id MonitorId, input MonitorResource) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c MonitorsClient) CreateOrUpdateThenPoll(ctx context.Context, id MonitorId, input MonitorResource) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c MonitorsClient) preparerForCreateOrUpdate(ctx context.Context, id MonitorId, input MonitorResource) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c MonitorsClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c MonitorsClient) Delete(ctx context.Context, id MonitorId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c MonitorsClient) DeleteThenPoll(ctx context.Context, id MonitorId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c MonitorsClient) preparerForDelete(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c MonitorsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_get_autorest.go
@@ -1,0 +1,68 @@
+package monitors
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *MonitorResource
+}
+
+// Get ...
+func (c MonitorsClient) Get(ctx context.Context, id MonitorId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c MonitorsClient) preparerForGet(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getaccountcredentials_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getaccountcredentials_autorest.go
@@ -1,0 +1,69 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetAccountCredentialsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *AccountInfoSecure
+}
+
+// GetAccountCredentials ...
+func (c MonitorsClient) GetAccountCredentials(ctx context.Context, id MonitorId) (result GetAccountCredentialsOperationResponse, err error) {
+	req, err := c.preparerForGetAccountCredentials(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetAccountCredentials", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetAccountCredentials", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGetAccountCredentials(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetAccountCredentials", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGetAccountCredentials prepares the GetAccountCredentials request.
+func (c MonitorsClient) preparerForGetAccountCredentials(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/getAccountCredentials", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGetAccountCredentials handles the response to the GetAccountCredentials request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForGetAccountCredentials(resp *http.Response) (result GetAccountCredentialsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getssodetails_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getssodetails_autorest.go
@@ -1,0 +1,70 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetSSODetailsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *SSODetailsResponse
+}
+
+// GetSSODetails ...
+func (c MonitorsClient) GetSSODetails(ctx context.Context, id MonitorId, input SSODetailsRequest) (result GetSSODetailsOperationResponse, err error) {
+	req, err := c.preparerForGetSSODetails(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetSSODetails", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetSSODetails", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGetSSODetails(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetSSODetails", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGetSSODetails prepares the GetSSODetails request.
+func (c MonitorsClient) preparerForGetSSODetails(ctx context.Context, id MonitorId, input SSODetailsRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/getSSODetails", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGetSSODetails handles the response to the GetSSODetails request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForGetSSODetails(resp *http.Response) (result GetSSODetailsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getvmhostpayload_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_getvmhostpayload_autorest.go
@@ -1,0 +1,69 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetVMHostPayloadOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *VMExtensionPayload
+}
+
+// GetVMHostPayload ...
+func (c MonitorsClient) GetVMHostPayload(ctx context.Context, id MonitorId) (result GetVMHostPayloadOperationResponse, err error) {
+	req, err := c.preparerForGetVMHostPayload(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetVMHostPayload", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetVMHostPayload", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGetVMHostPayload(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "GetVMHostPayload", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGetVMHostPayload prepares the GetVMHostPayload request.
+func (c MonitorsClient) preparerForGetVMHostPayload(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/getVMHostPayload", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGetVMHostPayload handles the response to the GetVMHostPayload request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForGetVMHostPayload(resp *http.Response) (result GetVMHostPayloadOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listappservices_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listappservices_autorest.go
@@ -1,0 +1,186 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListAppServicesOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]AppServiceInfo
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListAppServicesOperationResponse, error)
+}
+
+type ListAppServicesCompleteResult struct {
+	Items []AppServiceInfo
+}
+
+func (r ListAppServicesOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListAppServicesOperationResponse) LoadMore(ctx context.Context) (resp ListAppServicesOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListAppServices ...
+func (c MonitorsClient) ListAppServices(ctx context.Context, id MonitorId) (resp ListAppServicesOperationResponse, err error) {
+	req, err := c.preparerForListAppServices(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListAppServices(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListAppServices prepares the ListAppServices request.
+func (c MonitorsClient) preparerForListAppServices(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listAppServices", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListAppServicesWithNextLink prepares the ListAppServices request with the given nextLink token.
+func (c MonitorsClient) preparerForListAppServicesWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListAppServices handles the response to the ListAppServices request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListAppServices(resp *http.Response) (result ListAppServicesOperationResponse, err error) {
+	type page struct {
+		Values   []AppServiceInfo `json:"value"`
+		NextLink *string          `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListAppServicesOperationResponse, err error) {
+			req, err := c.preparerForListAppServicesWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListAppServices(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListAppServices", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListAppServicesComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListAppServicesComplete(ctx context.Context, id MonitorId) (ListAppServicesCompleteResult, error) {
+	return c.ListAppServicesCompleteMatchingPredicate(ctx, id, AppServiceInfoOperationPredicate{})
+}
+
+// ListAppServicesCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListAppServicesCompleteMatchingPredicate(ctx context.Context, id MonitorId, predicate AppServiceInfoOperationPredicate) (resp ListAppServicesCompleteResult, err error) {
+	items := make([]AppServiceInfo, 0)
+
+	page, err := c.ListAppServices(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListAppServicesCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]MonitorResource
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByResourceGroupOperationResponse, error)
+}
+
+type ListByResourceGroupCompleteResult struct {
+	Items []MonitorResource
+}
+
+func (r ListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp ListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByResourceGroup ...
+func (c MonitorsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp ListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c MonitorsClient) preparerForListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Dynatrace.Observability/monitors", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByResourceGroupWithNextLink prepares the ListByResourceGroup request with the given nextLink token.
+func (c MonitorsClient) preparerForListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []MonitorResource `json:"value"`
+		NextLink *string           `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByResourceGroupComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, MonitorResourceOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate MonitorResourceOperationPredicate) (resp ListByResourceGroupCompleteResult, err error) {
+	items := make([]MonitorResource, 0)
+
+	page, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listbysubscriptionid_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listbysubscriptionid_autorest.go
@@ -1,0 +1,187 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionIdOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]MonitorResource
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListBySubscriptionIdOperationResponse, error)
+}
+
+type ListBySubscriptionIdCompleteResult struct {
+	Items []MonitorResource
+}
+
+func (r ListBySubscriptionIdOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListBySubscriptionIdOperationResponse) LoadMore(ctx context.Context) (resp ListBySubscriptionIdOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListBySubscriptionId ...
+func (c MonitorsClient) ListBySubscriptionId(ctx context.Context, id commonids.SubscriptionId) (resp ListBySubscriptionIdOperationResponse, err error) {
+	req, err := c.preparerForListBySubscriptionId(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListBySubscriptionId(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListBySubscriptionId prepares the ListBySubscriptionId request.
+func (c MonitorsClient) preparerForListBySubscriptionId(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Dynatrace.Observability/monitors", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListBySubscriptionIdWithNextLink prepares the ListBySubscriptionId request with the given nextLink token.
+func (c MonitorsClient) preparerForListBySubscriptionIdWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListBySubscriptionId handles the response to the ListBySubscriptionId request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListBySubscriptionId(resp *http.Response) (result ListBySubscriptionIdOperationResponse, err error) {
+	type page struct {
+		Values   []MonitorResource `json:"value"`
+		NextLink *string           `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListBySubscriptionIdOperationResponse, err error) {
+			req, err := c.preparerForListBySubscriptionIdWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListBySubscriptionId(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListBySubscriptionId", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListBySubscriptionIdComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListBySubscriptionIdComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionIdCompleteResult, error) {
+	return c.ListBySubscriptionIdCompleteMatchingPredicate(ctx, id, MonitorResourceOperationPredicate{})
+}
+
+// ListBySubscriptionIdCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListBySubscriptionIdCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate MonitorResourceOperationPredicate) (resp ListBySubscriptionIdCompleteResult, err error) {
+	items := make([]MonitorResource, 0)
+
+	page, err := c.ListBySubscriptionId(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListBySubscriptionIdCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listhosts_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listhosts_autorest.go
@@ -1,0 +1,186 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListHostsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]VMInfo
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListHostsOperationResponse, error)
+}
+
+type ListHostsCompleteResult struct {
+	Items []VMInfo
+}
+
+func (r ListHostsOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListHostsOperationResponse) LoadMore(ctx context.Context) (resp ListHostsOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListHosts ...
+func (c MonitorsClient) ListHosts(ctx context.Context, id MonitorId) (resp ListHostsOperationResponse, err error) {
+	req, err := c.preparerForListHosts(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListHosts(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListHosts prepares the ListHosts request.
+func (c MonitorsClient) preparerForListHosts(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listHosts", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListHostsWithNextLink prepares the ListHosts request with the given nextLink token.
+func (c MonitorsClient) preparerForListHostsWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListHosts handles the response to the ListHosts request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListHosts(resp *http.Response) (result ListHostsOperationResponse, err error) {
+	type page struct {
+		Values   []VMInfo `json:"value"`
+		NextLink *string  `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListHostsOperationResponse, err error) {
+			req, err := c.preparerForListHostsWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListHosts(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListHosts", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListHostsComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListHostsComplete(ctx context.Context, id MonitorId) (ListHostsCompleteResult, error) {
+	return c.ListHostsCompleteMatchingPredicate(ctx, id, VMInfoOperationPredicate{})
+}
+
+// ListHostsCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListHostsCompleteMatchingPredicate(ctx context.Context, id MonitorId, predicate VMInfoOperationPredicate) (resp ListHostsCompleteResult, err error) {
+	items := make([]VMInfo, 0)
+
+	page, err := c.ListHosts(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListHostsCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listlinkableenvironments_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listlinkableenvironments_autorest.go
@@ -1,0 +1,187 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListLinkableEnvironmentsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]LinkableEnvironmentResponse
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListLinkableEnvironmentsOperationResponse, error)
+}
+
+type ListLinkableEnvironmentsCompleteResult struct {
+	Items []LinkableEnvironmentResponse
+}
+
+func (r ListLinkableEnvironmentsOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListLinkableEnvironmentsOperationResponse) LoadMore(ctx context.Context) (resp ListLinkableEnvironmentsOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListLinkableEnvironments ...
+func (c MonitorsClient) ListLinkableEnvironments(ctx context.Context, id MonitorId, input LinkableEnvironmentRequest) (resp ListLinkableEnvironmentsOperationResponse, err error) {
+	req, err := c.preparerForListLinkableEnvironments(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListLinkableEnvironments(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListLinkableEnvironments prepares the ListLinkableEnvironments request.
+func (c MonitorsClient) preparerForListLinkableEnvironments(ctx context.Context, id MonitorId, input LinkableEnvironmentRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listLinkableEnvironments", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListLinkableEnvironmentsWithNextLink prepares the ListLinkableEnvironments request with the given nextLink token.
+func (c MonitorsClient) preparerForListLinkableEnvironmentsWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListLinkableEnvironments handles the response to the ListLinkableEnvironments request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListLinkableEnvironments(resp *http.Response) (result ListLinkableEnvironmentsOperationResponse, err error) {
+	type page struct {
+		Values   []LinkableEnvironmentResponse `json:"value"`
+		NextLink *string                       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListLinkableEnvironmentsOperationResponse, err error) {
+			req, err := c.preparerForListLinkableEnvironmentsWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListLinkableEnvironments(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListLinkableEnvironments", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListLinkableEnvironmentsComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListLinkableEnvironmentsComplete(ctx context.Context, id MonitorId, input LinkableEnvironmentRequest) (ListLinkableEnvironmentsCompleteResult, error) {
+	return c.ListLinkableEnvironmentsCompleteMatchingPredicate(ctx, id, input, LinkableEnvironmentResponseOperationPredicate{})
+}
+
+// ListLinkableEnvironmentsCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListLinkableEnvironmentsCompleteMatchingPredicate(ctx context.Context, id MonitorId, input LinkableEnvironmentRequest, predicate LinkableEnvironmentResponseOperationPredicate) (resp ListLinkableEnvironmentsCompleteResult, err error) {
+	items := make([]LinkableEnvironmentResponse, 0)
+
+	page, err := c.ListLinkableEnvironments(ctx, id, input)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListLinkableEnvironmentsCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listmonitoredresources_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_listmonitoredresources_autorest.go
@@ -1,0 +1,186 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListMonitoredResourcesOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]MonitoredResource
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListMonitoredResourcesOperationResponse, error)
+}
+
+type ListMonitoredResourcesCompleteResult struct {
+	Items []MonitoredResource
+}
+
+func (r ListMonitoredResourcesOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListMonitoredResourcesOperationResponse) LoadMore(ctx context.Context) (resp ListMonitoredResourcesOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListMonitoredResources ...
+func (c MonitorsClient) ListMonitoredResources(ctx context.Context, id MonitorId) (resp ListMonitoredResourcesOperationResponse, err error) {
+	req, err := c.preparerForListMonitoredResources(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListMonitoredResources(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListMonitoredResources prepares the ListMonitoredResources request.
+func (c MonitorsClient) preparerForListMonitoredResources(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listMonitoredResources", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListMonitoredResourcesWithNextLink prepares the ListMonitoredResources request with the given nextLink token.
+func (c MonitorsClient) preparerForListMonitoredResourcesWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListMonitoredResources handles the response to the ListMonitoredResources request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForListMonitoredResources(resp *http.Response) (result ListMonitoredResourcesOperationResponse, err error) {
+	type page struct {
+		Values   []MonitoredResource `json:"value"`
+		NextLink *string             `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListMonitoredResourcesOperationResponse, err error) {
+			req, err := c.preparerForListMonitoredResourcesWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListMonitoredResources(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "ListMonitoredResources", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListMonitoredResourcesComplete retrieves all of the results into a single object
+func (c MonitorsClient) ListMonitoredResourcesComplete(ctx context.Context, id MonitorId) (ListMonitoredResourcesCompleteResult, error) {
+	return c.ListMonitoredResourcesCompleteMatchingPredicate(ctx, id, MonitoredResourceOperationPredicate{})
+}
+
+// ListMonitoredResourcesCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c MonitorsClient) ListMonitoredResourcesCompleteMatchingPredicate(ctx context.Context, id MonitorId, predicate MonitoredResourceOperationPredicate) (resp ListMonitoredResourcesCompleteResult, err error) {
+	items := make([]MonitoredResource, 0)
+
+	page, err := c.ListMonitoredResources(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListMonitoredResourcesCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/method_update_autorest.go
@@ -1,0 +1,69 @@
+package monitors
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *MonitorResource
+}
+
+// Update ...
+func (c MonitorsClient) Update(ctx context.Context, id MonitorId, input MonitorResourceUpdate) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "monitors.MonitorsClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c MonitorsClient) preparerForUpdate(ctx context.Context, id MonitorId, input MonitorResourceUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c MonitorsClient) responderForUpdate(resp *http.Response) (result UpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_accountinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_accountinfo.go
@@ -1,0 +1,9 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountInfo struct {
+	AccountId *string `json:"accountId,omitempty"`
+	RegionId  *string `json:"regionId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_accountinfosecure.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_accountinfosecure.go
@@ -1,0 +1,10 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountInfoSecure struct {
+	AccountId *string `json:"accountId,omitempty"`
+	ApiKey    *string `json:"apiKey,omitempty"`
+	RegionId  *string `json:"regionId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_appserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_appserviceinfo.go
@@ -1,0 +1,16 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AppServiceInfo struct {
+	AutoUpdateSetting *AutoUpdateSetting `json:"autoUpdateSetting,omitempty"`
+	AvailabilityState *AvailabilityState `json:"availabilityState,omitempty"`
+	HostGroup         *string            `json:"hostGroup,omitempty"`
+	HostName          *string            `json:"hostName,omitempty"`
+	LogModule         *LogModule         `json:"logModule,omitempty"`
+	MonitoringType    *MonitoringType    `json:"monitoringType,omitempty"`
+	ResourceId        *string            `json:"resourceId,omitempty"`
+	UpdateStatus      *UpdateStatus      `json:"updateStatus,omitempty"`
+	Version           *string            `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_dynatraceenvironmentproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_dynatraceenvironmentproperties.go
@@ -1,0 +1,11 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DynatraceEnvironmentProperties struct {
+	AccountInfo            *AccountInfo                     `json:"accountInfo,omitempty"`
+	EnvironmentInfo        *EnvironmentInfo                 `json:"environmentInfo,omitempty"`
+	SingleSignOnProperties *DynatraceSingleSignOnProperties `json:"singleSignOnProperties,omitempty"`
+	UserId                 *string                          `json:"userId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_dynatracesinglesignonproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_dynatracesinglesignonproperties.go
@@ -1,0 +1,12 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DynatraceSingleSignOnProperties struct {
+	AadDomains        *[]string           `json:"aadDomains,omitempty"`
+	EnterpriseAppId   *string             `json:"enterpriseAppId,omitempty"`
+	ProvisioningState *ProvisioningState  `json:"provisioningState,omitempty"`
+	SingleSignOnState *SingleSignOnStates `json:"singleSignOnState,omitempty"`
+	SingleSignOnUrl   *string             `json:"singleSignOnUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_environmentinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_environmentinfo.go
@@ -1,0 +1,11 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentInfo struct {
+	EnvironmentId         *string `json:"environmentId,omitempty"`
+	IngestionKey          *string `json:"ingestionKey,omitempty"`
+	LandingURL            *string `json:"landingURL,omitempty"`
+	LogsIngestionEndpoint *string `json:"logsIngestionEndpoint,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_identityproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_identityproperties.go
@@ -1,0 +1,11 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IdentityProperties struct {
+	PrincipalId            *string                          `json:"principalId,omitempty"`
+	TenantId               *string                          `json:"tenantId,omitempty"`
+	Type                   ManagedIdentityType              `json:"type"`
+	UserAssignedIdentities *map[string]UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_linkableenvironmentrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_linkableenvironmentrequest.go
@@ -1,0 +1,10 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinkableEnvironmentRequest struct {
+	Region        *string `json:"region,omitempty"`
+	TenantId      *string `json:"tenantId,omitempty"`
+	UserPrincipal *string `json:"userPrincipal,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_linkableenvironmentresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_linkableenvironmentresponse.go
@@ -1,0 +1,10 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinkableEnvironmentResponse struct {
+	EnvironmentId   *string   `json:"environmentId,omitempty"`
+	EnvironmentName *string   `json:"environmentName,omitempty"`
+	PlanData        *PlanData `json:"planData,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitoredresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitoredresource.go
@@ -1,0 +1,12 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitoredResource struct {
+	Id                     *string               `json:"id,omitempty"`
+	ReasonForLogsStatus    *string               `json:"reasonForLogsStatus,omitempty"`
+	ReasonForMetricsStatus *string               `json:"reasonForMetricsStatus,omitempty"`
+	SendingLogs            *SendingLogsStatus    `json:"sendingLogs,omitempty"`
+	SendingMetrics         *SendingMetricsStatus `json:"sendingMetrics,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorproperties.go
@@ -1,0 +1,15 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitorProperties struct {
+	DynatraceEnvironmentProperties *DynatraceEnvironmentProperties `json:"dynatraceEnvironmentProperties,omitempty"`
+	LiftrResourceCategory          *LiftrResourceCategories        `json:"liftrResourceCategory,omitempty"`
+	LiftrResourcePreference        *int64                          `json:"liftrResourcePreference,omitempty"`
+	MarketplaceSubscriptionStatus  *MarketplaceSubscriptionStatus  `json:"marketplaceSubscriptionStatus,omitempty"`
+	MonitoringStatus               *MonitoringStatus               `json:"monitoringStatus,omitempty"`
+	PlanData                       *PlanData                       `json:"planData,omitempty"`
+	ProvisioningState              *ProvisioningState              `json:"provisioningState,omitempty"`
+	UserInfo                       *UserInfo                       `json:"userInfo,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorresource.go
@@ -1,0 +1,19 @@
+package monitors
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitorResource struct {
+	Id         *string                `json:"id,omitempty"`
+	Identity   *IdentityProperties    `json:"identity,omitempty"`
+	Location   string                 `json:"location"`
+	Name       *string                `json:"name,omitempty"`
+	Properties MonitorProperties      `json:"properties"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Tags       *map[string]string     `json:"tags,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorresourceupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_monitorresourceupdate.go
@@ -1,0 +1,13 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitorResourceUpdate struct {
+	DynatraceEnvironmentProperties *DynatraceEnvironmentProperties `json:"dynatraceEnvironmentProperties,omitempty"`
+	MarketplaceSubscriptionStatus  *MarketplaceSubscriptionStatus  `json:"marketplaceSubscriptionStatus,omitempty"`
+	MonitoringStatus               *MonitoringStatus               `json:"monitoringStatus,omitempty"`
+	PlanData                       *PlanData                       `json:"planData,omitempty"`
+	Tags                           *map[string]string              `json:"tags,omitempty"`
+	UserInfo                       *UserInfo                       `json:"userInfo,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_plandata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_plandata.go
@@ -1,0 +1,29 @@
+package monitors
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlanData struct {
+	BillingCycle  *string `json:"billingCycle,omitempty"`
+	EffectiveDate *string `json:"effectiveDate,omitempty"`
+	PlanDetails   *string `json:"planDetails,omitempty"`
+	UsageType     *string `json:"usageType,omitempty"`
+}
+
+func (o *PlanData) GetEffectiveDateAsTime() (*time.Time, error) {
+	if o.EffectiveDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EffectiveDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *PlanData) SetEffectiveDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EffectiveDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_ssodetailsrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_ssodetailsrequest.go
@@ -1,0 +1,8 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SSODetailsRequest struct {
+	UserPrincipal *string `json:"userPrincipal,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_ssodetailsresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_ssodetailsresponse.go
@@ -1,0 +1,12 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SSODetailsResponse struct {
+	AadDomains      *[]string  `json:"aadDomains,omitempty"`
+	AdminUsers      *[]string  `json:"adminUsers,omitempty"`
+	IsSsoEnabled    *SSOStatus `json:"isSsoEnabled,omitempty"`
+	MetadataUrl     *string    `json:"metadataUrl,omitempty"`
+	SingleSignOnUrl *string    `json:"singleSignOnUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_userassignedidentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_userassignedidentity.go
@@ -1,0 +1,9 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserAssignedIdentity struct {
+	ClientId    string `json:"clientId"`
+	PrincipalId string `json:"principalId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_userinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_userinfo.go
@@ -1,0 +1,12 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserInfo struct {
+	Country      *string `json:"country,omitempty"`
+	EmailAddress *string `json:"emailAddress,omitempty"`
+	FirstName    *string `json:"firstName,omitempty"`
+	LastName     *string `json:"lastName,omitempty"`
+	PhoneNumber  *string `json:"phoneNumber,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_vmextensionpayload.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_vmextensionpayload.go
@@ -1,0 +1,9 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMExtensionPayload struct {
+	EnvironmentId *string `json:"environmentId,omitempty"`
+	IngestionKey  *string `json:"ingestionKey,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_vminfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/model_vminfo.go
@@ -1,0 +1,16 @@
+package monitors
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMInfo struct {
+	AutoUpdateSetting *AutoUpdateSetting `json:"autoUpdateSetting,omitempty"`
+	AvailabilityState *AvailabilityState `json:"availabilityState,omitempty"`
+	HostGroup         *string            `json:"hostGroup,omitempty"`
+	HostName          *string            `json:"hostName,omitempty"`
+	LogModule         *LogModule         `json:"logModule,omitempty"`
+	MonitoringType    *MonitoringType    `json:"monitoringType,omitempty"`
+	ResourceId        *string            `json:"resourceId,omitempty"`
+	UpdateStatus      *UpdateStatus      `json:"updateStatus,omitempty"`
+	Version           *string            `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/predicates.go
@@ -1,0 +1,126 @@
+package monitors
+
+type AppServiceInfoOperationPredicate struct {
+	HostGroup  *string
+	HostName   *string
+	ResourceId *string
+	Version    *string
+}
+
+func (p AppServiceInfoOperationPredicate) Matches(input AppServiceInfo) bool {
+
+	if p.HostGroup != nil && (input.HostGroup == nil && *p.HostGroup != *input.HostGroup) {
+		return false
+	}
+
+	if p.HostName != nil && (input.HostName == nil && *p.HostName != *input.HostName) {
+		return false
+	}
+
+	if p.ResourceId != nil && (input.ResourceId == nil && *p.ResourceId != *input.ResourceId) {
+		return false
+	}
+
+	if p.Version != nil && (input.Version == nil && *p.Version != *input.Version) {
+		return false
+	}
+
+	return true
+}
+
+type LinkableEnvironmentResponseOperationPredicate struct {
+	EnvironmentId   *string
+	EnvironmentName *string
+}
+
+func (p LinkableEnvironmentResponseOperationPredicate) Matches(input LinkableEnvironmentResponse) bool {
+
+	if p.EnvironmentId != nil && (input.EnvironmentId == nil && *p.EnvironmentId != *input.EnvironmentId) {
+		return false
+	}
+
+	if p.EnvironmentName != nil && (input.EnvironmentName == nil && *p.EnvironmentName != *input.EnvironmentName) {
+		return false
+	}
+
+	return true
+}
+
+type MonitorResourceOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p MonitorResourceOperationPredicate) Matches(input MonitorResource) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type MonitoredResourceOperationPredicate struct {
+	Id                     *string
+	ReasonForLogsStatus    *string
+	ReasonForMetricsStatus *string
+}
+
+func (p MonitoredResourceOperationPredicate) Matches(input MonitoredResource) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.ReasonForLogsStatus != nil && (input.ReasonForLogsStatus == nil && *p.ReasonForLogsStatus != *input.ReasonForLogsStatus) {
+		return false
+	}
+
+	if p.ReasonForMetricsStatus != nil && (input.ReasonForMetricsStatus == nil && *p.ReasonForMetricsStatus != *input.ReasonForMetricsStatus) {
+		return false
+	}
+
+	return true
+}
+
+type VMInfoOperationPredicate struct {
+	HostGroup  *string
+	HostName   *string
+	ResourceId *string
+	Version    *string
+}
+
+func (p VMInfoOperationPredicate) Matches(input VMInfo) bool {
+
+	if p.HostGroup != nil && (input.HostGroup == nil && *p.HostGroup != *input.HostGroup) {
+		return false
+	}
+
+	if p.HostName != nil && (input.HostName == nil && *p.HostName != *input.HostName) {
+		return false
+	}
+
+	if p.ResourceId != nil && (input.ResourceId == nil && *p.ResourceId != *input.ResourceId) {
+		return false
+	}
+
+	if p.Version != nil && (input.Version == nil && *p.Version != *input.Version) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors/version.go
@@ -1,0 +1,12 @@
+package monitors
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2021-09-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/monitors/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/README.md
@@ -1,0 +1,103 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules` Documentation
+
+The `tagrules` SDK allows for interaction with the Azure Resource Manager Service `dynatrace` (API Version `2021-09-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules"
+```
+
+
+### Client Initialization
+
+```go
+client := tagrules.NewTagRulesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `TagRulesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := tagrules.NewTagRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue", "ruleSetValue")
+
+payload := tagrules.TagRule{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TagRulesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := tagrules.NewTagRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue", "ruleSetValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TagRulesClient.Get`
+
+```go
+ctx := context.TODO()
+id := tagrules.NewTagRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue", "ruleSetValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TagRulesClient.List`
+
+```go
+ctx := context.TODO()
+id := tagrules.NewMonitorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `TagRulesClient.Update`
+
+```go
+ctx := context.TODO()
+id := tagrules.NewTagRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "monitorValue", "ruleSetValue")
+
+payload := tagrules.TagRuleUpdate{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/client.go
@@ -1,0 +1,18 @@
+package tagrules
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagRulesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewTagRulesClientWithBaseURI(endpoint string) TagRulesClient {
+	return TagRulesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/constants.go
@@ -1,0 +1,167 @@
+package tagrules
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateAccepted     ProvisioningState = "Accepted"
+	ProvisioningStateCanceled     ProvisioningState = "Canceled"
+	ProvisioningStateCreating     ProvisioningState = "Creating"
+	ProvisioningStateDeleted      ProvisioningState = "Deleted"
+	ProvisioningStateDeleting     ProvisioningState = "Deleting"
+	ProvisioningStateFailed       ProvisioningState = "Failed"
+	ProvisioningStateNotSpecified ProvisioningState = "NotSpecified"
+	ProvisioningStateSucceeded    ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating     ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateAccepted),
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleted),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateNotSpecified),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"accepted":     ProvisioningStateAccepted,
+		"canceled":     ProvisioningStateCanceled,
+		"creating":     ProvisioningStateCreating,
+		"deleted":      ProvisioningStateDeleted,
+		"deleting":     ProvisioningStateDeleting,
+		"failed":       ProvisioningStateFailed,
+		"notspecified": ProvisioningStateNotSpecified,
+		"succeeded":    ProvisioningStateSucceeded,
+		"updating":     ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type SendAadLogsStatus string
+
+const (
+	SendAadLogsStatusDisabled SendAadLogsStatus = "Disabled"
+	SendAadLogsStatusEnabled  SendAadLogsStatus = "Enabled"
+)
+
+func PossibleValuesForSendAadLogsStatus() []string {
+	return []string{
+		string(SendAadLogsStatusDisabled),
+		string(SendAadLogsStatusEnabled),
+	}
+}
+
+func parseSendAadLogsStatus(input string) (*SendAadLogsStatus, error) {
+	vals := map[string]SendAadLogsStatus{
+		"disabled": SendAadLogsStatusDisabled,
+		"enabled":  SendAadLogsStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SendAadLogsStatus(input)
+	return &out, nil
+}
+
+type SendActivityLogsStatus string
+
+const (
+	SendActivityLogsStatusDisabled SendActivityLogsStatus = "Disabled"
+	SendActivityLogsStatusEnabled  SendActivityLogsStatus = "Enabled"
+)
+
+func PossibleValuesForSendActivityLogsStatus() []string {
+	return []string{
+		string(SendActivityLogsStatusDisabled),
+		string(SendActivityLogsStatusEnabled),
+	}
+}
+
+func parseSendActivityLogsStatus(input string) (*SendActivityLogsStatus, error) {
+	vals := map[string]SendActivityLogsStatus{
+		"disabled": SendActivityLogsStatusDisabled,
+		"enabled":  SendActivityLogsStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SendActivityLogsStatus(input)
+	return &out, nil
+}
+
+type SendSubscriptionLogsStatus string
+
+const (
+	SendSubscriptionLogsStatusDisabled SendSubscriptionLogsStatus = "Disabled"
+	SendSubscriptionLogsStatusEnabled  SendSubscriptionLogsStatus = "Enabled"
+)
+
+func PossibleValuesForSendSubscriptionLogsStatus() []string {
+	return []string{
+		string(SendSubscriptionLogsStatusDisabled),
+		string(SendSubscriptionLogsStatusEnabled),
+	}
+}
+
+func parseSendSubscriptionLogsStatus(input string) (*SendSubscriptionLogsStatus, error) {
+	vals := map[string]SendSubscriptionLogsStatus{
+		"disabled": SendSubscriptionLogsStatusDisabled,
+		"enabled":  SendSubscriptionLogsStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SendSubscriptionLogsStatus(input)
+	return &out, nil
+}
+
+type TagAction string
+
+const (
+	TagActionExclude TagAction = "Exclude"
+	TagActionInclude TagAction = "Include"
+)
+
+func PossibleValuesForTagAction() []string {
+	return []string{
+		string(TagActionExclude),
+		string(TagActionInclude),
+	}
+}
+
+func parseTagAction(input string) (*TagAction, error) {
+	vals := map[string]TagAction{
+		"exclude": TagActionExclude,
+		"include": TagActionInclude,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TagAction(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/id_monitor.go
@@ -1,0 +1,124 @@
+package tagrules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = MonitorId{}
+
+// MonitorId is a struct representing the Resource ID for a Monitor
+type MonitorId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	MonitorName       string
+}
+
+// NewMonitorID returns a new MonitorId struct
+func NewMonitorID(subscriptionId string, resourceGroupName string, monitorName string) MonitorId {
+	return MonitorId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		MonitorName:       monitorName,
+	}
+}
+
+// ParseMonitorID parses 'input' into a MonitorId
+func ParseMonitorID(input string) (*MonitorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MonitorId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MonitorId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseMonitorIDInsensitively parses 'input' case-insensitively into a MonitorId
+// note: this method should only be used for API response data and not user input
+func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MonitorId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MonitorId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateMonitorID checks that 'input' can be parsed as a Monitor ID
+func ValidateMonitorID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMonitorID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Monitor ID
+func (id MonitorId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Dynatrace.Observability/monitors/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.MonitorName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Monitor ID
+func (id MonitorId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticDynatraceObservability", "Dynatrace.Observability", "Dynatrace.Observability"),
+		resourceids.StaticSegment("staticMonitors", "monitors", "monitors"),
+		resourceids.UserSpecifiedSegment("monitorName", "monitorValue"),
+	}
+}
+
+// String returns a human-readable description of this Monitor ID
+func (id MonitorId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Monitor Name: %q", id.MonitorName),
+	}
+	return fmt.Sprintf("Monitor (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/id_tagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/id_tagrule.go
@@ -1,0 +1,137 @@
+package tagrules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = TagRuleId{}
+
+// TagRuleId is a struct representing the Resource ID for a Tag Rule
+type TagRuleId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	MonitorName       string
+	RuleSetName       string
+}
+
+// NewTagRuleID returns a new TagRuleId struct
+func NewTagRuleID(subscriptionId string, resourceGroupName string, monitorName string, ruleSetName string) TagRuleId {
+	return TagRuleId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		MonitorName:       monitorName,
+		RuleSetName:       ruleSetName,
+	}
+}
+
+// ParseTagRuleID parses 'input' into a TagRuleId
+func ParseTagRuleID(input string) (*TagRuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TagRuleId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := TagRuleId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	if id.RuleSetName, ok = parsed.Parsed["ruleSetName"]; !ok {
+		return nil, fmt.Errorf("the segment 'ruleSetName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseTagRuleIDInsensitively parses 'input' case-insensitively into a TagRuleId
+// note: this method should only be used for API response data and not user input
+func ParseTagRuleIDInsensitively(input string) (*TagRuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TagRuleId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := TagRuleId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
+		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+	}
+
+	if id.RuleSetName, ok = parsed.Parsed["ruleSetName"]; !ok {
+		return nil, fmt.Errorf("the segment 'ruleSetName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateTagRuleID checks that 'input' can be parsed as a Tag Rule ID
+func ValidateTagRuleID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTagRuleID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Tag Rule ID
+func (id TagRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Dynatrace.Observability/monitors/%s/tagRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.MonitorName, id.RuleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Tag Rule ID
+func (id TagRuleId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticDynatraceObservability", "Dynatrace.Observability", "Dynatrace.Observability"),
+		resourceids.StaticSegment("staticMonitors", "monitors", "monitors"),
+		resourceids.UserSpecifiedSegment("monitorName", "monitorValue"),
+		resourceids.StaticSegment("staticTagRules", "tagRules", "tagRules"),
+		resourceids.UserSpecifiedSegment("ruleSetName", "ruleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Tag Rule ID
+func (id TagRuleId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Monitor Name: %q", id.MonitorName),
+		fmt.Sprintf("Rule Set Name: %q", id.RuleSetName),
+	}
+	return fmt.Sprintf("Tag Rule (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_createorupdate_autorest.go
@@ -1,0 +1,79 @@
+package tagrules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c TagRulesClient) CreateOrUpdate(ctx context.Context, id TagRuleId, input TagRule) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c TagRulesClient) CreateOrUpdateThenPoll(ctx context.Context, id TagRuleId, input TagRule) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c TagRulesClient) preparerForCreateOrUpdate(ctx context.Context, id TagRuleId, input TagRule) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c TagRulesClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package tagrules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c TagRulesClient) Delete(ctx context.Context, id TagRuleId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c TagRulesClient) DeleteThenPoll(ctx context.Context, id TagRuleId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c TagRulesClient) preparerForDelete(ctx context.Context, id TagRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c TagRulesClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_get_autorest.go
@@ -1,0 +1,68 @@
+package tagrules
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *TagRule
+}
+
+// Get ...
+func (c TagRulesClient) Get(ctx context.Context, id TagRuleId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c TagRulesClient) preparerForGet(ctx context.Context, id TagRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c TagRulesClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_list_autorest.go
@@ -1,0 +1,186 @@
+package tagrules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]TagRule
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []TagRule
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c TagRulesClient) List(ctx context.Context, id MonitorId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c TagRulesClient) preparerForList(ctx context.Context, id MonitorId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/tagRules", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c TagRulesClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c TagRulesClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []TagRule `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c TagRulesClient) ListComplete(ctx context.Context, id MonitorId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, TagRuleOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c TagRulesClient) ListCompleteMatchingPredicate(ctx context.Context, id MonitorId, predicate TagRuleOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]TagRule, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/method_update_autorest.go
@@ -1,0 +1,69 @@
+package tagrules
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *TagRule
+}
+
+// Update ...
+func (c TagRulesClient) Update(ctx context.Context, id TagRuleId, input TagRuleUpdate) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tagrules.TagRulesClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c TagRulesClient) preparerForUpdate(ctx context.Context, id TagRuleId, input TagRuleUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c TagRulesClient) responderForUpdate(resp *http.Response) (result UpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_filteringtag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_filteringtag.go
@@ -1,0 +1,10 @@
+package tagrules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FilteringTag struct {
+	Action *TagAction `json:"action,omitempty"`
+	Name   *string    `json:"name,omitempty"`
+	Value  *string    `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_logrules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_logrules.go
@@ -1,0 +1,11 @@
+package tagrules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LogRules struct {
+	FilteringTags        *[]FilteringTag             `json:"filteringTags,omitempty"`
+	SendAadLogs          *SendAadLogsStatus          `json:"sendAadLogs,omitempty"`
+	SendActivityLogs     *SendActivityLogsStatus     `json:"sendActivityLogs,omitempty"`
+	SendSubscriptionLogs *SendSubscriptionLogsStatus `json:"sendSubscriptionLogs,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_metricrules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_metricrules.go
@@ -1,0 +1,8 @@
+package tagrules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MetricRules struct {
+	FilteringTags *[]FilteringTag `json:"filteringTags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_monitoringtagrulesproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_monitoringtagrulesproperties.go
@@ -1,0 +1,10 @@
+package tagrules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MonitoringTagRulesProperties struct {
+	LogRules          *LogRules          `json:"logRules,omitempty"`
+	MetricRules       *MetricRules       `json:"metricRules,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_tagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_tagrule.go
@@ -1,0 +1,16 @@
+package tagrules
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagRule struct {
+	Id         *string                      `json:"id,omitempty"`
+	Name       *string                      `json:"name,omitempty"`
+	Properties MonitoringTagRulesProperties `json:"properties"`
+	SystemData *systemdata.SystemData       `json:"systemData,omitempty"`
+	Type       *string                      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_tagruleupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/model_tagruleupdate.go
@@ -1,0 +1,9 @@
+package tagrules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagRuleUpdate struct {
+	LogRules    *LogRules    `json:"logRules,omitempty"`
+	MetricRules *MetricRules `json:"metricRules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/predicates.go
@@ -1,0 +1,24 @@
+package tagrules
+
+type TagRuleOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p TagRuleOperationPredicate) Matches(input TagRule) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules/version.go
@@ -1,0 +1,12 @@
+package tagrules
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2021-09-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/tagrules/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,6 +258,8 @@ github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwar
 github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints
 github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints
 github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks
+github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/monitors
+github.com/hashicorp/go-azure-sdk/resource-manager/dynatrace/2021-09-01/tagrules
 github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/monitorsresource
 github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/rules
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationruleseventhubs

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -42,6 +42,7 @@ Desktop Virtualization
 Dev Test
 Digital Twins
 Disks
+Dynatrace
 Elastic
 Fluid Relay
 HDInsight

--- a/website/docs/r/dynatrace_monitors.html.markdown
+++ b/website/docs/r/dynatrace_monitors.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "Dynatrace"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dynatrace_monitors"
+description: |-
+  Manages Dynatrace monitors.
+---
+
+# azurerm_dynatrace_monitors
+
+Manages Dynatrace monitors.
+
+## Example Usage
+
+```hcl
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_dynatrace_monitors" "example" {
+  name                            = "exmpledynatracemonitor"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = "SystemAssigned"
+  monitoring_status               = "Enabled"
+  marketplace_subscription_status = "Active"
+
+  user_info {
+    first_name    = "Alice"
+    last_name     = "Bobab"
+    email_address = "alice@microsoft.com"
+    phone_number  = "123456"
+    country       = "westus"
+  }
+
+  plan_data {
+    usage_type     = "COMMITTED"
+    billing_cycle  = "MONTHLY"
+    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    effective_date = "2019-08-30T15:14:33Z"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Dynatrace monitor. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Dynatrace monitor should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure Region where the Dynatrace monitor should exist. Changing this forces a new resource to be created.
+
+* `identity_type` - (Optional) The kind of managed identity assigned to this resource. Possible values are `SystemAssigned`, `UserAssigned`. Changing this forces a new resource to be created.
+
+* `monitoring_status` - (Optional) Flag specifying if the resource monitoring is enabled or disabled. Possible values aree `Enabled`, `Disabled`.
+
+* `marketplace_subscription_status` - (Optional) Flag specifying the Marketplace Subscription Status of the resource. If payment is not made in time, the resource will go in Suspended state. Possible values are `Active`, `Suspended`.
+
+* `plan_data` - (Optional) Billing plan information. A `plan_data` block as defined below.
+
+* `user_info` - (Optional) User's information. A `user_info` block as defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `plan_data` block supports the following:
+
+* `billing_cycle` - (Optional) Different billing cycles. Possible values are `MONTHLY`, `WEEKLY`.
+
+* `effective_date` - (Optional) Date when plan was applied.
+
+* `plan_details` - (Optional) Plan id as published by Dynatrace.
+
+* `usage_type` - (Optional) Different usage type. Possible values are `PAYG`, `COMMITTED`.
+
+---
+
+A `user_info` block supports the following:
+
+* `country` - (Optional) Country of the user.
+
+* `email_address` - (Optional) Email of the user used by Dynatrace for contacting them if needed.
+
+* `first_name` - (Optional) First name of the user.
+
+* `last_name` - (Optional) Last name of the user.
+
+* `phone_number` - (Optional) phone number of the user by Dynatrace for contacting them if needed.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Dynatrace monitor.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 1 hour) Used when creating the Dynatrace monitor.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dynatrace monitor.
+* `update` - (Defaults to 1 hour) Used when updating the Dynatrace monitor.
+* `delete` - (Defaults to 1 hour) Used when deleting the Dynatrace monitor.
+
+## Import
+
+Dynatrace monitor can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_dynatrace_monitors.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Dynatrace.Observability/monitors/monitor1
+```

--- a/website/docs/r/dynatrace_monitors.html.markdown
+++ b/website/docs/r/dynatrace_monitors.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_dynatrace_monitors" "example" {
   plan_data {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
-    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
     effective_date = "2019-08-30T15:14:33Z"
   }
 }
@@ -74,7 +74,7 @@ A `plan_data` block supports the following:
 
 * `effective_date` - (Optional) Date when plan was applied.
 
-* `plan_details` - (Optional) Plan id as published by Dynatrace.
+* `plan` - (Optional) Plan id as published by Dynatrace.
 
 * `usage_type` - (Optional) Different usage type. Possible values are `PAYG`, `COMMITTED`.
 

--- a/website/docs/r/dynatrace_monitors.html.markdown
+++ b/website/docs/r/dynatrace_monitors.html.markdown
@@ -27,15 +27,15 @@ resource "azurerm_dynatrace_monitors" "example" {
   monitoring_status               = "Enabled"
   marketplace_subscription_status = "Active"
 
-  user_info {
-    first_name    = "Alice"
-    last_name     = "Bobab"
-    email_address = "alice@microsoft.com"
-    phone_number  = "123456"
-    country       = "westus"
+  user {
+    first_name   = "Alice"
+    last_name    = "Bobab"
+    email        = "alice@microsoft.com"
+    phone_number = "123456"
+    country      = "westus"
   }
 
-  plan_data {
+  plan {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
     plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
@@ -60,15 +60,15 @@ The following arguments are supported:
 
 * `marketplace_subscription_status` - (Optional) Flag specifying the Marketplace Subscription Status of the resource. If payment is not made in time, the resource will go in Suspended state. Possible values are `Active`, `Suspended`.
 
-* `plan_data` - (Optional) Billing plan information. A `plan_data` block as defined below.
+* `plan` - (Optional) Billing plan information. A `plan` block as defined below.
 
-* `user_info` - (Optional) User's information. A `user_info` block as defined below.
+* `user` - (Optional) User's information. A `user` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 
-A `plan_data` block supports the following:
+A `plan` block supports the following:
 
 * `billing_cycle` - (Optional) Different billing cycles. Possible values are `MONTHLY`, `WEEKLY`.
 
@@ -80,11 +80,11 @@ A `plan_data` block supports the following:
 
 ---
 
-A `user_info` block supports the following:
+A `user` block supports the following:
 
 * `country` - (Optional) Country of the user.
 
-* `email_address` - (Optional) Email of the user used by Dynatrace for contacting them if needed.
+* `email` - (Optional) Email of the user used by Dynatrace for contacting them if needed.
 
 * `first_name` - (Optional) First name of the user.
 

--- a/website/docs/r/dynatrace_tag_rules.html.markdown
+++ b/website/docs/r/dynatrace_tag_rules.html.markdown
@@ -27,15 +27,15 @@ resource "azurerm_dynatrace_monitors" "example" {
   monitoring_status               = "Enabled"
   marketplace_subscription_status = "Active"
 
-  user_info {
-    first_name    = "Alice"
-    last_name     = "Bobab"
-    email_address = "alice@microsoft.com"
-    phone_number  = "123456"
-    country       = "westus"
+  user {
+    first_name   = "Alice"
+    last_name    = "Bobab"
+    email        = "alice@microsoft.com"
+    phone_number = "123456"
+    country      = "westus"
   }
 
-  plan_data {
+  plan {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
     plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
@@ -47,18 +47,18 @@ resource "azurerm_dynatrace_tag_rules" "example" {
   name       = "examplestreamanalyticscluster"
   monitor_id = azurerm_dynatrace_monitors.test.id
 
-  log_rules {
+  log_rule {
     filtering_tag {
       name   = "Environment"
       value  = "Prod"
       action = "Include"
     }
-    send_aad_logs          = "Enabled"
-    send_activity_logs     = "Enabled"
-    send_subscription_logs = "Enabled"
+    send_aad_logs          = true
+    send_activity_logs     = true
+    send_subscription_logs = true
   }
 
-  metric_rules {
+  metric_rule {
     filtering_tag {
       name   = "Environment"
       value  = "Prod"
@@ -76,9 +76,9 @@ The following arguments are supported:
 
 * `monitor_id` - (Required) Name of the Dynatrace monitor. Changing this forces a new resource to be created.
 
-* `log_rules` - (Optional) Set of rules for sending logs for the Monitor resource. Changing this forces a new resource to be created.
+* `log_rule` - (Optional) Set of rules for sending logs for the Monitor resource. Changing this forces a new resource to be created.
 
-* `metric_rules` - (Optional) Set of rules for sending metrics for the Monitor resource. Changing this forces a new resource to be created.
+* `metric_rule` - (Optional) Set of rules for sending metrics for the Monitor resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/dynatrace_tag_rules.html.markdown
+++ b/website/docs/r/dynatrace_tag_rules.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_dynatrace_monitors" "example" {
   plan_data {
     usage_type     = "COMMITTED"
     billing_cycle  = "MONTHLY"
-    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    plan           = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
     effective_date = "2019-08-30T15:14:33Z"
   }
 }

--- a/website/docs/r/dynatrace_tag_rules.html.markdown
+++ b/website/docs/r/dynatrace_tag_rules.html.markdown
@@ -1,0 +1,104 @@
+---
+subcategory: "Dynatrace"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dynatrace_tag_rules"
+description: |-
+  Manages Dynatrace tag rules.
+---
+
+# azurerm_dynatrace_tag_rules
+
+Manages Dynatrace tag rules.
+
+## Example Usage
+
+```hcl
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_dynatrace_monitors" "example" {
+  name                            = "exmpledynatracemonitor"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.test.location
+  identity_type                   = "SystemAssigned"
+  monitoring_status               = "Enabled"
+  marketplace_subscription_status = "Active"
+
+  user_info {
+    first_name    = "Alice"
+    last_name     = "Bobab"
+    email_address = "alice@microsoft.com"
+    phone_number  = "123456"
+    country       = "westus"
+  }
+
+  plan_data {
+    usage_type     = "COMMITTED"
+    billing_cycle  = "MONTHLY"
+    plan_details   = "azureportalintegration_privatepreview@TIDhjdtn7tfnxcy"
+    effective_date = "2019-08-30T15:14:33Z"
+  }
+}
+
+resource "azurerm_dynatrace_tag_rules" "example" {
+  name       = "examplestreamanalyticscluster"
+  monitor_id = azurerm_dynatrace_monitors.test.id
+
+  log_rules {
+    filtering_tag {
+      name   = "Environment"
+      value  = "Prod"
+      action = "Include"
+    }
+    send_aad_logs          = "Enabled"
+    send_activity_logs     = "Enabled"
+    send_subscription_logs = "Enabled"
+  }
+
+  metric_rules {
+    filtering_tag {
+      name   = "Environment"
+      value  = "Prod"
+      action = "Include"
+    }
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Dynatrace tag rules. Changing this forces a new resource to be created.
+
+* `monitor_id` - (Required) Name of the Dynatrace monitor. Changing this forces a new resource to be created.
+
+* `log_rules` - (Optional) Set of rules for sending logs for the Monitor resource. Changing this forces a new resource to be created.
+
+* `metric_rules` - (Optional) Set of rules for sending metrics for the Monitor resource. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Dynatrace tag rules.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 1 hour) Used when creating the Dynatrace tag rules.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dynatrace tag rules.
+* `update` - (Defaults to 1 hour) Used when updating the Dynatrace tag rules.
+* `delete` - (Defaults to 1 hour) Used when deleting the Dynatrace tag rules.
+
+## Import
+
+Dynatrace tag rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_dynatrace_tag_rules.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Dynatrace.Observability/monitors/monitor1/tagRules/tagRules1
+```


### PR DESCRIPTION
* Created `azurerm_dynatrace_monitors`, `azurerm_dynatrace_tag_rules` resources for Dynatrace service.

* All tests passed.

Test results:
```

--- PASS: TestAccDynatraceMonitors_basic (330.78s)
--- PASS: TestAccDynatraceMonitors_update (421.85s)
--- PASS: TestAccDynatraceMonitors_requiresImport (288.72s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dynatrace     440.475s

--- PASS: TestAccDynatraceTagRules_basic (273.31s)
--- PASS: TestAccDynatraceTagRules_requiresImport (301.33s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dynatrace     318.335s

```
