### PR TITLE
Fix bug in sample for ACR geo replications

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_container_registry" "acr" {
     tags                    = {}
   }
   georeplications {
-    location                = "westeurope"
+    location                = "North Europe"
     zone_redundancy_enabled = true
     tags                    = {}
   }


### PR DESCRIPTION
This PR addresses a bug in the Azure Container Registry sample with geo replications.

As correctly mentioned in the `georeplications` description, `georeplications` may not contain the original location of the container registry. However, the sample configured both `azurerm_container_registry` and one of the `georeplications` to be deployed to `westeurope`.

Once this PR get merged into main, the geo replication will be deployed to `North Europe` instead.

Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>