### PR TITLE
`azurerm_iotcentral_application` - fix default `display_name`

### DIFF
--- a/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iotcentral/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iotcentral/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -135,6 +136,9 @@ func resourceIotCentralAppCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	displayName := d.Get("display_name").(string)
 	if displayName == "" {
 		displayName = id.ResourceName
+		if !features.FourPointOhBeta() {
+			displayName = id.ResourceGroupName
+		}
 	}
 
 	identity, err := identity.ExpandSystemAssigned(d.Get("identity").([]interface{}))

--- a/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_resource.go
@@ -134,7 +134,7 @@ func resourceIotCentralAppCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	displayName := d.Get("display_name").(string)
 	if displayName == "" {
-		displayName = id.ResourceGroupName
+		displayName = id.ResourceName
 	}
 
 	identity, err := identity.ExpandSystemAssigned(d.Get("identity").([]interface{}))

--- a/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -24,6 +24,7 @@ func TestAccIoTCentralApplication_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-iotcentralapp-%d", data.RandomInteger)),
 				check.That(data.ResourceName).Key("sku").HasValue("ST1"),
 				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
 			),

--- a/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -19,12 +20,17 @@ func TestAccIoTCentralApplication_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
 	r := IoTCentralApplicationResource{}
 
+	defaultDisplayName := fmt.Sprintf("acctest-iotcentralapp-%d", data.RandomInteger)
+	if !features.FourPointOhBeta() {
+		defaultDisplayName = fmt.Sprintf("acctestRG-%d", data.RandomInteger)
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-iotcentralapp-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("display_name").HasValue(defaultDisplayName),
 				check.That(data.ResourceName).Key("sku").HasValue("ST1"),
 				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
 			),

--- a/website/docs/r/iotcentral_application.html.markdown
+++ b/website/docs/r/iotcentral_application.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `display_name` - (Optional) A `display_name` name. Custom display name for the IoT Central application. Default is resource name. 
 
+~> **NOTE:** Due to a bug in the provider, the default value of `display_name` of a newly created IoT Central App will be the Resource Group Name, it will be fixed and use resource name in 4.0. For an existing IoT Central App, this could be fixed by specifying the `display_name` explicitly.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for the IoT Central Application. Defaults to `true`.


### PR DESCRIPTION
In the document and Update function, `display_name` is defaults to the ResourceName. However, in Create function it's ResourceGroupName, fixing the value there.

https://github.com/hashicorp/terraform-provider-azurerm/blob/a5a6c08e1c03b722a4b271d19d581bceb01433e6/website/docs/r/iotcentral_application.html.markdown?plain=1#L49

https://github.com/hashicorp/terraform-provider-azurerm/blob/a5a6c08e1c03b722a4b271d19d581bceb01433e6/internal/services/iotcentral/iotcentral_application_resource.go#L190-L193