### PR TITLE
Enhance - `azurerm_api_management_api` - support `contact`, `license`

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -110,7 +110,7 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 						"email": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							ValidateFunc: validate.EmailAddress,
 						},
 						"name": {
 							Type:         pluginsdk.TypeString,

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -100,6 +100,32 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"contact": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"email": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"url": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+						},
+					},
+				},
+			},
+
 			"description": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -158,6 +184,27 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 				},
 			},
 
+			"license": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"url": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+						},
+					},
+				},
+			},
+
 			"service_url": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -189,6 +236,12 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+
+			"terms_of_service_url": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 			},
 
 			"source_api_id": {
@@ -413,6 +466,12 @@ func resourceApiManagementApiCreateUpdate(d *pluginsdk.ResourceData, meta interf
 	openIDAuthorizationSettings := expandApiManagementOpenIDAuthenticationSettingsContract(openIDAuthorizationSettingsRaw)
 	authenticationSettings.Openid = openIDAuthorizationSettings
 
+	contactInfoRaw := d.Get("contact").([]interface{})
+	contactInfo := expandApiManagementApiContact(contactInfoRaw)
+
+	licenseInfoRaw := d.Get("license").([]interface{})
+	licenseInfo := expandApiManagementApiLicense(licenseInfoRaw)
+
 	params := apimanagement.APICreateOrUpdateParameter{
 		APICreateOrUpdateProperties: &apimanagement.APICreateOrUpdateProperties{
 			APIType:                       apiType,
@@ -427,6 +486,8 @@ func resourceApiManagementApiCreateUpdate(d *pluginsdk.ResourceData, meta interf
 			AuthenticationSettings:        authenticationSettings,
 			APIRevisionDescription:        utils.String(d.Get("revision_description").(string)),
 			APIVersionDescription:         utils.String(d.Get("version_description").(string)),
+			Contact:                       contactInfo,
+			License:                       licenseInfo,
 		},
 	}
 
@@ -440,6 +501,10 @@ func resourceApiManagementApiCreateUpdate(d *pluginsdk.ResourceData, meta interf
 
 	if versionSetId != "" {
 		params.APICreateOrUpdateProperties.APIVersionSetID = utils.String(versionSetId)
+	}
+
+	if v, ok := d.GetOk("terms_of_service_url"); ok {
+		params.APICreateOrUpdateProperties.TermsOfServiceURL = utils.String(v.(string))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, apiId, params, "")
@@ -508,6 +573,7 @@ func resourceApiManagementApiRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("version_set_id", props.APIVersionSetID)
 		d.Set("revision_description", props.APIRevisionDescription)
 		d.Set("version_description", props.APIVersionDescription)
+		d.Set("terms_of_service_url", props.TermsOfServiceURL)
 
 		if err := d.Set("protocols", flattenApiManagementApiProtocols(props.Protocols)); err != nil {
 			return fmt.Errorf("setting `protocols`: %s", err)
@@ -523,6 +589,14 @@ func resourceApiManagementApiRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 		if err := d.Set("openid_authentication", flattenApiManagementOpenIDAuthentication(props.AuthenticationSettings.Openid)); err != nil {
 			return fmt.Errorf("setting `openid_authentication`: %+v", err)
+		}
+
+		if err := d.Set("contact", flattenApiManagementApiContact(props.Contact)); err != nil {
+			return fmt.Errorf("setting `contact`: %+v", err)
+		}
+
+		if err := d.Set("license", flattenApiManagementApiLicense(props.License)); err != nil {
+			return fmt.Errorf("setting `license`: %+v", err)
 		}
 	}
 
@@ -691,6 +765,71 @@ func flattenApiManagementOpenIDAuthentication(input *apimanagement.OpenIDAuthent
 		}
 	}
 	result["bearer_token_sending_methods"] = pluginsdk.NewSet(pluginsdk.HashString, bearerTokenSendingMethods)
+
+	return []interface{}{result}
+}
+
+func expandApiManagementApiContact(input []interface{}) *apimanagement.APIContactInformation {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+	return &apimanagement.APIContactInformation{
+		Email: utils.String(v["email"].(string)),
+		Name:  utils.String(v["name"].(string)),
+		URL:   utils.String(v["url"].(string)),
+	}
+}
+
+func flattenApiManagementApiContact(contact *apimanagement.APIContactInformation) []interface{} {
+	if contact == nil {
+		return make([]interface{}, 0)
+	}
+
+	result := make(map[string]interface{})
+
+	if contact.Email != nil {
+		result["email"] = *contact.Email
+	}
+
+	if contact.Name != nil {
+		result["name"] = *contact.Name
+	}
+
+	if contact.URL != nil {
+		result["url"] = *contact.URL
+	}
+
+	return []interface{}{result}
+}
+
+func expandApiManagementApiLicense(input []interface{}) *apimanagement.APILicenseInformation {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+	return &apimanagement.APILicenseInformation{
+		Name: utils.String(v["name"].(string)),
+		URL:  utils.String(v["url"].(string)),
+	}
+}
+
+func flattenApiManagementApiLicense(license *apimanagement.APILicenseInformation) []interface{} {
+	if license == nil {
+		return make([]interface{}, 0)
+	}
+
+	result := make(map[string]interface{})
+
+	if license.Name != nil {
+		result["name"] = *license.Name
+	}
+
+	if license.URL != nil {
+		result["url"] = *license.URL
+	}
 
 	return []interface{}{result}
 }

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -380,6 +380,21 @@ func TestAccApiManagementApi_createRevisionFromExistingRevision(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApi_contact(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.contact(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ApiManagementApiResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ApiID(state.ID)
 	if err != nil {
@@ -610,6 +625,19 @@ resource "azurerm_api_management_api" "test" {
     header = "X-Butter-Robot-API-Key"
     query  = "location"
   }
+
+  contact {
+    email = "test@test.com"
+    name  = "test"
+    url   = "https://example:8080"
+  }
+
+  license {
+    name = "test-license"
+    url  = "https://example:8080/license"
+  }
+
+  terms_of_service_url = "https://example:8080/service"
 }
 `, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
@@ -779,8 +807,49 @@ resource "azurerm_api_management_api" "revision" {
   revision             = "18"
   source_api_id        = "${azurerm_api_management_api.test.id};rev=3"
   revision_description = "Creating a Revision of an existing API"
+  contact {
+    email = "test@test.com"
+    name  = "test"
+    url   = "https://example:8080"
+  }
+
+  license {
+    name = "test-license"
+    url  = "https://example:8080/license"
+  }
+
+  terms_of_service_url = "https://example:8080/service"
 }
 `, r.complete(data), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) contact(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+
+  contact {
+    email = "test@test.com"
+    name  = "test"
+    url   = "https://example:8080"
+  }
+
+  license {
+    name = "test-license"
+    url  = "https://example:8080/license"
+  }
+
+  terms_of_service_url = "https://example:8080/service"
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
 }
 
 func (ApiManagementApiResource) template(data acceptance.TestData, skuName string) string {

--- a/internal/services/apimanagement/validate/api_management_api_email_address.go
+++ b/internal/services/apimanagement/validate/api_management_api_email_address.go
@@ -1,0 +1,15 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func EmailAddress(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if matched := regexp.MustCompile(`^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("test: %s, %q is not an valida email address", k, v))
+	}
+	return warnings, errors
+}

--- a/internal/services/apimanagement/validate/api_management_api_email_address_test.go
+++ b/internal/services/apimanagement/validate/api_management_api_email_address_test.go
@@ -1,0 +1,47 @@
+package validate
+
+import "testing"
+
+func TestEmailAddress(t *testing.T) {
+	testData := []struct {
+		Value string
+		Error bool
+	}{
+		{
+			Value: "a",
+			Error: true,
+		},
+		{
+			Value: "abc",
+			Error: true,
+		},
+		{
+			Value: "123",
+			Error: true,
+		},
+		{
+			Value: "test.com",
+			Error: true,
+		},
+		{
+			Value: "test@.com",
+			Error: true,
+		},
+		{
+			Value: "test.com",
+			Error: true,
+		},
+		{
+			Value: "test@test.com",
+			Error: false,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Value)
+
+		_, err := EmailAddress(v.Value, "unit test")
+		if err != nil && !v.Error {
+			t.Fatalf("Expected pass but got an error: %s", err)
+		}
+	}
+}

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -68,9 +68,13 @@ The following arguments are supported:
 
 -> **NOTE:** `display_name`, `path` and `protocols` are required when `source_api_id` is not set.
 
+* `contact` - (Optional) A `contact` block as documented below.
+
 * `description` - (Optional) A description of the API Management API, which may include HTML formatting tags.
 
 * `import` - (Optional) A `import` block as documented below.
+
+* `license` - (Optional) A `license` block as documented below.
 
 * `oauth2_authorization` - (Optional) An `oauth2_authorization` block as documented below.
 
@@ -86,6 +90,8 @@ The following arguments are supported:
 
 * `subscription_required` - (Optional) Should this API require a subscription key?
 
+* `terms_of_service_url` - (Optional) Absolute URL of the Terms of Service for the API.
+
 * `version` - (Optional) The Version number of this API, if this API is versioned.
 
 * `version_set_id` - (Optional) The ID of the Version Set which this API is associated with.
@@ -100,6 +106,16 @@ The following arguments are supported:
 
 ---
 
+A `contact` block supports the following:
+
+* `email` - (Optional) The email address of the contact person/organization.
+
+* `name` - (Optional) The name of the contact person/organization.
+
+* `url` - (Optional) Absolute URL of the contact information.
+
+---
+
 A `import` block supports the following:
 
 * `content_format` - (Required) The format of the content from which the API Definition should be imported. Possible values are: `openapi`, `openapi+json`, `openapi+json-link`, `openapi-link`, `swagger-json`, `swagger-link-json`, `wadl-link-json`, `wadl-xml`, `wsdl` and `wsdl-link`.
@@ -107,6 +123,14 @@ A `import` block supports the following:
 * `content_value` - (Required) The Content from which the API Definition should be imported. When a `content_format` of `*-link-*` is specified this must be a URL, otherwise this must be defined inline.
 
 * `wsdl_selector` - (Optional) A `wsdl_selector` block as defined below, which allows you to limit the import of a WSDL to only a subset of the document. This can only be specified when `content_format` is `wsdl` or `wsdl-link`.
+
+---
+
+A `license` block supports the following:
+
+* `name` - (Optional) The name of the license .
+
+* `url` - (Optional) Absolute URL of the license.
 
 ---
 


### PR DESCRIPTION
Support config `contact`, `license`, `terms_of_service_url`

```log
=== RUN   TestAccApiManagementApi_basic
=== PAUSE TestAccApiManagementApi_basic
=== RUN   TestAccApiManagementApi_wordRevision
=== PAUSE TestAccApiManagementApi_wordRevision
=== RUN   TestAccApiManagementApi_blankPath
=== PAUSE TestAccApiManagementApi_blankPath
=== RUN   TestAccApiManagementApi_version
=== PAUSE TestAccApiManagementApi_version
=== RUN   TestAccApiManagementApi_oauth2Authorization
=== PAUSE TestAccApiManagementApi_oauth2Authorization
=== RUN   TestAccApiManagementApi_openidAuthentication
=== PAUSE TestAccApiManagementApi_openidAuthentication
=== RUN   TestAccApiManagementApi_requiresImport
=== PAUSE TestAccApiManagementApi_requiresImport
=== RUN   TestAccApiManagementApi_graphql
=== PAUSE TestAccApiManagementApi_graphql
=== RUN   TestAccApiManagementApi_soap
=== PAUSE TestAccApiManagementApi_soap
=== RUN   TestAccApiManagementApi_websocket
=== PAUSE TestAccApiManagementApi_websocket
=== RUN   TestAccApiManagementApi_soapPassthrough
=== PAUSE TestAccApiManagementApi_soapPassthrough
=== RUN   TestAccApiManagementApi_subscriptionRequired
=== PAUSE TestAccApiManagementApi_subscriptionRequired
=== RUN   TestAccApiManagementApi_importSwagger
=== PAUSE TestAccApiManagementApi_importSwagger
=== RUN   TestAccApiManagementApi_importWsdl
=== PAUSE TestAccApiManagementApi_importWsdl
=== RUN   TestAccApiManagementApi_importUpdate
=== PAUSE TestAccApiManagementApi_importUpdate
=== RUN   TestAccApiManagementApi_complete
=== PAUSE TestAccApiManagementApi_complete
=== RUN   TestAccApiManagementApi_cloneApi
=== PAUSE TestAccApiManagementApi_cloneApi
=== RUN   TestAccApiManagementApi_createNewVersionFromExisting
=== PAUSE TestAccApiManagementApi_createNewVersionFromExisting
=== RUN   TestAccApiManagementApi_createRevisionFromExisting
=== PAUSE TestAccApiManagementApi_createRevisionFromExisting
=== RUN   TestAccApiManagementApi_createRevisionFromExistingRevision
=== PAUSE TestAccApiManagementApi_createRevisionFromExistingRevision
=== RUN   TestAccApiManagementApi_contact
=== PAUSE TestAccApiManagementApi_contact
=== CONT  TestAccApiManagementApi_basic
=== CONT  TestAccApiManagementApi_subscriptionRequired
=== CONT  TestAccApiManagementApi_cloneApi
=== CONT  TestAccApiManagementApi_importUpdate
=== CONT  TestAccApiManagementApi_complete
=== CONT  TestAccApiManagementApi_importWsdl
=== CONT  TestAccApiManagementApi_importSwagger
=== CONT  TestAccApiManagementApi_createRevisionFromExisting
--- PASS: TestAccApiManagementApi_basic (542.01s)
=== CONT  TestAccApiManagementApi_createNewVersionFromExisting
--- PASS: TestAccApiManagementApi_cloneApi (549.29s)
=== CONT  TestAccApiManagementApi_contact
--- PASS: TestAccApiManagementApi_importWsdl (549.36s)
=== CONT  TestAccApiManagementApi_requiresImport
--- PASS: TestAccApiManagementApi_importSwagger (550.12s)
=== CONT  TestAccApiManagementApi_soapPassthrough
--- PASS: TestAccApiManagementApi_subscriptionRequired (550.60s)
=== CONT  TestAccApiManagementApi_websocket
--- PASS: TestAccApiManagementApi_createRevisionFromExisting (551.19s)
=== CONT  TestAccApiManagementApi_soap
--- PASS: TestAccApiManagementApi_complete (564.15s)
=== CONT  TestAccApiManagementApi_graphql
--- PASS: TestAccApiManagementApi_importUpdate (678.92s)
=== CONT  TestAccApiManagementApi_version
--- PASS: TestAccApiManagementApi_contact (518.18s)
=== CONT  TestAccApiManagementApi_openidAuthentication
--- PASS: TestAccApiManagementApi_soapPassthrough (520.43s)
=== CONT  TestAccApiManagementApi_oauth2Authorization
--- PASS: TestAccApiManagementApi_soap (525.18s)
=== CONT  TestAccApiManagementApi_blankPath
--- PASS: TestAccApiManagementApi_createNewVersionFromExisting (540.40s)
=== CONT  TestAccApiManagementApi_wordRevision
--- PASS: TestAccApiManagementApi_graphql (523.62s)
=== CONT  TestAccApiManagementApi_createRevisionFromExistingRevision
--- PASS: TestAccApiManagementApi_requiresImport (564.24s)
--- PASS: TestAccApiManagementApi_version (537.72s)
--- PASS: TestAccApiManagementApi_blankPath (435.38s)
--- PASS: TestAccApiManagementApi_wordRevision (502.94s)
--- PASS: TestAccApiManagementApi_oauth2Authorization (520.85s)
--- PASS: TestAccApiManagementApi_openidAuthentication (531.33s)
--- PASS: TestAccApiManagementApi_createRevisionFromExistingRevision (534.59s)
--- PASS: TestAccApiManagementApi_websocket (5274.84s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 5876.199s
```