### PR TITLE
Deprecate Resource: azurerm_cosmosdb_notebook_workspace

### DIFF
--- a/internal/services/cosmos/cosmosdb_notebook_workspace_resource.go
+++ b/internal/services/cosmos/cosmosdb_notebook_workspace_resource.go
@@ -34,6 +34,8 @@ func resourceCosmosDbNotebookWorkspace() *pluginsdk.Resource {
 			return err
 		}),
 
+		DeprecationMessage: `CosmosDb Notebook Workspace is now Deprecated - as such the 'azurerm_cosmosdb_notebook_workspace' resource is deprecated and will be removed in v4.0 of the AzureRM Provider`,
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/cosmos/cosmosdb_notebook_workspace_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_notebook_workspace_resource_test.go
@@ -16,6 +16,7 @@ import (
 type CosmosDbNotebookWorkspaceResource struct{}
 
 func TestAccCosmosDbNotebookWorkspace_basic(t *testing.T) {
+	t.Skip("Skipping as CosmosDb Notebook Workspace is deprecated")
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_notebook_workspace", "test")
 	r := CosmosDbNotebookWorkspaceResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -30,6 +31,7 @@ func TestAccCosmosDbNotebookWorkspace_basic(t *testing.T) {
 }
 
 func TestAccCosmosDbNotebookWorkspace_requiresImport(t *testing.T) {
+	t.Skip("Skipping as CosmosDb Notebook Workspace is deprecated")
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_notebook_workspace", "test")
 	r := CosmosDbNotebookWorkspaceResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/website/docs/r/cosmosdb_notebook_workspace.html.markdown
+++ b/website/docs/r/cosmosdb_notebook_workspace.html.markdown
@@ -10,7 +10,11 @@ description: |-
 
 Manages an SQL Notebook Workspace.
 
-!> CosmosDb Notebook Workspace is now Deprecated - as such the `azurerm_cosmosdb_notebook_workspace` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.
+!> **Note:** CosmosDb Notebook Workspace is now Deprecated - as such the `azurerm_cosmosdb_notebook_workspace` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.
+
+~> **NOTE:** CosmosDb Notebook (the feature itself) is not deprecated and will return: https://learn.microsoft.com/en-us/azure/cosmos-db/notebooks-faq.
+
+~> **NOTE:** However, CosmosDb Notebook feature no longer uses the permanent notebook workspace being referred to the public surface in the RP (have since moved to temporary notebooks workspaces which are short-lived <1 hour).
 
 ## Example Usage
 

--- a/website/docs/r/cosmosdb_notebook_workspace.html.markdown
+++ b/website/docs/r/cosmosdb_notebook_workspace.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an SQL Notebook Workspace.
 
+!> CosmosDb Notebook Workspace is now Deprecated - as such the `azurerm_cosmosdb_notebook_workspace` resource is deprecated and will be removed in v4.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Service team confirmed that the CosmoDb Notebook Workspace has been deprecated and currently service API doesn't allow to create new resource anymore so that the existing TCs failed. And they also confirmed they’re not planning any other APIs to replace this feature as of now.