### PR TITLE
windows_function_app & linux_function_app - Add support for Java 17

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -977,7 +977,7 @@ type ApplicationStackLinuxFunctionApp struct {
 	NodeVersion           string                   `tfschema:"node_version"`                // Supported values `12LTS`, `14LTS`
 	PythonVersion         string                   `tfschema:"python_version"`              // Supported values `3.9`, `3.8`, `3.7`
 	PowerShellCoreVersion string                   `tfschema:"powershell_core_version"`     // Supported values are `7.0`, `7.2`
-	JavaVersion           string                   `tfschema:"java_version"`                // Supported values `8`, `11`
+	JavaVersion           string                   `tfschema:"java_version"`                // Supported values `8`, `11`, `17` (In-Preview)
 	CustomHandler         bool                     `tfschema:"use_custom_runtime"`          // Supported values `true`
 	Docker                []ApplicationStackDocker `tfschema:"docker"`                      // Needs ElasticPremium or Basic (B1) Standard (S 1-3) or Premium(PxV2 or PxV3) LINUX Service Plan
 }
@@ -986,7 +986,7 @@ type ApplicationStackWindowsFunctionApp struct {
 	DotNetVersion         string `tfschema:"dotnet_version"`              // Supported values `3.1`. Version 6 is in preview on Windows Only
 	DotNetIsolated        bool   `tfschema:"use_dotnet_isolated_runtime"` // Supported values `true` for `dotnet-isolated`, `false` otherwise
 	NodeVersion           string `tfschema:"node_version"`                // Supported values `12LTS`, `14LTS`
-	JavaVersion           string `tfschema:"java_version"`                // Supported values `8`, `11`
+	JavaVersion           string `tfschema:"java_version"`                // Supported values `8`, `11`, `17` (In-Preview)
 	PowerShellCoreVersion string `tfschema:"powershell_core_version"`     // Supported values are `7.0`, `7.2`
 	CustomHandler         bool   `tfschema:"use_custom_runtime"`          // Supported values `true`
 }
@@ -1106,6 +1106,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						"8",
 						"11",
+						"17",
 					}, false),
 					ExactlyOneOf: []string{
 						"site_config.0.application_stack.0.dotnet_version",
@@ -1331,6 +1332,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						"8",
 						"11",
+						"17",
 					}, false),
 					ExactlyOneOf: []string{
 						"site_config.0.application_stack.0.dotnet_version",

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -130,7 +130,7 @@ func schemaAppServiceFunctionAppSiteConfig() *pluginsdk.Schema {
 				"java_version": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.StringInSlice([]string{"1.8", "11"}, false),
+					ValidateFunc: validation.StringInSlice([]string{"1.8", "11", "17"}, false),
 				},
 
 				"elastic_instance_minimum": {

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -275,7 +275,7 @@ The following arguments are supported:
 
 -> **NOTE** User has to explicitly set `ip_restriction` to empty slice (`[]`) to remove it.
 
-* `java_version` - (Optional) Java version hosted by the function app in Azure. Possible values are `1.8`, `11`.
+* `java_version` - (Optional) Java version hosted by the function app in Azure. Possible values are `1.8`, `11` & `17` (In-Preview).
 
 * `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -148,7 +148,7 @@ A `application_stack` block supports the following:
 
 * `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 
-* `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, and `11`.
+* `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, `11` & `17` (In-Preview).
 
 * `node_version` - (Optional) The version of Node to run. Possible values include `12`, `14`, `16` and `18`.
 

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -386,7 +386,7 @@ An `application_stack` block supports the following:
 
 * `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 
-* `java_version` - (Optional) The version of Java to use. Possible values are `8`, and `11`.
+* `java_version` - (Optional) The version of Java to use. Possible values are `8`, `11` & `17` (In-Preview).
 
 * `node_version` - (Optional) The version of Node to use. Possible values include `12`, and `14`
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -146,7 +146,7 @@ A `application_stack` block supports the following:
 
 * `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 
-* `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, and `11`.
+* `java_version` - (Optional) The Version of Java to use. Supported versions include `8`, `11` & `17` (In-Preview).
 
 * `node_version` - (Optional) The version of Node to run. Possible values include `~12`, `~14`, `~16` and `~18`.
 

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -379,7 +379,7 @@ An `application_stack` block supports the following:
 
 * `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 
-* `java_version` - (Optional) The version of Java to use. Possible values are `8`, and `11`
+* `java_version` - (Optional) The version of Java to use. Possible values are `8`, `11` & `17` (In-Preview).
 
 * `node_version` - (Optional) The version of Node to use. Possible values include `12`, and `14`
 


### PR DESCRIPTION
Fixes #18575 

This PR adds the support for version 17 of Java as mentioned in this post - https://azure.microsoft.com/en-us/updates/public-preview-java-17-support-in-azure-functions/

Since the post doesn't mention anything about the Web Apps (Windows, Linux) and hence decided not to add it in a separate PR.