### PR TITLE
`azurerm_iotcentral_application` - fix `sku` `template` and update method

### DIFF
--- a/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -41,8 +41,6 @@ func TestAccIoTCentralApplication_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("template").HasValue("iotc-pnp-preview@1.0.0"),
-				check.That(data.ResourceName).Key("tags.ENV").HasValue("Test"),
 			),
 		},
 		data.ImportStep(),
@@ -62,11 +60,31 @@ func TestAccIoTCentralApplication_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.update(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("ST1"),
-				check.That(data.ResourceName).Key("tags.ENV").HasValue("Test"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIoTCentralApplication_displayName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
+	r := IoTCentralApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.displayName(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.displayNameUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -137,6 +155,87 @@ func TestAccIoTCentralApplication_publicNetworkAccessEnabled(t *testing.T) {
 	})
 }
 
+func TestAccIoTCentralApplication_sku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
+	r := IoTCentralApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIoTCentralApplication_subDomain(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
+	r := IoTCentralApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subDomain(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.subDomainUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIoTCentralApplication_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
+	r := IoTCentralApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.tags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tagsUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIoTCentralApplication_templateProperty(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
+	r := IoTCentralApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.templateProperty(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccIoTCentralApplication_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
 	r := IoTCentralApplicationResource{}
@@ -182,7 +281,6 @@ resource "azurerm_iotcentral_application" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sub_domain          = "subdomain-%[1]d"
-  sku                 = "ST1"
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -235,6 +333,205 @@ resource "azurerm_iotcentral_application" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
+func (IoTCentralApplicationResource) displayName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  display_name = "display-name"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) displayNameUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  display_name = "display-name-2"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) sku(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  sku = "ST2"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) skuUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  sku = "ST0"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) subDomain(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) subDomainUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain2-%[1]d"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) tags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  tags = {
+    ENV = "Test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) tagsUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  tags = {
+    ENV     = "Test2"
+    Purpose = "AccTests"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IoTCentralApplicationResource) templateProperty(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_iotcentral_application" "test" {
+  name                = "acctest-iotcentralapp-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sub_domain          = "subdomain-%[1]d"
+
+  template = "iotc-distribution@1.0.0"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (IoTCentralApplicationResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -250,35 +547,10 @@ resource "azurerm_iotcentral_application" "test" {
   name                = "acctest-iotcentralapp-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sub_domain          = "subdomain-%[1]d"
+  sub_domain          = "subdomain2-%[1]d"
   display_name        = "some-display-name"
-  sku                 = "ST1"
-  template            = "iotc-pnp-preview@1.0.0"
-  tags = {
-    ENV = "Test"
-  }
-}
-`, data.RandomInteger, data.Locations.Primary)
-}
+  sku                 = "ST0"
 
-func (IoTCentralApplicationResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_iotcentral_application" "test" {
-  name                = "acctest-iotcentralapp-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sub_domain          = "subdomain-%[1]d"
-  display_name        = "some-display-name"
-  sku                 = "ST1"
   tags = {
     ENV = "Test"
   }

--- a/website/docs/r/iotcentral_application.html.markdown
+++ b/website/docs/r/iotcentral_application.html.markdown
@@ -52,9 +52,9 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for the IoT Central Application. Defaults to `true`.
 
-* `sku` - (Optional) A `sku` name. Possible values is `ST1`, `ST2`, Default value is `ST1`
+* `sku` - (Optional) A `sku` name. Possible values is `ST0`, `ST1`, `ST2`, Default value is `ST1`
 
-* `template` - (Optional) A `template` name. IoT Central application template name. Default is a custom application.
+* `template` - (Optional) A `template` name. IoT Central application template name. Default is a custom application. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
A few fixes for `azurerm_iotcentral_application`, and update the Update method to prepare for #18589
- when parent resource `azurerm_iotcentral_application` performs an update to the property with `UpdateThenPoll`, it wipes out the Network Rule Set, so using `CreateOrUpdateThenPoll` with modifying the existing resource.
- `azurerm_iotcentral_application.sku` supports Update, but was missing in the Update function, adding it there. (The update test didn't catch it because the sku in the updated test config is same as the default value.)
- Supported value `ST0` of `sku` is missing in the doc of `azurerm_iotcentral_application`, adding it there
- `azurerm_iotcentral_application.template` cannot be updated as described [here](https://learn.microsoft.com/azure/iot-central/core/overview-iot-central-admin#create-applications), so changing it to `ForceNew`. (The update api ignores the new value and doesn't throw an error)
- Adding few tests for `azurerm_iotcentral_application` to cover the Update scenarios of its properties