### PR TITLE
`azurerm_dns_aaaa_record` - fix TestAccAzureRMDnsAAAARecord_RecordsToAlias

### DIFF
--- a/internal/services/dns/dns_aaaa_record_resource_test.go
+++ b/internal/services/dns/dns_aaaa_record_resource_test.go
@@ -136,8 +136,10 @@ func TestAccAzureRMDnsAAAARecord_RecordsToAlias(t *testing.T) {
 			Config: r.AliasToRecords(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				acceptance.TestCheckResourceAttrPair(data.ResourceName, "target_resource_id", targetResourceName, "id"),
-				acceptance.TestCheckNoResourceAttr(data.ResourceName, "records"),
+				check.That(data.ResourceName).Key("target_resource_id").MatchesOtherKey(
+					check.That(targetResourceName).Key("id"),
+				),
+				check.That(data.ResourceName).Key("records.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
`azurerm_dns_aaaa_record` - fix TestAccAzureRMDnsAAAARecord_RecordsToAlias

Test results:

GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\Temp\GoLand\___2TestAccAzureRMDnsAAAARecord_RecordsToAlias_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_dns.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/dns #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\Temp\GoLand\___2TestAccAzureRMDnsAAAARecord_RecordsToAlias_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_dns.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccAzureRMDnsAAAARecord_RecordsToAlias\E$ #gosetup
=== RUN   TestAccAzureRMDnsAAAARecord_RecordsToAlias
=== PAUSE TestAccAzureRMDnsAAAARecord_RecordsToAlias
=== CONT  TestAccAzureRMDnsAAAARecord_RecordsToAlias
--- PASS: TestAccAzureRMDnsAAAARecord_RecordsToAlias (190.04s)
PASS

Process finished with the exit code 0