### PR TITLE
`compute` - fix test `TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
@@ -72,6 +72,9 @@ func TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage(
 		{
 			// provision a standard Virtual Machine with an Unmanaged Disk
 			Config: r.imagesFromVirtualMachinePrerequisitesWithVM(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(WindowsVirtualMachineResource{}.generalizeVirtualMachine, "azurerm_virtual_machine.source"),
+			),
 		},
 		{
 			// then delete the Virtual Machine
@@ -419,7 +422,9 @@ resource "azurerm_virtual_machine" "source" {
     admin_password = "P@ssword1234!"
   }
 
-  os_profile_windows_config {}
+  os_profile_windows_config {
+    provision_vm_agent = true
+  }
 }
 `, r.imagesFromVirtualMachinePrerequisites(data))
 }


### PR DESCRIPTION
Windows VM needs to be generalized so that it can become a valid image https://learn.microsoft.com/azure/virtual-machines/generalize#windows, and `provision_vm_agent` needs to be enabled to run the remote command. This was missing in this test earlier which caused it to fail.