### PR TITLE
`azurerm_hpc_cache` - fix acc test

### DIFF
--- a/internal/services/hpccache/hpc_cache.go
+++ b/internal/services/hpccache/hpc_cache.go
@@ -1,9 +1,13 @@
 package hpccache
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storagecache/mgmt/2021-09-01/storagecache"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func CacheGetAccessPolicyRuleByScope(policyRules []storagecache.NfsAccessRule, scope storagecache.NfsAccessRuleScope) (storagecache.NfsAccessRule, bool) {
@@ -56,4 +60,37 @@ func CacheInsertOrUpdateAccessPolicy(policies []storagecache.NfsAccessPolicy, po
 	}
 
 	return append(newPolicies, policy), nil
+}
+
+func resourceHPCCacheWaitForCreating(ctx context.Context, client *storagecache.CachesClient, resourceGroup, name string, d *pluginsdk.ResourceData) (storagecache.Cache, error) {
+	state := &pluginsdk.StateChangeConf{
+		MinTimeout: 30 * time.Second,
+		Delay:      10 * time.Second,
+		Pending:    []string{string(storagecache.ProvisioningStateTypeCreating)},
+		Target:     []string{string(storagecache.ProvisioningStateTypeSucceeded)},
+		Refresh:    resourceHPCCacheRefresh(ctx, client, resourceGroup, name),
+		Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+	}
+
+	resp, err := state.WaitForStateContext(ctx)
+	if err != nil {
+		return resp.(storagecache.Cache), fmt.Errorf("waiting for the HPC Cache %q to be missing (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	return resp.(storagecache.Cache), nil
+}
+
+func resourceHPCCacheRefresh(ctx context.Context, client *storagecache.CachesClient, resourceGroup, name string) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return resp, "NotFound", nil
+			}
+
+			return resp, "Error", fmt.Errorf("making Read request on HPC Cache %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+
+		return resp, string(resp.ProvisioningState), nil
+	}
 }

--- a/internal/services/hpccache/hpc_cache.go
+++ b/internal/services/hpccache/hpc_cache.go
@@ -69,7 +69,7 @@ func resourceHPCCacheWaitForCreating(ctx context.Context, client *storagecache.C
 		Pending:    []string{string(storagecache.ProvisioningStateTypeCreating)},
 		Target:     []string{string(storagecache.ProvisioningStateTypeSucceeded)},
 		Refresh:    resourceHPCCacheRefresh(ctx, client, resourceGroup, name),
-		Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
 	}
 
 	resp, err := state.WaitForStateContext(ctx)

--- a/internal/services/hpccache/hpc_cache_blob_nfs_target_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_blob_nfs_target_resource_test.go
@@ -337,6 +337,10 @@ resource "azurerm_hpc_cache" "test" {
   subnet_id           = azurerm_subnet.test.id
   sku_name            = "Standard_2G"
 
+  timeouts {
+    create = "60m"
+  }
+
   # hpc_cache_blob_target depends on below role_assignments, however these role_assignments need up to 5 minutes to take effect.
   # Since hpc_cache_blob_target depends on the hpc_cache and hpc_cache takes far more than 5 minutes to create, put the dependency here so role_assignments are ready before creating hpc_cache_blob_target.
   depends_on = [

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -246,7 +246,7 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	d.SetId(id.ID())
 
-	//wait for HPC Cache provision state to be succeeded. or further operations with it may fail.
+	// wait for HPC Cache provision state to be succeeded. or further operations with it may fail.
 	cacheClient := meta.(*clients.Client).HPCCache.CachesClient
 	_, err = resourceHPCCacheWaitForCreating(ctx, cacheClient, resourceGroup, name, d)
 	if err != nil {

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -157,6 +157,10 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 			requireAdditionalUpdate = true
 		}
 
+		if d.IsNewResource() && autoKeyRotationEnabled {
+			requireAdditionalUpdate = true
+		}
+
 		keyVaultKeyId := v.(string)
 		keyVaultDetails, err := storageCacheRetrieveKeyVault(ctx, keyVaultsClient, resourcesClient, keyVaultKeyId)
 		if err != nil {
@@ -241,6 +245,13 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	d.SetId(id.ID())
+
+	//wait for HPC Cache provision state to be succeeded.
+	//cacheClient := meta.(*clients.Client).HPCCache.CachesClient
+	//_, err = resourceHPCCacheWaitForCreating(ctx, cacheClient, resourceGroup, name, d)
+	//if err != nil {
+	//	return fmt.Errorf("waiting for the HPC Cache provision state %s (Resource Group: %s) : %+v", name, resourceGroup, err)
+	//}
 
 	return resourceHPCCacheRead(d, meta)
 }

--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -156,7 +156,7 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 			// It is by design that `automatically_rotate_key_to_latest_enabled` changes to `false` when `key_vault_key_id` is changed, needs to do an additional update to set it back
 			requireAdditionalUpdate = true
 		}
-
+		// For new created resource `automatically_rotate_key_to_latest_enabled` needs an additional update to set it to true to.
 		if d.IsNewResource() && autoKeyRotationEnabled {
 			requireAdditionalUpdate = true
 		}
@@ -246,12 +246,12 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	d.SetId(id.ID())
 
-	//wait for HPC Cache provision state to be succeeded.
-	//cacheClient := meta.(*clients.Client).HPCCache.CachesClient
-	//_, err = resourceHPCCacheWaitForCreating(ctx, cacheClient, resourceGroup, name, d)
-	//if err != nil {
-	//	return fmt.Errorf("waiting for the HPC Cache provision state %s (Resource Group: %s) : %+v", name, resourceGroup, err)
-	//}
+	//wait for HPC Cache provision state to be succeeded. or further operations with it may fail.
+	cacheClient := meta.(*clients.Client).HPCCache.CachesClient
+	_, err = resourceHPCCacheWaitForCreating(ctx, cacheClient, resourceGroup, name, d)
+	if err != nil {
+		return fmt.Errorf("waiting for the HPC Cache provision state %s (Resource Group: %s) : %+v", name, resourceGroup, err)
+	}
 
 	return resourceHPCCacheRead(d, meta)
 }


### PR DESCRIPTION
test
---
```
TF_ACC=1 go test -v ./internal/services/hpccache -run=TestAccHPCCacheBlobNFSTarget_accessPolicy -timeout=600m                                
=== RUN   TestAccHPCCacheBlobNFSTarget_accessPolicy
=== PAUSE TestAccHPCCacheBlobNFSTarget_accessPolicy
=== CONT  TestAccHPCCacheBlobNFSTarget_accessPolicy
--- PASS: TestAccHPCCacheBlobNFSTarget_accessPolicy (2683.31s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/hpccache      2684.438s

TF_ACC=1 go test -v ./internal/services/hpccache -run=TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled -timeout=600m   
=== RUN   TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled
=== PAUSE TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled
=== CONT  TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled
--- PASS: TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled (2419.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/hpccache      2420.154s

```