### PR TITLE
`azurerm_automation_module` - support update existing global automation module version

### DIFF
--- a/internal/services/automation/automation_module_resource.go
+++ b/internal/services/automation/automation_module_resource.go
@@ -105,7 +105,11 @@ func resourceAutomationModuleCreateUpdate(d *pluginsdk.ResourceData, meta interf
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		// for existing global module do update instead of raising ImportAsExistsError
+		isGlobal := existing.ModuleProperties != nil &&
+			existing.ModuleProperties.IsGlobal != nil &&
+			*existing.ModuleProperties.IsGlobal == true
+		if !utils.ResponseWasNotFound(existing.Response) && !isGlobal {
 			return tf.ImportAsExistsError("azurerm_automation_module", id.ID())
 		}
 	}


### PR DESCRIPTION
If you try update an existing global module, the current logic will block and raise an `ImportAsExistsError` which is inconvenient and confusing for customers to do an `import-then-apply` to update module version. So this pr tries to update an existing global module. one side effect is the `isGlobal` property will be set to false(the same as import-then-apply`


Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18198

