### PR TITLE
`dns` - parse resource IDs insensitively in the delete functions due to casing on the dnsZones segment

### DIFF
--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -197,7 +197,7 @@ func resourceDnsARecordDelete(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_aaaa_record_resource.go
+++ b/internal/services/dns/dns_aaaa_record_resource.go
@@ -199,7 +199,7 @@ func resourceDnsAaaaRecordDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -190,7 +190,7 @@ func resourceDnsCaaRecordDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -199,7 +199,7 @@ func resourceDnsCNameRecordDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_mx_record_resource.go
+++ b/internal/services/dns/dns_mx_record_resource.go
@@ -181,7 +181,7 @@ func resourceDnsMxRecordDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_ns_record_resource.go
+++ b/internal/services/dns/dns_ns_record_resource.go
@@ -211,7 +211,7 @@ func resourceDnsNsRecordDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_ptr_record_resource.go
+++ b/internal/services/dns/dns_ptr_record_resource.go
@@ -164,7 +164,7 @@ func resourceDnsPtrRecordDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_srv_record_resource.go
+++ b/internal/services/dns/dns_srv_record_resource.go
@@ -188,7 +188,7 @@ func resourceDnsSrvRecordDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -173,7 +173,7 @@ func resourceDnsTxtRecordDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeID(d.Id())
+	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -264,7 +264,7 @@ func resourceDnsZoneDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := zones.ParseDnsZoneID(d.Id())
+	id, err := zones.ParseDnsZoneIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18554
This PR is used to resolve the following scenario:
1. The dns zone resource has already been created by a provider version before https://github.com/hashicorp/terraform-provider-azurerm/pull/17986
2. Delete the dns zone with a provider version after https://github.com/hashicorp/terraform-provider-azurerm/pull/17986