### PR TITLE
Enhance - `azurerm_api_management_api_operatio` - support config `example`,  `schema_id` and `type_name`

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_resource.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource.go
@@ -221,7 +221,11 @@ func resourceApiManagementApiOperationRead(d *pluginsdk.ResourceData, meta inter
 			return fmt.Errorf("flattening `response`: %+v", err)
 		}
 
-		flattenedTemplateParams := schemaz.FlattenApiManagementOperationParameterContract(props.TemplateParameters)
+		flattenedTemplateParams, err := schemaz.FlattenApiManagementOperationParameterContract(props.TemplateParameters)
+		if err != nil {
+			return err
+		}
+
 		if err := d.Set("template_parameter", flattenedTemplateParams); err != nil {
 			return fmt.Errorf("flattening `template_parameter`: %+v", err)
 		}
@@ -301,8 +305,18 @@ func flattenApiManagementOperationRequestContract(input *apimanagement.RequestCo
 		output["description"] = *input.Description
 	}
 
-	output["header"] = schemaz.FlattenApiManagementOperationParameterContract(input.Headers)
-	output["query_parameter"] = schemaz.FlattenApiManagementOperationParameterContract(input.QueryParameters)
+	header, err := schemaz.FlattenApiManagementOperationParameterContract(input.Headers)
+	if err != nil {
+		return nil, err
+	}
+	output["header"] = header
+
+	queryParameter, err := schemaz.FlattenApiManagementOperationParameterContract(input.QueryParameters)
+	if err != nil {
+		return nil, err
+	}
+	output["query_parameter"] = queryParameter
+
 	representation, err := schemaz.FlattenApiManagementOperationRepresentation(input.Representations)
 	if err != nil {
 		return nil, err
@@ -365,7 +379,11 @@ func flattenApiManagementOperationResponseContract(input *[]apimanagement.Respon
 			output["status_code"] = int(*v.StatusCode)
 		}
 
-		output["header"] = schemaz.FlattenApiManagementOperationParameterContract(v.Headers)
+		header, err := schemaz.FlattenApiManagementOperationParameterContract(v.Headers)
+		if err != nil {
+			return nil, err
+		}
+		output["header"] = header
 
 		representation, err := schemaz.FlattenApiManagementOperationRepresentation(v.Representations)
 		if err != nil {

--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -344,6 +344,14 @@ resource "azurerm_api_management_api_operation" "test" {
 func (r ApiManagementApiOperationResource) headers(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+resource "azurerm_api_management_api_schema" "test" {
+  api_name            = azurerm_api_management_api.test.name
+  api_management_name = azurerm_api_management_api.test.api_management_name
+  resource_group_name = azurerm_api_management_api.test.resource_group_name
+  schema_id           = "acctestSchema%d"
+  content_type        = "application/json"
+  value               = file("testdata/api_management_api_schema_swagger.json")
+}
 
 resource "azurerm_api_management_api_operation" "test" {
   operation_id        = "acctest-operation"
@@ -379,6 +387,16 @@ resource "azurerm_api_management_api_operation" "test" {
       name     = "X-Test-Operation"
       required = true
       type     = "string"
+
+      type_name = "User"
+      schema_id = azurerm_api_management_api_schema.test.schema_id
+      example {
+        description    = "This is a test description"
+        external_value = "https://example.com/foo/bar"
+        name           = "test"
+        summary        = "This is a test summary"
+        value          = "backend-Request-Test"
+      }
     }
 
     representation {
@@ -401,7 +419,7 @@ SAMPLE
     }
   }
 }
-`, r.template(data))
+`, r.template(data), data.RandomInteger)
 }
 
 func (r ApiManagementApiOperationResource) representation(data acceptance.TestData) string {

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -94,6 +94,12 @@ A `form_parameter` block supports the following:
 * `default_value` - (Optional) The default value for this Form Parameter.
 
 * `values` - (Optional) One or more acceptable values for this Form Parameter.
+ 
+* `example` - (Optional) (Optional) One or more `example` blocks as defined above.
+
+* `schema_id` - (Optional) The name of the Schema.
+
+* `type_name` - (Optional) The type name defined by the Schema.
 
 ---
 
@@ -111,6 +117,11 @@ A `header` block supports the following:
 
 * `values` - (Optional) One or more acceptable values for this Header.
 
+* `example` - (Optional) (Optional) One or more `example` blocks as defined above.
+
+* `schema_id` - (Optional) The name of the Schema.
+
+* `type_name` - (Optional) The type name defined by the Schema.
 ---
 
 A `query_parameter` block supports the following:
@@ -126,6 +137,12 @@ A `query_parameter` block supports the following:
 * `default_value` - (Optional) The default value for this Query Parameter.
 
 * `values` - (Optional) One or more acceptable values for this Query Parameter.
+
+* `example` - (Optional) (Optional) One or more `example` blocks as defined above.
+
+* `schema_id` - (Optional) The name of the Schema.
+
+* `type_name` - (Optional) The type name defined by the Schema.
 
 ---
 
@@ -186,6 +203,12 @@ A `template_parameter` block supports the following:
 * `default_value` - (Optional) The default value for this Template Parameter.
 
 * `values` - (Optional) One or more acceptable values for this Template Parameter.
+
+* `example` - (Optional) (Optional) One or more `example` blocks as defined above.
+
+* `schema_id` - (Optional) The name of the Schema.
+
+* `type_name` - (Optional) The type name defined by the Schema.
 
 ---
 


### PR DESCRIPTION
Now `request.header, request.queryParameter, request.representation.formParameter, response.header, response.representation.formParameter`  support config: `example`,  `schema_id` and `type_name`

```log
=== PAUSE TestAccApiManagementApiOperation_requestRepresentations
=== RUN   TestAccApiManagementApiOperation_representations
=== PAUSE TestAccApiManagementApiOperation_representations
=== RUN   TestAccApiManagementApiOperation_complete
=== PAUSE TestAccApiManagementApiOperation_complete
=== CONT  TestAccApiManagementApiOperation_basic
=== CONT  TestAccApiManagementApiOperation_requestRepresentations
=== CONT  TestAccApiManagementApiOperation_complete
=== CONT  TestAccApiManagementApiOperation_representations
=== CONT  TestAccApiManagementApiOperation_requiresImport
=== CONT  TestAccApiManagementApiOperation_customMethod
=== CONT  TestAccApiManagementApiOperation_headers
--- PASS: TestAccApiManagementApiOperation_basic (559.65s)
--- PASS: TestAccApiManagementApiOperation_complete (560.33s)
--- PASS: TestAccApiManagementApiOperation_customMethod (574.42s)
--- PASS: TestAccApiManagementApiOperation_headers (582.33s)
--- PASS: TestAccApiManagementApiOperation_requiresImport (604.36s)
--- PASS: TestAccApiManagementApiOperation_representations (667.25s)
--- PASS: TestAccApiManagementApiOperation_requestRepresentations (670.39s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 707.504s
```