### PR TITLE
`azurerm_resource_group` - fix the issue failed when creating

### DIFF
--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -82,12 +82,11 @@ func resourceResourceGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface
 	// workaround for the consistency: https://github.com/hashicorp/terraform-provider-azurerm/issues/18268
 	log.Printf("[DEBUG] Waiting for resource group %s to be fully created..", name)
 	stateConf := &pluginsdk.StateChangeConf{
-		Pending:                   []string{"NotFound"},
-		Target:                    []string{"Exists"},
-		Refresh:                   resourceGroupCreatedRefresh(ctx, client, name),
-		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 2,
-		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		Pending:    []string{"NotFound"},
+		Target:     []string{"Exists"},
+		Refresh:    resourceGroupCreatedRefresh(ctx, client, name),
+		MinTimeout: 10 * time.Second,
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {


### PR DESCRIPTION
fix #18268

Test
```
TF_ACC=1 go test -v ./internal/services/resource -run=TestAccResourceGroup_basic              
=== RUN   TestAccResourceGroup_basic
=== PAUSE TestAccResourceGroup_basic
=== CONT  TestAccResourceGroup_basic
--- PASS: TestAccResourceGroup_basic (227.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      228.285s
```