### PR TITLE
`compute` - remove invalid test `TestAccImage_standaloneImageZoneRedundant`

### DIFF
--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -64,30 +64,6 @@ func TestAccImage_standaloneImage_hyperVGeneration_V2(t *testing.T) {
 	})
 }
 
-func TestAccImage_standaloneImageZoneRedundant(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_image", "test")
-	r := ImageResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			// need to create a vm and then reference it in the image creation
-			Config:  r.setupUnmanagedDisks(data, "ZRS"),
-			Destroy: false,
-			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
-			),
-		},
-		{
-			Config: r.standaloneImageProvision(data, "ZRS", ""),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That("azurerm_image.test").ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccImage_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_image", "test")
 	r := ImageResource{}


### PR DESCRIPTION
This is failing due to `The platform image 'Canonical:UbuntuServer:16.04-LTS:latest' is not available.` After further investigation, firstly, this image is available in the platform. And when trying with adding `zones`, I got `Virtual Machines deployed to an Availability Zone must use managed disks.`
Since ZoneRedundant has to specify `zones`, and `zones` only support managed disk, we are not able to use an unmanaged disk to create VM with "ZRS" storage account type.