### PR TITLE
`compute` - fix tests with `ZRS` storage type

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -237,7 +237,7 @@ func TestAccLinuxVirtualMachine_diskOSStorageTypeStandardSSDZRS(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.diskOSStorageAccountType(data, "StandardSSD_ZRS"),
+			Config: r.diskOSStorageAccountTypeWithRestrictedLocation(data, "StandardSSD_ZRS", "westeurope"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -869,38 +869,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 func (r LinuxVirtualMachineResource) diskOSStorageAccountTypeWithRestrictedLocation(data acceptance.TestData, accountType string, location string) string {
 	// Limited regional availability for some storage account type
 	data.Locations.Primary = location
-
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2s_v2"
-  admin_username      = "adminuser"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "%s"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger, accountType)
+	return r.diskOSStorageAccountType(data, accountType)
 }
 
 func (r LinuxVirtualMachineResource) diskOSWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -237,7 +237,7 @@ func TestAccWindowsVirtualMachine_diskOSStorageTypeStandardSSDZRS(t *testing.T) 
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.diskOSStorageAccountType(data, "StandardSSD_ZRS"),
+			Config: r.diskOSStorageAccountTypeWithRestrictedLocation(data, "StandardSSD_ZRS", "westeurope"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -252,7 +252,7 @@ func TestAccWindowsVirtualMachine_diskOSStorageTypePremiumZRS(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.diskOSStorageAccountType(data, "Premium_ZRS"),
+			Config: r.diskOSStorageAccountTypeWithRestrictedLocation(data, "Premium_ZRS", "westeurope"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -825,6 +825,12 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data), accountType)
+}
+
+func (r WindowsVirtualMachineResource) diskOSStorageAccountTypeWithRestrictedLocation(data acceptance.TestData, accountType string, location string) string {
+	// Limited regional availability for some storage account type
+	data.Locations.Primary = location
+	return r.diskOSStorageAccountType(data, accountType)
 }
 
 func (r WindowsVirtualMachineResource) diskOSWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {


### PR DESCRIPTION
Similar to #18331, fixing other tests with `ZRS` storage type. This tests were failing in other region with `Supported SKUs for this region are Premium_LRS,StandardSSD_LRS,Standard_LRS,UltraSSD_LRS`.
Updating the `diskOSStorageAccountTypeWithRestrictedLocation` as well to reuse the config `diskOSStorageAccountType`, 