### PR TITLE
`azurerm_xxx_policy_assignment` - fix AccTest for checking list existance

### DIFF
--- a/internal/services/policy/assignment_management_group_resource_test.go
+++ b/internal/services/policy/assignment_management_group_resource_test.go
@@ -62,7 +62,7 @@ func TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceM
 			Config: r.withBuiltInPolicyNonComplianceMessageUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("non_compliance_message").DoesNotExist(),
+				check.That(data.ResourceName).Key("non_compliance_message.0").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/policy/assignment_resource_group_resource_test.go
+++ b/internal/services/policy/assignment_resource_group_resource_test.go
@@ -62,7 +62,7 @@ func TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMes
 			Config: r.withBuiltInPolicyNonComplianceMessageUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("non_compliance_message").DoesNotExist(),
+				check.That(data.ResourceName).Key("non_compliance_message.0").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/policy/assignment_resource_test.go
+++ b/internal/services/policy/assignment_resource_test.go
@@ -62,7 +62,7 @@ func TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage(
 			Config: r.withBuiltInPolicyNonComplianceMessageUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("non_compliance_message").DoesNotExist(),
+				check.That(data.ResourceName).Key("non_compliance_message.0").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/policy/assignment_subscription_resource_test.go
+++ b/internal/services/policy/assignment_subscription_resource_test.go
@@ -62,7 +62,7 @@ func TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMess
 			Config: r.withBuiltInPolicyNonComplianceMessageUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("non_compliance_message").DoesNotExist(),
+				check.That(data.ResourceName).Key("non_compliance_message.0").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
current failure message like:
```
    testcase.go:110: Step 3/6 error: Check failed: Check 2/2 error: 
azurerm_subscription_policy_assignment.test: list or set attribute 'non_compliance_message' must be checked by element count key (non_compliance_message.#) 
or element value keys (e.g. non_compliance_message.0). Set element value checks should use TestCheckTypeSet functions instead.
```

## fixed tests list:

- TestAccManagementGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
- TestAccResourceGroupPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
- TestAccResourcePolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage
- TestAccSubscriptionPolicyAssignment_basicWithBuiltInPolicyNonComplianceMessage

## **current fail status:**
![image](https://user-images.githubusercontent.com/2633022/190957581-ae9c30f7-764f-4b30-b87e-63ba48ce48d1.png)

----

## **these four tests passed now:**
![image](https://user-images.githubusercontent.com/2633022/190957398-b0d36797-88d7-44b9-826c-36eca3b5545b.png)
