### PR TITLE
`azurerm_iothub_dps_certificate` - Fix `name` validation

### DIFF
--- a/internal/services/iothub/iothub_dps_certificate_resource.go
+++ b/internal/services/iothub/iothub_dps_certificate_resource.go
@@ -40,7 +40,7 @@ func resourceIotHubDPSCertificate() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.IoTHubName,
+				ValidateFunc: validate.IoTHubDpsCertificateName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/internal/services/iothub/validate/iot_hub_dps_certificate_name.go
+++ b/internal/services/iothub/validate/iot_hub_dps_certificate_name.go
@@ -1,0 +1,24 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func IoTHubDpsCertificateName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if value == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+	}
+
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf("%q may contain at most 64 characters", k))
+	}
+
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z-._]+$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters or the following: -._", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/iothub/validate/iot_hub_dps_certificate_name_test.go
+++ b/internal/services/iothub/validate/iot_hub_dps_certificate_name_test.go
@@ -1,0 +1,30 @@
+package validate
+
+import "testing"
+
+func TestIoTHubDpsCertificateName(t *testing.T) {
+	validNames := []string{
+		"validName123",
+		"cert_a-1.cer",
+		"1234567890123456789012345678901234567890123456789012345678901234",
+	}
+	for _, v := range validNames {
+		_, errors := IoTHubDpsCertificateName(v, "example")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid IoT Hub DPS Certificate Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"",
+		"invalid!",
+		"!@£",
+		"12345678901234567890123456789012345678901234567890123456789012345",
+	}
+	for _, v := range invalidNames {
+		_, errors := IoTHubDpsCertificateName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid IoT Hub DPS Certificate Name", v)
+		}
+	}
+}


### PR DESCRIPTION
Fix #18367
Correcting the validation of `name` in `azurerm_iothub_dps_certificate`. The restrictions come from Azure Portal:
![image](https://user-images.githubusercontent.com/10579712/194993147-0928f094-b11b-46e8-959f-afc199e1d279.png)
![image](https://user-images.githubusercontent.com/10579712/194993184-2e3b0eaa-44c9-43d4-a381-1d9da0a60166.png)
