### PR TITLE
Add missing identity_ids argument reference to `azurerm_cosmosdb_account` resource documentation

### DIFF
--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -221,6 +221,8 @@ A `identity` block supports the following:
 
 * `type` - (Required) The Type of Managed Identity assigned to this Cosmos account. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
 
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Cosmos Account.
+
 ---
 
 A `restore` block supports the following:


### PR DESCRIPTION
This PR adds missing documentation reference to cosmosdb_account resource identity block.

Previous PR #18378 added support for setting user assigned identities however the `identity_ids` argument is missing from the html markdown