### PR TITLE
`vm/vmss` - fix unexpected set of `source_image_reference`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -880,7 +880,7 @@ func resourceLinuxVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 
 		d.Set("source_image_id", storageImageId)
 
-		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
+		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference, storageImageId != "")); err != nil {
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
 		}
 	}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -932,10 +932,6 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 				return fmt.Errorf("setting `data_disk`: %+v", err)
 			}
 
-			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference)); err != nil {
-				return fmt.Errorf("setting `source_image_reference`: %+v", err)
-			}
-
 			var storageImageId string
 			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
 				storageImageId = *storageProfile.ImageReference.ID
@@ -947,6 +943,10 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 				storageImageId = *storageProfile.ImageReference.SharedGalleryImageID
 			}
 			d.Set("source_image_id", storageImageId)
+
+			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference, storageImageId != "")); err != nil {
+				return fmt.Errorf("setting `source_image_reference`: %+v", err)
+			}
 		}
 
 		extensionOperationsEnabled := true

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -1225,10 +1225,6 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 				return fmt.Errorf("setting `data_disk`: %+v", err)
 			}
 
-			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference)); err != nil {
-				return fmt.Errorf("setting `source_image_reference`: %+v", err)
-			}
-
 			var storageImageId string
 			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
 				storageImageId = *storageProfile.ImageReference.ID
@@ -1240,6 +1236,10 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 				storageImageId = *storageProfile.ImageReference.SharedGalleryImageID
 			}
 			d.Set("source_image_id", storageImageId)
+
+			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference, storageImageId != "")); err != nil {
+				return fmt.Errorf("setting `source_image_reference`: %+v", err)
+			}
 		}
 
 		if osProfile := profile.OsProfile; osProfile != nil {

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -435,9 +435,9 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) (*
 	}, nil
 }
 
-func flattenSourceImageReference(input *compute.ImageReference) []interface{} {
+func flattenSourceImageReference(input *compute.ImageReference, hasImageId bool) []interface{} {
 	// since the image id is pulled out as a separate field, if that's set we should return an empty block here
-	if input == nil || input.ID != nil {
+	if input == nil || hasImageId {
 		return []interface{}{}
 	}
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -930,7 +930,7 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 		}
 		d.Set("source_image_id", storageImageId)
 
-		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
+		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference, storageImageId != "")); err != nil {
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
 		}
 	}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -965,10 +965,6 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 				return fmt.Errorf("setting `data_disk`: %+v", err)
 			}
 
-			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference)); err != nil {
-				return fmt.Errorf("setting `source_image_reference`: %+v", err)
-			}
-
 			var storageImageId string
 			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
 				storageImageId = *storageProfile.ImageReference.ID
@@ -980,6 +976,10 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 				storageImageId = *storageProfile.ImageReference.SharedGalleryImageID
 			}
 			d.Set("source_image_id", storageImageId)
+
+			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference, storageImageId != "")); err != nil {
+				return fmt.Errorf("setting `source_image_reference`: %+v", err)
+			}
 		}
 
 		extensionOperationsEnabled := true


### PR DESCRIPTION
Fix #18663
Fix #18661

When adding the support for Community Image and Direct Shared Image, the pre-check for these newly added ID was missing when setting the `source_image_reference`. Fixing the issue by checking if `storageImageId` is empty to include all three cases.

Currently Community Image and Direct Shared Image are not supported for Gallery resource yet so acc tests could not be added yet. Will add the acc tests after they are supported