### PR TITLE
data source `azurerm_client_config` `azurerm_public_maintenance_configurations` `azurerm_public_ips` - Use static id instead of timestamp

### DIFF
--- a/internal/services/authorization/client_config_data_source.go
+++ b/internal/services/authorization/client_config_data_source.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -46,7 +47,8 @@ func dataSourceArmClientConfigRead(d *pluginsdk.ResourceData, meta interface{}) 
 	_, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	d.SetId(fmt.Sprintf("clientConfigs/clientId=%s;objectId=%s;subscriptionId=%s;tenantId=%s", client.Account.ClientId, client.Account.ObjectId, client.Account.SubscriptionId, client.Account.TenantId))
+	id := fmt.Sprintf("clientConfigs/clientId=%s;objectId=%s;subscriptionId=%s;tenantId=%s", client.Account.ClientId, client.Account.ObjectId, client.Account.SubscriptionId, client.Account.TenantId)
+	d.SetId(base64.StdEncoding.EncodeToString([]byte(id)))
 	d.Set("client_id", client.Account.ClientId)
 	d.Set("object_id", client.Account.ObjectId)
 	d.Set("subscription_id", client.Account.SubscriptionId)

--- a/internal/services/authorization/client_config_data_source.go
+++ b/internal/services/authorization/client_config_data_source.go
@@ -45,7 +45,7 @@ func dataSourceArmClientConfigRead(d *pluginsdk.ResourceData, meta interface{}) 
 	_, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId("armClientConfig")
 	d.Set("client_id", client.Account.ClientId)
 	d.Set("object_id", client.Account.ObjectId)
 	d.Set("subscription_id", client.Account.SubscriptionId)

--- a/internal/services/authorization/client_config_data_source.go
+++ b/internal/services/authorization/client_config_data_source.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -45,7 +46,7 @@ func dataSourceArmClientConfigRead(d *pluginsdk.ResourceData, meta interface{}) 
 	_, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	d.SetId("armClientConfig")
+	d.SetId(fmt.Sprintf("clientConfigs/clientId=%s;objectId=%s;subscriptionId=%s;tenantId=%s", client.Account.ClientId, client.Account.ObjectId, client.Account.SubscriptionId, client.Account.TenantId))
 	d.Set("client_id", client.Account.ClientId)
 	d.Set("object_id", client.Account.ObjectId)
 	d.Set("subscription_id", client.Account.SubscriptionId)

--- a/internal/services/maintenance/public_maintenance_configurations_data_source.go
+++ b/internal/services/maintenance/public_maintenance_configurations_data_source.go
@@ -174,7 +174,7 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("setting `configs`: %+v", err)
 	}
 
-	d.SetId(fmt.Sprintf("publicMaintenanceConfigurations/location:%s/scope:%s/recurEvery:%s", locationFilter, scopeFilter, recurEveryFilterRaw))
+	d.SetId(fmt.Sprintf("publicMaintenanceConfigurations/location=%s;scope=%s;recurEvery=%s", locationFilter, scopeFilter, recurEveryFilterRaw))
 	return nil
 }
 

--- a/internal/services/maintenance/public_maintenance_configurations_data_source.go
+++ b/internal/services/maintenance/public_maintenance_configurations_data_source.go
@@ -123,10 +123,11 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 
 	filteredPublicConfigs := make([]interface{}, 0)
 
-	recurEveryFilter := d.Get("recur_every").(string)
-	if recurEveryFilter == recurFridayToSunday {
+	recurEveryFilterRaw := d.Get("recur_every").(string)
+	recurEveryFilter := recurEveryFilterRaw
+	if recurEveryFilterRaw == recurFridayToSunday {
 		recurEveryFilter = "week Friday, Saturday, Sunday"
-	} else if recurEveryFilter == recurMondayToThursday {
+	} else if recurEveryFilterRaw == recurMondayToThursday {
 		recurEveryFilter = "week Monday, Tuesday, Wednesday, Thursday"
 	}
 
@@ -173,7 +174,7 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("setting `configs`: %+v", err)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(fmt.Sprintf("publicMaintenanceConfigurations/location:%s/scope:%s/recurEvery:%s", locationFilter, scopeFilter, recurEveryFilterRaw))
 	return nil
 }
 

--- a/internal/services/maintenance/public_maintenance_configurations_data_source.go
+++ b/internal/services/maintenance/public_maintenance_configurations_data_source.go
@@ -1,6 +1,7 @@
 package maintenance
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -174,7 +175,8 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("setting `configs`: %+v", err)
 	}
 
-	d.SetId(fmt.Sprintf("publicMaintenanceConfigurations/location=%s;scope=%s;recurEvery=%s", locationFilter, scopeFilter, recurEveryFilterRaw))
+	id := fmt.Sprintf("publicMaintenanceConfigurations/location=%s;scope=%s;recurEvery=%s", locationFilter, scopeFilter, recurEveryFilterRaw)
+	d.SetId(base64.StdEncoding.EncodeToString([]byte(id)))
 	return nil
 }
 

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -128,7 +128,7 @@ func dataSourcePublicIPsRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		filteredIPAddresses = append(filteredIPAddresses, element)
 	}
 
-	d.SetId(fmt.Sprintf("publicIPs/resourceGroup:%s/namePrefix:%s/attachmentStatus:%s/allocationType:%s", resourceGroup, prefix, attachmentStatus, allocationType))
+	d.SetId(fmt.Sprintf("networkPublicIPs/resourceGroup/%s/namePrefix=%s;attachmentStatus=%s;allocationType=%s", resourceGroup, prefix, attachmentStatus, allocationType))
 
 	results := flattenDataSourcePublicIPs(filteredIPAddresses)
 	if err := d.Set("public_ips", results); err != nil {

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"strings"
@@ -128,7 +129,8 @@ func dataSourcePublicIPsRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		filteredIPAddresses = append(filteredIPAddresses, element)
 	}
 
-	d.SetId(fmt.Sprintf("networkPublicIPs/resourceGroup/%s/namePrefix=%s;attachmentStatus=%s;allocationType=%s", resourceGroup, prefix, attachmentStatus, allocationType))
+	id := fmt.Sprintf("networkPublicIPs/resourceGroup/%s/namePrefix=%s;attachmentStatus=%s;allocationType=%s", resourceGroup, prefix, attachmentStatus, allocationType)
+	d.SetId(base64.StdEncoding.EncodeToString([]byte(id)))
 
 	results := flattenDataSourcePublicIPs(filteredIPAddresses)
 	if err := d.Set("public_ips", results); err != nil {


### PR DESCRIPTION
Similar to #17766 and [shared_image_versions_data_source](https://github.com/hashicorp/terraform-provider-azurerm/blob/24d67dab775787d4d0418bec7b3101854fdd7dcf/internal/services/compute/shared_image_versions_data_source.go#L127), `time.Now()` changes on each apply, so if we reference the data source like `output "v" { value = data.azurerm_... }`, it will output a diff on each apply. Using the static id to fix this diff.