### PR TITLE
`aurerm_public_ip` - fix AccTest failure of `TestAccPublicIpStatic_ipTags` and `TestAccDataSourcePublicIP_static`

### DIFF
--- a/internal/services/network/public_ip_data_source_test.go
+++ b/internal/services/network/public_ip_data_source_test.go
@@ -79,7 +79,7 @@ resource "azurerm_public_ip" "test" {
   domain_name_label       = "acctest-%d"
   idle_timeout_in_minutes = 30
   sku                     = "Standard"
-  zones                   = ["1", "2"]
+  zones                   = ["1", "2", "3"]
 
   ip_tags = {
     RoutingPreference = "Internet"

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -836,6 +836,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 
   ip_tags = {
     RoutingPreference = "Internet"


### PR DESCRIPTION
the current error message is:
`TestAccPublicIpStatic_ipTags` : `Either provide a non-empty Zones array, or remove RoutingPreference from IpTags.`

`TestAccDataSourcePublicIP_static`:  `zonal PublicIPAddress cannot support for routing preference feature`

and more information during my local test
`Starting with api version 2020-08-01 new PublicIPAddresses without zones in a zonal region (like /subscriptions/xxx-xxx/resourceGroups/acctestRG-network-220916105333249192/providers/Microsoft.Network/publicIPAddresses/acctestpublicip-220916105333249192) do not support RoutingPreference. Either provide a non-empty Zones array, or remove RoutingPreference from IpTags`

and issue for zones property when creating a public IP address: https://github.com/Azure/azure-rest-api-specs/issues/20691


now these two tests passed:

![image](https://user-images.githubusercontent.com/2633022/190561094-a2d5a76b-9b38-4e68-9f75-d35257ef056b.png)
