### PR TITLE
`azurerm_application_insights_analytics_item` - fix failed test case `TestAccApplicationInsightsAnalyticsItem_multiple`

### DIFF
--- a/internal/services/applicationinsights/application_insights_analytics_item_resource.go
+++ b/internal/services/applicationinsights/application_insights_analytics_item_resource.go
@@ -160,7 +160,8 @@ func resourceApplicationInsightsAnalyticsItemCreateUpdate(d *pluginsdk.ResourceD
 		// We cannot get specific analytics items without their itemID which is why we need to list all the
 		// available items of a certain type and scope in order to check whether a resource already exists and needs
 		// to be imported first
-		existing, err := client.List(ctx, appInsightsId.ResourceGroup, appInsightsId.Name, itemScopePath, itemScope, insights.ItemTypeParameter(typeName), &includeContent)
+		// https://github.com/Azure/azure-rest-api-specs/issues/20712 itemScopePath should be set to insights.ItemScopePathAnalyticsItems in List method
+		existing, err := client.List(ctx, appInsightsId.ResourceGroup, appInsightsId.Name, insights.ItemScopePathAnalyticsItems, itemScope, insights.ItemTypeParameter(typeName), &includeContent)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("checking for presence of existing Application Insights Analytics Items %+v", err)


### PR DESCRIPTION
related to https://github.com/Azure/azure-rest-api-specs/issues/20712

Test Result:
todo

Original Failure:
```
------- Stdout: -------
=== RUN   TestAccApplicationInsightsAnalyticsItem_multiple
=== PAUSE TestAccApplicationInsightsAnalyticsItem_multiple
=== CONT  TestAccApplicationInsightsAnalyticsItem_multiple
testcase.go:110: Step 1/4 error: Error running apply: exit status 1
Error: checking for presence of existing Application Insights Analytics Items insights.AnalyticsItemsClient#List: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: error response cannot be parsed: {"" '\x00' '\x00'} error: EOF
with azurerm_application_insights_analytics_item.test2,
on terraform_plugin_test.tf line 26, in resource "azurerm_application_insights_analytics_item" "test2":
26: resource "azurerm_application_insights_analytics_item" "test2" {
--- FAIL: TestAccApplicationInsightsAnalyticsItem_multiple (162.55s)
FAIL
```