### PR TITLE
`azurerm_kubernetes_cluster` - support the `web_app_routing` block with `dns_zone_resource_id` argument.

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -470,9 +470,9 @@ resource "azurerm_kubernetes_cluster" "test" {
   dns_prefix          = "acctestaks%[1]d"
 
   default_node_pool {
-    name          = "default"
-    node_count    = 1
-    vm_size       = "Standard_DS2_v2"
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
   }
 
   identity {

--- a/internal/services/dns/validate/dns_zone_id.go
+++ b/internal/services/dns/validate/dns_zone_id.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
+)
+
+// ValidateDnsZoneIDInsensitively checks that 'input' can be parsed as a Dns Zone ID
+func ValidateDnsZoneIDInsensitively(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := zones.ParseDnsZoneIDInsensitively(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -219,6 +219,8 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+* `web_app_routing` - (Optional) A `web_app_routing` block as defined below.
+
 * `windows_profile` - (Optional) A `windows_profile` block as defined below.
 
 ---
@@ -665,6 +667,14 @@ A `sysctl_config` block supports the following:
 * `vm_swappiness` - (Optional) The sysctl setting vm.swappiness. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 * `vm_vfs_cache_pressure` - (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+---
+
+A `web_app_routing` block supports the following:
+
+* `dns_zone_resource_id` - (Optional) Resource ID of the DNS Zone to be associated with the web app. Used only when Web App Routing is enabled."
+
+~> **Note:** Once `dns_zone_resource_id` has been set to a non-null value, we can only remove this setting by deleting the `web_app_routing` block, and we cannot set it to `null` again. 
 
 ---
 


### PR DESCRIPTION
This pr will close #18386 ad replace pr #18482 by adding new nested block `web_app_routing` with `dns_zone_resource_id` argument.

For now there is a bug in service side, after set `dns_zone_resoource_id` to a non-null value we're not able to set it back to null, even by turning off `web_app_routing` then turn it on again. I've opened a [bug issue](https://github.com/Azure/azure-rest-api-specs/issues/20908), and added a notice in the document.