### PR TITLE
`azurerm_dedicated_hardware_security_module`  - Support the `management_network_profile` property

### DIFF
--- a/internal/services/hsm/dedicated_hardware_security_module_resource.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource.go
@@ -59,12 +59,44 @@ func resourceDedicatedHardwareSecurityModule() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(dedicatedhsms.SkuNameSafeNetLunaNetworkHSMASevenNineZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSSixZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSTwoFiveZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSTwoFiveZeroZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSSixZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSTwoFiveZero),
+					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSTwoFiveZeroZero),
 				}, false),
 			},
 
 			"network_profile": {
 				Type:     pluginsdk.TypeList,
 				Required: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"network_interface_private_ip_addresses": {
+							Type:     pluginsdk.TypeSet,
+							Required: true,
+							ForceNew: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: azValidate.IPv4Address,
+							},
+						},
+
+						"subnet_id": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: networkValidate.SubnetID,
+						},
+					},
+				},
+			},
+
+			"management_network_profile": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -123,10 +155,17 @@ func resourceDedicatedHardwareSecurityModuleCreate(d *pluginsdk.ResourceData, me
 	}
 
 	skuName := dedicatedhsms.SkuName(d.Get("sku_name").(string))
+	if _, ok := d.GetOk("management_network_profile"); ok {
+		if skuName == dedicatedhsms.SkuNameSafeNetLunaNetworkHSMASevenNineZero {
+			return fmt.Errorf("management_network_profile should not be specified when sku_name is %s", skuName)
+		}
+	}
+
 	parameters := dedicatedhsms.DedicatedHsm{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: dedicatedhsms.DedicatedHsmProperties{
-			NetworkProfile: expandDedicatedHsmNetworkProfile(d.Get("network_profile").([]interface{})),
+			NetworkProfile:           expandDedicatedHsmNetworkProfile(d.Get("network_profile").([]interface{})),
+			ManagementNetworkProfile: expandDedicatedHsmNetworkProfile(d.Get("management_network_profile").([]interface{})),
 		},
 		Sku: dedicatedhsms.Sku{
 			Name: &skuName,
@@ -182,6 +221,10 @@ func resourceDedicatedHardwareSecurityModuleRead(d *pluginsdk.ResourceData, meta
 		d.Set("zones", zones.Flatten(model.Zones))
 
 		props := model.Properties
+
+		if err := d.Set("management_network_profile", flattenDedicatedHsmNetworkProfile(props.ManagementNetworkProfile)); err != nil {
+			return fmt.Errorf("setting management_network_profile: %+v", err)
+		}
 
 		if err := d.Set("network_profile", flattenDedicatedHsmNetworkProfile(props.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting network_profile: %+v", err)

--- a/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
@@ -224,10 +224,15 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
   name                = "acctest-hsm-%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "SafeNet Luna Network HSM A790"
+  sku_name            = "payShield10K_LMK1_CPS60"
 
   network_profile {
     network_interface_private_ip_addresses = ["10.2.1.8"]
+    subnet_id                              = azurerm_subnet.test2.id
+  }
+
+  management_network_profile {
+    network_interface_private_ip_addresses = ["10.2.1.9"]
     subnet_id                              = azurerm_subnet.test2.id
   }
 

--- a/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
@@ -66,7 +66,7 @@ func TestAccDedicatedHardwareSecurityModule_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.managementNetworkProfile(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -133,13 +133,6 @@ resource "azurerm_virtual_network" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 
-resource "azurerm_subnet" "test" {
-  name                 = "acctest-computesubnet-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.2.0.0/24"]
-}
-
 resource "azurerm_subnet" "test2" {
   name                 = "acctest-hsmsubnet-%d"
   resource_group_name  = azurerm_resource_group.test.name
@@ -189,7 +182,7 @@ resource "azurerm_virtual_network_gateway" "test" {
     subnet_id                     = azurerm_subnet.test3.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (DedicatedHardwareSecurityModuleResource) basic(data acceptance.TestData) string {
@@ -205,6 +198,34 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
 
   network_profile {
     network_interface_private_ip_addresses = ["10.2.1.8"]
+    subnet_id                              = azurerm_subnet.test2.id
+  }
+
+  stamp_id = "stamp2"
+
+  depends_on = [azurerm_virtual_network_gateway.test]
+}
+`, template, data.RandomString)
+}
+
+func (DedicatedHardwareSecurityModuleResource) managementNetworkProfile(data acceptance.TestData) string {
+	template := DedicatedHardwareSecurityModuleResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_hardware_security_module" "test" {
+  name                = "acctest-hsm-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "payShield10K_LMK1_CPS60"
+
+  network_profile {
+    network_interface_private_ip_addresses = ["10.2.1.8"]
+    subnet_id                              = azurerm_subnet.test2.id
+  }
+
+  management_network_profile {
+    network_interface_private_ip_addresses = ["10.2.1.9"]
     subnet_id                              = azurerm_subnet.test2.id
   }
 

--- a/website/docs/r/dedicated_hardware_security_module.html.markdown
+++ b/website/docs/r/dedicated_hardware_security_module.html.markdown
@@ -89,7 +89,12 @@ resource "azurerm_dedicated_hardware_security_module" "example" {
   name                = "example-hsm"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  sku_name            = "SafeNet Luna Network HSM A790"
+  sku_name            = "payShield10K_LMK1_CPS60"
+
+  management_network_profile {
+    network_interface_private_ip_addresses = ["10.2.1.7"]
+    subnet_id                              = azurerm_subnet.example2.id
+  }
 
   network_profile {
     network_interface_private_ip_addresses = ["10.2.1.8"]
@@ -118,7 +123,11 @@ The following arguments are supported:
 
 * `network_profile` - (Required)  A `network_profile` block as defined below.
 
-* `sku_name` - (Required) The SKU name of the dedicated hardware security module. Changing this forces a new Dedicated Hardware Security Module to be created.
+* `sku_name` - (Required) The SKU name of the dedicated hardware security module. Possible values are `payShield10K_LMK1_CPS60`,`payShield10K_LMK1_CPS250`,`payShield10K_LMK1_CPS2500`,`payShield10K_LMK2_CPS60`,`payShield10K_LMK2_CPS250`,`payShield10K_LMK2_CPS2500` and `SafeNet Luna Network HSM A790`. Changing this forces a new Dedicated Hardware Security Module to be created.
+
+* `management_network_profile` - (Optional)  A `management_network_profile` block as defined below.
+
+->**NOTE:**  The `management_network_profile` should not be specified when `sku_name` is `SafeNet Luna Network HSM A790`.
 
 * `stamp_id` - (Optional) The ID of the stamp. Possible values are `stamp1` or `stamp2`. Changing this forces a new Dedicated Hardware Security Module to be created.
 
@@ -129,6 +138,12 @@ The following arguments are supported:
 ---
 
 An `network_profile` block exports the following:
+
+* `network_interface_private_ip_addresses` - (Required) The private IPv4 address of the network interface. Changing this forces a new Dedicated Hardware Security Module to be created.
+
+* `subnet_id` - (Required) The ID of the subnet. Changing this forces a new Dedicated Hardware Security Module to be created.
+
+A `management_network_profile` block exports the following:
 
 * `network_interface_private_ip_addresses` - (Required) The private IPv4 address of the network interface. Changing this forces a new Dedicated Hardware Security Module to be created.
 


### PR DESCRIPTION
- Support the `management_network_profile` for resource `azurerm_dedicated_hardware_security_module`.  API is [here](https://github.com/Azure/azure-rest-api-specs/blob/f203c1b73639b7e2f85aa96902cfe36c6dd2ffad/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/stable/2021-11-30/dedicatedhsm.json#L624).
- Delete unused  azurerm_subnet resource created in test case.
- Add `sku_name` possible values.