### PR TITLE
`azurerm_marketplace_agreement` - fix acc tests

### DIFF
--- a/internal/services/compute/marketplace_agreement_resource_test.go
+++ b/internal/services/compute/marketplace_agreement_resource_test.go
@@ -15,35 +15,20 @@ import (
 
 type MarketplaceAgreementResource struct{}
 
-func TestAccMarketplaceAgreement(t *testing.T) {
-	testCases := map[string]map[string]func(t *testing.T){
-		"basic": {
-			"basic":             testAccMarketplaceAgreement_basic,
-			"requiresImport":    testAccMarketplaceAgreement_requiresImport,
-			"agreementCanceled": testAccMarketplaceAgreement_agreementCanceled,
-		},
-	}
-
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
-}
-
-func testAccMarketplaceAgreement_basic(t *testing.T) {
+func TestAccMarketplaceAgreement_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_marketplace_agreement", "test")
 	r := MarketplaceAgreementResource{}
+	offer := "waf"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.empty(),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(offer)),
+			),
+		},
+		{
+			Config: r.basic(offer),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("license_text_link").Exists(),
@@ -54,33 +39,28 @@ func testAccMarketplaceAgreement_basic(t *testing.T) {
 	})
 }
 
-func testAccMarketplaceAgreement_requiresImport(t *testing.T) {
+func TestAccMarketplaceAgreement_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_marketplace_agreement", "test")
 	r := MarketplaceAgreementResource{}
+	offer := "barracuda-ng-firewall"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.empty(),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(offer)),
+			),
+		},
+		{
+			Config: r.basic(offer),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		{
-			Config:      r.requiresImportConfig(data),
+			Config:      r.requiresImport(offer),
 			ExpectError: acceptance.RequiresImportError("azurerm_marketplace_agreement"),
 		},
-	})
-}
-
-func testAccMarketplaceAgreement_agreementCanceled(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_marketplace_agreement", "test")
-	r := MarketplaceAgreementResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		data.DisappearsStep(acceptance.DisappearsStepData{
-			Config:       r.basicConfig,
-			TestResource: r,
-		}),
 	})
 }
 
@@ -95,41 +75,34 @@ func (t MarketplaceAgreementResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("retrieving Compute Marketplace Agreement %q", id)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
-}
-
-func (MarketplaceAgreementResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.PlanID(state.ID)
-	if err != nil {
-		return nil, err
+	if resp.ID == nil {
+		return utils.Bool(false), nil
 	}
 
-	resp, err := client.Compute.MarketplaceAgreementsClient.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return nil, fmt.Errorf("marketplace agreement %q does not exist", id)
+	if props := resp.AgreementProperties; props != nil {
+		if accept := props.Accepted; accept != nil && *accept {
+			return utils.Bool(true), nil
 		}
-		return nil, fmt.Errorf("canceling Marketplace Agreement : %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return utils.Bool(false), nil
 }
 
-func (MarketplaceAgreementResource) basicConfig(_ acceptance.TestData) string {
-	return `
+func (MarketplaceAgreementResource) basic(offer string) string {
+	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_marketplace_agreement" "test" {
   publisher = "barracudanetworks"
-  offer     = "waf"
+  offer     = "%s"
   plan      = "hourly"
 }
-`
+`, offer)
 }
 
-func (r MarketplaceAgreementResource) requiresImportConfig(data acceptance.TestData) string {
+func (r MarketplaceAgreementResource) requiresImport(offer string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -138,5 +111,39 @@ resource "azurerm_marketplace_agreement" "import" {
   offer     = azurerm_marketplace_agreement.test.offer
   plan      = azurerm_marketplace_agreement.test.plan
 }
-`, r.basicConfig(data))
+`, r.basic(offer))
+}
+
+func (MarketplaceAgreementResource) empty() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
+}
+
+func (r MarketplaceAgreementResource) cancelExistingAgreement(offer string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Compute.MarketplaceAgreementsClient
+		id := parse.NewPlanID(client.SubscriptionID, "barracudanetworks", offer, "hourly")
+
+		existing, err := client.Get(ctx, id.AgreementName, id.OfferName, id.Name)
+		if err != nil {
+			return err
+		}
+
+		if props := existing.AgreementProperties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("marketplace agreement %q does not exist", id)
+					}
+					return fmt.Errorf("canceling Marketplace Agreement : %+v", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
The subscription can only have one registration of same marketplace agreement. This change updates the tests to use different `offer` so that tests running in parallel won't affect each other.
- `testAccMarketplaceAgreement_agreementCanceled` has been removed, the test for Destroy will be done at post-test destroy
- updated Exists() to return `true` when `accept` is `true`, to match the condition in Read()
- add an empty step in each test to run `cancelExistingAgreement()` to clean up potential existing agreement left up by other broken tests 