### PR TITLE
fix clients_gen.go after accidental removal of import

### DIFF
--- a/internal/clients/client_gen.go
+++ b/internal/clients/client_gen.go
@@ -3,19 +3,20 @@ package clients
 // NOTE: this file is generated - manual changes will be overwritten.
 
 import (
-	loadtests_v2021_12_01_preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2021-12-01-preview"
-  managedidentity_2018_11_30 "github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2018-11-30"
+	loadtestservice_v2021_12_01_preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2021-12-01-preview"
+	managedidentity_v2018_11_30 "github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2018-11-30"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
-	loadtest "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice/client"
+	loadtestservice "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice/client"
+	managedidentity "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/client"
 )
 
 type autoClient struct {
-	LoadTestService *loadtests_v2021_12_01_preview.Client
-	ManagedIdentity *managedidentity_2018_11_30.Client
+	LoadTestService *loadtestservice_v2021_12_01_preview.Client
+	ManagedIdentity *managedidentity_v2018_11_30.Client
 }
 
 func buildAutoClients(client *autoClient, o *common.ClientOptions) error {
-	client.LoadTestService = loadtest.NewClient(o)
+	client.LoadTestService = loadtestservice.NewClient(o)
 	client.ManagedIdentity = managedidentity.NewClient(o)
 	return nil
 }


### PR DESCRIPTION
Import was accidentally removed in #18632. Regenerated the content.