### PR TITLE
Added sku_name to ensure example can be copy-pasted

### DIFF
--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -28,6 +28,7 @@ resource "azurerm_dns_zone" "example" {
 resource "azurerm_cdn_frontdoor_profile" "example" {
   name                = "example-profile"
   resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard_AzureFrontDoor"
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "example" {


### PR DESCRIPTION
The resource `azurerm_cdn_frontdoor_profile` has a required property `sku_name`. Adding it to the example so the example can be copy-pasted.

Without the `sku_name`, the below error occurrs.

```
│ Error: Missing required argument
│ 
│   on frontdoor-premium.tf line 6, in resource "azurerm_cdn_frontdoor_profile" "example":
│    6: resource "azurerm_cdn_frontdoor_profile" "example" {
│ 
│ The argument "sku_name" is required, but no definition was found.
```
