### PR TITLE
`azurerm_automation_webhook` - fix missing `URI` of request body when `uri` provided

### DIFF
--- a/internal/services/automation/automation_webhook.go
+++ b/internal/services/automation/automation_webhook.go
@@ -142,6 +142,7 @@ func resourceAutomationWebhookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	if d.IsNewResource() {
 		if v := d.Get("uri"); v != nil && v.(string) != "" {
 			uri = v.(string)
+			parameters.WebhookCreateOrUpdateProperties.URI = &uri
 		} else {
 			resp, err := client.GenerateURI(ctx, id.ResourceGroup, id.AutomationAccountName)
 			if err != nil {


### PR DESCRIPTION
which cause cannot trigger the webhook by this uri. I have tested locally and reproduced the issue: when URI provided cannot trigger the runbook in the main branch, and works as expected under this commit.

Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18269