### PR TITLE
`azurerm_application_gateway` - fix T`estAccApplicationGateway_sslCertificateManualChangeIgnoreChange`

### DIFF
--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -4791,6 +4792,9 @@ func (ApplicationGatewayResource) changeCert(certificateName string) acceptance.
 
 		agw.SslCertificates = &newSslCertificates
 
+		// ctx has to refresh timeout value or it may timeout
+		ctx, cancel := context.WithTimeout(ctx, time.Minute*90)
+		defer cancel()
 		future, err := clients.Network.ApplicationGatewaysClient.CreateOrUpdate(ctx, resourceGroup, gatewayName, agw)
 		if err != nil {
 			return fmt.Errorf("Bad: updating AGW: %+v", err)


### PR DESCRIPTION
`ApplicationGatewaysClient.CreateOrUpdate` with ctx from provider will timeout. so use a new context with a new timeout value.

current failure message: 

```
    testcase.go:110: Step 1/2 error: Check failed: Check 3/3 error: Check 1/1 error: Bad: waiting for update of AGW: Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded`
```

![image](https://user-images.githubusercontent.com/2633022/191883023-4d6b8527-0bba-4770-9889-d69c45fb3083.png)
