### PR TITLE
`azurerm_express_route_xxx` - set all bandwith of express route connection 1 gbps

### DIFF
--- a/internal/services/network/express_route_circuit_connection_resource_test.go
+++ b/internal/services/network/express_route_circuit_connection_resource_test.go
@@ -176,7 +176,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctest-erp-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Equinix-Seattle-SE2"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }

--- a/internal/services/network/express_route_circuit_connection_resource_test.go
+++ b/internal/services/network/express_route_circuit_connection_resource_test.go
@@ -177,7 +177,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Equinix-Seattle-SE2"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
 
@@ -186,7 +186,7 @@ resource "azurerm_express_route_circuit" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.test.id
-  bandwidth_in_gbps     = 5
+  bandwidth_in_gbps     = 1
 
   sku {
     tier   = "Standard"
@@ -199,7 +199,7 @@ resource "azurerm_express_route_port" "peer_test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
 
@@ -208,7 +208,7 @@ resource "azurerm_express_route_circuit" "peer_test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.peer_test.id
-  bandwidth_in_gbps     = 5
+  bandwidth_in_gbps     = 1
 
   sku {
     tier   = "Standard"

--- a/internal/services/network/express_route_circuit_resource_test.go
+++ b/internal/services/network/express_route_circuit_resource_test.go
@@ -558,7 +558,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Airtel-Chennai2-CLS"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
 
@@ -567,7 +567,7 @@ resource "azurerm_express_route_circuit" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.test.id
-  bandwidth_in_gbps     = 5
+  bandwidth_in_gbps     = 1
 
   sku {
     tier   = "Standard"
@@ -593,7 +593,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Airtel-Chennai2-CLS"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
 
@@ -602,7 +602,7 @@ resource "azurerm_express_route_circuit" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.test.id
-  bandwidth_in_gbps     = 10
+  bandwidth_in_gbps     = 1
 
   sku {
     tier   = "Standard"

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -188,7 +188,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
 
@@ -197,7 +197,7 @@ resource "azurerm_express_route_circuit" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.test.id
-  bandwidth_in_gbps     = 5
+  bandwidth_in_gbps     = 1
 
   sku {
     tier   = "Premium"

--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -139,7 +139,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Airtel-Chennai2-CLS"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   tags = {
     ENV = "Test"
@@ -158,7 +158,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Area51-ERDirect"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   link1 {
     admin_enabled = true
@@ -199,7 +199,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   identity {
     type         = "UserAssigned"
@@ -266,7 +266,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra2"
-  bandwidth_in_gbps   = 10
+  bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
`cannot be created as requested bandwidth 10 is not available at peering location Equinix-Seattle-SE2`