### PR TITLE
TestCase: Fix TC for Log Analytics Data Source Windows Event

### DIFF
--- a/internal/services/loganalytics/log_analytics_datasource_windows_event_resource.go
+++ b/internal/services/loganalytics/log_analytics_datasource_windows_event_resource.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -199,7 +198,7 @@ func flattenLogAnalyticsDataSourceWindowsEventEventType(eventTypes []dataSourceW
 	for _, e := range eventTypes {
 		// The casing isn't preserved by the API for event types, so we need to normalise it here until
 		// https://github.com/Azure/azure-rest-api-specs/issues/18163 is fixed
-		output = append(output, strings.ToLower(e.EventType))
+		output = append(output, e.EventType)
 	}
 	return output
 }


### PR DESCRIPTION
This PR is to fix TC for `azurerm_log_analytics_datasource_windows_event`.

![image](https://user-images.githubusercontent.com/19754191/192734123-34595f3c-025f-4f25-9b9e-3e4582b27703.png)
![image](https://user-images.githubusercontent.com/19754191/192732084-e5faa67c-de2e-4e9f-97c1-3b6b8df37918.png)