### PR TITLE
`azurerm_virtual_hub` - fix acc test `TestAccVirtualHub_basic` and `TestAccDataSourceAzureRMVirtualHub_basic`

### DIFF
--- a/internal/services/network/virtual_hub_data_source_test.go
+++ b/internal/services/network/virtual_hub_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceAzureRMVirtualHub_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("address_prefix").Exists(),
 				check.That(data.ResourceName).Key("virtual_wan_id").Exists(),
 				check.That(data.ResourceName).Key("virtual_router_asn").Exists(),
-				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),
+				check.That(data.ResourceName).Key("virtual_router_ips.#").Exists(),
 			),
 		},
 	})

--- a/internal/services/network/virtual_hub_resource_test.go
+++ b/internal/services/network/virtual_hub_resource_test.go
@@ -25,7 +25,7 @@ func TestAccVirtualHub_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("virtual_router_asn").Exists(),
-				check.That(data.ResourceName).Key("virtual_router_ips").Exists(),
+				check.That(data.ResourceName).Key("virtual_router_ips.#").Exists(),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
current test failure message: `list or set attribute 'virtual_router_ips' must be checked by element count key (virtual_router_ips.#) or element value keys (e.g. virtual_router_ips.0). Set element value checks should use TestCheckTypeSet functions instead`

![image](https://user-images.githubusercontent.com/2633022/190570508-295fe46f-e379-428e-ad81-44a490056cf2.png)
