### PR TITLE
Fix currentStack is being reset when other site_config values are changed.

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -2880,9 +2880,13 @@ func ExpandSiteConfigWindows(siteConfig []SiteConfigWindows, existing *web.SiteC
 		expanded = existing
 	}
 
-	currentStack := ""
-
 	winSiteConfig := siteConfig[0]
+
+	currentStack := ""
+	if len(winSiteConfig.ApplicationStack) == 1 {
+		winAppStack := winSiteConfig.ApplicationStack[0]
+		currentStack = winAppStack.CurrentStack
+	}
 
 	if servicePlan.Sku != nil && servicePlan.Sku.Name != nil {
 		if isFreeOrSharedServicePlan(*servicePlan.Sku.Name) {

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -800,9 +800,14 @@ func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot,
 		expanded = existing
 	}
 
+	winSlotSiteConfig := siteConfig[0]
+
 	currentStack := ""
 
-	winSlotSiteConfig := siteConfig[0]
+	if len(winSlotSiteConfig.ApplicationStack) == 1 {
+		winAppStack := winSlotSiteConfig.ApplicationStack[0]
+		currentStack = winAppStack.CurrentStack
+	}
 
 	if metadata.ResourceData.HasChange("site_config.0.always_on") {
 		expanded.AlwaysOn = utils.Bool(winSlotSiteConfig.AlwaysOn)


### PR DESCRIPTION
## Background(Problem)
Few months ago, I've submitted [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/17490) that fixes current_stack is always being reset every time we update azure app service(windows) infrastructure.

After time passes, I've identified that whenever site_config's value changes - is resets site_config again. 
Again, it turns out I had to double-apply all the time whenever I apply updates to Azure infrastructure.

## Investigation & Possible Cause
With little golang knowledge and Terraform Azure RM Provider's architecture style, I've found that currentStack variable in `internal/services/appservice/helpers/web_app_schema.go : func ExpandSiteConfigWindows` is always being reset when site_config expansion starts. - But if `metadata.ResourceData.HasChange("site_config.0.application_stack")` is false, meaning user did not really intended to modify application_stack - it never expands application_stack and set to empty value and sent empty value to app service.

However, if user intended to change application_stack, it will update application_stack correctly.

## Reproduce?
1. Create any windows app service(slot does not matter.)
2. Set site_config value(anything, i.e health_check)
3. Apply - provision infrastructure.
4. After provisioning, modify site_config's value(i.e remove health_check)
5. Apply - provision infrastructure.
6. After provisioning(updating) call `terraform plan`
7. Notice there is "current_stack" changes.

## Solutions
- Get state's configuration
- if state contains ApplicationStack, set currentStack to previously-saved state's value.
- Otherwise, leave it empty string.
- if user really intended to modify application_stack -> https://github.com/uniquegood/terraform-provider-azurerm/blob/d52244c412b2f203cbf7483df6ed2f77559ccad0/internal/services/appservice/helpers/web_app_schema.go#L2919 code will be executed hence it will update application_stack properly.
- If not application_stack will be remained as - is.

## Related Issues
- Entrypoint(Issue): https://github.com/hashicorp/terraform-provider-azurerm/issues/16257
- Issue Reply: https://github.com/hashicorp/terraform-provider-azurerm/issues/16257#issuecomment-1191336320

## Others
Please let me know if I am doing something wrong. Feedbacks, other suggestions are always welcome!
Thanks 👍