### PR TITLE
Docs: Add a note about flow log overwriting existing storage lifecycle management rules

### DIFF
--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages a Network Watcher Flow Log.
 
+~> **Note** The `azurerm_network_watcher_flow_log` creates a new storage lifecyle management rule that overwrites existing rules. Please make sure to use a `storage_account` with no existing management rules, until the [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/6935) is fixed.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
By default the flow log netwok watcher adds a new lifecycle managment rule to the provided storage, which overwrites existing rules after running a second plan.

The issue is tacked in https://github.com/hashicorp/terraform-provider-azurerm/issues/6935