### PR TITLE
`virtual_machine_extension` `virtual_machine_scale_set_extension` - support for `failure_suppression_enabled`

### DIFF
--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -79,6 +79,12 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"failure_suppression_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"settings": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,
@@ -140,6 +146,7 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 	typeHandlerVersion := d.Get("type_handler_version").(string)
 	autoUpgradeMinor := d.Get("auto_upgrade_minor_version").(bool)
 	enableAutomaticUpgrade := d.Get("automatic_upgrade_enabled").(bool)
+	suppressFailure := d.Get("failure_suppression_enabled").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
 	extension := compute.VirtualMachineExtension{
@@ -150,6 +157,7 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 			TypeHandlerVersion:      &typeHandlerVersion,
 			AutoUpgradeMinorVersion: &autoUpgradeMinor,
 			EnableAutomaticUpgrade:  &enableAutomaticUpgrade,
+			SuppressFailures:        &suppressFailure,
 		},
 		Tags: tags.Expand(t),
 	}
@@ -223,6 +231,12 @@ func resourceVirtualMachineExtensionsRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("type_handler_version", props.TypeHandlerVersion)
 		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
 		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
+
+		suppressFailure := false
+		if props.SuppressFailures != nil {
+			suppressFailure = *props.SuppressFailures
+		}
+		d.Set("failure_suppression_enabled", suppressFailure)
 
 		if settings := props.Settings; settings != nil {
 			settingsVal := settings.(map[string]interface{})

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -40,6 +40,29 @@ func TestAccVirtualMachineExtension_basic(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineExtension_failureSuppressionEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
+	r := VirtualMachineExtensionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("failure_suppression_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithFailureSuppressionEnabledUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualMachineExtension_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
 	r := VirtualMachineExtensionResource{}
@@ -560,6 +583,111 @@ SETTINGS
   tags = {
     environment = "Production"
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualMachineExtensionResource) basicWithFailureSuppressionEnabledUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctvm-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  network_interface_ids = [azurerm_network_interface.test.id]
+  vm_size               = "Standard_F2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "hostname%d"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                 = "acctvme-%d"
+  virtual_machine_id   = azurerm_virtual_machine.test.id
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.0"
+
+  failure_suppression_enabled = true
+
+  settings = <<SETTINGS
+	{
+		"commandToExecute": "hostname"
+	}
+SETTINGS
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -86,6 +86,12 @@ func resourceVirtualMachineScaleSetExtension() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"failure_suppression_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"force_update_tag": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -168,6 +174,7 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 			TypeHandlerVersion:       utils.String(d.Get("type_handler_version").(string)),
 			AutoUpgradeMinorVersion:  utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
 			EnableAutomaticUpgrade:   utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
+			SuppressFailures:         utils.Bool(d.Get("failure_suppression_enabled").(bool)),
 			ProtectedSettings:        protectedSettings,
 			ProvisionAfterExtensions: provisionAfterExtensions,
 			Settings:                 settings,
@@ -205,6 +212,10 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 		// if this isn't specified it defaults to false
 		AutoUpgradeMinorVersion: utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
 		EnableAutomaticUpgrade:  utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
+	}
+
+	if d.HasChange("failure_suppression_enabled") {
+		props.SuppressFailures = utils.Bool(d.Get("failure_suppression_enabled").(bool))
 	}
 
 	if d.HasChange("force_update_tag") {
@@ -316,6 +327,12 @@ func resourceVirtualMachineScaleSetExtensionRead(d *pluginsdk.ResourceData, meta
 		d.Set("publisher", props.Publisher)
 		d.Set("type", props.Type)
 		d.Set("type_handler_version", props.TypeHandlerVersion)
+
+		suppressFailure := false
+		if props.SuppressFailures != nil {
+			suppressFailure = *props.SuppressFailures
+		}
+		d.Set("failure_suppression_enabled", suppressFailure)
 
 		settings := ""
 		if props.Settings != nil {

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -155,6 +155,10 @@ $ az vm extension image list --location westus -o table
 
 ~> **Please Note:** Certain VM Extensions require that the keys in the `settings` block are case sensitive. If you're seeing unhelpful errors, please ensure the keys are consistent with how Azure is expecting them (for instance, for the `JsonADDomainExtension` extension, the keys are expected to be in `TitleCase`.)
 
+* `failure_suppression_enabled` - (Optional) Should failures from the extension be suppressed? Possible values are `true` or `false`. Defaults to `false`.
+
+-> **NOTE:** Operational failures such as not connecting to the VM will not be suppressed regardless of the `failure_suppression_enabled` value.
+
 * `protected_settings` - (Optional) The protected_settings passed to the
     extension, like settings, these are specified as a JSON object in a string.
 

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -82,6 +82,10 @@ $ az vmss extension image list --location westus -o table
 
 * `automatic_upgrade_enabled` - (Optional) Should the Extension be automatically updated whenever the Publisher releases a new version of this VM Extension? Defaults to `false`.
 
+* `failure_suppression_enabled` - (Optional) Should failures from the extension be suppressed? Possible values are `true` or `false`. Defaults to `false`.
+
+-> **NOTE:** Operational failures such as not connecting to the VM will not be suppressed regardless of the `failure_suppression_enabled` value.
+
 * `force_update_tag` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
 
 * `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.


### PR DESCRIPTION
To add support for `failure_suppression_enabled` to the extracted resource. This was added to VMSS earlier
https://github.com/hashicorp/terraform-provider-azurerm/blob/fa35df5cce72dc7466be7c19d0225cc879156127/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown?plain=1#L302-L304