### PR TITLE
`azurerm_hdinsight_hadoop_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_spark_cluster`: add supoort for `script_actions`

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -37,6 +37,29 @@ func TestAccHDInsightHadoopCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHadoopCluster_roleScriptActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	r := HDInsightHadoopClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleScriptActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.head_node.0.script_actions",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightHadoopCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
 	r := HDInsightHadoopClusterResource{}
@@ -796,6 +819,61 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightHadoopClusterResource) roleScriptActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hadoop_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    hadoop = "3.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+	  script_actions {
+		name = "scriptactiontest"
+		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+		parameters = "headnode"
+	  }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -869,11 +869,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
       vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
-	  script_actions {
-		name = "scriptactiontest"
-		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
-		parameters = "headnode"
-	  }
+      script_actions {
+        name       = "scriptactiontest"
+        uri        = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+        parameters = "headnode"
+      }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -693,11 +693,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
       vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
-	  script_actions {
-		name = "scriptactiontest"
-		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
-		parameters = "headnode"
-	  }
+      script_actions {
+        name       = "scriptactiontest"
+        uri        = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+        parameters = "headnode"
+      }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -37,6 +37,29 @@ func TestAccHDInsightHBaseCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightHBaseCluster_roleScriptActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
+	r := HDInsightHBaseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleScriptActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.head_node.0.script_actions",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightHBaseCluster_gen2basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
 	r := HDInsightHBaseClusterResource{}
@@ -620,6 +643,61 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
       vm_size  = "Standard_D3_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D3_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightHBaseClusterResource) roleScriptActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hbase_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    hbase = "2.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+	  script_actions {
+		name = "scriptactiontest"
+		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+		parameters = "headnode"
+	  }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -37,6 +37,29 @@ func TestAccHDInsightInteractiveQueryCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightInteractiveQueryCluster_roleScriptActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
+	r := HDInsightInteractiveQueryClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleScriptActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.head_node.0.script_actions",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightInteractiveQueryCluster_gen2basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
 	r := HDInsightInteractiveQueryClusterResource{}
@@ -643,6 +666,61 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
       vm_size  = "Standard_D13_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D14_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HDInsightInteractiveQueryClusterResource) roleScriptActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_interactive_query_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    interactive_hive = "3.1"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D13_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+	  script_actions {
+		name = "scriptactiontest"
+		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+		parameters = "headnode"
+	  }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -716,11 +716,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
       vm_size  = "Standard_D13_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
-	  script_actions {
-		name = "scriptactiontest"
-		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
-		parameters = "headnode"
-	  }
+      script_actions {
+        name       = "scriptactiontest"
+        uri        = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+        parameters = "headnode"
+      }
     }
 
     worker_node {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -37,6 +37,29 @@ func TestAccHDInsightSparkCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightSparkCluster_roleScriptActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	r := HDInsightSparkClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleScriptActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("https_endpoint").Exists(),
+				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.head_node.0.script_actions",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func TestAccHDInsightSparkCluster_gen2basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
 	r := HDInsightSparkClusterResource{}
@@ -750,6 +773,61 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 }
 `, r.gen2template(data), data.RandomInteger)
+}
+
+func (r HDInsightSparkClusterResource) roleScriptActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_spark_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  component_version {
+    spark = "2.4"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+	  script_actions {
+		name = "scriptactiontest"
+		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+		parameters = "headnode"
+	  }
+    }
+
+    worker_node {
+      vm_size               = "Standard_A4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+    }
+
+    zookeeper_node {
+      vm_size  = "Medium"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r HDInsightSparkClusterResource) privateLink(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -806,11 +806,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
       vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
-	  script_actions {
-		name = "scriptactiontest"
-		uri = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
-		parameters = "headnode"
-	  }
+      script_actions {
+        name       = "scriptactiontest"
+        uri        = "https://hdiconfigactions.blob.core.windows.net/linuxgiraphconfigactionv01/giraph-installer-v01.sh"
+        parameters = "headnode"
+      }
     }
 
     worker_node {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -399,6 +399,31 @@ type HttpEndpointModel struct {
 	SubDomainSuffix    string   `tfschema:"sub_domain_suffix"`
 }
 
+func ExpandHDInsightsRolesScriptActions(input []interface{}) *[]hdinsight.ScriptAction {
+	if len(input) == 0 {
+		return nil
+	}
+
+	scriptActions := make([]hdinsight.ScriptAction, 0)
+
+	for _, vs := range input {
+		v := vs.(map[string]interface{})
+
+		name := v["name"].(string)
+		uri := v["uri"].(string)
+		parameters := v["parameters"].(string)
+
+		scriptAction := hdinsight.ScriptAction{
+			Name:       utils.String(name),
+			URI:        utils.String(uri),
+			Parameters: utils.String(parameters),
+		}
+		scriptActions = append(scriptActions, scriptAction)
+	}
+
+	return &scriptActions
+}
+
 func ExpandHDInsightsConfigurations(input []interface{}) map[string]interface{} {
 	vs := input[0].(map[string]interface{})
 
@@ -978,6 +1003,8 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 			ForceNew:     true,
 			ValidateFunc: azure.ValidateResourceIDOrEmpty,
 		},
+
+		"script_actions": SchemaHDInsightsScriptActions(),
 	}
 
 	if definition.CanSpecifyInstanceCount {
@@ -1124,6 +1151,7 @@ func ExpandHDInsightNodeDefinition(name string, input []interface{}, definition 
 	password := v["password"].(string)
 	virtualNetworkId := v["virtual_network_id"].(string)
 	subnetId := v["subnet_id"].(string)
+	scriptActions := v["script_actions"].([]interface{})
 
 	role := hdinsight.Role{
 		Name: utils.String(name),
@@ -1135,6 +1163,7 @@ func ExpandHDInsightNodeDefinition(name string, input []interface{}, definition 
 				Username: utils.String(username),
 			},
 		},
+		ScriptActions: ExpandHDInsightsRolesScriptActions(scriptActions),
 	}
 
 	virtualNetworkSpecified := virtualNetworkId != ""
@@ -1315,6 +1344,7 @@ func FlattenHDInsightNodeDefinition(input *hdinsight.Role, existing []interface{
 		"ssh_keys":           pluginsdk.NewSet(pluginsdk.HashString, []interface{}{}),
 		"subnet_id":          "",
 		"virtual_network_id": "",
+		"script_actions":     make([]interface{}, 0),
 	}
 
 	if profile := input.OsProfile; profile != nil {
@@ -1340,6 +1370,9 @@ func FlattenHDInsightNodeDefinition(input *hdinsight.Role, existing []interface{
 		// we should be "safe" to try and pull it from the state instead, but clearly this isn't ideal
 		vmSize := existingV["vm_size"].(string)
 		output["vm_size"] = vmSize
+
+		scriptActions := existingV["script_actions"].([]interface{})
+		output["script_actions"] = scriptActions
 	}
 
 	if profile := input.VirtualNetworkProfile; profile != nil {

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -155,6 +155,18 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `script_actions` - (Optional)  The script action which will run on the cluster.
+
+---
+
+A `script_action` block supports the following:
+
+* `name` - (Required) The name of the script action.
+
+* `uri` - (Required) The URI to the script.
+
+* `parameters` - (Required) The parameters for the script provided.
+
 ---
 
 A `roles` block supports the following:

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -155,6 +155,18 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `script_actions` - (Optional)  The script action which will run on the cluster.
+
+---
+
+A `script_action` block supports the following:
+
+* `name` - (Required) The name of the script action.
+
+* `uri` - (Required) The URI to the script.
+
+* `parameters` - (Required) The parameters for the script provided.
+
 ---
 
 A `roles` block supports the following:

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -158,6 +158,19 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `script_actions` - (Optional)  The script action which will run on the cluster.
+
+---
+
+A `script_action` block supports the following:
+
+* `name` - (Required) The name of the script action.
+
+* `uri` - (Required) The URI to the script.
+
+* `parameters` - (Required) The parameters for the script provided.
+
+
 ---
 
 A `roles` block supports the following:

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -157,6 +157,18 @@ A `head_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Head Nodes should be provisioned within. Changing this forces a new resource to be created.
 
+* `script_actions` - (Optional)  The script action which will run on the cluster.
+
+---
+
+A `script_action` block supports the following:
+
+* `name` - (Required) The name of the script action.
+
+* `uri` - (Required) The URI to the script.
+
+* `parameters` - (Required) The parameters for the script provided.
+
 ---
 
 A `roles` block supports the following:


### PR DESCRIPTION
* Add support for `script_action` property in HDInsight clusters.

* Test results:

```
--- PASS: TestAccHDInsightHadoopCluster_roleScriptActions (1195.02s)
--- PASS: TestAccHDInsightInteractiveQueryCluster_roleScriptActions (1223.77s)
--- PASS: TestAccHDInsightHBaseCluster_roleScriptActions (1253.67s)
--- PASS: TestAccHDInsightSparkCluster_roleScriptActions (2109.94s)
```