### PR TITLE
`azurerm_monitor_metric_alert` - fix ordering of multi `criteria` 

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -88,7 +88,7 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 
 			// static criteria
 			"criteria": {
-				Type:         pluginsdk.TypeSet,
+				Type:         pluginsdk.TypeList,
 				Optional:     true,
 				MinItems:     1,
 				ExactlyOneOf: []string{"criteria", "dynamic_criteria", "application_insights_web_test_location_availability_criteria"},
@@ -172,7 +172,7 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 
 			//lintignore: S018
 			"dynamic_criteria": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MinItems: 1,
 				// Curently, it allows to define only one dynamic criteria in one metric alert.
@@ -578,13 +578,13 @@ func resourceMonitorMetricAlertDelete(d *pluginsdk.ResourceData, meta interface{
 
 func expandMonitorMetricAlertCriteria(d *pluginsdk.ResourceData, isLegacy bool) (insights.BasicMetricAlertCriteria, error) {
 	switch {
-	case d.Get("criteria").(*pluginsdk.Set).Len() != 0:
+	case len(d.Get("criteria").([]interface{})) != 0:
 		if isLegacy {
-			return expandMonitorMetricAlertSingleResourceMultiMetricCriteria(d.Get("criteria").(*pluginsdk.Set).List()), nil
+			return expandMonitorMetricAlertSingleResourceMultiMetricCriteria(d.Get("criteria").([]interface{})), nil
 		}
-		return expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(d.Get("criteria").(*pluginsdk.Set).List()), nil
-	case d.Get("dynamic_criteria").(*pluginsdk.Set).Len() != 0:
-		return expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(d.Get("dynamic_criteria").(*pluginsdk.Set).List()), nil
+		return expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(d.Get("criteria").([]interface{})), nil
+	case len(d.Get("dynamic_criteria").([]interface{})) != 0:
+		return expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(d.Get("dynamic_criteria").([]interface{})), nil
 	case len(d.Get("application_insights_web_test_location_availability_criteria").([]interface{})) != 0:
 		return expandMonitorMetricAlertWebtestLocAvailCriteria(d.Get("application_insights_web_test_location_availability_criteria").([]interface{})), nil
 	default:


### PR DESCRIPTION
resolves #18410 

Modify `criteria` and `dynamic_criteria` from `TypeSet` to `TypeList`, and add a testcase `TestAccMonitorMetricAlert_multiCriteria`.

Test Result:
![image](https://user-images.githubusercontent.com/104055472/191399070-54a0f126-402a-4314-b955-8d534c8bc7c9.png)