### PR TITLE
Make location required in `azurerm_network_watcher_flow_log` 

### DIFF
--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -152,6 +152,7 @@ func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
 			"location": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ForceNew:         true,
 				ValidateFunc:     location.EnhancedValidate,
 				StateFunc:        location.StateFunc,


### PR DESCRIPTION
This PR requires the user to provided a `location` to avoid having a mismatch.

Fixes #18365
