### PR TITLE
Fix docs for data.azurerm_automation_account

### DIFF
--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -47,13 +47,13 @@ output "automation_account_id" {
 
 An `identity` block exports the following:
 
-* `type` - The type of Managed Service Identity that is configured on this API Management Service.
+* `type` - The type of Managed Service Identity that is configured on this Automation Account.
 
-* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+* `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Automation Account.
 
-* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this API Management Service.
+* `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Automation Account.
 
-* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this API Management Service.
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Automation Account.
 
 ## Timeouts
 


### PR DESCRIPTION
The documentation for the identity block in the attributes reference for the data source data.azurerm_automation_account referenced API Managment when it should have mentioned an automation account. Created issue #18503  to track this error in documentation

This change to the provider was added with #18478, however, the documentation was not changed correctly in the pull request.