### PR TITLE
Allow Virtual Machine Scale Sets to have both Rolling upgrade mode and Automatic OS Upgrade 

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -132,8 +132,9 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	if upgradeMode != compute.UpgradeModeAutomatic && len(automaticOSUpgradePolicyRaw) > 0 {
-		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic`")
+	canHaveAutomaticOsUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	if !canHaveAutomaticOsUpgradePolicy && len(automaticOSUpgradePolicyRaw) > 0 {
+		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic` or `Rolling`")
 	}
 
 	shouldHaveRollingUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -129,8 +129,9 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		return err
 	}
 
-	if upgradeMode != compute.UpgradeModeAutomatic && len(automaticOSUpgradePolicyRaw) > 0 {
-		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic`")
+	canHaveAutomaticOsUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling
+	if !canHaveAutomaticOsUpgradePolicy && len(automaticOSUpgradePolicyRaw) > 0 {
+		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic` or `Rolling`")
 	}
 
 	shouldHaveRollingUpgradePolicy := upgradeMode == compute.UpgradeModeAutomatic || upgradeMode == compute.UpgradeModeRolling

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -122,7 +122,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 -> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
 
-* `automatic_os_upgrade_policy` - (Optional) An `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to `Automatic`.
+* `automatic_os_upgrade_policy` - (Optional) An `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to either `Automatic` or `Rolling`.
 
 * `automatic_instance_repair` - (Optional) An `automatic_instance_repair` block as defined below. To enable the automatic instance repair, this Virtual Machine Scale Set must have a valid `health_probe_id` or an [Application Health Extension](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension).
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -110,7 +110,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 * `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below.
 
-* `automatic_os_upgrade_policy` - (Optional) An `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to `Automatic`.
+* `automatic_os_upgrade_policy` - (Optional) An `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to either `Automatic` or `Rolling`.
 
 * `automatic_instance_repair` - (Optional) An `automatic_instance_repair` block as defined below. To enable the automatic instance repair, this Virtual Machine Scale Set must have a valid `health_probe_id` or an [Application Health Extension](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension).
 


### PR DESCRIPTION
Currently when creating/updating VMSS through the AzureRM provider, you are unable to use the `Rolling` upgrade mode and have `Automatic OS Policy` enabled. You receive the following error: 

> an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic`"

After looking through the VMSS documentation, I can't see any technical reason for this and I have managed to create/update a VMSS through the Azure Portal with both the `Rolling` upgrade mode and `Automatic OS Upgrade` enabled with the resulting ARM template below.

Looking at the VMSS resources, I think it is changing a couple checks to allow Rolling to be specified and with no further changes needed. I  have tested by building locally and running locally and it has worked as expected

```
"properties": {
                "singlePlacementGroup": true,
                "upgradePolicy": {
                    "mode": "Rolling",
                    "rollingUpgradePolicy": {
                        "maxBatchInstancePercent": 20,
                        "maxUnhealthyInstancePercent": 100,
                        "maxUnhealthyUpgradedInstancePercent": 20,
                        "pauseTimeBetweenBatches": "PT60S",
                        "enableCrossZoneUpgrade": false,
                        "prioritizeUnhealthyInstances": false
                    },
                    "automaticOSUpgradePolicy": {
                        "enableAutomaticOSUpgrade": true,
                        "useRollingUpgradePolicy": false,
                        "disableAutomaticRollback": false
                    }
                },
                .....
```
![image](https://user-images.githubusercontent.com/6190956/193470878-a929847a-dd55-464f-b1e0-5e089818b225.png)

#13745
