### PR TITLE
Add ForceNew to name of azurerm_iothub_route

### DIFF
--- a/internal/services/iothub/iothub_route_resource.go
+++ b/internal/services/iothub/iothub_route_resource.go
@@ -42,6 +42,7 @@ func resourceIotHubRoute() *pluginsdk.Resource {
 			"name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
 					regexp.MustCompile("^[-_.a-zA-Z0-9]{1,64}$"),
 					"Route Name name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.",

--- a/website/docs/r/iothub_route.html.markdown
+++ b/website/docs/r/iothub_route.html.markdown
@@ -78,7 +78,7 @@ resource "azurerm_iothub_route" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the route.
+* `name` - (Required) The name of the route. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group under which the IotHub Route resource has to be created. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
When changing the name of an iothub_route you'll get an error because the id of the route won't change accordingly. So ForceNew is added.