### PR TITLE
New resource: `azurerm_sentinel_data_connector_office_atp`

### DIFF
--- a/internal/services/sentinel/registration.go
+++ b/internal/services/sentinel/registration.go
@@ -48,6 +48,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_sentinel_data_connector_microsoft_cloud_app_security":                  resourceSentinelDataConnectorMicrosoftCloudAppSecurity(),
 		"azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection": resourceSentinelDataConnectorMicrosoftDefenderAdvancedThreatProtection(),
 		"azurerm_sentinel_data_connector_office_365":                                    resourceSentinelDataConnectorOffice365(),
+		"azurerm_sentinel_data_connector_office_atp":                                    resourceSentinelDataConnectorOfficeATP(),
 		"azurerm_sentinel_data_connector_threat_intelligence":                           resourceSentinelDataConnectorThreatIntelligence(),
 		"azurerm_sentinel_automation_rule":                                              resourceSentinelAutomationRule(),
 	}

--- a/internal/services/sentinel/sentinel_data_connector_office_atp.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp.go
@@ -1,0 +1,163 @@
+package sentinel
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/securityinsight/mgmt/2022-01-01-preview/securityinsight"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func resourceSentinelDataConnectorOfficeATP() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceSentinelDataConnectorOfficeATPCreate,
+		Read:   resourceSentinelDataConnectorOfficeATPRead,
+		Delete: resourceSentinelDataConnectorOfficeATPDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
+			_, err := parse.DataConnectorID(id)
+			return err
+		}, importSentinelDataConnector(securityinsight.DataConnectorKindOfficeATP)),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"log_analytics_workspace_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: workspaces.ValidateWorkspaceID,
+			},
+
+			"tenant_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+		},
+	}
+}
+
+func resourceSentinelDataConnectorOfficeATPCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Sentinel.DataConnectorsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	workspaceId, err := workspaces.ParseWorkspaceID(d.Get("log_analytics_workspace_id").(string))
+	if err != nil {
+		return err
+	}
+	name := d.Get("name").(string)
+	id := parse.NewDataConnectorID(workspaceId.SubscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, name)
+
+	if d.IsNewResource() {
+		resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_sentinel_data_connector_office_atp", id.ID())
+		}
+	}
+
+	tenantId := d.Get("tenant_id").(string)
+	if tenantId == "" {
+		tenantId = meta.(*clients.Client).Account.TenantId
+	}
+
+	param := securityinsight.OfficeATPDataConnector{
+		Name: &name,
+		OfficeATPDataConnectorProperties: &securityinsight.OfficeATPDataConnectorProperties{
+			TenantID: &tenantId,
+			DataTypes: &securityinsight.AlertsDataTypeOfDataConnector{
+				Alerts: &securityinsight.DataConnectorDataTypeCommon{
+					State: securityinsight.DataTypeStateEnabled,
+				},
+			},
+		},
+		Kind: securityinsight.KindBasicDataConnectorKindOfficeATP,
+	}
+
+	if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, param); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceSentinelDataConnectorOfficeATPRead(d, meta)
+}
+
+func resourceSentinelDataConnectorOfficeATPRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Sentinel.DataConnectorsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataConnectorID(d.Id())
+	if err != nil {
+		return err
+	}
+	workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] %s was not found - removing from state!", id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	dc, ok := resp.Value.(securityinsight.OfficeATPDataConnector)
+	if !ok {
+		return fmt.Errorf("%s was not an Office ATP Data Connector", id)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("log_analytics_workspace_id", workspaceId.ID())
+	d.Set("tenant_id", dc.TenantID)
+
+	return nil
+}
+
+func resourceSentinelDataConnectorOfficeATPDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Sentinel.DataConnectorsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataConnectorID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err = client.Delete(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return nil
+}

--- a/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
@@ -1,0 +1,153 @@
+package sentinel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type SentinelDataConnectorOfficeATPResource struct{}
+
+func TestAccAzureRMSentinelDataConnectorOfficeATP_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_office_atp", "test")
+	r := SentinelDataConnectorOfficeATPResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMSentinelDataConnectorOfficeATP_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_office_atp", "test")
+	r := SentinelDataConnectorOfficeATPResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMSentinelDataConnectorOfficeATP_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_office_atp", "test")
+	r := SentinelDataConnectorOfficeATPResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r SentinelDataConnectorOfficeATPResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	client := clients.Sentinel.DataConnectorsClient
+
+	id, err := parse.DataConnectorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r SentinelDataConnectorOfficeATPResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_office_atp" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorOfficeATPResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_sentinel_data_connector_office_atp" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  tenant_id                  = data.azurerm_client_config.test.tenant_id
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorOfficeATPResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_office_atp" "import" {
+  name                       = azurerm_sentinel_data_connector_office_atp.test.name
+  log_analytics_workspace_id = azurerm_sentinel_data_connector_office_atp.test.log_analytics_workspace_id
+}
+`, template)
+}
+
+func (r SentinelDataConnectorOfficeATPResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sentinel-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/docs/r/sentinel_data_connector_office_atp.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_atp.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "Sentinel"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sentinel_data_connector_office_atp"
+description: |-
+  Manages a Office ATP Data Connector.
+---
+
+# azurerm_sentinel_data_connector_office_atp
+
+Manages a Office ATP Data Connector.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
+resource "azurerm_sentinel_data_connector_office_atp" "example" {
+  name                       = "example"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace that this Office ATP Data Connector resides in. Changing this forces a new Office ATP Data Connector to be created.
+
+* `name` - (Required) The name which should be used for this Office ATP Data Connector. Changing this forces a new Office ATP Data Connector to be created.
+
+---
+
+* `tenant_id` - (Optional) The ID of the tenant that this Office ATP Data Connector connects to. Changing this forces a new Office ATP Data Connector to be created.
+
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Office ATP Data Connector.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Office ATP Data Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Office ATP Data Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Office ATP Data Connector.
+
+## Import
+
+Office ATP Data Connectors can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sentinel_data_connector_office_atp.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/dataConnectors/dc1
+```


### PR DESCRIPTION
New resource: `azurerm_sentinel_data_connector_office_atp`. Related to #18195.

## Test

```
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel -run=TestAccAzureRMSentinelDataConnectorOfficeATP_
=== RUN   TestAccAzureRMSentinelDataConnectorOfficeATP_basic
=== PAUSE TestAccAzureRMSentinelDataConnectorOfficeATP_basic
=== RUN   TestAccAzureRMSentinelDataConnectorOfficeATP_complete
=== PAUSE TestAccAzureRMSentinelDataConnectorOfficeATP_complete
=== RUN   TestAccAzureRMSentinelDataConnectorOfficeATP_requiresImport
=== PAUSE TestAccAzureRMSentinelDataConnectorOfficeATP_requiresImpor
=== CONT  TestAccAzureRMSentinelDataConnectorOfficeATP_basic
=== CONT  TestAccAzureRMSentinelDataConnectorOfficeATP_requiresImport
=== CONT  TestAccAzureRMSentinelDataConnectorOfficeATP_complete
--- PASS: TestAccAzureRMSentinelDataConnectorOfficeATP_complete (144.14s)
--- PASS: TestAccAzureRMSentinelDataConnectorOfficeATP_basic (146.18s)
--- PASS: TestAccAzureRMSentinelDataConnectorOfficeATP_requiresImport (159.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      159.057s
```