### PR TITLE
`azurerm_logic_app_standard` - fix acctest

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -390,7 +390,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("expanding `app_settings`: %+v", err)
 	}
 	if vnetRouteAll, ok := appSettings["WEBSITE_VNET_ROUTE_ALL"]; ok {
-		if !d.HasChange("site_config.0.vnet_route_all_enabled") { // the HasChange method returned true when `site_config` is set without `vnet_route_all_enabled`
+		if !d.HasChange("site_config.0.vnet_route_all_enabled") {
 			vnetRouteAllEnabled, _ := strconv.ParseBool(*vnetRouteAll)
 			siteConfig.VnetRouteAllEnabled = &vnetRouteAllEnabled
 		}

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -444,7 +444,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("waiting for the update of %s: %+v", id, err)
 	}
 
-	if d.HasChange("site_config") { //update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
+	if d.HasChange("site_config") { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
 		siteConfigResource := web.SiteConfigResource{
 			SiteConfig: &siteConfig,
 		}
@@ -1221,7 +1221,7 @@ func expandLogicAppStandardSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig
 		siteConfig.FtpsState = web.FtpsState(v.(string))
 	}
 
-	//get from `d` rather than the config map, or it will be covered by the zero-value "0" instead of nil.
+	// get value from `d` rather than the `config` map, or it will be covered by the zero-value "0" instead of nil.
 	if v, ok := d.GetOk("site_config.0.pre_warmed_instance_count"); ok {
 		siteConfig.PreWarmedInstanceCount = utils.Int32(int32(v.(int)))
 	}

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1725,7 +1725,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
   tags = {
-    "SkipNRMSNSG"      = "true"
+    "SkipNRMSNSG" = "true"
   }
 }
 
@@ -1809,7 +1809,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
   tags = {
-    "SkipNRMSNSG"      = "true"
+    "SkipNRMSNSG" = "true"
   }
 }
 
@@ -1894,7 +1894,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
   tags = {
-    "SkipNRMSNSG"      = "true"
+    "SkipNRMSNSG" = "true"
   }
 }
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1724,6 +1724,9 @@ func (LogicAppStandardResource) vNetIntegration_basic(data acceptance.TestData) 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
+  tags = {
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -1805,6 +1808,9 @@ func (LogicAppStandardResource) vNetIntegration_subnet1(data acceptance.TestData
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
+  tags = {
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -1887,6 +1893,9 @@ func (LogicAppStandardResource) vNetIntegration_subnet2(data acceptance.TestData
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
+  tags = {
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_storage_account" "test" {


### PR DESCRIPTION
fix a bug in reading `site_config` block and adjust update order to improve acctest

<details>
<summary>test</summary>

```
 TF_ACC=1 go test -v ./internal/services/logic -run=TestAccLogicAppStandard -timeout=600m
=== RUN   TestAccLogicAppStandardDataSource_basic
=== PAUSE TestAccLogicAppStandardDataSource_basic
=== RUN   TestAccLogicAppStandard_basic
=== PAUSE TestAccLogicAppStandard_basic
=== RUN   TestAccLogicAppStandard_containerized
=== PAUSE TestAccLogicAppStandard_containerized
=== RUN   TestAccLogicAppStandard_extensionBundle
=== PAUSE TestAccLogicAppStandard_extensionBundle
=== RUN   TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
=== PAUSE TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
=== RUN   TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
=== PAUSE TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
=== RUN   TestAccLogicAppStandard_requiresImport
=== PAUSE TestAccLogicAppStandard_requiresImport
=== RUN   TestAccLogicAppStandard_tags
=== PAUSE TestAccLogicAppStandard_tags
=== RUN   TestAccLogicAppStandard_tagsUpdate
=== PAUSE TestAccLogicAppStandard_tagsUpdate
=== RUN   TestAccLogicAppStandard_appSettings
=== PAUSE TestAccLogicAppStandard_appSettings
=== RUN   TestAccLogicAppStandard_customShare
=== PAUSE TestAccLogicAppStandard_customShare
=== RUN   TestAccLogicAppStandard_siteConfig
=== PAUSE TestAccLogicAppStandard_siteConfig
=== RUN   TestAccLogicAppStandard_healthCheck
=== PAUSE TestAccLogicAppStandard_healthCheck
=== RUN   TestAccLogicAppStandard_connectionStrings
=== PAUSE TestAccLogicAppStandard_connectionStrings
=== RUN   TestAccLogicAppStandard_updateVersion
=== PAUSE TestAccLogicAppStandard_updateVersion
=== RUN   TestAccLogicAppStandard_3264bit
=== PAUSE TestAccLogicAppStandard_3264bit
=== RUN   TestAccLogicAppStandard_httpsOnly
=== PAUSE TestAccLogicAppStandard_httpsOnly
=== RUN   TestAccLogicAppStandard_createIdentity
=== PAUSE TestAccLogicAppStandard_createIdentity
=== RUN   TestAccLogicAppStandard_updateIdentity
=== PAUSE TestAccLogicAppStandard_updateIdentity
=== RUN   TestAccLogicAppStandard_corsSettings
=== PAUSE TestAccLogicAppStandard_corsSettings
=== RUN   TestAccLogicAppStandard_enableHttp2
=== PAUSE TestAccLogicAppStandard_enableHttp2
=== RUN   TestAccLogicAppStandard_minTlsVersion
=== PAUSE TestAccLogicAppStandard_minTlsVersion
=== RUN   TestAccLogicAppStandard_ftpsState
=== PAUSE TestAccLogicAppStandard_ftpsState
=== RUN   TestAccLogicAppStandard_preWarmedInstanceCount
=== PAUSE TestAccLogicAppStandard_preWarmedInstanceCount
=== RUN   TestAccLogicAppStandard_computedPreWarmedInstanceCount
=== PAUSE TestAccLogicAppStandard_computedPreWarmedInstanceCount
=== RUN   TestAccLogicAppStandard_oneIpRestriction
=== PAUSE TestAccLogicAppStandard_oneIpRestriction
=== RUN   TestAccLogicAppStandard_oneServiceTagIpRestriction
=== PAUSE TestAccLogicAppStandard_oneServiceTagIpRestriction
=== RUN   TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
=== PAUSE TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
=== RUN   TestAccLogicAppStandard_oneVNetSubnetIpRestriction
=== PAUSE TestAccLogicAppStandard_oneVNetSubnetIpRestriction
=== RUN   TestAccLogicAppStandard_ipRestrictionRemoved
=== PAUSE TestAccLogicAppStandard_ipRestrictionRemoved
=== RUN   TestAccLogicAppStandard_manyIpRestrictions
=== PAUSE TestAccLogicAppStandard_manyIpRestrictions
=== RUN   TestAccLogicAppStandard_updateStorageAccountKey
=== PAUSE TestAccLogicAppStandard_updateStorageAccountKey
=== RUN   TestAccLogicAppStandard_clientCertMode
=== PAUSE TestAccLogicAppStandard_clientCertMode
=== RUN   TestAccLogicAppStandard_elasticInstanceMinimum
=== PAUSE TestAccLogicAppStandard_elasticInstanceMinimum
=== RUN   TestAccLogicAppStandard_appScaleLimit
=== PAUSE TestAccLogicAppStandard_appScaleLimit
=== RUN   TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
=== PAUSE TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
=== RUN   TestAccLogicAppStandard_dotnetVersion4
=== PAUSE TestAccLogicAppStandard_dotnetVersion4
=== RUN   TestAccLogicAppStandard_dotnetVersion5
=== PAUSE TestAccLogicAppStandard_dotnetVersion5
=== RUN   TestAccLogicAppStandard_dotnetVersion6
=== PAUSE TestAccLogicAppStandard_dotnetVersion6
=== RUN   TestAccLogicAppStandard_vNetIntegration
=== PAUSE TestAccLogicAppStandard_vNetIntegration
=== RUN   TestAccLogicAppStandard_vNetIntegrationUpdate
=== PAUSE TestAccLogicAppStandard_vNetIntegrationUpdate
=== CONT  TestAccLogicAppStandardDataSource_basic
=== CONT  TestAccLogicAppStandard_minTlsVersion
=== CONT  TestAccLogicAppStandard_updateStorageAccountKey
=== CONT  TestAccLogicAppStandard_oneServiceTagIpRestriction
=== CONT  TestAccLogicAppStandard_siteConfig
=== CONT  TestAccLogicAppStandard_computedPreWarmedInstanceCount
=== CONT  TestAccLogicAppStandard_httpsOnly
=== CONT  TestAccLogicAppStandard_ipRestrictionRemoved
--- PASS: TestAccLogicAppStandardDataSource_basic (321.78s)
=== CONT  TestAccLogicAppStandard_3264bit
--- PASS: TestAccLogicAppStandard_httpsOnly (326.43s)
=== CONT  TestAccLogicAppStandard_updateVersion
--- PASS: TestAccLogicAppStandard_oneServiceTagIpRestriction (350.51s)
=== CONT  TestAccLogicAppStandard_connectionStrings
--- PASS: TestAccLogicAppStandard_computedPreWarmedInstanceCount (351.65s)
=== CONT  TestAccLogicAppStandard_healthCheck
--- PASS: TestAccLogicAppStandard_minTlsVersion (353.10s)
=== CONT  TestAccLogicAppStandard_preWarmedInstanceCount
--- PASS: TestAccLogicAppStandard_siteConfig (357.41s)
=== CONT  TestAccLogicAppStandard_ftpsState
--- PASS: TestAccLogicAppStandard_ipRestrictionRemoved (497.96s)
=== CONT  TestAccLogicAppStandard_dotnetVersion4
--- PASS: TestAccLogicAppStandard_ftpsState (252.44s)
=== CONT  TestAccLogicAppStandard_vNetIntegrationUpdate
--- PASS: TestAccLogicAppStandard_preWarmedInstanceCount (257.04s)
=== CONT  TestAccLogicAppStandard_vNetIntegration
--- PASS: TestAccLogicAppStandard_updateStorageAccountKey (627.76s)
=== CONT  TestAccLogicAppStandard_dotnetVersion6
--- PASS: TestAccLogicAppStandard_connectionStrings (312.73s)
=== CONT  TestAccLogicAppStandard_dotnetVersion5
--- PASS: TestAccLogicAppStandard_healthCheck (319.48s)
=== CONT  TestAccLogicAppStandard_oneIpRestriction
--- PASS: TestAccLogicAppStandard_updateVersion (417.37s)
=== CONT  TestAccLogicAppStandard_requiresImport
--- PASS: TestAccLogicAppStandard_dotnetVersion4 (254.07s)
=== CONT  TestAccLogicAppStandard_customShare
--- PASS: TestAccLogicAppStandard_3264bit (444.59s)
=== CONT  TestAccLogicAppStandard_appSettings
--- PASS: TestAccLogicAppStandard_dotnetVersion6 (325.61s)
=== CONT  TestAccLogicAppStandard_tagsUpdate
--- PASS: TestAccLogicAppStandard_dotnetVersion5 (314.21s)
=== CONT  TestAccLogicAppStandard_tags
--- PASS: TestAccLogicAppStandard_oneIpRestriction (314.54s)
=== CONT  TestAccLogicAppStandard_manyIpRestrictions
--- PASS: TestAccLogicAppStandard_vNetIntegration (392.05s)
=== CONT  TestAccLogicAppStandard_corsSettings
--- PASS: TestAccLogicAppStandard_customShare (309.25s)
=== CONT  TestAccLogicAppStandard_enableHttp2
--- PASS: TestAccLogicAppStandard_requiresImport (357.73s)
=== CONT  TestAccLogicAppStandard_extensionBundle
--- PASS: TestAccLogicAppStandard_appSettings (467.91s)
=== CONT  TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
--- PASS: TestAccLogicAppStandard_manyIpRestrictions (256.44s)
=== CONT  TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
--- PASS: TestAccLogicAppStandard_corsSettings (263.56s)
=== CONT  TestAccLogicAppStandard_updateIdentity
--- PASS: TestAccLogicAppStandard_tags (314.69s)
=== CONT  TestAccLogicAppStandard_oneVNetSubnetIpRestriction
--- PASS: TestAccLogicAppStandard_enableHttp2 (247.04s)
=== CONT  TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
--- PASS: TestAccLogicAppStandard_tagsUpdate (413.16s)
=== CONT  TestAccLogicAppStandard_appScaleLimit
--- PASS: TestAccLogicAppStandard_extensionBundle (351.14s)
=== CONT  TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
--- PASS: TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled (325.27s)
=== CONT  TestAccLogicAppStandard_containerized
--- PASS: TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled (320.81s)
=== CONT  TestAccLogicAppStandard_elasticInstanceMinimum
--- PASS: TestAccLogicAppStandard_oneVNetSubnetIpRestriction (292.38s)
=== CONT  TestAccLogicAppStandard_createIdentity
--- PASS: TestAccLogicAppStandard_vNetIntegrationUpdate (982.31s)
=== CONT  TestAccLogicAppStandard_clientCertMode
--- PASS: TestAccLogicAppStandard_appScaleLimit (309.27s)
=== CONT  TestAccLogicAppStandard_basic
--- PASS: TestAccLogicAppStandard_updateIdentity (441.47s)
--- PASS: TestAccLogicAppStandard_runtimeScaleMonitoringEnabled (370.32s)
--- PASS: TestAccLogicAppStandard_containerized (273.55s)
--- PASS: TestAccLogicAppStandard_changeIpToServiceTagIpRestriction (525.02s)
--- PASS: TestAccLogicAppStandard_createIdentity (287.79s)
--- PASS: TestAccLogicAppStandard_elasticInstanceMinimum (333.71s)
--- PASS: TestAccLogicAppStandard_basic (308.05s)
--- PASS: TestAccLogicAppStandard_clientCertMode (651.33s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 2243.520s
```

</details>