### PR TITLE
Features: log_analytics_workspace block change default value for permanently_delete_on_destroy flag

### DIFF
--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -145,7 +145,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 					"permanently_delete_on_destroy": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
-						Default:  true,
+						Default:  !features.FourPointOhBeta(),
 					},
 				},
 			},

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -913,7 +913,7 @@ func TestExpandFeaturesLogAnalyticsWorkspace(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
-					PermanentlyDeleteOnDestroy: true,
+					PermanentlyDeleteOnDestroy: !features.FourPointOhBeta(),
 				},
 			},
 		},

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -146,6 +146,8 @@ The `log_analytics_workspace` block supports the following:
 
 * `permanently_delete_on_destroy` - (Optional) Should the `azurerm_log_analytics_workspace` be permanently deleted (e.g. purged) when destroyed? Defaults to `true`.
 
+-> **Note:** This will be defaulted to `false` in the next major version of the Azure Provider (4.0).
+
 ---
 
 The `resource_group` block supports the following:


### PR DESCRIPTION
Change the default value of the log analytics workspaces `permanently_delete_on_destroy` feature flag to bring in into alignment with the [product documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/delete-workspace#considerations-when-deleting-a-workspace).