### PR TITLE
Enhacne - `azurerm_api_management_logger` - Recreate if `resource_id` changed

### DIFF
--- a/internal/services/apimanagement/api_management_logger_resource.go
+++ b/internal/services/apimanagement/api_management_logger_resource.go
@@ -46,6 +46,7 @@ func resourceApiManagementLogger() *pluginsdk.Resource {
 			"resource_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
 

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `eventhub` - (Optional) An `eventhub` block as documented below.
 
-* `resource_id` - (Optional) The target resource id which will be linked in the API-Management portal page.
+* `resource_id` - (Optional) The target resource id which will be linked in the API-Management portal page. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Fixes #18466 
`resource_id` cannot updated, recreate the resource if `resource_id` changed.
```log
=== PAUSE TestAccApiManagementLogger_basicEventHub
=== RUN   TestAccApiManagementLogger_requiresImport
=== PAUSE TestAccApiManagementLogger_requiresImport
=== RUN   TestAccApiManagementLogger_basicApplicationInsights
=== PAUSE TestAccApiManagementLogger_basicApplicationInsights
=== RUN   TestAccApiManagementLogger_complete
=== PAUSE TestAccApiManagementLogger_complete
=== RUN   TestAccApiManagementLogger_update
=== PAUSE TestAccApiManagementLogger_update
=== CONT  TestAccApiManagementLogger_basicEventHub
=== CONT  TestAccApiManagementLogger_complete
=== CONT  TestAccApiManagementLogger_basicApplicationInsights
=== CONT  TestAccApiManagementLogger_requiresImport
=== CONT  TestAccApiManagementLogger_update
--- PASS: TestAccApiManagementLogger_basicEventHub (565.63s)
--- PASS: TestAccApiManagementLogger_basicApplicationInsights (629.55s)
--- PASS: TestAccApiManagementLogger_complete (631.79s)
--- PASS: TestAccApiManagementLogger_requiresImport (681.36s)
--- PASS: TestAccApiManagementLogger_update (1317.92s)
```