### PR TITLE
`d/azurerm_databricks_workspace` - Add `location`

### DIFF
--- a/internal/services/databricks/databricks_workspace_data_source.go
+++ b/internal/services/databricks/databricks_workspace_data_source.go
@@ -29,6 +29,8 @@ func dataSourceDatabricksWorkspace() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
+			"location": commonschema.LocationComputed(),
+
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -76,6 +78,7 @@ func dataSourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 		}
 		d.Set("workspace_id", model.Properties.WorkspaceId)
 		d.Set("workspace_url", model.Properties.WorkspaceUrl)
+		d.Set("location", model.Location)
 
 		return tags.FlattenAndSet(d, model.Tags)
 	}

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -21,6 +21,7 @@ func TestAccDatabricksWorkspaceDataSource_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				acceptance.TestMatchResourceAttr(data.ResourceName, "workspace_url", regexp.MustCompile("azuredatabricks.net")),
 				check.That(data.ResourceName).Key("workspace_id").Exists(),
+				check.That(data.ResourceName).Key("location").Exists(),
 			),
 		},
 	})


### PR DESCRIPTION
Fixes #18487

## Docs
- [x] Were already there by mistake for `location`

## Acceptance tests:
<img width="982" alt="Acceptance Test Results on TC" src="https://user-images.githubusercontent.com/8375124/192147010-b1b8533d-90db-4ee6-b4d8-530b8fba3c1d.png">
