### PR TITLE
`azurerm_app_service_connection`: changing default behavior of `vnet_solution`

### DIFF
--- a/internal/services/serviceconnector/service_connector_app_service_resource.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource.go
@@ -72,7 +72,6 @@ func (r AppServiceConnectorResource) Arguments() map[string]*schema.Schema {
 		"vnet_solution": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  string(servicelinker.VNetSolutionTypePrivateLink),
 			ValidateFunc: validation.StringInSlice([]string{
 				string(servicelinker.VNetSolutionTypeServiceEndpoint),
 				string(servicelinker.VNetSolutionTypePrivateLink),


### PR DESCRIPTION
* The original behavior was set `vnet_solution` to `VNetSolutionTypePrivateLink`. Now it's changed to `null` by service team's request.

* All related tests are passing.
```
--- PASS: TestAccServiceConnectorAppServiceCosmosdb_basic (978.20s)
--- PASS: TestAccServiceConnectorAppService_complete (1026.74s)
--- PASS: TestAccServiceConnectorSpringCloudCosmosdb_basic (1035.89s)
--- PASS: TestAccServiceConnectorSpringCloud_complete (1146.73s)
--- PASS: TestAccServiceConnectorAppServiceCosmosdb_update (1221.24s)
--- PASS: TestAccServiceConnectorSpringCloudCosmosdb_update (1885.30s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/serviceconnector      1899.145s
```
