### PR TITLE
`r/azurerm_healthcare_fhir` - `public_network_access_enabled` added

### DIFF
--- a/internal/services/healthcare/healthcare_fhir_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_resource.go
@@ -185,8 +185,7 @@ func resourceHealthcareApisFhirService() *pluginsdk.Resource {
 
 			"public_network_access_enabled": {
 				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 
 			"tags": commonschema.Tags(),
@@ -240,12 +239,6 @@ func resourceHealthcareApisFhirServiceCreate(d *pluginsdk.ResourceData, meta int
 	if hasValues {
 		parameters.FhirServiceProperties.AccessPolicies = expandAccessPolicy(accessPolicyObjectIds.(*pluginsdk.Set).List())
 	}
-
-	publicNetworkAccess := healthcareapis.PublicNetworkAccessEnabled
-	if !d.Get("public_network_access_enabled").(bool) {
-		publicNetworkAccess = healthcareapis.PublicNetworkAccessDisabled
-	}
-	parameters.FhirServiceProperties.PublicNetworkAccess = publicNetworkAccess
 
 	storageAcc, hasValues := d.GetOk("configuration_export_storage_account_name")
 	if hasValues {
@@ -365,12 +358,6 @@ func resourceHealthcareApisFhirServiceUpdate(d *pluginsdk.ResourceData, meta int
 			AccessPolicies:              expandAccessPolicy(d.Get("access_policy_object_ids").(*pluginsdk.Set).List()),
 		},
 	}
-
-	publicNetworkAccess := healthcareapis.PublicNetworkAccessEnabled
-	if !d.Get("public_network_access_enabled").(bool) {
-		publicNetworkAccess = healthcareapis.PublicNetworkAccessDisabled
-	}
-	parameters.FhirServiceProperties.PublicNetworkAccess = publicNetworkAccess
 
 	storageAcc, hasValues := d.GetOk("configuration_export_storage_account_name")
 	if hasValues {

--- a/internal/services/healthcare/healthcare_fhir_resource_test.go
+++ b/internal/services/healthcare/healthcare_fhir_resource_test.go
@@ -125,35 +125,6 @@ func TestAccHealthcareApiFhirService_updateCors(t *testing.T) {
 	})
 }
 
-func TestAccHealthcareApiFhirService_publicNetworkingDisabled(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_healthcare_fhir_service", "test")
-	r := HealthcareApiFhirServiceResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.publicNetworkEnabled(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.publicNetworkEnabled(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccHealthcareApiFhirService_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_healthcare_fhir_service", "test")
 	r := HealthcareApiFhirServiceResource{}
@@ -439,26 +410,6 @@ resource "azurerm_healthcare_fhir_service" "test" {
   configuration_export_storage_account_name = azurerm_storage_account.test.name
 }
 `, r.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary, data.RandomInteger, data.RandomInteger)
-}
-
-func (r HealthcareApiFhirServiceResource) publicNetworkEnabled(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_healthcare_fhir_service" "test" {
-  name                          = "fhir%d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  workspace_id                  = azurerm_healthcare_workspace.test.id
-  kind                          = "fhir-R4"
-  public_network_access_enabled = "%t"
-
-  authentication {
-    authority = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47"
-    audience  = "https://acctestfhir.fhir.azurehealthcareapis.com"
-  }
-}
-`, r.template(data), data.RandomInteger, enabled)
 }
 
 func (HealthcareApiFhirServiceResource) template(data acceptance.TestData) string {

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -85,8 +85,6 @@ The following arguments are supported:
 
 * `configuration_export_storage_account_name` - (Optional) Specifies the name of the storage account which the operation configuration information is exported to.
 
-* `public_network_access_enabled` - (Optional) Whether to enabled public networks when data plane traffic coming from public networks while private endpoint is enabled.
-
 ---
 An `identity` block supports the following:
 
@@ -113,6 +111,8 @@ An `authentication` supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the Healthcare FHIR Service.
+
+* `public_network_access_enabled` - Whether public networks access is enabled.
 
 ## Timeouts
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
Fixes #18549

No acctest added, as it is only one Computed property and would need an extensive setup:
```hcl
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "example" {
  name     = "${var.prefix}-resources"
  location = var.location
}

resource "azurerm_virtual_network" "example" {
  name                = "${var.prefix}-vnet"
  address_space       = ["10.0.0.0/16"]
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_subnet" "endpoint" {
  name                 = "endpoint"
  resource_group_name  = azurerm_resource_group.example.name
  virtual_network_name = azurerm_virtual_network.example.name
  address_prefixes     = ["10.0.2.0/24"]

  enforce_private_link_endpoint_network_policies = true
}

resource "azurerm_private_dns_zone" "example" {
  name                = "privatelink.azurehealthcareapis.com"
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_private_dns_zone" "example2" {
  name                = "privatelink.dicom.azurehealthcareapis.com"
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_healthcare_workspace" "example" {
  name                = "${var.prefix}hcws"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
}

resource "azurerm_healthcare_fhir_service" "example" {
  name                = "${var.prefix}-fhir"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  workspace_id        = azurerm_healthcare_workspace.example.id
  kind                = "fhir-R4"

  authentication {
    authority = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47"
    audience  = "https://acctestfhir.fhir.azurehealthcareapis.com"
  }
}

resource "azurerm_private_endpoint" "example" {
  name                = "${var.prefix}-pe"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  subnet_id           = azurerm_subnet.endpoint.id

  private_dns_zone_group {
    name                 = "private-dns-zone-group"
    private_dns_zone_ids = [azurerm_private_dns_zone.example.id, azurerm_private_dns_zone.example2.id]
  }

  private_service_connection {
    name                           = "hcws-connection"
    is_manual_connection           = false
    private_connection_resource_id = azurerm_healthcare_workspace.example.id
    subresource_names              = ["healthcareworkspace"]
  }
}
```