### PR TITLE
Data source: `azurerm_key_vault_certificate_data` - fix PEM private key block header for EC keys

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -231,7 +231,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	}
 
 	var keyX509 []byte
-	var pemKeyHeader string = "PRIVATE KEY"
+	var pemKeyHeader string
 	if privateKey != nil {
 		switch v := privateKey.(type) {
 		case *ecdsa.PrivateKey:
@@ -239,6 +239,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 			if err != nil {
 				return fmt.Errorf("marshalling private key type %+v (%q): %+v", v, id.Name, err)
 			}
+			pemKeyHeader = "EC PRIVATE KEY"
 		case *rsa.PrivateKey:
 			keyX509 = x509.MarshalPKCS1PrivateKey(privateKey.(*rsa.PrivateKey))
 			pemKeyHeader = "RSA PRIVATE KEY"


### PR DESCRIPTION
Currently `azurerm_key_vault_certificate_data` uses a general `-----BEGIN PRIVATE KEY-----` header for EC private keys.
This breaks tools like hashicorp/tls's `tls_locally_signed_cert` which expect [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format for `ca_private_key_pem`: `-----BEGIN EC PRIVATE KEY-----`.

This was already fixed for RSA private keys in #12896. This PR does the same fix it for EC based keys too.

fixes #13965

----

<details>
<summary>Output from keyvault acceptance tests</summary>

**There were a few failures here, but looks like it's just because I picked a bad location, and my service principal having limited access to Active Directory**

```
[cfosli]$ ARM_CLIENT_ID={redacted} ARM_CLIENT_SECRET={redacted} ARM_SUBSCRIPTION_ID={redacted} ARM_TENANT_ID={redacted} ARM_TEST_LOCATION=westeurope ARM_TEST_LOCATION_ALT=northeurope ARM_TEST_LOCATION_ALT2=eastus make acctests SERVICE=keyvault TESTTIMEOUT='240m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault  -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccEncryptedValueDataSource_encryptAndDecrypt
=== PAUSE TestAccEncryptedValueDataSource_encryptAndDecrypt
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_key
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_key
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_secret
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_secret
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_certificate
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_certificate
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_keySecret
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_keySecret
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_keyCertificate
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_keyCertificate
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_secretCertificate
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_secretCertificate
=== RUN   TestAccDataSourceKeyVaultAccessPolicy_keySecretCertificate
=== PAUSE TestAccDataSourceKeyVaultAccessPolicy_keySecretCertificate
=== RUN   TestAccKeyVaultAccessPolicy_basic
=== PAUSE TestAccKeyVaultAccessPolicy_basic
=== RUN   TestAccKeyVaultAccessPolicy_requiresImport
=== PAUSE TestAccKeyVaultAccessPolicy_requiresImport
=== RUN   TestAccKeyVaultAccessPolicy_multiple
=== PAUSE TestAccKeyVaultAccessPolicy_multiple
=== RUN   TestAccKeyVaultAccessPolicy_update
=== PAUSE TestAccKeyVaultAccessPolicy_update
=== RUN   TestAccKeyVaultAccessPolicy_nonExistentVault
=== PAUSE TestAccKeyVaultAccessPolicy_nonExistentVault
=== RUN   TestAccDataSourceKeyVaultCertificateData_basic
=== PAUSE TestAccDataSourceKeyVaultCertificateData_basic
=== RUN   TestAccDataSourceKeyVaultCertificateData_ecdsa_PFX
=== PAUSE TestAccDataSourceKeyVaultCertificateData_ecdsa_PFX
=== RUN   TestAccDataSourceKeyVaultCertificateData_ecdsa_PEM
=== PAUSE TestAccDataSourceKeyVaultCertificateData_ecdsa_PEM
=== RUN   TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PEM
=== PAUSE TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PEM
=== RUN   TestAccDataSourceKeyVaultCertificateData_rsa_single_PEM
=== PAUSE TestAccDataSourceKeyVaultCertificateData_rsa_single_PEM
=== RUN   TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PFX
=== PAUSE TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PFX
=== RUN   TestAccDataSourceKeyVaultCertificate_basic
=== PAUSE TestAccDataSourceKeyVaultCertificate_basic
=== RUN   TestAccDataSourceKeyVaultCertificate_generated
=== PAUSE TestAccDataSourceKeyVaultCertificate_generated
=== RUN   TestAccDataSourceKeyVaultCertificate_generatedEllipticCurve
=== PAUSE TestAccDataSourceKeyVaultCertificate_generatedEllipticCurve
=== RUN   TestAccDataSourceKeyVaultCertificateIssuer_basic
=== PAUSE TestAccDataSourceKeyVaultCertificateIssuer_basic
=== RUN   TestAccKeyVaultCertificateIssuer_basic
=== PAUSE TestAccKeyVaultCertificateIssuer_basic
=== RUN   TestAccKeyVaultCertificateIssuer_requiresImport
=== PAUSE TestAccKeyVaultCertificateIssuer_requiresImport
=== RUN   TestAccKeyVaultCertificateIssuer_complete
=== PAUSE TestAccKeyVaultCertificateIssuer_complete
=== RUN   TestAccKeyVaultCertificateIssuer_update
=== PAUSE TestAccKeyVaultCertificateIssuer_update
=== RUN   TestAccKeyVaultCertificateIssuer_disappears
=== PAUSE TestAccKeyVaultCertificateIssuer_disappears
=== RUN   TestAccKeyVaultCertificate_basicImportPFX
=== PAUSE TestAccKeyVaultCertificate_basicImportPFX
=== RUN   TestAccKeyVaultCertificate_requiresImport
=== PAUSE TestAccKeyVaultCertificate_requiresImport
=== RUN   TestAccKeyVaultCertificate_disappears
=== PAUSE TestAccKeyVaultCertificate_disappears
=== RUN   TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted
=== PAUSE TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted
=== RUN   TestAccKeyVaultCertificate_basicGenerate
=== PAUSE TestAccKeyVaultCertificate_basicGenerate
=== RUN   TestAccKeyVaultCertificate_basicGenerateUnknownIssuer
=== PAUSE TestAccKeyVaultCertificate_basicGenerateUnknownIssuer
=== RUN   TestAccKeyVaultCertificate_softDeleteRecovery
=== PAUSE TestAccKeyVaultCertificate_softDeleteRecovery
=== RUN   TestAccKeyVaultCertificate_basicGenerateSans
=== PAUSE TestAccKeyVaultCertificate_basicGenerateSans
=== RUN   TestAccKeyVaultCertificate_basicGenerateTags
=== PAUSE TestAccKeyVaultCertificate_basicGenerateTags
=== RUN   TestAccKeyVaultCertificate_updateTags
=== PAUSE TestAccKeyVaultCertificate_updateTags
=== RUN   TestAccKeyVaultCertificate_basicGenerateEllipticCurve
=== PAUSE TestAccKeyVaultCertificate_basicGenerateEllipticCurve
=== RUN   TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize
=== PAUSE TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize
=== RUN   TestAccKeyVaultCertificate_basicExtendedKeyUsage
=== PAUSE TestAccKeyVaultCertificate_basicExtendedKeyUsage
=== RUN   TestAccKeyVaultCertificate_emptyExtendedKeyUsage
=== PAUSE TestAccKeyVaultCertificate_emptyExtendedKeyUsage
=== RUN   TestAccKeyVaultCertificate_withExternalAccessPolicy
=== PAUSE TestAccKeyVaultCertificate_withExternalAccessPolicy
=== RUN   TestAccKeyVaultCertificate_purge
=== PAUSE TestAccKeyVaultCertificate_purge
=== RUN   TestAccKeyVaultCertificate_unorderedKeyUsage
=== PAUSE TestAccKeyVaultCertificate_unorderedKeyUsage
=== RUN   TestAccDataSourceKeyVault_basic
=== PAUSE TestAccDataSourceKeyVault_basic
=== RUN   TestAccDataSourceKeyVault_complete
=== PAUSE TestAccDataSourceKeyVault_complete
=== RUN   TestAccDataSourceKeyVault_networkAcls
=== PAUSE TestAccDataSourceKeyVault_networkAcls
=== RUN   TestAccDataSourceKeyVault_update
=== PAUSE TestAccDataSourceKeyVault_update
=== RUN   TestAccDataSourceKeyVaultKey_complete
=== PAUSE TestAccDataSourceKeyVaultKey_complete
=== RUN   TestAccKeyVaultKey_basicEC
=== PAUSE TestAccKeyVaultKey_basicEC
=== RUN   TestAccKeyVaultKey_requiresImport
=== PAUSE TestAccKeyVaultKey_requiresImport
=== RUN   TestAccKeyVaultKey_basicECHSM
=== PAUSE TestAccKeyVaultKey_basicECHSM
=== RUN   TestAccKeyVaultKey_curveEC
=== PAUSE TestAccKeyVaultKey_curveEC
=== RUN   TestAccKeyVaultKey_basicRSA
=== PAUSE TestAccKeyVaultKey_basicRSA
=== RUN   TestAccKeyVaultKey_basicRSAHSM
=== PAUSE TestAccKeyVaultKey_basicRSAHSM
=== RUN   TestAccKeyVaultKey_complete
=== PAUSE TestAccKeyVaultKey_complete
=== RUN   TestAccKeyVaultKey_softDeleteRecovery
=== PAUSE TestAccKeyVaultKey_softDeleteRecovery
=== RUN   TestAccKeyVaultKey_update
=== PAUSE TestAccKeyVaultKey_update
=== RUN   TestAccKeyVaultKey_updatedExternally
=== PAUSE TestAccKeyVaultKey_updatedExternally
=== RUN   TestAccKeyVaultKey_disappears
=== PAUSE TestAccKeyVaultKey_disappears
=== RUN   TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted
=== PAUSE TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted
=== RUN   TestAccKeyVaultKey_withExternalAccessPolicy
=== PAUSE TestAccKeyVaultKey_withExternalAccessPolicy
=== RUN   TestAccKeyVaultKey_purge
=== PAUSE TestAccKeyVaultKey_purge
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/data_source
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/data_source/basic
    testcase.go:117: Step 1/1 error: Error running apply: exit status 1

        Error: creating Managed H S M: (Name "kvHsm220917161633899220" / Resource Group "acctestRG-KV-220917161633899220"): keyvault.ManagedHsmsClient#CreateOrUpdate: Failure sending request: StatusCode=503 -- Original Error: Code="503" Message="Pool creation is disabled in this region"

          with azurerm_key_vault_managed_hardware_security_module.test,
          on terraform_plugin_test.tf line 17, in resource "azurerm_key_vault_managed_hardware_security_module" "test":
          17: resource "azurerm_key_vault_managed_hardware_security_module" "test" {

=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/basic
    testcase.go:117: Step 1/2 error: Error running apply: exit status 1

        Error: creating Managed H S M: (Name "kvHsm220917162724534323" / Resource Group "acctestRG-KV-220917162724534323"): keyvault.ManagedHsmsClient#CreateOrUpdate: Failure sending request: StatusCode=503 -- Original Error: Code="503" Message="Pool creation is disabled in this region"

          with azurerm_key_vault_managed_hardware_security_module.test,
          on terraform_plugin_test.tf line 16, in resource "azurerm_key_vault_managed_hardware_security_module" "test":
          16: resource "azurerm_key_vault_managed_hardware_security_module" "test" {

=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/update
    testcase.go:117: Step 1/2 error: Error running apply: exit status 1

        Error: creating Managed H S M: (Name "kvHsm220917163734196502" / Resource Group "acctestRG-KV-220917163734196502"): keyvault.ManagedHsmsClient#CreateOrUpdate: Failure sending request: StatusCode=503 -- Original Error: Code="503" Message="Pool creation is disabled in this region"

          with azurerm_key_vault_managed_hardware_security_module.test,
          on terraform_plugin_test.tf line 16, in resource "azurerm_key_vault_managed_hardware_security_module" "test":
          16: resource "azurerm_key_vault_managed_hardware_security_module" "test" {

=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/complete
    testcase.go:117: Step 1/2 error: Error running apply: exit status 1

        Error: creating Managed H S M: (Name "kvHsm220917164728553180" / Resource Group "acctestRG-KV-220917164728553180"): keyvault.ManagedHsmsClient#CreateOrUpdate: Failure sending request: StatusCode=503 -- Original Error: Code="503" Message="Pool creation is disabled in this region"

          with azurerm_key_vault_managed_hardware_security_module.test,
          on terraform_plugin_test.tf line 16, in resource "azurerm_key_vault_managed_hardware_security_module" "test":
          16: resource "azurerm_key_vault_managed_hardware_security_module" "test" {

--- FAIL: TestAccKeyVaultManagedHardwareSecurityModule (2450.94s)
    --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/data_source (650.64s)
        --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/data_source/basic (650.64s)
    --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/resource (1800.31s)
        --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/resource/basic (609.66s)
        --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/resource/update (594.36s)
        --- FAIL: TestAccKeyVaultManagedHardwareSecurityModule/resource/complete (596.29s)
=== RUN   TestAccKeyVaultManagedStorageAccountSasTokenDefinition_basic
=== PAUSE TestAccKeyVaultManagedStorageAccountSasTokenDefinition_basic
=== RUN   TestAccKeyVaultManagedStorageAccountSasTokenDefinition_requiresImport
=== PAUSE TestAccKeyVaultManagedStorageAccountSasTokenDefinition_requiresImport
=== RUN   TestAccKeyVaultManagedStorageAccountSasTokenDefinition_complete
=== PAUSE TestAccKeyVaultManagedStorageAccountSasTokenDefinition_complete
=== RUN   TestAccKeyVaultManagedStorageAccountSasTokenDefinition_update
=== PAUSE TestAccKeyVaultManagedStorageAccountSasTokenDefinition_update
=== RUN   TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery
=== PAUSE TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery
=== RUN   TestAccKeyVaultManagedStorageAccount_basic
=== PAUSE TestAccKeyVaultManagedStorageAccount_basic
=== RUN   TestAccKeyVaultManagedStorageAccount_requiresImport
=== PAUSE TestAccKeyVaultManagedStorageAccount_requiresImport
=== RUN   TestAccKeyVaultManagedStorageAccount_complete
=== PAUSE TestAccKeyVaultManagedStorageAccount_complete
=== RUN   TestAccKeyVaultManagedStorageAccount_update
=== PAUSE TestAccKeyVaultManagedStorageAccount_update
=== RUN   TestAccKeyVaultManagedStorageAccount_recovery
=== PAUSE TestAccKeyVaultManagedStorageAccount_recovery
=== RUN   TestAccKeyVault_basic
=== PAUSE TestAccKeyVault_basic
=== RUN   TestAccKeyVault_requiresImport
=== PAUSE TestAccKeyVault_requiresImport
=== RUN   TestAccKeyVault_networkAcls
=== PAUSE TestAccKeyVault_networkAcls
=== RUN   TestAccKeyVault_networkAclsAllowed
=== PAUSE TestAccKeyVault_networkAclsAllowed
=== RUN   TestAccKeyVault_accessPolicyUpperLimit
=== PAUSE TestAccKeyVault_accessPolicyUpperLimit
=== RUN   TestAccKeyVault_disappears
=== PAUSE TestAccKeyVault_disappears
=== RUN   TestAccKeyVault_complete
=== PAUSE TestAccKeyVault_complete
=== RUN   TestAccKeyVault_update
=== PAUSE TestAccKeyVault_update
=== RUN   TestAccKeyVault_upgradeSKU
=== PAUSE TestAccKeyVault_upgradeSKU
=== RUN   TestAccKeyVault_updateContacts
=== PAUSE TestAccKeyVault_updateContacts
=== RUN   TestAccKeyVault_justCert
=== PAUSE TestAccKeyVault_justCert
=== RUN   TestAccKeyVault_softDelete
=== PAUSE TestAccKeyVault_softDelete
=== RUN   TestAccKeyVault_softDeleteRecovery
=== PAUSE TestAccKeyVault_softDeleteRecovery
=== RUN   TestAccKeyVault_softDeleteRecoveryDisabled
=== PAUSE TestAccKeyVault_softDeleteRecoveryDisabled
=== RUN   TestAccKeyVault_purgeProtectionEnabled
=== PAUSE TestAccKeyVault_purgeProtectionEnabled
=== RUN   TestAccKeyVault_purgeProtectionAndSoftDeleteEnabled
=== PAUSE TestAccKeyVault_purgeProtectionAndSoftDeleteEnabled
=== RUN   TestAccKeyVault_purgeProtectionViaUpdate
=== PAUSE TestAccKeyVault_purgeProtectionViaUpdate
=== RUN   TestAccKeyVault_purgeProtectionAttemptToDisable
=== PAUSE TestAccKeyVault_purgeProtectionAttemptToDisable
=== RUN   TestAccKeyVault_deletePolicy
=== PAUSE TestAccKeyVault_deletePolicy
=== RUN   TestAccDataSourceKeyVaultSecret_basic
=== PAUSE TestAccDataSourceKeyVaultSecret_basic
=== RUN   TestAccDataSourceKeyVaultSecret_complete
=== PAUSE TestAccDataSourceKeyVaultSecret_complete
=== RUN   TestAccKeyVaultSecret_basic
=== PAUSE TestAccKeyVaultSecret_basic
=== RUN   TestAccKeyVaultSecret_requiresImport
=== PAUSE TestAccKeyVaultSecret_requiresImport
=== RUN   TestAccKeyVaultSecret_disappears
=== PAUSE TestAccKeyVaultSecret_disappears
=== RUN   TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted
=== PAUSE TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted
=== RUN   TestAccKeyVaultSecret_complete
=== PAUSE TestAccKeyVaultSecret_complete
=== RUN   TestAccKeyVaultSecret_update
=== PAUSE TestAccKeyVaultSecret_update
=== RUN   TestAccKeyVaultSecret_updatingValueChangedExternally
=== PAUSE TestAccKeyVaultSecret_updatingValueChangedExternally
=== RUN   TestAccKeyVaultSecret_recovery
=== PAUSE TestAccKeyVaultSecret_recovery
=== RUN   TestAccKeyVaultSecret_withExternalAccessPolicy
=== PAUSE TestAccKeyVaultSecret_withExternalAccessPolicy
=== RUN   TestAccKeyVaultSecret_purge
=== PAUSE TestAccKeyVaultSecret_purge
=== RUN   TestAccDataSourceKeyVaultSecrets_basic
=== PAUSE TestAccDataSourceKeyVaultSecrets_basic
=== CONT  TestAccKeyVaultSecret_complete
=== CONT  TestAccKeyVault_purgeProtectionViaUpdate
=== CONT  TestAccDataSourceKeyVault_basic
=== CONT  TestAccEncryptedValueDataSource_encryptAndDecrypt
=== CONT  TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted
=== CONT  TestAccKeyVaultSecret_disappears
=== CONT  TestAccKeyVaultSecret_requiresImport
=== CONT  TestAccKeyVaultSecret_basic
=== CONT  TestAccDataSourceKeyVaultSecret_complete
=== CONT  TestAccDataSourceKeyVaultSecret_basic
=== CONT  TestAccKeyVault_deletePolicy
=== CONT  TestAccKeyVault_purgeProtectionAttemptToDisable
--- PASS: TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted (248.50s)
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery
--- PASS: TestAccDataSourceKeyVault_basic (261.22s)
=== CONT  TestAccKeyVault_purgeProtectionAndSoftDeleteEnabled
--- PASS: TestAccKeyVaultSecret_disappears (261.35s)
=== CONT  TestAccKeyVault_purgeProtectionEnabled
--- PASS: TestAccKeyVault_purgeProtectionAttemptToDisable (284.30s)
=== CONT  TestAccKeyVault_softDeleteRecoveryDisabled
--- PASS: TestAccEncryptedValueDataSource_encryptAndDecrypt (292.35s)
=== CONT  TestAccKeyVault_softDeleteRecovery
--- PASS: TestAccDataSourceKeyVaultSecret_basic (292.41s)
=== CONT  TestAccKeyVault_softDelete
--- PASS: TestAccDataSourceKeyVaultSecret_complete (292.70s)
=== CONT  TestAccKeyVault_justCert
--- PASS: TestAccKeyVaultSecret_complete (295.74s)
=== CONT  TestAccKeyVault_updateContacts
--- PASS: TestAccKeyVaultSecret_basic (295.89s)
=== CONT  TestAccKeyVault_upgradeSKU
--- PASS: TestAccKeyVaultSecret_requiresImport (317.38s)
=== CONT  TestAccKeyVault_update
--- PASS: TestAccKeyVault_purgeProtectionViaUpdate (318.72s)
=== CONT  TestAccKeyVault_complete
--- PASS: TestAccKeyVault_deletePolicy (338.48s)
=== CONT  TestAccKeyVault_disappears
--- PASS: TestAccKeyVault_purgeProtectionEnabled (240.95s)
=== CONT  TestAccKeyVault_accessPolicyUpperLimit
--- PASS: TestAccKeyVault_purgeProtectionAndSoftDeleteEnabled (246.94s)
=== CONT  TestAccKeyVault_networkAclsAllowed
=== CONT  TestAccKeyVault_update
    testcase.go:110: Step 2/4 error: Error running apply: exit status 1

        Error: updating Vault: (Name "vault220917165724840260" / Resource Group "acctestRG-220917165724840260"): keyvault.VaultsClient#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InsufficientPermissions" Message="Caller is not allowed to change permission model. For more information on how to change the permissions model follow this link: https://go.microsoft.com/fwlink/?linkid=2155160. Details: oid=78e1ee05-9110-4054-a2e2-5889c1225179; action=Microsoft.Authorization/roleAssignments/write; resource=/subscriptions/8b813ab6-f295-4c58-8fc2-b0a199790709/resourcegroups/acctestRG-220917165724840260/providers/Microsoft.KeyVault/vaults/vault220917165724840260; decision=NotAllowed; "

          with azurerm_key_vault.test,
          on terraform_plugin_test.tf line 14, in resource "azurerm_key_vault" "test":
          14: resource "azurerm_key_vault" "test" {

--- PASS: TestAccKeyVault_softDelete (264.81s)
=== CONT  TestAccKeyVault_networkAcls
--- PASS: TestAccKeyVault_disappears (231.68s)
=== CONT  TestAccKeyVault_requiresImport
--- PASS: TestAccKeyVault_complete (262.41s)
=== CONT  TestAccKeyVault_basic
--- PASS: TestAccKeyVault_softDeleteRecoveryDisabled (312.62s)
=== CONT  TestAccKeyVaultManagedStorageAccount_recovery
--- PASS: TestAccKeyVault_upgradeSKU (316.35s)
=== CONT  TestAccKeyVaultManagedStorageAccount_update
--- PASS: TestAccKeyVault_justCert (319.85s)
=== CONT  TestAccKeyVaultManagedStorageAccount_complete
=== CONT  TestAccKeyVaultManagedStorageAccount_update
    testcase.go:110: Step 1/4 error: Error running pre-apply refresh: exit status 1

        Error: Listing service principals for filter "displayName eq 'Azure Key Vault'"

          with data.azuread_service_principal.test,
          on terraform_plugin_test.tf line 53, in data "azuread_service_principal" "test":
          53: data "azuread_service_principal" "test" {

        ServicePrincipalsClient.BaseClient.Get(): unexpected status 403 with OData
        error: Authorization_RequestDenied: Insufficient privileges to complete the
        operation.
--- FAIL: TestAccKeyVaultManagedStorageAccount_update (9.75s)
=== CONT  TestAccKeyVaultManagedStorageAccount_requiresImport
=== CONT  TestAccKeyVaultManagedStorageAccount_complete
    testcase.go:110: Step 1/2 error: Error running pre-apply refresh: exit status 1

        Error: Listing service principals for filter "displayName eq 'Azure Key Vault'"

          with data.azuread_service_principal.test,
          on terraform_plugin_test.tf line 53, in data "azuread_service_principal" "test":
          53: data "azuread_service_principal" "test" {

        ServicePrincipalsClient.BaseClient.Get(): unexpected status 403 with OData
        error: Authorization_RequestDenied: Insufficient privileges to complete the
        operation.
--- FAIL: TestAccKeyVaultManagedStorageAccount_complete (9.56s)
=== CONT  TestAccKeyVaultManagedStorageAccount_basic
--- FAIL: TestAccKeyVault_update (343.78s)
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_update
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_recovery (499.51s)
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_complete
--- PASS: TestAccKeyVault_softDeleteRecovery (489.05s)
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_requiresImport
--- PASS: TestAccKeyVault_networkAclsAllowed (287.60s)
=== CONT  TestAccKeyVaultManagedStorageAccountSasTokenDefinition_basic
--- PASS: TestAccKeyVault_accessPolicyUpperLimit (330.05s)
=== CONT  TestAccKeyVaultKey_purge
--- PASS: TestAccKeyVault_basic (267.70s)
=== CONT  TestAccKeyVaultSecret_withExternalAccessPolicy
--- PASS: TestAccKeyVault_requiresImport (288.53s)
=== CONT  TestAccKeyVaultKey_withExternalAccessPolicy
--- PASS: TestAccKeyVaultManagedStorageAccount_basic (258.55s)
=== CONT  TestAccDataSourceKeyVaultSecrets_basic
--- PASS: TestAccKeyVaultManagedStorageAccount_requiresImport (280.47s)
=== CONT  TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted
--- PASS: TestAccKeyVault_networkAcls (371.15s)
=== CONT  TestAccKeyVaultSecret_purge
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_complete (264.48s)
=== CONT  TestAccKeyVaultKey_disappears
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_update (351.67s)
=== CONT  TestAccKeyVaultKey_updatedExternally
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_basic (263.09s)
=== CONT  TestAccKeyVaultKey_basicECHSM
--- PASS: TestAccKeyVaultManagedStorageAccountSasTokenDefinition_requiresImport (278.25s)
=== CONT  TestAccKeyVaultKey_requiresImport
--- PASS: TestAccKeyVault_updateContacts (766.91s)
=== CONT  TestAccKeyVaultKey_update
--- PASS: TestAccKeyVaultManagedStorageAccount_recovery (497.75s)
=== CONT  TestAccKeyVaultKey_basicEC
--- PASS: TestAccKeyVaultKey_purge (291.69s)
=== CONT  TestAccKeyVaultKey_softDeleteRecovery
--- PASS: TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted (232.20s)
=== CONT  TestAccKeyVaultKey_complete
--- PASS: TestAccKeyVaultSecret_withExternalAccessPolicy (348.40s)
=== CONT  TestAccKeyVaultKey_basicRSAHSM
--- PASS: TestAccKeyVaultKey_withExternalAccessPolicy (367.65s)
=== CONT  TestAccKeyVaultKey_basicRSA
--- PASS: TestAccDataSourceKeyVaultSecrets_basic (363.85s)
=== CONT  TestAccKeyVaultKey_curveEC
--- PASS: TestAccKeyVaultSecret_purge (325.62s)
=== CONT  TestAccDataSourceKeyVaultKey_complete
--- PASS: TestAccKeyVaultKey_disappears (249.93s)
=== CONT  TestAccDataSourceKeyVault_update
--- PASS: TestAccKeyVaultKey_basicECHSM (291.18s)
=== CONT  TestAccDataSourceKeyVault_networkAcls
--- PASS: TestAccKeyVaultKey_updatedExternally (379.10s)
=== CONT  TestAccDataSourceKeyVault_complete
--- PASS: TestAccKeyVaultKey_basicEC (297.29s)
=== CONT  TestAccKeyVaultCertificateIssuer_basic
--- PASS: TestAccKeyVaultKey_update (337.87s)
=== CONT  TestAccKeyVaultCertificate_unorderedKeyUsage
--- PASS: TestAccKeyVaultKey_complete (279.65s)
=== CONT  TestAccKeyVaultCertificate_purge
--- PASS: TestAccKeyVaultKey_requiresImport (375.22s)
=== CONT  TestAccKeyVaultCertificate_withExternalAccessPolicy
--- PASS: TestAccKeyVaultKey_basicRSAHSM (288.64s)
=== CONT  TestAccKeyVaultCertificate_emptyExtendedKeyUsage
=== CONT  TestAccDataSourceKeyVault_update
    testcase.go:110: Step 2/2 error: Error running apply: exit status 1

        Error: updating Vault: (Name "vault220917161633893204" / Resource Group "acctestRG-220917161633893204"): keyvault.VaultsClient#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InsufficientPermissions" Message="Caller is not allowed to change permission model. For more information on how to change the permissions model follow this link: https://go.microsoft.com/fwlink/?linkid=2155160. Details: oid=78e1ee05-9110-4054-a2e2-5889c1225179; action=Microsoft.Authorization/roleAssignments/write; resource=/subscriptions/8b813ab6-f295-4c58-8fc2-b0a199790709/resourcegroups/acctestRG-220917161633893204/providers/Microsoft.KeyVault/vaults/vault220917161633893204; decision=NotAllowed; "

          with azurerm_key_vault.test,
          on terraform_plugin_test.tf line 15, in resource "azurerm_key_vault" "test":
          15: resource "azurerm_key_vault" "test" {

--- PASS: TestAccKeyVaultKey_basicRSA (278.84s)
=== CONT  TestAccKeyVaultCertificate_basicExtendedKeyUsage
--- PASS: TestAccKeyVaultKey_curveEC (292.34s)
=== CONT  TestAccKeyVaultSecret_updatingValueChangedExternally
--- PASS: TestAccDataSourceKeyVaultKey_complete (294.97s)
=== CONT  TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize
--- FAIL: TestAccDataSourceKeyVault_update (287.77s)
=== CONT  TestAccKeyVaultCertificate_basicGenerateEllipticCurve
--- PASS: TestAccKeyVaultCertificateIssuer_basic (262.07s)
=== CONT  TestAccKeyVaultSecret_recovery
--- PASS: TestAccDataSourceKeyVault_complete (269.07s)
=== CONT  TestAccKeyVaultCertificate_updateTags
--- PASS: TestAccDataSourceKeyVault_networkAcls (317.91s)
=== CONT  TestAccKeyVaultCertificate_disappears
--- PASS: TestAccKeyVaultKey_softDeleteRecovery (555.58s)
=== CONT  TestAccKeyVaultCertificate_requiresImport
--- PASS: TestAccKeyVaultCertificate_unorderedKeyUsage (319.19s)
=== CONT  TestAccKeyVaultCertificate_basicGenerateTags
--- PASS: TestAccKeyVaultCertificate_purge (315.62s)
=== CONT  TestAccKeyVaultCertificate_basicImportPFX
--- PASS: TestAccKeyVaultCertificate_emptyExtendedKeyUsage (290.69s)
=== CONT  TestAccKeyVaultCertificate_basicGenerateSans
--- PASS: TestAccKeyVaultCertificate_basicExtendedKeyUsage (294.36s)
=== CONT  TestAccKeyVaultCertificateIssuer_disappears
--- PASS: TestAccKeyVaultCertificate_withExternalAccessPolicy (401.92s)
=== CONT  TestAccKeyVaultCertificate_softDeleteRecovery
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurve (296.07s)
=== CONT  TestAccKeyVaultCertificateIssuer_update
--- PASS: TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize (300.09s)
=== CONT  TestAccKeyVaultCertificate_basicGenerateUnknownIssuer
--- PASS: TestAccKeyVaultSecret_updatingValueChangedExternally (379.78s)
=== CONT  TestAccKeyVaultCertificateIssuer_complete
--- PASS: TestAccKeyVaultCertificate_disappears (273.38s)
=== CONT  TestAccKeyVaultCertificate_basicGenerate
--- PASS: TestAccKeyVaultCertificate_requiresImport (315.23s)
=== CONT  TestAccKeyVaultCertificateIssuer_requiresImport
--- PASS: TestAccKeyVaultCertificate_basicImportPFX (281.12s)
=== CONT  TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted
--- PASS: TestAccKeyVaultCertificate_updateTags (350.80s)
=== CONT  TestAccKeyVaultAccessPolicy_nonExistentVault
--- PASS: TestAccKeyVaultCertificate_basicGenerateTags (300.37s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PFX
--- PASS: TestAccKeyVaultCertificateIssuer_disappears (262.65s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_rsa_single_PEM
--- PASS: TestAccKeyVaultCertificate_basicGenerateSans (312.87s)
=== CONT  TestAccDataSourceKeyVaultCertificateIssuer_basic
--- PASS: TestAccKeyVaultCertificate_basicGenerateUnknownIssuer (289.90s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PEM
--- PASS: TestAccKeyVaultCertificateIssuer_update (342.16s)
=== CONT  TestAccDataSourceKeyVaultCertificate_generatedEllipticCurve
--- PASS: TestAccKeyVaultSecret_recovery (534.71s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_ecdsa_PEM
--- PASS: TestAccKeyVaultCertificate_basicGenerate (304.52s)
=== CONT  TestAccDataSourceKeyVaultCertificate_generated
--- PASS: TestAccKeyVaultAccessPolicy_nonExistentVault (246.91s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_ecdsa_PFX
--- PASS: TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted (252.36s)
=== CONT  TestAccDataSourceKeyVaultCertificate_basic
--- PASS: TestAccKeyVaultCertificateIssuer_requiresImport (288.28s)
=== CONT  TestAccDataSourceKeyVaultCertificateData_basic
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PFX (274.45s)
=== CONT  TestAccKeyVaultSecret_update
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_single_PEM (296.26s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_secretCertificate
--- PASS: TestAccDataSourceKeyVaultCertificateIssuer_basic (276.08s)
=== CONT  TestAccKeyVaultAccessPolicy_update
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_secretCertificate (45.52s)
=== CONT  TestAccKeyVaultAccessPolicy_multiple
--- PASS: TestAccKeyVaultCertificate_softDeleteRecovery (568.75s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_secret
--- PASS: TestAccDataSourceKeyVaultCertificateData_rsa_bundle_PEM (286.36s)
=== CONT  TestAccKeyVaultAccessPolicy_requiresImport
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_secret (59.34s)
=== CONT  TestAccKeyVaultAccessPolicy_basic
--- PASS: TestAccDataSourceKeyVaultCertificateData_ecdsa_PEM (291.93s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_keySecretCertificate
--- PASS: TestAccDataSourceKeyVaultCertificate_generatedEllipticCurve (292.25s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_keyCertificate
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_keyCertificate (43.13s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_key
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_keySecretCertificate (48.75s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_keySecret
--- PASS: TestAccDataSourceKeyVaultCertificate_basic (278.21s)
=== CONT  TestAccDataSourceKeyVaultAccessPolicy_certificate
--- PASS: TestAccDataSourceKeyVaultCertificate_generated (312.22s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_basic (286.06s)
--- PASS: TestAccDataSourceKeyVaultCertificateData_ecdsa_PFX (340.05s)
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_key (83.79s)
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_keySecret (84.06s)
--- PASS: TestAccDataSourceKeyVaultAccessPolicy_certificate (97.16s)
--- PASS: TestAccKeyVaultSecret_update (357.35s)
--- PASS: TestAccKeyVaultAccessPolicy_update (330.93s)
--- PASS: TestAccKeyVaultAccessPolicy_multiple (311.22s)
--- PASS: TestAccKeyVaultAccessPolicy_requiresImport (329.11s)
--- PASS: TestAccKeyVaultAccessPolicy_basic (300.77s)
=== CONT  TestAccKeyVaultCertificateIssuer_complete
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: purging Vault: (Name "acctestkv-6l8um" / Resource Group "acctestRG-220917161633892216"): Future#WaitForCompletion: context has been cancelled: StatusCode=202 -- Original Error: context deadline exceeded

--- FAIL: TestAccKeyVaultCertificateIssuer_complete (2045.40s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      6413.018s
FAIL
make: *** [GNUmakefile:100: acctests] Error 1
```
</details>