### PR TITLE
Upgrade kusto resource to sdk version 2022-07-07

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+// TODO update kusto cluster with pandora sdk
 func resourceKustoCluster() *pluginsdk.Resource {
 	s := &pluginsdk.Resource{
 		Create: resourceKustoClusterCreateUpdate,


### PR DESCRIPTION
Upgrade kusto resource to sdk version 2022-07-07 using new go-azure-sdk and remove track one sdk dependencies.