### PR TITLE
Docs: Fix possible value of `threat_intel_mode` in `azurerm_firewall` resource

### DIFF
--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -80,9 +80,7 @@ The following arguments are supported:
 
 * `management_ip_configuration` - (Optional) A `management_ip_configuration` block as documented below, which allows force-tunnelling of traffic to be performed by the firewall. Adding or removing this block or changing the `subnet_id` in an existing block forces a new resource to be created.
 
-* `threat_intel_mode` - (Optional) The operation mode for threat intelligence-based filtering. Possible values are: `Off`, `Alert`,`Deny` and `""`(empty string). Defaults to `Alert`.
-
--> **NOTE:** If `virtual_hub_settting` is specified, the `threat_intel_mode` has to be explicitly set as `""`.
+* `threat_intel_mode` - (Optional) The operation mode for threat intelligence-based filtering. Possible values are: `Off`, `Alert` and `Deny`. Defaults to `Alert`.
 
 * `virtual_hub` - (Optional) A `virtual_hub` block as documented below.
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18505  the empty string value removed from validation function since azurerm 3.0.

related pr/commit: https://github.com/hashicorp/terraform-provider-azurerm/commit/673e6e6603f28c56520dc49defea0bb47f41cb7f#diff-9b29e7d553e1b06cad14665d2ee767d5ffeefad32821d783e74f7372fbcde3d0