### PR TITLE
`compute` - ensure `azurerm_marketplace_agreement` cleaned up before vm/vmss test

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -46,7 +46,7 @@ func TestAccLinuxVirtualMachine_imageFromPlan(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.template(data),
+			Config: r.empty(),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
 			),
@@ -399,6 +399,14 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (LinuxVirtualMachineResource) empty() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
 }
 
 func (r LinuxVirtualMachineResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -1,11 +1,16 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
@@ -35,10 +40,19 @@ func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
 func TestAccLinuxVirtualMachine_imageFromPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
+	publisher := "cloudwhizsolutions"
+	offer := "jenkins-docker-container-with-ubuntu-server"
+	sku := "jenkins-docker-container-with-ubuntu-server-cw"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.imageFromPlan(data),
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
+			),
+		},
+		{
+			Config: r.imageFromPlan(data, publisher, offer, sku),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -232,18 +246,18 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, r.imageFromExistingMachinePrep(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineResource) imageFromPlan(data acceptance.TestData) string {
+func (r LinuxVirtualMachineResource) imageFromPlan(data acceptance.TestData, publisher string, offer string, sku string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_marketplace_agreement" "test" {
-  publisher = "cloudwhizsolutions"
-  offer     = "jenkins-docker-container-with-ubuntu-server"
-  plan      = "jenkins-docker-container-with-ubuntu-server-cw"
+  publisher = "%[3]s"
+  offer     = "%[4]s"
+  plan      = "%[5]s"
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
+  name                            = "acctestVM-%[2]d"
   resource_group_name             = azurerm_resource_group.test.name
   location                        = azurerm_resource_group.test.location
   size                            = "Standard_F2"
@@ -266,21 +280,21 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   plan {
-    name      = "jenkins-docker-container-with-ubuntu-server-cw"
-    product   = "jenkins-docker-container-with-ubuntu-server"
-    publisher = "cloudwhizsolutions"
+    publisher = "%[3]s"
+    product   = "%[4]s"
+    name      = "%[5]s"
   }
 
   source_image_reference {
-    publisher = "cloudwhizsolutions"
-    offer     = "jenkins-docker-container-with-ubuntu-server"
-    sku       = "jenkins-docker-container-with-ubuntu-server-cw"
+    publisher = "%[3]s"
+    offer     = "%[4]s"
+    sku       = "%[5]s"
     version   = "latest"
   }
 
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, publisher, offer, sku)
 }
 
 func (r LinuxVirtualMachineResource) imageFromSharedImageGallery(data acceptance.TestData) string {
@@ -385,4 +399,30 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Compute.MarketplaceAgreementsClient
+		id := parse.NewPlanID(client.SubscriptionID, publisher, offer, sku)
+
+		existing, err := client.Get(ctx, id.AgreementName, id.OfferName, id.Name)
+		if err != nil {
+			return err
+		}
+
+		if props := existing.AgreementProperties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("marketplace agreement %q does not exist", id)
+					}
+					return fmt.Errorf("canceling Marketplace Agreement : %+v", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }

--- a/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
@@ -166,12 +166,12 @@ func TestAccLinuxVirtualMachineScaleSet_imagesPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
 	publisher := "cloudwhizsolutions"
-	offer := "ubuntu-20-04-minimal-lts-cw"
-	sku := "ubuntu-20-04-lts-minimal-cw"
+	offer := "jenkins-with-centos-7-7-cw"
+	sku := "jenkins-with-centos-77-cw"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.template(data),
+			Config: r.empty(),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
 			),
@@ -750,6 +750,14 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
 `, r.template(data), data.RandomInteger, publisher, offer, sku)
+}
+
+func (LinuxVirtualMachineScaleSetResource) empty() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
 }
 
 func (r LinuxVirtualMachineScaleSetResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {

--- a/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_images_resource_test.go
@@ -1,11 +1,16 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestAccLinuxVirtualMachineScaleSet_imagesAutomaticUpdate(t *testing.T) {
@@ -160,10 +165,19 @@ func TestAccLinuxVirtualMachineScaleSet_imagesRollingUpdate(t *testing.T) {
 func TestAccLinuxVirtualMachineScaleSet_imagesPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
+	publisher := "cloudwhizsolutions"
+	offer := "ubuntu-20-04-minimal-lts-cw"
+	sku := "ubuntu-20-04-lts-minimal-cw"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.imagesPlan(data),
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
+			),
+		},
+		{
+			Config: r.imagesPlan(data, publisher, offer, sku),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -683,18 +697,18 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, version)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) imagesPlan(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) imagesPlan(data acceptance.TestData, publisher string, offer string, sku string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_marketplace_agreement" "test" {
-  publisher = "cloudwhizsolutions"
-  offer     = "jenkins-docker-container-with-ubuntu-server"
-  plan      = "jenkins-docker-container-with-ubuntu-server-cw"
+  publisher = "%[3]s"
+  offer     = "%[4]s"
+  plan      = "%[5]s"
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+  name                = "acctestvmss-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "Standard_F2"
@@ -705,9 +719,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   disable_password_authentication = false
 
   source_image_reference {
-    publisher = "cloudwhizsolutions"
-    offer     = "jenkins-docker-container-with-ubuntu-server"
-    sku       = "jenkins-docker-container-with-ubuntu-server-cw"
+    publisher = "%[3]s"
+    offer     = "%[4]s"
+    sku       = "%[5]s"
     version   = "latest"
   }
 
@@ -728,12 +742,38 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 
   plan {
-    name      = "jenkins-docker-container-with-ubuntu-server-cw"
-    product   = "jenkins-docker-container-with-ubuntu-server"
-    publisher = "cloudwhizsolutions"
+    publisher = "%[3]s"
+    product   = "%[4]s"
+    name      = "%[5]s"
   }
 
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, publisher, offer, sku)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Compute.MarketplaceAgreementsClient
+		id := parse.NewPlanID(client.SubscriptionID, publisher, offer, sku)
+
+		existing, err := client.Get(ctx, id.AgreementName, id.OfferName, id.Name)
+		if err != nil {
+			return err
+		}
+
+		if props := existing.AgreementProperties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("marketplace agreement %q does not exist", id)
+					}
+					return fmt.Errorf("canceling Marketplace Agreement : %+v", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }

--- a/internal/services/compute/windows_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_images_test.go
@@ -40,10 +40,19 @@ func TestAccWindowsVirtualMachine_imageFromImage(t *testing.T) {
 func TestAccWindowsVirtualMachine_imageFromPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
+	publisher := "plesk"
+	offer := "plesk-onyx-windows"
+	sku := "plsk-win-hst-azr-m"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.imageFromPlan(data),
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
+			),
+		},
+		{
+			Config: r.imageFromPlan(data, publisher, offer, sku),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -217,14 +226,14 @@ resource "azurerm_windows_virtual_machine" "test" {
 `, r.imageFromExistingMachinePrep(data))
 }
 
-func (r WindowsVirtualMachineResource) imageFromPlan(data acceptance.TestData) string {
+func (r WindowsVirtualMachineResource) imageFromPlan(data acceptance.TestData, publisher string, offer string, sku string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_marketplace_agreement" "test" {
-  publisher = "plesk"
-  offer     = "plesk-onyx-windows"
-  plan      = "plsk-win-hst-azr-m"
+  publisher = "%[2]s"
+  offer     = "%[3]s"
+  plan      = "%[4]s"
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
@@ -244,21 +253,21 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   plan {
-    name      = "plsk-win-hst-azr-m"
-    product   = "plesk-onyx-windows"
-    publisher = "plesk"
+    publisher = "%[2]s"
+    product   = "%[3]s"
+    name      = "%[4]s"
   }
 
   source_image_reference {
-    publisher = "plesk"
-    offer     = "plesk-onyx-windows"
-    sku       = "plsk-win-hst-azr-m"
+    publisher = "%[2]s"
+    offer     = "%[3]s"
+    sku       = "%[4]s"
     version   = "latest"
   }
 
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
-`, r.template(data))
+`, r.template(data), publisher, offer, sku)
 }
 
 func (r WindowsVirtualMachineResource) imageFromSharedImageGallery(data acceptance.TestData) string {
@@ -391,4 +400,30 @@ func (WindowsVirtualMachineResource) generalizeVirtualMachine(ctx context.Contex
 	}
 
 	return nil
+}
+
+func (r WindowsVirtualMachineResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Compute.MarketplaceAgreementsClient
+		id := parse.NewPlanID(client.SubscriptionID, publisher, offer, sku)
+
+		existing, err := client.Get(ctx, id.AgreementName, id.OfferName, id.Name)
+		if err != nil {
+			return err
+		}
+
+		if props := existing.AgreementProperties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("marketplace agreement %q does not exist", id)
+					}
+					return fmt.Errorf("canceling Marketplace Agreement : %+v", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }

--- a/internal/services/compute/windows_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_images_test.go
@@ -46,7 +46,7 @@ func TestAccWindowsVirtualMachine_imageFromPlan(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.template(data),
+			Config: r.empty(),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
 			),
@@ -358,6 +358,14 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data))
+}
+
+func (WindowsVirtualMachineResource) empty() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
 }
 
 func (WindowsVirtualMachineResource) generalizeVirtualMachine(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
@@ -1,11 +1,16 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestAccWindowsVirtualMachineScaleSet_imagesAutomaticUpdate(t *testing.T) {
@@ -175,10 +180,19 @@ func TestAccWindowsVirtualMachineScaleSet_imagesRollingUpdate(t *testing.T) {
 func TestAccWindowsVirtualMachineScaleSet_imagesPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
+	publisher := "plesk"
+	offer := "plesk-onyx-windows"
+	sku := "plsk-win-byol-azr-m"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.imagesPlan(data),
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
+			),
+		},
+		{
+			Config: r.imagesPlan(data, publisher, offer, sku),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -689,14 +703,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger, version)
 }
 
-func (r WindowsVirtualMachineScaleSetResource) imagesPlan(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) imagesPlan(data acceptance.TestData, publisher string, offer string, sku string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_marketplace_agreement" "test" {
-  publisher = "plesk"
-  offer     = "plesk-onyx-windows"
-  plan      = "plsk-win-hst-azr-m"
+  publisher = "%[2]s"
+  offer     = "%[3]s"
+  plan      = "%[4]s"
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
@@ -709,9 +723,9 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   admin_password      = "P@ssword1234!"
 
   source_image_reference {
-    publisher = "plesk"
-    offer     = "plesk-onyx-windows"
-    sku       = "plsk-win-hst-azr-m"
+    publisher = "%[2]s"
+    offer     = "%[3]s"
+    sku       = "%[4]s"
     version   = "latest"
   }
 
@@ -732,12 +746,38 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   }
 
   plan {
-    name      = "plsk-win-hst-azr-m"
-    product   = "plesk-onyx-windows"
-    publisher = "plesk"
+    publisher = "%[2]s"
+    product   = "%[3]s"
+    name      = "%[4]s"
   }
 
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
-`, r.template(data))
+`, r.template(data), publisher, offer, sku)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Compute.MarketplaceAgreementsClient
+		id := parse.NewPlanID(client.SubscriptionID, publisher, offer, sku)
+
+		existing, err := client.Get(ctx, id.AgreementName, id.OfferName, id.Name)
+		if err != nil {
+			return err
+		}
+
+		if props := existing.AgreementProperties; props != nil {
+			if accepted := props.Accepted; accepted != nil && *accepted {
+				resp, err := client.Cancel(ctx, id.AgreementName, id.OfferName, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(resp.Response) {
+						return fmt.Errorf("marketplace agreement %q does not exist", id)
+					}
+					return fmt.Errorf("canceling Marketplace Agreement : %+v", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_images_resource_test.go
@@ -186,7 +186,7 @@ func TestAccWindowsVirtualMachineScaleSet_imagesPlan(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.template(data),
+			Config: r.empty(),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
 			),
@@ -754,6 +754,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   depends_on = ["azurerm_marketplace_agreement.test"]
 }
 `, r.template(data), publisher, offer, sku)
+}
+
+func (WindowsVirtualMachineScaleSetResource) empty() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+`
 }
 
 func (r WindowsVirtualMachineScaleSetResource) cancelExistingAgreement(publisher string, offer string, sku string) acceptance.ClientCheckFunc {


### PR DESCRIPTION
`azurerm_marketplace_agreement` with same combination of `publisher/offer/sku` could only be registered once in the same subscription. If the test exits unexpected, there will be remaining `azurerm_marketplace_agreement` in the subscription. And since it's not within a specific Resource Group, it's not easy to clean up. Thus, adding additional code to cancel the Marketplace Agreement before the tests which use it, similar to https://github.com/hashicorp/terraform-provider-azurerm/blob/5455c89b189b107828305cb9d177612641dc7e3a/internal/services/compute/marketplace_agreement_resource_test.go#L125
And also updating the offer/sku to be different for VM and VMSS test, so that they won't conflict with each other.