### PR TITLE
`comupte` - fix `health_probe_id` update and network tests

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -1,12 +1,16 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking(t *testing.T) {
@@ -24,38 +28,36 @@ func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking(t *testing.
 	})
 }
 
-// This is not a valid test case, so I am removing it. In order to make this work you need to
-// stop and deallocated all VMs in the VMSS in order to enable/disable accelerated networking
-// https://docs.microsoft.com/azure/virtual-network/create-vm-accelerated-networking-cli#enable-accelerated-networking-on-existing-vms
+func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
 
-// func TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated(t *testing.T) {
-// 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
-// 	r := LinuxVirtualMachineScaleSetResource{}
-
-// 	data.ResourceTest(t, r, []acceptance.TestStep{
-// 		{
-// 			Config: r.networkAcceleratedNetworking(data, false),
-// 			Check: acceptance.ComposeTestCheckFunc(
-// 				check.That(data.ResourceName).ExistsInAzure(r),
-// 			),
-// 		},
-// 		data.ImportStep("admin_password"),
-// 		{
-// 			Config: r.networkAcceleratedNetworking(data, true),
-// 			Check: acceptance.ComposeTestCheckFunc(
-// 				check.That(data.ResourceName).ExistsInAzure(r),
-// 			),
-// 		},
-// 		data.ImportStep("admin_password"),
-// 		{
-// 			Config: r.networkAcceleratedNetworking(data, false),
-// 			Check: acceptance.ComposeTestCheckFunc(
-// 				check.That(data.ResourceName).ExistsInAzure(r),
-// 			),
-// 		},
-// 		data.ImportStep("admin_password"),
-// 	})
-// }
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkAcceleratedNetworking(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				// Accelerated Networking can only be changed when VM is not running
+				data.CheckWithClientForResource(r.deallocateVirtualMachineScaleSet(), "azurerm_linux_virtual_machine_scale_set.test"),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.networkAcceleratedNetworking(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.networkAcceleratedNetworking(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
 
 func TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
@@ -448,21 +450,6 @@ func TestAccLinuxVirtualMachineScaleSet_networkPublicIPTags(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_RoutingPreferenceIPTags(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.ilpip(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-	})
-}
-
 func (r LinuxVirtualMachineScaleSetResource) networkAcceleratedNetworking(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
@@ -471,7 +458,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                = "acctestvmss-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F4"
+  sku                 = "Standard_F2"
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
@@ -1604,56 +1591,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) networkPublicIPTags(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2"
-  instances           = 1
-  admin_username      = "adminuser"
-  admin_password      = "P@ssword1234!"
-
-  disable_password_authentication = false
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
-  }
-
-  os_disk {
-    storage_account_type = "Standard_LRS"
-    caching              = "ReadWrite"
-  }
-
-  network_interface {
-    name    = "primary"
-    primary = true
-
-    ip_configuration {
-      name      = "first"
-      primary   = true
-      subnet_id = azurerm_subnet.test.id
-
-      public_ip_address {
-        name = "first"
-
-        ip_tag {
-          tag  = "/Sql"
-          type = "FirstPartyUsage"
-        }
-      }
-    }
-  }
-}
-`, r.template(data), data.RandomInteger)
-}
-
 func (r LinuxVirtualMachineScaleSetResource) networkPublicIPVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -1711,9 +1648,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) ilpip(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) networkPublicIPTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_public_ip" "test" {
   name                = "test-ip-%[2]d"
@@ -1807,4 +1744,24 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomStringOfLength(9))
+}
+
+func (LinuxVirtualMachineScaleSetResource) deallocateVirtualMachineScaleSet() func(context.Context, *clients.Client, *pluginsdk.InstanceState) error {
+	return func(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+		id, err := parse.VirtualMachineScaleSetID(state.ID)
+		if err != nil {
+			return err
+		}
+
+		future, err := client.Compute.VMScaleSetClient.Deallocate(ctx, id.ResourceGroup, id.Name, nil)
+		if err != nil {
+			return err
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Compute.VMScaleSetClient.Client); err != nil {
+			return err
+		}
+
+		return nil
+	}
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -431,19 +431,14 @@ func TestAccLinuxVirtualMachineScaleSet_updateHealthProbeSku(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.updateLoadBalancerHealthProbeSKUBasic(data),
+			Config: r.updateLoadBalancerHealthProbeSKU(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
-		// Have to remove VMSS to change the sku of load balancer
 		{
-			Config: r.updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data),
-			Check:  acceptance.ComposeTestCheckFunc(),
-		},
-		{
-			Config: r.updateLoadBalancerHealthProbeSKUStandard(data),
+			Config: r.updateLoadBalancerHealthProbeSKU(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1925,39 +1920,48 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUBasic(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKU(data acceptance.TestData, isStandardSku bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
+  count = 2
+
+  name                    = "acctestpip${count.index}-%[2]d"
   location                = azurerm_resource_group.test.location
   resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Dynamic"
+  allocation_method       = count.index == 0 ? "Dynamic" : "Static"
   idle_timeout_in_minutes = 4
+  sku                     = count.index == 0 ? "Basic" : "Standard"
 }
 
 resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
+  count = 2
+
+  name                = "acctestlb${count.index}-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
+  sku                 = count.index == 0 ? "Basic" : "Standard"
 
   frontend_ip_configuration {
     name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
+    public_ip_address_id = azurerm_public_ip.test[count.index].id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
+  count = 2
+
+  name            = "test${count.index}"
+  loadbalancer_id = azurerm_lb.test[count.index].id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
+  count = 2
+
+  name                           = "test${count.index}"
   resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
+  loadbalancer_id                = azurerm_lb.test[count.index].id
   frontend_ip_configuration_name = "internal"
   protocol                       = "Tcp"
   frontend_port_start            = 80
@@ -1966,17 +1970,21 @@ resource "azurerm_lb_nat_pool" "test" {
 }
 
 resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
+  count = 2
+
+  loadbalancer_id = azurerm_lb.test[count.index].id
+  name            = "acctest-lb-probe${count.index}"
   port            = 22
   protocol        = "Tcp"
 }
 
 resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
+  count = 2
+
+  name                           = "AccTestLBRule${count.index}"
+  loadbalancer_id                = azurerm_lb.test[count.index].id
+  probe_id                       = azurerm_lb_probe.test[count.index].id
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test[count.index].id]
   frontend_ip_configuration_name = "internal"
   protocol                       = "Tcp"
   frontend_port                  = 22
@@ -1991,7 +1999,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
-  health_probe_id     = azurerm_lb_probe.test.id
+  health_probe_id     = %[3]t ? azurerm_lb_probe.test[1].id : azurerm_lb_probe.test[0].id
 
   disable_password_authentication = false
 
@@ -2022,182 +2030,14 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
       name                                   = "internal"
       primary                                = true
       subnet_id                              = azurerm_subnet.test.id
-      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
-      load_balancer_inbound_nat_rules_ids    = [azurerm_lb_nat_pool.test.id]
+      load_balancer_backend_address_pool_ids = %[3]t ? [azurerm_lb_backend_address_pool.test[1].id] : [azurerm_lb_backend_address_pool.test[0].id]
+      load_balancer_inbound_nat_rules_ids    = %[3]t ? [azurerm_lb_nat_pool.test[1].id] : [azurerm_lb_nat_pool.test[0].id]
     }
   }
 
   depends_on = [azurerm_lb_rule.test]
 }
-`, r.template(data), data.RandomInteger)
-}
-
-func (r LinuxVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Dynamic"
-  idle_timeout_in_minutes = 4
-}
-
-resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
-
-  frontend_ip_configuration {
-    name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
-}
-
-resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
-  resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port_start            = 80
-  frontend_port_end              = 81
-  backend_port                   = 8080
-}
-
-resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
-  port            = 22
-  protocol        = "Tcp"
-}
-
-resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port                  = 22
-  backend_port                   = 22
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r LinuxVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUStandard(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Static"
-  idle_timeout_in_minutes = 4
-  sku                     = "Standard"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-
-  frontend_ip_configuration {
-    name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
-}
-
-resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
-  resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port_start            = 80
-  frontend_port_end              = 81
-  backend_port                   = 8080
-}
-
-resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
-  port            = 22
-  protocol        = "Tcp"
-}
-
-resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port                  = 22
-  backend_port                   = 22
-}
-
-resource "azurerm_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2"
-  instances           = 1
-  admin_username      = "adminuser"
-  admin_password      = "P@ssword1234!"
-  health_probe_id     = azurerm_lb_probe.test.id
-
-  disable_password_authentication = false
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
-  }
-
-  os_disk {
-    storage_account_type = "Standard_LRS"
-    caching              = "ReadWrite"
-  }
-
-  data_disk {
-    storage_account_type = "Standard_LRS"
-    caching              = "ReadWrite"
-    disk_size_gb         = 10
-    lun                  = 10
-  }
-
-  network_interface {
-    name    = "example"
-    primary = true
-
-    ip_configuration {
-      name                                   = "internal"
-      primary                                = true
-      subnet_id                              = azurerm_subnet.test.id
-      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
-      load_balancer_inbound_nat_rules_ids    = [azurerm_lb_nat_pool.test.id]
-    }
-  }
-
-  depends_on = [azurerm_lb_rule.test]
-}
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, isStandardSku)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) otherScaleInPolicy(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -425,7 +425,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisable
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_updateHealthProbe(t *testing.T) {
+func TestAccLinuxVirtualMachineScaleSet_updateHealthProbeSku(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
 
@@ -436,12 +436,19 @@ func TestAccLinuxVirtualMachineScaleSet_updateHealthProbe(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep("admin_password"),
+		// Have to remove VMSS to change the sku of load balancer
+		{
+			Config: r.updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
 		{
 			Config: r.updateLoadBalancerHealthProbeSKUStandard(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep("admin_password"),
 	})
 }
 
@@ -2021,6 +2028,66 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 
   depends_on = [azurerm_lb_rule.test]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_public_ip" "test" {
+  name                    = "acctestpip-%[2]d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  allocation_method       = "Dynamic"
+  idle_timeout_in_minutes = 4
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+
+  frontend_ip_configuration {
+    name                 = "internal"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name            = "test"
+  loadbalancer_id = azurerm_lb.test.id
+}
+
+resource "azurerm_lb_nat_pool" "test" {
+  name                           = "test"
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  frontend_ip_configuration_name = "internal"
+  protocol                       = "Tcp"
+  frontend_port_start            = 80
+  frontend_port_end              = 81
+  backend_port                   = 8080
+}
+
+resource "azurerm_lb_probe" "test" {
+  loadbalancer_id = azurerm_lb.test.id
+  name            = "acctest-lb-probe"
+  port            = 22
+  protocol        = "Tcp"
+}
+
+resource "azurerm_lb_rule" "test" {
+  name                           = "AccTestLBRule"
+  loadbalancer_id                = azurerm_lb.test.id
+  probe_id                       = azurerm_lb_probe.test.id
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
+  frontend_ip_configuration_name = "internal"
+  protocol                       = "Tcp"
+  frontend_port                  = 22
+  backend_port                   = 22
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -639,7 +639,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		}
 	}
 
-	if d.HasChange("network_interface") {
+	if d.HasChange("network_interface") || d.HasChange("health_probe_id") {
 		networkInterfacesRaw := d.Get("network_interface").([]interface{})
 		networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(networkInterfacesRaw)
 		if err != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_network_resource_test.go
@@ -47,7 +47,36 @@ func TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworking(t *tes
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicAcceleratedNetworking(data),
+			Config: r.basicAcceleratedNetworking(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
+func TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworkingUpdated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAcceleratedNetworking(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+		{
+			Config: r.basicAcceleratedNetworking(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+		{
+			Config: r.basicAcceleratedNetworking(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -402,7 +431,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 `, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
 }
 
-func (OrchestratedVirtualMachineScaleSetResource) basicAcceleratedNetworking(data acceptance.TestData) string {
+func (OrchestratedVirtualMachineScaleSetResource) basicAcceleratedNetworking(data acceptance.TestData, enabled bool) string {
 	r := OrchestratedVirtualMachineScaleSetResource{}
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -421,7 +450,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  sku_name  = "Standard_D4_v2"
+  sku_name  = "Standard_D2s_v3" # intentional for accelerated networking
   instances = 2
 
   platform_fault_domain_count = 2
@@ -439,7 +468,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   network_interface {
     name                          = "TestNetworkProfile-%[1]d"
     primary                       = true
-    enable_accelerated_networking = true
+    enable_accelerated_networking = %[4]t
 
     ip_configuration {
       name      = "TestIPConfiguration"
@@ -466,7 +495,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data), enabled)
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) basicEmptyPublicIP(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -532,19 +532,14 @@ func TestAccWindowsVirtualMachineScaleSet_updateHealthProbeSku(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.updateLoadBalancerHealthProbeSKUBasic(data),
+			Config: r.updateLoadBalancerHealthProbeSKU(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
-		// Have to remove VMSS to change the sku of load balancer
 		{
-			Config: r.updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data),
-			Check:  acceptance.ComposeTestCheckFunc(),
-		},
-		{
-			Config: r.updateLoadBalancerHealthProbeSKUStandard(data),
+			Config: r.updateLoadBalancerHealthProbeSKU(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2362,39 +2357,48 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 `, r.template(data), trimmedName)
 }
 
-func (r WindowsVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUBasic(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKU(data acceptance.TestData, isStandardSku bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
+  count = 2
+
+  name                    = "acctestpip${count.index}-%[2]d"
   location                = azurerm_resource_group.test.location
   resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Dynamic"
+  allocation_method       = count.index == 0 ? "Dynamic" : "Static"
   idle_timeout_in_minutes = 4
+  sku                     = count.index == 0 ? "Basic" : "Standard"
 }
 
 resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
+  count = 2
+
+  name                = "acctestlb${count.index}-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
+  sku                 = count.index == 0 ? "Basic" : "Standard"
 
   frontend_ip_configuration {
     name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
+    public_ip_address_id = azurerm_public_ip.test[count.index].id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
+  count = 2
+
+  name            = "test${count.index}"
+  loadbalancer_id = azurerm_lb.test[count.index].id
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
+  count = 2
+
+  name                           = "test${count.index}"
   resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
+  loadbalancer_id                = azurerm_lb.test[count.index].id
   frontend_ip_configuration_name = "internal"
   protocol                       = "Tcp"
   frontend_port_start            = 80
@@ -2403,17 +2407,21 @@ resource "azurerm_lb_nat_pool" "test" {
 }
 
 resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
+  count = 2
+
+  loadbalancer_id = azurerm_lb.test[count.index].id
+  name            = "acctest-lb-probe${count.index}"
   port            = 22
   protocol        = "Tcp"
 }
 
 resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
+  count = 2
+
+  name                           = "AccTestLBRule${count.index}"
+  loadbalancer_id                = azurerm_lb.test[count.index].id
+  probe_id                       = azurerm_lb_probe.test[count.index].id
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test[count.index].id]
   frontend_ip_configuration_name = "internal"
   protocol                       = "Tcp"
   frontend_port                  = 22
@@ -2428,7 +2436,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
-  health_probe_id     = azurerm_lb_probe.test.id
+  health_probe_id     = %[3]t ? azurerm_lb_probe.test[1].id : azurerm_lb_probe.test[0].id
 
   source_image_reference {
     publisher = "MicrosoftWindowsServer"
@@ -2457,180 +2465,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
       name                                   = "internal"
       primary                                = true
       subnet_id                              = azurerm_subnet.test.id
-      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
-      load_balancer_inbound_nat_rules_ids    = [azurerm_lb_nat_pool.test.id]
+      load_balancer_backend_address_pool_ids = %[3]t ? [azurerm_lb_backend_address_pool.test[1].id] : [azurerm_lb_backend_address_pool.test[0].id]
+      load_balancer_inbound_nat_rules_ids    = %[3]t ? [azurerm_lb_nat_pool.test[1].id] : [azurerm_lb_nat_pool.test[0].id]
     }
   }
 
   depends_on = [azurerm_lb_rule.test]
 }
-`, r.template(data), data.RandomInteger)
-}
-
-func (r WindowsVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUBasicVmssRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Dynamic"
-  idle_timeout_in_minutes = 4
-}
-
-resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
-
-  frontend_ip_configuration {
-    name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
-}
-
-resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
-  resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port_start            = 80
-  frontend_port_end              = 81
-  backend_port                   = 8080
-}
-
-resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
-  port            = 22
-  protocol        = "Tcp"
-}
-
-resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port                  = 22
-  backend_port                   = 22
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r WindowsVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKUStandard(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_public_ip" "test" {
-  name                    = "acctestpip-%[2]d"
-  location                = azurerm_resource_group.test.location
-  resource_group_name     = azurerm_resource_group.test.name
-  allocation_method       = "Static"
-  idle_timeout_in_minutes = 4
-  sku                     = "Standard"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "acctestlb-%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-
-  frontend_ip_configuration {
-    name                 = "internal"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  name            = "test"
-  loadbalancer_id = azurerm_lb.test.id
-}
-
-resource "azurerm_lb_nat_pool" "test" {
-  name                           = "test"
-  resource_group_name            = azurerm_resource_group.test.name
-  loadbalancer_id                = azurerm_lb.test.id
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port_start            = 80
-  frontend_port_end              = 81
-  backend_port                   = 8080
-}
-
-resource "azurerm_lb_probe" "test" {
-  loadbalancer_id = azurerm_lb.test.id
-  name            = "acctest-lb-probe"
-  port            = 22
-  protocol        = "Tcp"
-}
-
-resource "azurerm_lb_rule" "test" {
-  name                           = "AccTestLBRule"
-  loadbalancer_id                = azurerm_lb.test.id
-  probe_id                       = azurerm_lb_probe.test.id
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
-  frontend_ip_configuration_name = "internal"
-  protocol                       = "Tcp"
-  frontend_port                  = 22
-  backend_port                   = 22
-}
-
-resource "azurerm_windows_virtual_machine_scale_set" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2"
-  instances           = 1
-  admin_username      = "adminuser"
-  admin_password      = "P@ssword1234!"
-  health_probe_id     = azurerm_lb_probe.test.id
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2019-Datacenter"
-    version   = "latest"
-  }
-
-  os_disk {
-    storage_account_type = "Standard_LRS"
-    caching              = "ReadWrite"
-  }
-
-  data_disk {
-    storage_account_type = "Standard_LRS"
-    caching              = "ReadWrite"
-    disk_size_gb         = 10
-    lun                  = 10
-  }
-
-  network_interface {
-    name    = "example"
-    primary = true
-
-    ip_configuration {
-      name                                   = "internal"
-      primary                                = true
-      subnet_id                              = azurerm_subnet.test.id
-      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
-      load_balancer_inbound_nat_rules_ids    = [azurerm_lb_nat_pool.test.id]
-    }
-  }
-
-  depends_on = [azurerm_lb_rule.test]
-}
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, isStandardSku)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) otherScaleInPolicy(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -648,7 +648,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	if d.HasChange("network_interface") {
+	if d.HasChange("network_interface") || d.HasChange("health_probe_id") {
 		networkInterfacesRaw := d.Get("network_interface").([]interface{})
 		networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(networkInterfacesRaw)
 		if err != nil {


### PR DESCRIPTION
Code:
- Add `d.HasChange("health_probe_id")` so that the update could be detected

Tests:
- `*_otherHealthProbeUpdate`: Fix by the code change
- `*_networkAcceleratedNetworking`: Adding deallocate operation in test so that the property can be updated
- `*_networkPublicIPTags`: Tune the parameter so that property could be set
- `*_updateHealthProbe`: Add a new test step to delete the VMSS then update the sku of Load Balancer, otherwise it cannot be updated.