### PR TITLE
`azurerm_orchestrated_virtual_machine_scale_set` - set `network_inter…

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -435,12 +435,14 @@ func orchestratedVirtualMachineScaleSetPublicIPAddressSchema() *pluginsdk.Schema
 				"sku_name": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					ForceNew:     true,
 					ValidateFunc: validate.OrchestratedVirtualMachineScaleSetPublicIPSku,
 				},
 
 				"version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					ForceNew: true,
 					Default:  string(compute.IPVersionIPv4),
 					ValidateFunc: validation.StringInSlice([]string{
 						string(compute.IPVersionIPv4),

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -407,9 +407,9 @@ A `public_ip_address` block supports the following:
 
 * `public_ip_prefix_id` - (Optional) The ID of the Public IP Address Prefix from where Public IP Addresses should be allocated. Changing this forces a new resource to be created.
 
-* `sku_name` - (Optional) Specifies what Public IP Address SKU the Public IP Address should be provisioned as. Possible vaules include `Basic_Regional`, `Basic_Global`, `Standard_Regional` or `Standard_Global`. Defaults to `Basic_Regional`. For more information about Public IP Address SKU's and their capabilities, please see the [product documentation](https://docs.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#sku).
+* `sku_name` - (Optional) Specifies what Public IP Address SKU the Public IP Address should be provisioned as. Possible vaules include `Basic_Regional`, `Basic_Global`, `Standard_Regional` or `Standard_Global`. Defaults to `Basic_Regional`. For more information about Public IP Address SKU's and their capabilities, please see the [product documentation](https://docs.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#sku). Changing this forces a new resource to be created.
 
-* `version` - (Optional) The Internet Protocol Version which should be used for this public IP address. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`.
+* `version` - (Optional) The Internet Protocol Version which should be used for this public IP address. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
…face.public_ip_address.sku_name/version` to `ForceNew`

Similar to `public_ip_prefix_id`, these two properties do not exist in the Update logic in [expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate](https://github.com/hashicorp/terraform-provider-azurerm/blob/cb0fd4de6a6035606dbaf347a0ceb591219bee65/internal/services/compute/orchestrated_virtual_machine_scale_set.go#L1202) because [VirtualMachineScaleSetUpdatePublicIPAddressConfiguration](https://github.com/hashicorp/terraform-provider-azurerm/blob/cb0fd4de6a6035606dbaf347a0ceb591219bee65/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute/models.go#L21377) does not have them. So need to mark these as `ForceNew`