### PR TITLE
Data Source: `azurerm_automation_account` - support of `identity` property

### DIFF
--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	identity2 "github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/automationaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -33,14 +34,19 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
 			"secondary_key": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
 			"endpoint": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
 			"private_endpoint_connection": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -96,6 +102,15 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("primary_key", iresp.Keys.Primary)
 		d.Set("secondary_key", iresp.Keys.Secondary)
 	}
+
+	identity, err := identity2.FlattenSystemAndUserAssignedMap(resp.Model.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	if err := d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
 	d.Set("endpoint", iresp.Endpoint)
 	if resp.Model != nil && resp.Model.Properties != nil {
 		d.Set("private_endpoint_connection", flattenPrivateEndpointConnections(resp.Model.Properties.PrivateEndpointConnections))

--- a/internal/services/automation/automation_account_data_source_test.go
+++ b/internal/services/automation/automation_account_data_source_test.go
@@ -36,11 +36,19 @@ resource "azurerm_automation_account" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Basic"
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 data "azurerm_automation_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
   name                = azurerm_automation_account.test.name
+}
+
+output "automation_account_system_managed_identity_principal_id" {
+  value = data.azurerm_automation_account.test.identity[0].principal_id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -37,9 +37,23 @@ output "automation_account_id" {
 
 * `secondary_key` - The Secondary Access Key for the Automation Account.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `endpoint` - The Endpoint for this Automation Account.
 
 * `hybrid_service_url` - The URL of automation hybrid service which is used for hybrid worker on-boarding With this Automation Account.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - The type of Managed Service Identity that is configured on this API Management Service.
+
+* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+
+* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this API Management Service.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18453

```
=== RUN   TestAccDataSourceAutomationAccount
=== PAUSE TestAccDataSourceAutomationAccount
=== CONT  TestAccDataSourceAutomationAccount
--- PASS: TestAccDataSourceAutomationAccount (145.35s)
PASS

```