### PR TITLE
`azurerm_subscription_policy_assignment` - `allowed location policy` in subscription assignment should contain all location in AccTest

### DIFF
--- a/internal/services/policy/assignment_management_group_resource_test.go
+++ b/internal/services/policy/assignment_management_group_resource_test.go
@@ -301,7 +301,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -327,7 +327,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -353,7 +353,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
 
@@ -384,7 +384,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -410,7 +410,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -436,7 +436,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -466,7 +466,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -496,7 +496,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -527,7 +527,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 }
@@ -547,7 +547,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   description          = "This is a policy assignment from an acceptance test"
@@ -583,10 +583,10 @@ provider "azurerm" {
 %[1]s
 
 resource "azurerm_policy_definition" "test" {
-  name                = "acctestpol-%[2]s"
+  name                = "acctestpol-mg-%[2]s"
   policy_type         = "Custom"
   mode                = "All"
-  display_name        = "acctestpol-%[2]s"
+  display_name        = "acctestpol-mg-%[2]s"
   description         = "Description for %[2]s"
   management_group_id = azurerm_management_group.test.id
   metadata            = <<METADATA
@@ -680,7 +680,7 @@ POLICY_RULE
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 }
@@ -697,7 +697,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   metadata = jsonencode({
@@ -713,10 +713,10 @@ func (r ManagementGroupAssignmentTestResource) templateWithCustomPolicy(data acc
 %[1]s
 
 resource "azurerm_policy_definition" "test" {
-  name                = "acctestpol-%[2]s"
+  name                = "acctestpol-mg-%[2]s"
   policy_type         = "Custom"
   mode                = "All"
-  display_name        = "acctestpol-%[2]s"
+  display_name        = "acctestpol-mg-%[2]s"
   management_group_id = azurerm_management_group.test.id
 
   policy_rule = <<POLICY_RULE
@@ -758,7 +758,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -795,7 +795,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_management_group_policy_assignment" "test" {
-  name                 = "acctestpol-%[2]s"
+  name                 = "acctestpol-mg-%[2]s"
   management_group_id  = azurerm_management_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q

--- a/internal/services/policy/assignment_resource_group_resource_test.go
+++ b/internal/services/policy/assignment_resource_group_resource_test.go
@@ -272,7 +272,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -298,7 +298,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -324,7 +324,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
 
@@ -355,7 +355,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -381,7 +381,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location
@@ -407,7 +407,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location
@@ -437,7 +437,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location
@@ -467,7 +467,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location
@@ -502,7 +502,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 }
@@ -520,7 +520,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   description          = "This is a policy assignment from an acceptance test"
@@ -559,7 +559,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   metadata = jsonencode({
@@ -620,7 +620,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location
@@ -652,7 +652,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-rg-%[2]d"
   resource_group_id    = azurerm_resource_group.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = azurerm_resource_group.test.location

--- a/internal/services/policy/assignment_subscription_resource_test.go
+++ b/internal/services/policy/assignment_subscription_resource_test.go
@@ -281,7 +281,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -307,7 +307,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -333,7 +333,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
 
@@ -364,7 +364,7 @@ data "azurerm_policy_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
@@ -390,7 +390,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -416,7 +416,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -446,7 +446,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -476,7 +476,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -511,7 +511,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 }
@@ -529,7 +529,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   description          = "This is a policy assignment from an acceptance test"
@@ -568,7 +568,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = azurerm_policy_definition.test.id
   metadata = jsonencode({
@@ -624,7 +624,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q
@@ -661,7 +661,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_subscription_policy_assignment" "test" {
-  name                 = "acctestpa-%[2]d"
+  name                 = "acctestpa-sub-%[2]d"
   subscription_id      = data.azurerm_subscription.test.id
   policy_definition_id = data.azurerm_policy_set_definition.test.id
   location             = %[3]q

--- a/internal/services/policy/assignment_subscription_resource_test.go
+++ b/internal/services/policy/assignment_subscription_resource_test.go
@@ -262,6 +262,11 @@ func (r SubscriptionAssignmentTestResource) Exists(ctx context.Context, client *
 	return utils.Bool(true), nil
 }
 
+// subscription assignment for allowed location policy should contain all locations, or it will block some network resource create
+func (r SubscriptionAssignmentTestResource) locations(data acceptance.TestData) string {
+	return fmt.Sprintf(`["%s", "%s", "%s"]`, data.Locations.Primary, data.Locations.Secondary, data.Locations.Ternary)
+}
+
 func (r SubscriptionAssignmentTestResource) withBuiltInPolicyBasic(data acceptance.TestData) string {
 	template := r.template()
 	return fmt.Sprintf(`
@@ -281,11 +286,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%s"]
+      "value" = %s
     }
   })
 }
-`, template, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger, r.locations(data))
 }
 
 func (r SubscriptionAssignmentTestResource) withBuiltInPolicyUpdated(data acceptance.TestData) string {
@@ -307,11 +312,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%[3]s", "%[4]s"]
+      "value" = %[3]s
     }
   })
 }
-`, template, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+`, template, data.RandomInteger, r.locations(data))
 }
 
 func (r SubscriptionAssignmentTestResource) withBuiltInPolicyNonComplianceMessage(data acceptance.TestData) string {
@@ -338,11 +343,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
 
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%s"]
+      "value" = %s
     }
   })
 }
-`, template, data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger, r.locations(data))
 }
 
 func (r SubscriptionAssignmentTestResource) withBuiltInPolicyNonComplianceMessageUpdated(data acceptance.TestData) string {
@@ -364,11 +369,11 @@ resource "azurerm_subscription_policy_assignment" "test" {
   policy_definition_id = data.azurerm_policy_definition.test.id
   parameters = jsonencode({
     "listOfAllowedLocations" = {
-      "value" = ["%[3]s", "%[4]s"]
+      "value" = %s
     }
   })
 }
-`, template, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+`, template, data.RandomInteger, r.locations(data))
 }
 
 func (r SubscriptionAssignmentTestResource) withBuiltInPolicySetBasic(data acceptance.TestData) string {


### PR DESCRIPTION
The subscription scope assignment of the `allowed Location` policy will block other parallel tests to create network resources if `listOfAllowedLocations` do not contain all locations of `data.Location`.

sample test failure message: `Service returned an error. Status=403 Code="RequestDisallowedByPolicy" Message="Resource 'acctestua220914001902798275' was disallowed by policy. Policy identifiers: '[{\"policyAssignment\":{\"name\":\"acctestpa-xxx\",\"id\":\"/subscriptions/*******/providers/Microsoft.Authorization/policyAssignments/acctestpa-xxx\"}`

and add different name patterns for different kinds of policy assignment resources for debugging purposes.

all tests shall pass stably except these four fixed in PR https://github.com/hashicorp/terraform-provider-azurerm/pull/18427

![image](https://user-images.githubusercontent.com/2633022/190971706-7d7d264f-5735-481b-b47d-8ce6b0db0ba5.png)
