### PR TITLE
`azurerm_orchestrated_virtual_machine_scale_set` - support for the `user_data_base64` property

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
@@ -268,6 +268,28 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabledWithExtension
 	})
 }
 
+func TestAccOrchestratedVirtualMachineScaleSet_otherUserData(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherUserData(data, "Hello World"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.otherUserData(data, "Goodbye World"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
 	r := OrchestratedVirtualMachineScaleSetResource{}
@@ -1138,6 +1160,87 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) otherUserData(data acceptance.TestData, userData string) string {
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  name = "acctest%[4]s"
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  zones = []
+
+  sku_name  = "Standard_D1_v2"
+  instances = 1
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  user_data = "%[1]d"
+
+  tags = {
+    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data), data.RandomString, userData)
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) otherCapacityReservationGroupId(data acceptance.TestData) string {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
@@ -1234,7 +1234,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 
-  user_data = base64encode("%[5]s")
+  user_data_base64 = base64encode("%[5]s")
 
   tags = {
     "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
@@ -1234,7 +1234,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 
-  user_data = "%[1]d"
+  user_data = "%[5]s"
 
   tags = {
     "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_other_resource_test.go
@@ -279,14 +279,14 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherUserData(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 		{
 			Config: r.otherUserData(data, "Goodbye World"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 	})
 }
 
@@ -1234,7 +1234,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 
-  user_data = "%[5]s"
+  user_data = base64encode("%[5]s")
 
   tags = {
     "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -248,6 +248,13 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"user_data": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsBase64,
+			},
 		},
 	}
 }
@@ -375,6 +382,10 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			return err
 		}
 		virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
+	}
+
+	if userData, ok := d.GetOk("user_data"); ok {
+		virtualMachineProfile.UserData = utils.String(userData.(string))
 	}
 
 	osType := compute.OperatingSystemTypesWindows
@@ -1062,6 +1073,11 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
+	if d.HasChange("user_data") {
+		updateInstances = true
+		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data").(string))
+	}
+
 	update.VirtualMachineScaleSetUpdateProperties = &updateProps
 
 	if updateInstances {
@@ -1266,6 +1282,8 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
 		}
 		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+		d.Set("user_data", profile.UserData)
+
 	}
 	d.Set("extension_operations_enabled", extensionOperationsEnabled)
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -1283,7 +1283,6 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 		}
 		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
 		d.Set("user_data", profile.UserData)
-
 	}
 	d.Set("extension_operations_enabled", extensionOperationsEnabled)
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -249,7 +249,7 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"user_data": {
+			"user_data_base64": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				Sensitive:    true,
@@ -384,7 +384,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
 	}
 
-	if userData, ok := d.GetOk("user_data"); ok {
+	if userData, ok := d.GetOk("user_data_base64"); ok {
 		virtualMachineProfile.UserData = utils.String(userData.(string))
 	}
 
@@ -1073,9 +1073,9 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	if d.HasChange("user_data") {
+	if d.HasChange("user_data_base64") {
 		updateInstances = true
-		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data").(string))
+		updateProps.VirtualMachineProfile.UserData = utils.String(d.Get("user_data_base64").(string))
 	}
 
 	update.VirtualMachineScaleSetUpdateProperties = &updateProps
@@ -1282,7 +1282,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
 		}
 		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
-		d.Set("user_data", profile.UserData)
+		d.Set("user_data_base64", profile.UserData)
 	}
 	d.Set("extension_operations_enabled", extensionOperationsEnabled)
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -101,7 +101,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
-* `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
+* `user_data_base64` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
 
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group which the Orchestrated Virtual Machine should be assigned to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -101,6 +101,8 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
+* `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
+
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group which the Orchestrated Virtual Machine should be assigned to. Changing this forces a new resource to be created.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Orchestrated Virtual Machine should be located. Changing this forces a new Orchestrated Virtual Machine to be created.


### PR DESCRIPTION
Adds user data to VMSS azurerm_orchestrated_virtual_machine_scale_set resource, the VMSS API requires this value to be base64 encoded hence the schema validation 