### PR TITLE
`azurerm_linux_function_app_slot`: remove `resource_group_name` property

### DIFF
--- a/website/docs/r/web_app_active_slot.html.markdown
+++ b/website/docs/r/web_app_active_slot.html.markdown
@@ -84,10 +84,10 @@ resource "azurerm_linux_web_app" "example" {
 }
 
 resource "azurerm_linux_web_app_slot" "example" {
-  name                = "example-linux-web-app-slot"
-  app_service_name    = azurerm_linux_web_app.example.name
-  location            = azurerm_service_plan.example.location
-  service_plan_id     = azurerm_service_plan.example.id
+  name             = "example-linux-web-app-slot"
+  app_service_name = azurerm_linux_web_app.example.name
+  location         = azurerm_service_plan.example.location
+  service_plan_id  = azurerm_service_plan.example.id
 
   site_config {}
 }

--- a/website/docs/r/web_app_active_slot.html.markdown
+++ b/website/docs/r/web_app_active_slot.html.markdown
@@ -86,7 +86,6 @@ resource "azurerm_linux_web_app" "example" {
 resource "azurerm_linux_web_app_slot" "example" {
   name                = "example-linux-web-app-slot"
   app_service_name    = azurerm_linux_web_app.example.name
-  resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_service_plan.example.location
   service_plan_id     = azurerm_service_plan.example.id
 


### PR DESCRIPTION
`resource_group_name` doesn't required for app service slot and it was removed from provider. fixing the docs to match the behavior.

fix:https://github.com/hashicorp/terraform-provider-azurerm/issues/18515