### PR TITLE
`azurerm_monitor_diagnostic_setting` - fix `workspace_id` parsing error

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -336,7 +336,7 @@ func resourceMonitorDiagnosticSettingRead(d *pluginsdk.ResourceData, meta interf
 
 			workspaceId := ""
 			if props.WorkspaceId != nil && *props.WorkspaceId != "" {
-				parsedId, err := workspaces.ParseWorkspaceID(*props.WorkspaceId)
+				parsedId, err := workspaces.ParseWorkspaceIDInsensitively(*props.WorkspaceId)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
resolves #18346 

There is existing `workspace_id` with lower case `resourcegroup` returned by GET, the resource's READ function should be compatible with these part.