### PR TITLE
`azurerm_automation_software_update_configuration` - fix windows update classification use a comma separate string

### DIFF
--- a/internal/services/automation/automation_software_update_configuration.go
+++ b/internal/services/automation/automation_software_update_configuration.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/automation/mgmt/2020-01-13-preview/automation"
@@ -512,12 +513,20 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 					"classification_included": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						ValidateFunc: validation.StringInSlice(func() (vs []string) {
+						ValidateFunc: func(i interface{}, s string) (warns []string, errors []error) {
+							possibleValuesMap := map[string]struct{}{}
 							for _, v := range automation.PossibleWindowsUpdateClassesValues() {
-								vs = append(vs, string(v))
+								possibleValuesMap[string(v)] = struct{}{}
+							}
+							// A comma separated string with required values (only for windows)
+							for _, key := range strings.Split(i.(string), ",") {
+								key = strings.TrimSpace(key)
+								if _, ok := possibleValuesMap[key]; !ok {
+									errors = append(errors, fmt.Errorf("%s not allowed for classification_included", key))
+								}
 							}
 							return
-						}(), false),
+						},
 					},
 
 					"excluded_knowledge_base_numbers": {

--- a/internal/services/automation/automation_software_update_configuration.go
+++ b/internal/services/automation/automation_software_update_configuration.go
@@ -274,10 +274,13 @@ func targetsFromSDK(prop *automation.TargetProperties) []Target {
 }
 
 type Windows struct {
-	Classification string   `tfschema:"classification_included"`
-	ExcludedKbs    []string `tfschema:"excluded_knowledge_base_numbers"`
-	IncludedKbs    []string `tfschema:"included_knowledge_base_numbers"`
-	RebootSetting  string   `tfschema:"reboot"`
+	// Classification Deprecated, use Classifications instead
+	Classification string `tfschema:"classification_included"`
+
+	Classifications []string `tfschema:"classifications_included"`
+	ExcludedKbs     []string `tfschema:"excluded_knowledge_base_numbers"`
+	IncludedKbs     []string `tfschema:"included_knowledge_base_numbers"`
+	RebootSetting   string   `tfschema:"reboot"`
 }
 
 type SoftwareUpdateConfigurationModel struct {
@@ -321,8 +324,12 @@ func (s *SoftwareUpdateConfigurationModel) ToSDKModel() automation.SoftwareUpdat
 
 	if len(s.Windows) > 0 {
 		w := s.Windows[0]
+
 		upd.Windows = &automation.WindowsProperties{
-			IncludedUpdateClassifications: automation.WindowsUpdateClasses(w.Classification),
+			IncludedUpdateClassifications: automation.WindowsUpdateClasses(strings.Join(w.Classifications, ",")),
+		}
+		if len(w.Classifications) == 0 && w.Classification != "" {
+			upd.Windows.IncludedUpdateClassifications = automation.WindowsUpdateClasses(w.Classification)
 		}
 
 		if w.RebootSetting != "" {
@@ -414,7 +421,12 @@ func (s *SoftwareUpdateConfigurationModel) LoadSDKModel(prop *automation.Softwar
 					ExcludedKbs:    pointer.ToSliceOfStrings(w.ExcludedKbNumbers),
 					IncludedKbs:    pointer.ToSliceOfStrings(w.IncludedKbNumbers),
 					RebootSetting:  utils.NormalizeNilableString(w.RebootSetting),
-				}}
+				},
+			}
+
+			for _, v := range strings.Split(string(w.IncludedUpdateClassifications), ",") {
+				s.Windows[0].Classifications = append(s.Windows[0].Classifications, strings.TrimSpace(v))
+			}
 		}
 
 		s.Duration = utils.NormalizeNilableString(conf.Duration)
@@ -507,25 +519,39 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 		"windows": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
+			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 
 					"classification_included": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: func(i interface{}, s string) (warns []string, errors []error) {
-							possibleValuesMap := map[string]struct{}{}
+						Type:          pluginsdk.TypeString,
+						Optional:      true,
+						Computed:      true,
+						ConflictsWith: []string{"windows.0.classifications_included"},
+						AtLeastOneOf:  []string{"windows.0.classification_included", "windows.0.classifications_included"},
+						Deprecated:    "windows classification can be set as a list, use `classifications_included` instead.",
+						ValidateFunc: validation.StringInSlice(func() (vs []string) {
 							for _, v := range automation.PossibleWindowsUpdateClassesValues() {
-								possibleValuesMap[string(v)] = struct{}{}
-							}
-							// A comma separated string with required values (only for windows)
-							for _, key := range strings.Split(i.(string), ",") {
-								key = strings.TrimSpace(key)
-								if _, ok := possibleValuesMap[key]; !ok {
-									errors = append(errors, fmt.Errorf("%s not allowed for classification_included", key))
-								}
+								vs = append(vs, string(v))
 							}
 							return
+						}(), false),
+					},
+
+					"classifications_included": {
+						Type:          pluginsdk.TypeList,
+						Optional:      true,
+						Computed:      true,
+						ConflictsWith: []string{"windows.0.classification_included"},
+						AtLeastOneOf:  []string{"windows.0.classification_included", "windows.0.classifications_included"},
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice(func() (res []string) {
+								for _, v := range automation.PossibleWindowsUpdateClassesValues() {
+									res = append(res, string(v))
+								}
+								return
+							}(), false),
 						},
 					},
 

--- a/internal/services/automation/automation_software_update_configuration_test.go
+++ b/internal/services/automation/automation_software_update_configuration_test.go
@@ -81,6 +81,21 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 	})
 }
 
+func TestAccSoftwareUpdateConfiguration_windows(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windows(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always return null
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
 func (a SoftwareUpdateConfigurationResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
@@ -187,6 +202,63 @@ resource "azurerm_automation_software_update_configuration" "test" {
     frequency          = "Hour"
     time_zone          = "Etc/UTC"
     advanced_week_days = ["Monday", "Tuesday"]
+  }
+
+  depends_on = [azurerm_log_analytics_linked_service.test]
+}
+`, a.template(data), data.RandomInteger, a.startTime, a.expireTime)
+}
+
+func (a SoftwareUpdateConfigurationResource) windows(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_automation_software_update_configuration" "test" {
+  automation_account_id = azurerm_automation_account.test.id
+  name                  = "acctest-suc-%[2]d"
+  operating_system      = "Windows"
+
+  windows {
+    classification_included = "Critical, Security"
+    reboot                  = "IfRequired"
+  }
+
+  duration            = "PT1H1M1S"
+  virtual_machine_ids = []
+
+  target {
+    azure_query {
+      scope     = [azurerm_resource_group.test.id]
+      locations = [azurerm_resource_group.test.location]
+      tags {
+        tag    = "foo"
+        values = ["barbar2"]
+      }
+      tag_filter = "Any"
+    }
+
+    non_azure_query {
+      function_alias = "savedSearch1"
+      workspace_id   = azurerm_log_analytics_workspace.test.id
+    }
+  }
+
+  schedule {
+    description         = "foo-schedule"
+    start_time          = "%[3]s"
+    expiry_time         = "%[4]s"
+    is_enabled          = true
+    interval            = 1
+    frequency           = "Hour"
+    time_zone           = "Etc/UTC"
+    advanced_week_days  = ["Monday", "Tuesday"]
+    advanced_month_days = [1, 10, 15]
+    monthly_occurrence {
+      occurrence = 1
+      day        = "Tuesday"
+    }
   }
 
   depends_on = [azurerm_log_analytics_linked_service.test]

--- a/internal/services/automation/automation_software_update_configuration_test.go
+++ b/internal/services/automation/automation_software_update_configuration_test.go
@@ -221,7 +221,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
   operating_system      = "Windows"
 
   windows {
-    classification_included = "Critical, Security"
+    classifications_included = ["Critical", "Security"]
     reboot                  = "IfRequired"
   }
 

--- a/internal/services/automation/automation_software_update_configuration_test.go
+++ b/internal/services/automation/automation_software_update_configuration_test.go
@@ -222,7 +222,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
   windows {
     classifications_included = ["Critical", "Security"]
-    reboot                  = "IfRequired"
+    reboot                   = "IfRequired"
   }
 
   duration            = "PT1H1M1S"

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -91,7 +91,9 @@ A `linux` block supports the following:
 
 A `windows` block supports the following:
 
-* `classification_included` - (Optional) Specifies the update classification. A comma separated string with possible values. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
+* `classification_included` - (Deprecated) Specifies the update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
+
+* `classifications_included` - (Optional) Specifies the list of update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
 * `excluded_knowledge_base_numbers` - (Optional) Specifies a list of knowledge base numbers excluded.
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -91,7 +91,7 @@ A `linux` block supports the following:
 
 A `windows` block supports the following:
 
-* `classification_included` - (Optional) Specifies the update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
+* `classification_included` - (Optional) Specifies the update classification. A comma separated string with possible values. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
 * `excluded_knowledge_base_numbers` - (Optional) Specifies a list of knowledge base numbers excluded.
 


### PR DESCRIPTION
swagger definition as a comma-separated string

```
"includedUpdateClassifications": {
  "description": "Update classification included in the software update configuration. A comma separated string with required values",
  "type": "string",
  "enum": [
  "Unclassified",
```

https://github.com/Azure/azure-rest-api-specs/blob/99977890f7a2e8cf9b4e229f452c1af7b30184e4/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json#L400

```
--- PASS: TestAccSoftwareUpdateConfiguration_basic (166.01s)
--- PASS: TestAccSoftwareUpdateConfiguration_update (125.49s)
--- PASS: TestAccSoftwareUpdateConfiguration_windows (160.53s)
PASS

```

Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18537
