### PR TITLE
`azurerm_dev_test_lab`: Deprecate `storage_type`

### DIFF
--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -104,7 +104,7 @@ func resourceDevTestLab() *pluginsdk.Resource {
 
 	if !features.FourPointOhBeta() {
 		resource.Schema["storage_type"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeBool,
+			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  string(dtl.Premium),
 			ValidateFunc: validation.StringInSlice([]string{

--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devtestlabs/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devtestlabs/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devtestlabs/validate"
@@ -21,7 +22,7 @@ import (
 )
 
 func resourceDevTestLab() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDevTestLabCreateUpdate,
 		Read:   resourceDevTestLabRead,
 		Update: resourceDevTestLabCreateUpdate,
@@ -100,6 +101,21 @@ func resourceDevTestLab() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["storage_type"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  string(dtl.Premium),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(dtl.Standard),
+				string(dtl.Premium),
+			}, false),
+			Deprecated: "`storage_type` is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0.",
+		}
+	}
+
+	return resource
 }
 
 func resourceDevTestLabCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/website/docs/r/dev_test_lab.html.markdown
+++ b/website/docs/r/dev_test_lab.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `storage_type` - (Optional) The type of storage used by the Dev Test Lab. Possible values are `Standard` and `Premium`. Defaults to `Premium`. Changing this forces a new resource to be created.
 
+-> **Note:** `storage_type` has been deprecated as the API no longer supports it and will be removed in Version 4.0 of the provider.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
* Current API does not support `storage_type`, this is causing lots of test failing in team city. 
* No Swagger available for new API version, so deprecating this attribute for good.