### PR TITLE
Remove warning about OIDC feature flag needing to be registered

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -147,8 +147,6 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `oidc_issuer_enabled` - (Required) Enable or Disable the [OIDC issuer URL](https://docs.microsoft.com/azure/aks/cluster-configuration#oidc-issuer-preview)
 
--> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableOIDCIssuerPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/azure/aks/cluster-configuration#oidc-issuer-preview) for more information.
-
 * `oms_agent` - (Optional) A `oms_agent` block as defined below.
 
 * `open_service_mesh_enabled` - (Optional) Is Open Service Mesh enabled? For more details, please visit [Open Service Mesh for AKS](https://docs.microsoft.com/azure/aks/open-service-mesh-about).


### PR DESCRIPTION
I was able to enable this without enabling a feature flag and the documentation no longer mentions this

It was removed from the docs in https://github.com/MicrosoftDocs/azure-docs/commit/12b9519e72f7ef2416530aed7e744afec6597fdd