### PR TITLE
`azurerm_eventhub_namespace`: update docs

### DIFF
--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -79,7 +79,7 @@ A `network_rulesets` block supports the following:
 
 * `default_action` - (Required) The default action to take when a rule is not matched. Possible values are `Allow` and `Deny`.
 
-* `public_network_access` - (Optional)  Is public network access enabled for the EventHub Namespace? Defaults to `true`.
+* `public_network_access_enabled` - (Optional)  Is public network access enabled for the EventHub Namespace? Defaults to `true`.
 
 * ~> **Note:** The public network access setting at the network rule sets level should be the same as it's at the namespace level.
 


### PR DESCRIPTION
updated property from `public_network_access` to `public_network_access_enabled`

fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18485