### PR TITLE
`azurerm_api_connection` - add parameter_value_type property

### DIFF
--- a/internal/services/connections/api_connection_resource.go
+++ b/internal/services/connections/api_connection_resource.go
@@ -83,6 +83,11 @@ func resourceConnection() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
+			"parameter_value_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 
 			"tags": commonschema.Tags(),
 		},
@@ -118,8 +123,9 @@ func resourceConnectionCreate(d *schema.ResourceData, meta interface{}) error {
 			Api: &connections.ApiReference{
 				Id: utils.String(managedAppId.ID()),
 			},
-			DisplayName:     utils.String(d.Get("display_name").(string)),
-			ParameterValues: parameterValues,
+			DisplayName:        utils.String(d.Get("display_name").(string)),
+			ParameterValues:    parameterValues,
+			ParameterValueType: utils.String(d.Get("parameter_value_type").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/model_apiconnectiondefinitionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/model_apiconnectiondefinitionproperties.go
@@ -17,6 +17,7 @@ type ApiConnectionDefinitionProperties struct {
 	DisplayName              *string                       `json:"displayName,omitempty"`
 	NonSecretParameterValues *map[string]string            `json:"nonSecretParameterValues,omitempty"`
 	ParameterValues          *map[string]string            `json:"parameterValues,omitempty"`
+	ParameterValueType			 *string                       `json:"parameterValueType,omitempty"`
 	Statuses                 *[]ConnectionStatusDefinition `json:"statuses,omitempty"`
 	TestLinks                *[]ApiConnectionTestLink      `json:"testLinks,omitempty"`
 }


### PR DESCRIPTION
I have been attempting to configure a logic app with an API connection using managed identity, specifically with Sentinel, but this does not seem to be supported. According to the [documentation ](https://docs.microsoft.com/en-us/azure/logic-apps/create-managed-service-identity?tabs=consumption#arm-template-for-api-connections-and-managed-identities) the property `parameterValueType` needs to be set to `Alternative`, but this property does not exist in this provider. This PR adds that property.

I have had a hard time finding relevant documentation for this or others having this issue, so feedback or alternative solutions is highly appreciated.