### PR TITLE
`data\azurerm_virtual_machine_scale_set` - fix `version` in `public_ip_address`

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -736,6 +736,11 @@ func virtualMachineScaleSetPublicIPAddressSchemaForDataSource() *pluginsdk.Schem
 					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
+
+				"version": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
 			},
 		},
 	}

--- a/internal/services/compute/virtual_machine_scale_set_data_source_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source_test.go
@@ -59,6 +59,20 @@ func TestAccDataSourceVirtualMachineScaleSet_orchestrated(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceVirtualMachineScaleSet_publicIPAddress(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
+	r := VirtualMachineScaleSetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.publicIPAddress(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+			),
+		},
+	})
+}
+
 func (VirtualMachineScaleSetDataSource) basicLinux(data acceptance.TestData) string {
 	template := LinuxVirtualMachineScaleSetResource{}.identitySystemAssigned(data)
 	return fmt.Sprintf(`
@@ -90,6 +104,18 @@ func (VirtualMachineScaleSetDataSource) orchestrated(data acceptance.TestData) s
 
 data "azurerm_virtual_machine_scale_set" "test" {
   name                = azurerm_orchestrated_virtual_machine_scale_set.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (VirtualMachineScaleSetDataSource) publicIPAddress(data acceptance.TestData) string {
+	template := WindowsVirtualMachineScaleSetResource{}.networkPublicIP(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_virtual_machine_scale_set" "test" {
+  name                = azurerm_windows_virtual_machine_scale_set.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
 `, template)


### PR DESCRIPTION
Fix #18645

-When adding `version` to the `public_ip_address` for VMSS resource, the one in data source was missing, and it fails because both resource and data source of VMSS uses same flatten method for the `public_ip_address`. Adding the `version` there as well
- Adding an acc test as well to cover the `public_ip_address` property so it won't cause regression in the future