### PR TITLE
azurerm_mssql_elasticpool: gen5 with 8-10vCPU supports 2048 GB max data size

### DIFF
--- a/internal/services/mssql/helper/elasticpool.go
+++ b/internal/services/mssql/helper/elasticpool.go
@@ -174,8 +174,8 @@ var getvCoreMaxGB = map[string]map[string]map[int]float64{
 		"gen5": {
 			4:  1024,
 			6:  1536,
-			8:  1536,
-			10: 1536,
+			8:  2048,
+			10: 2048,
 			12: 3072,
 			14: 3072,
 			16: 3072,


### PR DESCRIPTION
As per [azure documentation](https://learn.microsoft.com/en-us/azure/azure-sql/database/resource-limits-vcore-elastic-pools?view=azuresql#business-critical-service-tier-generation-5-compute-platform-part-1), the elastic pool BC_Gen5_8 and BC_Gen5_10 supports 2048 GB max data size (GB).
