### PR TITLE
`azurerm_healthcare_fhir_service` - `oci_artifact` support

### DIFF
--- a/internal/services/healthcare/healthcare_fhir_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_resource.go
@@ -118,6 +118,32 @@ func resourceHealthcareApisFhirService() *pluginsdk.Resource {
 				},
 			},
 
+			"oci_artifact": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"login_server": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"image_name": {
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+							Optional:     true,
+						},
+
+						"digest": {
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+							Optional:     true,
+						},
+					},
+				},
+			},
+
 			"cors": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -242,11 +268,18 @@ func resourceHealthcareApisFhirServiceCreate(d *pluginsdk.ResourceData, meta int
 		}
 	}
 
-	acrConfig, hasValues := d.GetOk("container_registry_login_server_url")
+	acrConfig := healthcareapis.FhirServiceAcrConfiguration{}
+	ociArtifactsRaw, hasValues := d.GetOk("oci_artifact")
 	if hasValues {
-		result := expandFhirAcrLoginServer(acrConfig.(*pluginsdk.Set).List())
-		parameters.FhirServiceProperties.AcrConfiguration = result
+		ociArtifacts := expandOciArtifacts(ociArtifactsRaw.([]interface{}))
+		acrConfig.OciArtifacts = ociArtifacts
 	}
+	loginServersRaw, hasValues := d.GetOk("container_registry_login_server_url")
+	if hasValues {
+		loginServers := expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
+		acrConfig.LoginServers = loginServers
+	}
+	parameters.FhirServiceProperties.AcrConfiguration = &acrConfig
 
 	future, err := client.CreateOrUpdate(ctx, fhirServiceId.ResourceGroup, fhirServiceId.WorkspaceName, fhirServiceId.Name, parameters)
 	if err != nil {
@@ -311,6 +344,12 @@ func resourceHealthcareApisFhirServiceRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("authentication", flattenFhirAuthentication(props.AuthenticationConfiguration))
 		d.Set("cors", flattenFhirCorsConfiguration(props.CorsConfiguration))
 		d.Set("container_registry_login_server_url", flattenFhirAcrLoginServer(props.AcrConfiguration))
+		if acrConfig := props.AcrConfiguration; acrConfig != nil {
+			if artifacts := acrConfig.OciArtifacts; artifacts != nil {
+				d.Set("oci_artifact", flattenOciArtifacts(artifacts))
+			}
+
+		}
 		if props.ExportConfiguration != nil && props.ExportConfiguration.StorageAccountName != nil {
 			d.Set("configuration_export_storage_account_name", props.ExportConfiguration.StorageAccountName)
 		}
@@ -321,6 +360,31 @@ func resourceHealthcareApisFhirServiceRead(d *pluginsdk.ResourceData, meta inter
 	}
 
 	return nil
+}
+
+func expandOciArtifacts(input []interface{}) *[]healthcareapis.ServiceOciArtifactEntry {
+	output := make([]healthcareapis.ServiceOciArtifactEntry, 0)
+
+	for _, artifactSet := range input {
+		artifactRaw := artifactSet.(map[string]interface{})
+
+		loginServer := artifactRaw["login_server"].(string)
+		artifact := healthcareapis.ServiceOciArtifactEntry{
+			LoginServer: &loginServer,
+			ImageName:   nil,
+			Digest:      nil,
+		}
+		if image := artifactRaw["image_name"].(string); image != "" {
+			artifact.ImageName = &image
+		}
+		if digest := artifactRaw["digest"].(string); digest != "" {
+			artifact.Digest = &digest
+		}
+
+		output = append(output, artifact)
+	}
+
+	return &output
 }
 
 func resourceHealthcareApisFhirServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -358,11 +422,18 @@ func resourceHealthcareApisFhirServiceUpdate(d *pluginsdk.ResourceData, meta int
 		}
 	}
 
-	acrConfig, hasValues := d.GetOk("container_registry_login_server_url")
+	acrConfig := healthcareapis.FhirServiceAcrConfiguration{}
+	ociArtifactsRaw, hasValues := d.GetOk("oci_artifact")
 	if hasValues {
-		result := expandFhirAcrLoginServer(acrConfig.(*pluginsdk.Set).List())
-		parameters.FhirServiceProperties.AcrConfiguration = result
+		ociArtifacts := expandOciArtifacts(ociArtifactsRaw.([]interface{}))
+		acrConfig.OciArtifacts = ociArtifacts
 	}
+	loginServersRaw, hasValues := d.GetOk("container_registry_login_server_url")
+	if hasValues {
+		loginServers := expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
+		acrConfig.LoginServers = loginServers
+	}
+	parameters.FhirServiceProperties.AcrConfiguration = &acrConfig
 
 	future, err := client.CreateOrUpdate(ctx, fhirServiceId.ResourceGroup, fhirServiceId.WorkspaceName, fhirServiceId.Name, parameters)
 	if err != nil {
@@ -520,30 +591,26 @@ func expandFhirCorsConfiguration(input []interface{}) *healthcareapis.FhirServic
 	return cors
 }
 
-func expandFhirAcrLoginServer(input []interface{}) *healthcareapis.FhirServiceAcrConfiguration {
+func expandFhirAcrLoginServer(input []interface{}) *[]string {
 	acrLoginServers := make([]string, 0)
 
 	if len(input) == 0 {
-		return &healthcareapis.FhirServiceAcrConfiguration{
-			LoginServers: &acrLoginServers,
-		}
+		return &acrLoginServers
 	}
 
 	for _, item := range input {
 		acrLoginServers = append(acrLoginServers, item.(string))
 	}
-	return &healthcareapis.FhirServiceAcrConfiguration{
-		LoginServers: &acrLoginServers,
-	}
+	return &acrLoginServers
 }
 
-func flattenFhirAcrLoginServer(acrLoginServer *healthcareapis.FhirServiceAcrConfiguration) []string {
+func flattenFhirAcrLoginServer(acrConfig *healthcareapis.FhirServiceAcrConfiguration) []string {
 	result := make([]string, 0)
-	if acrLoginServer == nil {
+	if acrConfig == nil {
 		return result
 	}
 
-	if loginServer := acrLoginServer.LoginServers; loginServer != nil {
+	if loginServer := acrConfig.LoginServers; loginServer != nil {
 		result = append(result, *loginServer...)
 	}
 	return result
@@ -561,6 +628,29 @@ func flattenFhirAccessPolicy(policies *[]healthcareapis.FhirServiceAccessPolicyE
 			result = append(result, *objectId)
 		}
 	}
+	return result
+}
+
+func flattenOciArtifacts(artifacts *[]healthcareapis.ServiceOciArtifactEntry) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if artifacts == nil {
+		return result
+	}
+	for _, artifact := range *artifacts {
+		artifactRaw := make(map[string]interface{})
+
+		if loginServer := artifact.LoginServer; loginServer != nil {
+			artifactRaw["login_server"] = *loginServer
+		}
+		if imageName := artifact.ImageName; imageName != nil {
+			artifactRaw["image_name"] = *imageName
+		}
+		if digest := artifact.Digest; digest != nil {
+			artifactRaw["digest"] = *digest
+		}
+		result = append(result, artifactRaw)
+	}
+
 	return result
 }
 

--- a/internal/services/healthcare/healthcare_fhir_resource_test.go
+++ b/internal/services/healthcare/healthcare_fhir_resource_test.go
@@ -265,6 +265,10 @@ resource "azurerm_healthcare_fhir_service" "test" {
 
   container_registry_login_server_url = [azurerm_container_registry.test.login_server]
 
+  oci_artifact {
+    login_server = azurerm_container_registry.test.login_server
+  }
+
   cors {
     allowed_origins     = ["https://acctest.com:123", "https://acctest1.com:3389"]
     allowed_headers     = ["*"]

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -81,6 +81,8 @@ The following arguments are supported:
 
 * `container_registry_login_server_url` - (Optional) A list of azure container registry settings used for convert data operation of the service instance.
 
+* `oci_artifact` - (Optional) [A list](/docs/configuration/attr-as-blocks.html) of objects describing [OCI artifacts for export](https://learn.microsoft.com/en-gb/azure/healthcare-apis/fhir/de-identified-export) as defined below.
+
 * `authentication` - (Required) An `authentication` block as defined below.
 
 * `configuration_export_storage_account_name` - (Optional) Specifies the name of the storage account which the operation configuration information is exported to.
@@ -107,6 +109,17 @@ An `authentication` supports the following:
 * `authority` - (Optional) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
   Authority must be registered to Azure AD and in the following format: https://{Azure-AD-endpoint}/{tenant-id}.
 * `audience` - (Optional) The intended audience to receive authentication tokens for the service. The default value is https://<name>.fhir.azurehealthcareapis.com
+
+---
+
+A `oci_artifact` block supports the following:
+
+* `login_server` - (Required) An Azure container registry used for export operations of the service instance.
+
+* `image_name` - (Optional) An image within Azure container registry used for export operations of the service instance.
+
+* `digest` - (Optional) A digest of an image within Azure container registry used for export operations of the service instance to narrow the artifacts down.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #18552

## Acceptance test (local)
```bash
❯ go install && make acctests SERVICE='healthcare' TESTARGS='-run=TestAccHealthcareApiFhirService_updateAcrLoginServer'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/healthcare -run=TestAccHealthcareApiFhirService_updateAcrLoginServer -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccHealthcareApiFhirService_updateAcrLoginServer
=== PAUSE TestAccHealthcareApiFhirService_updateAcrLoginServer
=== CONT  TestAccHealthcareApiFhirService_updateAcrLoginServer
--- PASS: TestAccHealthcareApiFhirService_updateAcrLoginServer (2855.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/healthcare    2856.962s
```