### PR TITLE
Fix `TestAccOrchestratedVirtualMachineScaleSet_publicIPSkuName`

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_network_resource_test.go
@@ -1123,7 +1123,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
         name                    = "TestPublicIPConfiguration"
         domain_name_label       = "test-domain-label"
         idle_timeout_in_minutes = 4
-        sku_name                = "Basic_Regional"
+        sku_name                = "Standard_Regional"
       }
     }
   }


### PR DESCRIPTION
This test fails intermittently due to `Code="SubnetWithNatGatewayAndBasicSkuResourceNotAllowed" Message="NAT Gateway cannot be deployed on subnet containing Basic SKU Public IP addresses or Basic SKU Load Balancer.` when `azurerm_nat_gateway_public_ip_association` in the test config finish creation first. This test case uses the common config template `natgateway_template`, so instead of touching the template, updating the `sku_name` to `Standard_Regional` to avoid this. This property cannot be updated per #18569 and doesn't have a default value, so changing the value shall not break the  test scenario.