### PR TITLE
`azurerm_sentinel_alert_rule_scheduled` - support for the `techniques` property

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -95,6 +95,16 @@ func flattenAlertRuleTactics(input *[]securityinsight.AttackTactic) []interface{
 	return output
 }
 
+func expandAlertRuleTechnicals(input []interface{}) *[]string {
+	result := make([]string, 0)
+
+	for _, e := range input {
+		result = append(result, e.(string))
+	}
+
+	return &result
+}
+
 func expandAlertRuleIncidentConfiguration(input []interface{}, createIncidentKey string, withGroupByPrefix bool) *securityinsight.IncidentConfiguration {
 	if len(input) == 0 || input[0] == nil {
 		return nil

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -142,6 +142,15 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 				},
 			},
 
+			"techniques": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			// TODO 4.0 - rename this to "incident"
 			"incident_configuration": {
 				Type:     pluginsdk.TypeList,
@@ -421,6 +430,7 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 			Description:           utils.String(d.Get("description").(string)),
 			DisplayName:           utils.String(d.Get("display_name").(string)),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
+			Techniques:            expandAlertRuleTechnicals(d.Get("techniques").(*pluginsdk.Set).List()),
 			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident_configuration").([]interface{}), "create_incident", true),
 			Severity:              securityinsight.AlertSeverity(d.Get("severity").(string)),
 			Enabled:               utils.Bool(d.Get("enabled").(bool)),
@@ -509,6 +519,9 @@ func resourceSentinelAlertRuleScheduledRead(d *pluginsdk.ResourceData, meta inte
 		d.Set("display_name", prop.DisplayName)
 		if err := d.Set("tactics", flattenAlertRuleTactics(prop.Tactics)); err != nil {
 			return fmt.Errorf("setting `tactics`: %+v", err)
+		}
+		if err := d.Set("techniques", prop.Techniques); err != nil {
+			return fmt.Errorf("setting `techniques`: %+v", err)
 		}
 		if err := d.Set("incident_configuration", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration, "create_incident", true)); err != nil {
 			return fmt.Errorf("setting `incident_configuration`: %+v", err)

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -175,6 +175,7 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
+  techniques                 = ["T1560","T1123"]
   severity                   = "Low"
   enabled                    = false
   incident_configuration {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -175,7 +175,7 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
-  techniques                 = ["T1560","T1123"]
+  techniques                 = ["T1560", "T1123"]
   severity                   = "Low"
   enabled                    = false
   incident_configuration {

--- a/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
@@ -104,6 +104,8 @@ The following arguments are supported:
 
 * `tactics` - (Optional) A list of categories of attacks by which to classify the rule. Possible values are `Collection`, `CommandAndControl`, `CredentialAccess`, `DefenseEvasion`, `Discovery`, `Execution`, `Exfiltration`, `Impact`, `InitialAccess`, `LateralMovement`, `Persistence`,  `PrivilegeEscalation`, `ImpairProcessControl`, `InhibitResponseFunction`, `Reconnaissance` and `ResourceDevelopment`.
 
+* `techniques` - (Optional) A list of techniques of attacks by which to classify the rule.
+
 * `trigger_operator` - (Optional) The alert trigger operator, combined with `trigger_threshold`, setting alert threshold of this Sentinel Scheduled Alert Rule. Possible values are `Equal`, `GreaterThan`, `LessThan`, `NotEqual`.
 
 * `trigger_threshold` - (Optional) The baseline number of query results generated, combined with `trigger_operator`, setting alert threshold of this Sentinel Scheduled Alert Rule.


### PR DESCRIPTION
fix #16265

Test
---
```
 TF_ACC=1 go test -v ./internal/services/sentinel -run=TestAccSentinelAlertRuleScheduled -timeout=60m        
=== RUN   TestAccSentinelAlertRuleScheduled_basic
=== PAUSE TestAccSentinelAlertRuleScheduled_basic
=== RUN   TestAccSentinelAlertRuleScheduled_complete
=== PAUSE TestAccSentinelAlertRuleScheduled_complete
=== RUN   TestAccSentinelAlertRuleScheduled_update
=== PAUSE TestAccSentinelAlertRuleScheduled_update
=== RUN   TestAccSentinelAlertRuleScheduled_requiresImport
=== PAUSE TestAccSentinelAlertRuleScheduled_requiresImport
=== RUN   TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== PAUSE TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== RUN   TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== PAUSE TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== CONT  TestAccSentinelAlertRuleScheduled_basic
=== CONT  TestAccSentinelAlertRuleScheduled_requiresImport
=== CONT  TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting
=== CONT  TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleScheduled_update
=== CONT  TestAccSentinelAlertRuleScheduled_complete
--- PASS: TestAccSentinelAlertRuleScheduled_basic (198.77s)
--- PASS: TestAccSentinelAlertRuleScheduled_requiresImport (239.06s)
--- PASS: TestAccSentinelAlertRuleScheduled_complete (245.99s)
--- PASS: TestAccSentinelAlertRuleScheduled_withAlertRuleTemplateGuid (264.16s)
--- PASS: TestAccSentinelAlertRuleScheduled_updateEventGroupingSetting (358.40s)
--- PASS: TestAccSentinelAlertRuleScheduled_update (419.89s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      421.011s

```