### PR TITLE
Fix `*_extensionsAutomaticUpgradeWithServiceFabricExtension`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_extensions_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_extensions_test.go
@@ -1024,14 +1024,13 @@ provider "azurerm" {
 }
 
 resource "azurerm_service_fabric_cluster" "test" {
-  name                 = "acctest-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  reliability_level    = "Silver"
-  upgrade_mode         = "Manual"
-  cluster_code_version = "8.1.316.9590"
-  vm_image             = "Windows"
-  management_endpoint  = "http://example:80"
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  reliability_level   = "Silver"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Linux"
+  management_endpoint = "http://example:80"
 
   node_type {
     name                 = "backend"

--- a/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
@@ -1002,14 +1002,13 @@ provider "azurerm" {
 }
 
 resource "azurerm_service_fabric_cluster" "test" {
-  name                 = local.vm_name
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  reliability_level    = "Silver"
-  upgrade_mode         = "Manual"
-  cluster_code_version = "8.2.1486.9590"
-  vm_image             = "Windows"
-  management_endpoint  = "http://example:80"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  reliability_level   = "Silver"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Windows"
+  management_endpoint = "http://example:80"
 
   node_type {
     name                 = "backend"


### PR DESCRIPTION
- `TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension` fails with `Version '8.1.316.9590' is not valid. Available versions are ...`. Since this test focuses on fabric extension and not the version, thus updating the test config to use `Automatic` upgrade mode for Service Fabric without specifying the version, so that it won't fail when old versions are deprecated.
- Also fixing the `vm_image` type in the test
- Applying same change for the one in Windows VMSS.