### PR TITLE
Handle gone gracefully in read for azurerm_mssql_server_dns_alias

### DIFF
--- a/internal/services/mssql/mssql_server_dns_alias_resource.go
+++ b/internal/services/mssql/mssql_server_dns_alias_resource.go
@@ -107,6 +107,9 @@ func (m ServerDNSAliasResource) Read() sdk.ResourceFunc {
 			client := metadata.Client.MSSQL.ServerDNSAliasClient
 			alias, err := client.Get(ctx, id.ResourceGroup, id.ServerName, id.DnsAliaseName)
 			if err != nil {
+				if utils.ResponseWasNotFound(alias.Response) {
+					return metadata.MarkAsGone(id)
+				}
 				return err
 			}
 			state := ServerDNSAliasModel{


### PR DESCRIPTION
This PR handles manual resource deletion gracefully for `azurerm_mssql_server_dns_alias` resource as mentioned here:

https://learn.hashicorp.com/tutorials/terraform/provider-setup#implement-read

> When you create something in Terraform but delete it manually, Terraform should gracefully handle it. If the API returns an error when the resource doesn't exist, the read function should check to see if the resource is available first. If the resource isn't available, the function should set the ID to an empty string so Terraform "destroys" the resource in state. The following code snippet is an example of how this can be implemented; you do not need to add this to your configuration for this tutorial.

Fixes #18614
