### PR TITLE
`azurerm_subnet_route_table_association` : Fix property `route_table_id` to use `validate.RouteTableID` validation instead of `azure.ValidateResourceID`

### DIFF
--- a/internal/services/network/subnet_route_table_association_resource.go
+++ b/internal/services/network/subnet_route_table_association_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -46,7 +48,7 @@ func resourceSubnetRouteTableAssociation() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				ValidateFunc: validate.RouteTableID,
 			},
 		},
 	}


### PR DESCRIPTION
Fix #[18416](https://github.com/hashicorp/terraform-provider-azurerm/issues/18416).