### PR TITLE
Data Source: `azurerm_storage_account` - support for the `azure_files_identity_based_auth` property

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -280,12 +280,12 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"azure_files_identity_based_auth": {
+			"azure_files_authentication": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"directory_service_type": {
+						"directory_type": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
@@ -314,24 +314,12 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},
-									"azure_storage_sid": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-									"sam_account_name": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
-									"account_type": {
+									"storage_sid": {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},
 								},
 							},
-						},
-						"default_share_permission": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
 						},
 					},
 				},
@@ -471,8 +459,8 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		d.Set("infrastructure_encryption_enabled", infrastructureEncryption)
 
-		if err := d.Set("azure_files_identity_based_auth", flattenAzureRmStorageAccountAzureFilesIdentityBasedAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
-			return fmt.Errorf("setting `azure_files_identity_based_auth`: %+v", err)
+		if err := d.Set("azure_files_authentication", flattenArmStorageAccountAzureFilesAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
+			return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
 		}
 	}
 
@@ -491,72 +479,4 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
-}
-
-func flattenAzureRmStorageAccountAzureFilesIdentityBasedAuthentication(input *storage.AzureFilesIdentityBasedAuthentication) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"directory_service_type":   input.DirectoryServiceOptions,
-			"active_directory":         flattenArmStorageAccountActiveDirectoryProperties(input.ActiveDirectoryProperties),
-			"default_share_permission": input.DefaultSharePermission,
-		},
-	}
-}
-
-func flattenAzureRmStorageAccountActiveDirectoryProperties(input *storage.ActiveDirectoryProperties) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-
-	var domainName string
-	if input.DomainName != nil {
-		domainName = *input.DomainName
-	}
-
-	var netBiosDomainName string
-	if input.NetBiosDomainName != nil {
-		netBiosDomainName = *input.NetBiosDomainName
-	}
-
-	var forestName string
-	if input.ForestName != nil {
-		forestName = *input.ForestName
-	}
-
-	var domainGuid string
-	if input.DomainGUID != nil {
-		domainGuid = *input.DomainGUID
-	}
-
-	var domainSid string
-	if input.DomainSid != nil {
-		domainSid = *input.DomainSid
-	}
-
-	var azureStorageSid string
-	if input.AzureStorageSid != nil {
-		azureStorageSid = *input.AzureStorageSid
-	}
-
-	var samAccountName string
-	if input.SamAccountName != nil {
-		samAccountName = *input.SamAccountName
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"domain_name":          domainName,
-			"net_bios_domain_name": netBiosDomainName,
-			"forest_name":          forestName,
-			"domain_guid":          domainGuid,
-			"domain_sid":           domainSid,
-			"azure_storage_sid":    azureStorageSid,
-			"sam_account_name":     samAccountName,
-			"account_type":         string(input.AccountType),
-		},
-	}
 }

--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -298,7 +298,7 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},
-									"net_bios_domain_name": {
+									"netbios_domain_name": {
 										Type:     pluginsdk.TypeString,
 										Computed: true,
 									},

--- a/internal/services/storage/storage_account_data_source_test.go
+++ b/internal/services/storage/storage_account_data_source_test.go
@@ -139,6 +139,25 @@ func TestAccDataSourceStorageAccount_systemAssignedUserAssignedIdentity(t *testi
 	})
 }
 
+func TestAccDataSourceStorageAccount_azureFilesAuthentication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageAccountDataSource{}.azureFilesAuthenticationAD(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("azure_files_authentication.0.directory_type").HasValue("AD"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.storage_sid").HasValue("S-1-5-21-2400535526-2334094090-2402026252-0012"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.domain_name").HasValue("adtest.com"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.domain_sid").HasValue("S-1-5-21-2400535526-2334094090-2402026252-0012"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.domain_guid").HasValue("aebfc118-9fa9-4732-a21f-d98e41a77ae1"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.forest_name").HasValue("adtest.com"),
+				check.That(data.ResourceName).Key("azure_files_authentication.0.active_directory.0.netbios_domain_name").HasValue("adtest.com"),
+			),
+		},
+	})
+}
+
 func (d StorageAccountDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -354,4 +373,42 @@ data "azurerm_storage_account" "test" {
   resource_group_name = azurerm_storage_account.test.resource_group_name
 }
 `, d.identityTemplate(data), data.RandomString)
+}
+
+func (d StorageAccountDataSource) azureFilesAuthenticationAD(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  azure_files_authentication {
+    directory_type = "AD"
+    active_directory {
+      storage_sid         = "S-1-5-21-2400535526-2334094090-2402026252-0012"
+      domain_name         = "adtest.com"
+      domain_sid          = "S-1-5-21-2400535526-2334094090-2402026252-0012"
+      domain_guid         = "aebfc118-9fa9-4732-a21f-d98e41a77ae1"
+      forest_name         = "adtest.com"
+      netbios_domain_name = "adtest.com"
+    }
+  }
+}
+
+data "azurerm_storage_account" "test" {
+  name                = azurerm_storage_account.test.name
+  resource_group_name = azurerm_storage_account.test.resource_group_name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -132,6 +132,8 @@ output "storage_account_tier" {
 
 * `infrastructure_encryption_enabled` - Is infrastructure encryption enabled? See [here](https://docs.microsoft.com/azure/storage/common/infrastructure-encryption-enable/)
     for more information.
+
+* `azure_files_identity_based_auth` - A `azure_files_identity_based_auth` block as documented below.
 ---
 
 * `custom_domain` supports the following:
@@ -149,6 +151,36 @@ output "storage_account_tier" {
 * `principal_id` - The Principal ID for the Service Principal associated with the Identity of this Storage Account.
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this Storage Account.
+
+---
+
+`azure_files_identity_based_auth` supports the following:
+
+* `directory_service_type` - The directory service used for this Storage Account.
+
+* `active_directory` - An `active_directory` block as documented below.
+
+* `default_share_permission` - The default share permission for users using Kerberos authentication if RBAC role is not assigned.
+
+---
+
+`active_directory` supports the following:
+
+* `domain_name` - The primary domain that the AD DNS server is authoritative for.
+
+* `net_bios_domain_name` - The NetBIOS domain name.
+
+* `forest_name` - The name of the Active Directory forest.
+
+* `domain_guid` - The domain GUID.
+
+* `domain_sid` - The domain security identifier.
+
+* `azure_storage_sid` - The security identifier for Azure Storage.
+
+* `sam_account_name` - The name of the SAM account for Azure Storage.
+
+* `account_type` - The Active Directory account type for Azure Storage.
 
 ## Timeouts
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -133,7 +133,7 @@ output "storage_account_tier" {
 * `infrastructure_encryption_enabled` - Is infrastructure encryption enabled? See [here](https://docs.microsoft.com/azure/storage/common/infrastructure-encryption-enable/)
     for more information.
 
-* `azure_files_identity_based_auth` - A `azure_files_identity_based_auth` block as documented below.
+* `azure_files_authentication` - A `azure_files_authentication` block as documented below.
 ---
 
 * `custom_domain` supports the following:
@@ -154,13 +154,11 @@ output "storage_account_tier" {
 
 ---
 
-`azure_files_identity_based_auth` supports the following:
+`azure_files_authentication` supports the following:
 
-* `directory_service_type` - The directory service used for this Storage Account.
+* `directory_type` - The directory service used for this Storage Account.
 
 * `active_directory` - An `active_directory` block as documented below.
-
-* `default_share_permission` - The default share permission for users using Kerberos authentication if RBAC role is not assigned.
 
 ---
 
@@ -176,11 +174,7 @@ output "storage_account_tier" {
 
 * `domain_sid` - The domain security identifier.
 
-* `azure_storage_sid` - The security identifier for Azure Storage.
-
-* `sam_account_name` - The name of the SAM account for Azure Storage.
-
-* `account_type` - The Active Directory account type for Azure Storage.
+* `storage_sid` - The security identifier for Azure Storage.
 
 ## Timeouts
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -166,7 +166,7 @@ output "storage_account_tier" {
 
 * `domain_name` - The primary domain that the AD DNS server is authoritative for.
 
-* `net_bios_domain_name` - The NetBIOS domain name.
+* `netbios_domain_name` - The NetBIOS domain name.
 
 * `forest_name` - The name of the Active Directory forest.
 


### PR DESCRIPTION
Fix #18372

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccDataSourceStorageAccount_azureFilesAuthentication'
=== RUN   TestAccDataSourceStorageAccount_azureFilesAuthentication
=== PAUSE TestAccDataSourceStorageAccount_azureFilesAuthentication
=== CONT  TestAccDataSourceStorageAccount_azureFilesAuthentication
--- PASS: TestAccDataSourceStorageAccount_azureFilesAuthentication (99.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       99.081s
```