### PR TITLE
`azurerm_app_service_connection`, `azurerm_spring_cloud_connection`: add acc tests for key vault, replacing documentation example code

### DIFF
--- a/website/docs/r/service_connector_app_service.html.markdown
+++ b/website/docs/r/service_connector_app_service.html.markdown
@@ -18,43 +18,20 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_cosmosdb_account" "example" {
-  name                = "example-cosmosdb-account"
-  location            = azurerm_resource_group.example.location
-  resource_group_name = azurerm_resource_group.example.name
-  offer_type          = "Standard"
-  kind                = "GlobalDocumentDB"
+data "azurerm_client_config" "current" {}
 
-  consistency_policy {
-    consistency_level       = "BoundedStaleness"
-    max_interval_in_seconds = 10
-    max_staleness_prefix    = 200
-  }
-
-  geo_location {
-    location          = azurerm_resource_group.example.location
-    failover_priority = 0
-  }
-}
-
-resource "azurerm_cosmosdb_sql_database" "example" {
-  name                = "cosmos-sql-db"
-  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
-  account_name        = azurerm_cosmosdb_account.example.name
-  throughput          = 400
-}
-
-resource "azurerm_cosmosdb_sql_container" "example" {
-  name                = "example-container"
-  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
-  account_name        = azurerm_cosmosdb_account.example.name
-  database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition"
+resource "azurerm_key_vault" "example" {
+  name                       = "example-key-vault"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
 }
 
 resource "azurerm_service_plan" "example" {
   location            = azurerm_resource_group.example.location
-  name                = "example-serviceplan"
+  name                = "example-service-plan"
   resource_group_name = azurerm_resource_group.example.name
   sku_name            = "P1v2"
   os_type             = "Linux"
@@ -62,16 +39,16 @@ resource "azurerm_service_plan" "example" {
 
 resource "azurerm_linux_web_app" "example" {
   location            = azurerm_resource_group.example.location
-  name                = "example-linuxwebapp"
+  name                = "example-web-app"
   resource_group_name = azurerm_resource_group.example.name
   service_plan_id     = azurerm_service_plan.example.id
   site_config {}
 }
 
 resource "azurerm_app_service_connection" "example" {
-  name               = "example-serviceconnector"
+  name               = "example-app-service-connection"
   app_service_id     = azurerm_linux_web_app.example.id
-  target_resource_id = azurerm_cosmosdb_sql_database.example.id
+  target_resource_id = azurerm_key_vault.example.id
   authentication {
     type = "systemAssignedIdentity"
   }


### PR DESCRIPTION
* Replaced example in documentation per service team's request.

* Add acc tests for key vault as target resource.

```
--- PASS: TestAccServiceConnectorSpringCloudKeyVault_basic (951.26s)
PASS

--- PASS: TestAccServiceConnectorAppServiceKeyVault_basic (831.23s)
PASS

```