### PR TITLE
Docs: Fix wrong attributes in azurerm_data_protection_backup_instance_blob_storage

### DIFF
--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -72,8 +72,6 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) The ID of the source Storage Account. Changing this forces a new Backup Instance Blob Storage to be created.
 
-* `storage_account_location` - (Required) The location of the source Storage Account. Changing this forces a new Backup Instance Blob Storage to be created.
-
 * `backup_policy_id` - (Required) The ID of the Backup Policy.
 
 ## Attributes Reference

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Backup Instance Blob Storage. Changing this forces a new Backup Instance Blob Storage to be created.
 
+* `location` - The Location in which the Resources should be provisioned.
+
 * `resource_group_name` - (Required) The name of the Resource Group where the Backup Instance Blob Storage should exist. Changing this forces a new Backup Instance Blob Storage to be created.
 
 * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Instance Blob Storage should exist. Changing this forces a new Backup Instance Blob Storage to be created.

--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -68,8 +68,6 @@ The following arguments are supported:
 
 * `location` - The Location in which the Resources should be provisioned.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Backup Instance Blob Storage should exist. Changing this forces a new Backup Instance Blob Storage to be created.
-
 * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Instance Blob Storage should exist. Changing this forces a new Backup Instance Blob Storage to be created.
 
 * `storage_account_id` - (Required) The ID of the source Storage Account. Changing this forces a new Backup Instance Blob Storage to be created.


### PR DESCRIPTION
### What’s Updated

Edited argument description in the in the `azurerm_data_protection_backup_instance_blob_storage` resource page's Argument Reference Section.

- [x] Removed the argument `resource_group_name`
- [x] Removed the argument `storage_account_location`
- [x] Added the argument `location`

### Related Issues & PRs

* #13380
* https://github.com/hashicorp/terraform-provider-azurerm/pull/13643
* https://github.com/hashicorp/terraform-provider-azurerm/pull/13850

From the PRs above, only the Example Usage was updated.
The Arguments Reference was not.

### References
* https://registry.terraform.io/providers/hashicorp/azurerm/3.23.0/docs/resources/data_protection_backup_instance_blob_storage#arguments-reference
