### PR TITLE
dns: adding state migrations/removing the case-insensitive workarounds

### DIFF
--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -38,6 +40,11 @@ func resourceDnsARecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'A' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ARecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -149,7 +156,7 @@ func resourceDnsARecordRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -13,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/dns/dns_aaaa_record_resource.go
+++ b/internal/services/dns/dns_aaaa_record_resource.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -13,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/dns/dns_aaaa_record_resource.go
+++ b/internal/services/dns/dns_aaaa_record_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -41,6 +43,11 @@ func resourceDnsAAAARecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'AAAA' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.AAAARecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -152,7 +159,7 @@ func resourceDnsAaaaRecordRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"

--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -39,6 +41,11 @@ func resourceDnsCaaRecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'CAA' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CAARecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -150,7 +157,7 @@ func resourceDnsCaaRecordRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -13,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -39,6 +41,11 @@ func resourceDnsCNameRecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'CNAME' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CNAMERecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -150,7 +157,7 @@ func resourceDnsCNameRecordRead(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_mx_record_resource.go
+++ b/internal/services/dns/dns_mx_record_resource.go
@@ -6,14 +6,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )

--- a/internal/services/dns/dns_mx_record_resource.go
+++ b/internal/services/dns/dns_mx_record_resource.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -39,6 +41,11 @@ func resourceDnsMxRecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'MX' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.MXRecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -141,7 +148,7 @@ func resourceDnsMxRecordRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_ns_record_resource.go
+++ b/internal/services/dns/dns_ns_record_resource.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/dns/dns_ns_record_resource.go
+++ b/internal/services/dns/dns_ns_record_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -37,6 +39,11 @@ func resourceDnsNsRecord() *pluginsdk.Resource {
 				return fmt.Errorf("this resource only supports 'NS' records")
 			}
 			return nil
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NSRecordV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -170,7 +177,7 @@ func resourceDnsNsRecordRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_ptr_record_resource.go
+++ b/internal/services/dns/dns_ptr_record_resource.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )

--- a/internal/services/dns/dns_ptr_record_resource.go
+++ b/internal/services/dns/dns_ptr_record_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -38,6 +40,12 @@ func resourceDnsPtrRecord() *pluginsdk.Resource {
 			}
 			return nil
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.PTRRecordV0ToV1{},
+		}),
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,
@@ -123,7 +131,7 @@ func resourceDnsPtrRecordRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_srv_record_resource.go
+++ b/internal/services/dns/dns_srv_record_resource.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )

--- a/internal/services/dns/dns_srv_record_resource.go
+++ b/internal/services/dns/dns_srv_record_resource.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -28,6 +30,7 @@ func resourceDnsSrvRecord() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			parsed, err := recordsets.ParseRecordTypeID(id)
 			if err != nil {
@@ -38,6 +41,12 @@ func resourceDnsSrvRecord() *pluginsdk.Resource {
 			}
 			return nil
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.SRVRecordV0ToV1{},
+		}),
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,
@@ -147,7 +156,7 @@ func resourceDnsSrvRecordRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -5,14 +5,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
-
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/migration"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -29,6 +31,7 @@ func resourceDnsTxtRecord() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			parsed, err := recordsets.ParseRecordTypeID(id)
 			if err != nil {
@@ -39,6 +42,12 @@ func resourceDnsTxtRecord() *pluginsdk.Resource {
 			}
 			return nil
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.TXTRecordV0ToV1{},
+		}),
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:     pluginsdk.TypeString,
@@ -133,7 +142,7 @@ func resourceDnsTxtRecordRead(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := recordsets.ParseRecordTypeIDInsensitively(d.Id())
+	id, err := recordsets.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -28,9 +28,10 @@ func resourceDnsZone() *pluginsdk.Resource {
 		Update: resourceDnsZoneCreateUpdate,
 		Delete: resourceDnsZoneDelete,
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.DnsZoneV0ToV1{},
+			1: migration.DnsZoneV1ToV2{},
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -210,7 +211,7 @@ func resourceDnsZoneRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := zones.ParseDnsZoneIDInsensitively(d.Id())
+	id, err := zones.ParseDnsZoneID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/dns/migration/a_record_v0_to_v1.go
+++ b/internal/services/dns/migration/a_record_v0_to_v1.go
@@ -13,7 +13,7 @@ var _ pluginsdk.StateUpgrade = ARecordV0ToV1{}
 
 type ARecordV0ToV1 struct{}
 
-func (A ARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (ARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -65,7 +65,7 @@ func (A ARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A ARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (ARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/a_record_v0_to_v1.go
+++ b/internal/services/dns/migration/a_record_v0_to_v1.go
@@ -1,0 +1,80 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ARecordV0ToV1{}
+
+type ARecordV0ToV1 struct{}
+
+func (A ARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"records": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+			Set:      pluginsdk.HashString,
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"target_resource_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A ARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/aaaa_record_v0_to_v1.go
+++ b/internal/services/dns/migration/aaaa_record_v0_to_v1.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = AAAARecordV0ToV1{}
 
 type AAAARecordV0ToV1 struct{}
 
-func (A AAAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (AAAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -71,7 +71,7 @@ func (A AAAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A AAAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (AAAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/aaaa_record_v0_to_v1.go
+++ b/internal/services/dns/migration/aaaa_record_v0_to_v1.go
@@ -1,0 +1,86 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = AAAARecordV0ToV1{}
+
+type AAAARecordV0ToV1 struct{}
+
+func (A AAAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"records": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Set:           set.HashIPv6Address,
+			ConflictsWith: []string{"target_resource_id"},
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
+		"target_resource_id": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"records"},
+		},
+	}
+}
+
+func (A AAAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/caa_record_v0_to_v1.go
+++ b/internal/services/dns/migration/caa_record_v0_to_v1.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = CAARecordV0ToV1{}
 
 type CAARecordV0ToV1 struct{}
 
-func (A CAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (CAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -79,7 +79,7 @@ func (A CAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A CAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (CAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/caa_record_v0_to_v1.go
+++ b/internal/services/dns/migration/caa_record_v0_to_v1.go
@@ -1,0 +1,106 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = CAARecordV0ToV1{}
+
+type CAARecordV0ToV1 struct{}
+
+func (A CAARecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"record": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"flags": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+
+					"tag": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"value": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Set: resourceDnsCaaRecordHash,
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A CAARecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}
+
+func resourceDnsCaaRecordHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if m, ok := v.(map[string]interface{}); ok {
+		buf.WriteString(fmt.Sprintf("%d-", m["flags"].(int)))
+		buf.WriteString(fmt.Sprintf("%s-", m["tag"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
+	}
+
+	return pluginsdk.HashString(buf.String())
+}

--- a/internal/services/dns/migration/cname_record_v0_to_v1.go
+++ b/internal/services/dns/migration/cname_record_v0_to_v1.go
@@ -1,0 +1,80 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = CNAMERecordV0ToV1{}
+
+type CNAMERecordV0ToV1 struct{}
+
+func (A CNAMERecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"record": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"target_resource_id"},
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"target_resource_id": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"record"},
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A CNAMERecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/cname_record_v0_to_v1.go
+++ b/internal/services/dns/migration/cname_record_v0_to_v1.go
@@ -13,7 +13,7 @@ var _ pluginsdk.StateUpgrade = CNAMERecordV0ToV1{}
 
 type CNAMERecordV0ToV1 struct{}
 
-func (A CNAMERecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (CNAMERecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -65,7 +65,7 @@ func (A CNAMERecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A CNAMERecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (CNAMERecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/dns_zone_v1_to_v2.go
+++ b/internal/services/dns/migration/dns_zone_v1_to_v2.go
@@ -1,0 +1,141 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = DnsZoneV1ToV2{}
+
+type DnsZoneV1ToV2 struct{}
+
+func (DnsZoneV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"number_of_record_sets": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"max_number_of_record_sets": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"name_servers": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Set: pluginsdk.HashString,
+		},
+
+		"soa_record": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"email": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"host_name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"expire_time": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  2419200,
+					},
+
+					"minimum_ttl": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  300,
+					},
+
+					"refresh_time": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  3600,
+					},
+
+					"retry_time": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  300,
+					},
+
+					"serial_number": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  1,
+					},
+
+					"ttl": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  3600,
+					},
+
+					"tags": {
+						Type:     pluginsdk.TypeMap,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+
+					"fqdn": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (DnsZoneV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		id, err := zones.ParseDnsZoneIDInsensitively(oldId)
+		if err != nil {
+			return rawState, err
+		}
+		newId := id.ID()
+		log.Printf("Updating `id` from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/mx_record_v0_to_v1.go
+++ b/internal/services/dns/migration/mx_record_v0_to_v1.go
@@ -1,0 +1,102 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = MXRecordV0ToV1{}
+
+type MXRecordV0ToV1 struct{}
+
+func (A MXRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "@",
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"record": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"preference": {
+						// TODO: this should become an Int
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"exchange": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Set: resourceDnsMxRecordHash,
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A MXRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}
+
+func resourceDnsMxRecordHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if m, ok := v.(map[string]interface{}); ok {
+		buf.WriteString(fmt.Sprintf("%s-", m["preference"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
+	}
+
+	return pluginsdk.HashString(buf.String())
+}

--- a/internal/services/dns/migration/mx_record_v0_to_v1.go
+++ b/internal/services/dns/migration/mx_record_v0_to_v1.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = MXRecordV0ToV1{}
 
 type MXRecordV0ToV1 struct{}
 
-func (A MXRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (MXRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -76,7 +76,7 @@ func (A MXRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A MXRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (MXRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/ns_record_v0_to_v1.go
+++ b/internal/services/dns/migration/ns_record_v0_to_v1.go
@@ -1,0 +1,76 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = NSRecordV0ToV1{}
+
+type NSRecordV0ToV1 struct{}
+
+func (A NSRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"records": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A NSRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/ns_record_v0_to_v1.go
+++ b/internal/services/dns/migration/ns_record_v0_to_v1.go
@@ -13,7 +13,7 @@ var _ pluginsdk.StateUpgrade = NSRecordV0ToV1{}
 
 type NSRecordV0ToV1 struct{}
 
-func (A NSRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (NSRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -61,7 +61,7 @@ func (A NSRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A NSRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (NSRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/ptr_record_v0_to_v1.go
+++ b/internal/services/dns/migration/ptr_record_v0_to_v1.go
@@ -1,0 +1,77 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = PTRRecordV0ToV1{}
+
+type PTRRecordV0ToV1 struct{}
+
+func (A PTRRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"records": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Set: pluginsdk.HashString,
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A PTRRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/ptr_record_v0_to_v1.go
+++ b/internal/services/dns/migration/ptr_record_v0_to_v1.go
@@ -13,7 +13,7 @@ var _ pluginsdk.StateUpgrade = PTRRecordV0ToV1{}
 
 type PTRRecordV0ToV1 struct{}
 
-func (A PTRRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (PTRRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -62,7 +62,7 @@ func (A PTRRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A PTRRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (PTRRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/srv_record_v0_to_v1.go
+++ b/internal/services/dns/migration/srv_record_v0_to_v1.go
@@ -1,0 +1,112 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = SRVRecordV0ToV1{}
+
+type SRVRecordV0ToV1 struct{}
+
+func (A SRVRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"record": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+
+					"weight": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+
+					"port": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+
+					"target": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Set: resourceDnsSrvRecordHash,
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A SRVRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}
+
+func resourceDnsSrvRecordHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if m, ok := v.(map[string]interface{}); ok {
+		buf.WriteString(fmt.Sprintf("%d-", m["priority"].(int)))
+		buf.WriteString(fmt.Sprintf("%d-", m["weight"].(int)))
+		buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
+		buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
+	}
+
+	return pluginsdk.HashString(buf.String())
+}

--- a/internal/services/dns/migration/srv_record_v0_to_v1.go
+++ b/internal/services/dns/migration/srv_record_v0_to_v1.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = SRVRecordV0ToV1{}
 
 type SRVRecordV0ToV1 struct{}
 
-func (A SRVRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (SRVRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -84,7 +84,7 @@ func (A SRVRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A SRVRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (SRVRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)

--- a/internal/services/dns/migration/txt_record_v0_to_v1.go
+++ b/internal/services/dns/migration/txt_record_v0_to_v1.go
@@ -1,0 +1,83 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var _ pluginsdk.StateUpgrade = TXTRecordV0ToV1{}
+
+type TXTRecordV0ToV1 struct{}
+
+func (A TXTRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zone_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"record": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"value": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringLenBetween(1, 1024),
+					},
+				},
+			},
+		},
+
+		"ttl": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func (A TXTRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/dns/migration/txt_record_v0_to_v1.go
+++ b/internal/services/dns/migration/txt_record_v0_to_v1.go
@@ -14,7 +14,7 @@ var _ pluginsdk.StateUpgrade = TXTRecordV0ToV1{}
 
 type TXTRecordV0ToV1 struct{}
 
-func (A TXTRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
+func (TXTRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
@@ -68,7 +68,7 @@ func (A TXTRecordV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (A TXTRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+func (TXTRecordV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldId := rawState["id"].(string)
 		parsedId, err := recordsets.ParseRecordTypeIDInsensitively(oldId)


### PR DESCRIPTION
These should have been implemented as state migrations, so this PR fixes this, which ultimately fixes #18554

Supersedes #18676