### PR TITLE
Modified ADLS2 ACLs parsing to properly treat default entries.

### DIFF
--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -354,7 +354,7 @@ func resourceStorageDataLakeGen2FileSystemRead(d *pluginsdk.ResourceData, meta i
 			if err != nil {
 				return fmt.Errorf("parsing response ACL %q: %s", pathResponse.ACL, err)
 			}
-			ace = FlattenDataLakeGen2AceList(acl)
+			ace = FlattenDataLakeGen2AceList(d, acl)
 			owner = pathResponse.Owner
 			group = pathResponse.Group
 		}

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -334,7 +334,7 @@ func resourceStorageDataLakeGen2PathRead(d *pluginsdk.ResourceData, meta interfa
 	if err != nil {
 		return fmt.Errorf("parsing response ACL %q: %s", resp.ACL, err)
 	}
-	d.Set("ace", FlattenDataLakeGen2AceList(acl))
+	d.Set("ace", FlattenDataLakeGen2AceList(d, acl))
 
 	return nil
 }

--- a/internal/services/storage/storage_filesystem_ace.go
+++ b/internal/services/storage/storage_filesystem_ace.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/tombuildsstuff/giovanni/storage/accesscontrol"
 )
 
@@ -46,10 +47,17 @@ func ExpandDataLakeGen2AceList(input []interface{}) (*accesscontrol.ACL, error) 
 	return &accesscontrol.ACL{Entries: aceList}, nil
 }
 
-func FlattenDataLakeGen2AceList(acl accesscontrol.ACL) []interface{} {
-	output := make([]interface{}, len(acl.Entries))
+func FlattenDataLakeGen2AceList(d *pluginsdk.ResourceData, acl accesscontrol.ACL) []interface{} {
+	existingACLs, _ := ExpandDataLakeGen2AceList(d.Get("ace").(*pluginsdk.Set).List())
+	output := make([]interface{}, 0)
 
-	for i, v := range acl.Entries {
+	for _, v := range acl.Entries {
+		// Filter ACL defalt entries (ones without ID value, for scopes 'user', 'group', 'other', 'mask').
+		//    Include default entries, only if use in a configuration, to match the state file.
+		if v.TagQualifier == nil && existingACLs != nil && !isACLContainingEntry(existingACLs, v.TagType, v.TagQualifier, v.IsDefault) {
+			continue
+		}
+
 		ace := make(map[string]interface{})
 
 		scope := "access"
@@ -65,7 +73,22 @@ func FlattenDataLakeGen2AceList(acl accesscontrol.ACL) []interface{} {
 		ace["id"] = id
 		ace["permissions"] = v.Permissions
 
-		output[i] = ace
+		output = append(output, ace)
 	}
+
 	return output
+}
+
+func isACLContainingEntry(acl *accesscontrol.ACL, tagType accesscontrol.TagType, tagQualifier *uuid.UUID, isDefault bool) bool {
+	if acl == nil || acl.Entries == nil || len(acl.Entries) == 0 {
+		return false
+	}
+
+	for _, v := range acl.Entries {
+		if v.TagType == tagType && v.TagQualifier == tagQualifier && v.IsDefault == isDefault {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Description
------------
By default, API is adding default rules for ACLs. You can overwrite them, modify, but they are always being added to a specific filesystem path.

That created a never-ending apply/plan cycle, when terraform expects to have specific list of ACLs and API adjusts it from their side.

Changes
----------
The change is checking whether terraform wants to modify default ACLs, and if no - hides them from the list.

That makes sure we don't mix auto-added ACLs with the ones we do not expect to see. That is applied only to non-custom ACL entries.

Tests
--------

```bash
# go test -v -timeout 3000s -run ^TestAccStorageDataLakeGen2 github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/
=== RUN   TestAccStorageDataLakeGen2FileSystem_basic
=== PAUSE TestAccStorageDataLakeGen2FileSystem_basic
=== RUN   TestAccStorageDataLakeGen2FileSystem_requiresImport
=== PAUSE TestAccStorageDataLakeGen2FileSystem_requiresImport
=== RUN   TestAccStorageDataLakeGen2FileSystem_withDefaultACL
=== PAUSE TestAccStorageDataLakeGen2FileSystem_withDefaultACL
=== RUN   TestAccStorageDataLakeGen2FileSystem_UpdateDefaultACL
=== PAUSE TestAccStorageDataLakeGen2FileSystem_UpdateDefaultACL
=== RUN   TestAccStorageDataLakeGen2FileSystem_properties
=== PAUSE TestAccStorageDataLakeGen2FileSystem_properties
=== RUN   TestAccStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion
=== PAUSE TestAccStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion
=== RUN   TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
=== PAUSE TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
=== RUN   TestAccStorageDataLakeGen2FileSystem_withSuperUsers
=== PAUSE TestAccStorageDataLakeGen2FileSystem_withSuperUsers
=== RUN   TestAccStorageDataLakeGen2Path_basic
=== PAUSE TestAccStorageDataLakeGen2Path_basic
=== RUN   TestAccStorageDataLakeGen2Path_requiresImport
=== PAUSE TestAccStorageDataLakeGen2Path_requiresImport
=== RUN   TestAccStorageDataLakeGen2Path_withSimpleACLAndUpdate
=== PAUSE TestAccStorageDataLakeGen2Path_withSimpleACLAndUpdate
=== RUN   TestAccStorageDataLakeGen2Path_withSimpleACL
=== PAUSE TestAccStorageDataLakeGen2Path_withSimpleACL
=== RUN   TestAccStorageDataLakeGen2Path_withACLWithSpecificUserAndDefaults
=== PAUSE TestAccStorageDataLakeGen2Path_withACLWithSpecificUserAndDefaults
=== RUN   TestAccStorageDataLakeGen2Path_withOwner
=== PAUSE TestAccStorageDataLakeGen2Path_withOwner
=== RUN   TestAccStorageDataLakeGen2Path_withSuperUsers
=== PAUSE TestAccStorageDataLakeGen2Path_withSuperUsers
=== CONT  TestAccStorageDataLakeGen2FileSystem_basic
=== CONT  TestAccStorageDataLakeGen2Path_basic
=== CONT  TestAccStorageDataLakeGen2Path_withACLWithSpecificUserAndDefaults
=== CONT  TestAccStorageDataLakeGen2FileSystem_properties
--- PASS: TestAccStorageDataLakeGen2FileSystem_basic (127.50s)
=== CONT  TestAccStorageDataLakeGen2Path_withSuperUsers
--- PASS: TestAccStorageDataLakeGen2Path_basic (149.22s)
=== CONT  TestAccStorageDataLakeGen2Path_withOwner
--- PASS: TestAccStorageDataLakeGen2Path_withACLWithSpecificUserAndDefaults (162.82s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_withDefaultACL
--- PASS: TestAccStorageDataLakeGen2FileSystem_properties (249.68s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_UpdateDefaultACL
--- PASS: TestAccStorageDataLakeGen2Path_withSuperUsers (170.32s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_requiresImport
--- PASS: TestAccStorageDataLakeGen2Path_withOwner (285.87s)
=== CONT  TestAccStorageDataLakeGen2Path_withSimpleACLAndUpdate
--- PASS: TestAccStorageDataLakeGen2FileSystem_withDefaultACL (274.82s)
=== CONT  TestAccStorageDataLakeGen2Path_withSimpleACL
--- PASS: TestAccStorageDataLakeGen2FileSystem_requiresImport (183.59s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_withOwnerGroup
--- PASS: TestAccStorageDataLakeGen2FileSystem_UpdateDefaultACL (282.75s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_withSuperUsers
--- PASS: TestAccStorageDataLakeGen2Path_withSimpleACL (142.06s)
=== CONT  TestAccStorageDataLakeGen2Path_requiresImport
--- PASS: TestAccStorageDataLakeGen2FileSystem_withOwnerGroup (107.48s)
=== CONT  TestAccStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion
--- PASS: TestAccStorageDataLakeGen2Path_withSimpleACLAndUpdate (274.19s)
--- PASS: TestAccStorageDataLakeGen2FileSystem_withSuperUsers (178.01s)
--- PASS: TestAccStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion (172.19s)
--- PASS: TestAccStorageDataLakeGen2Path_requiresImport (217.87s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       797.602s
#
```