### PR TITLE
`azurerm_servicebus_namespace_disaster_recovery_config`: support alias_authorization_rule_id

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -48,6 +49,12 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: resourcegroups.ValidateName,
 				AtLeastOneOf: []string{"namespace_id", "resource_group_name", "namespace_name"},
+			},
+
+			"auth_rule_id_of_the_alias": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"partner_namespace_id": {
@@ -124,7 +131,16 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.Resour
 
 	d.SetId(id.ID())
 
-	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, d.Get("name").(string))
+	// the auth rule cannot be retrieved by dr config name, the shared access policy should either be specified by user or using the default one which is `RootManageSharedAccessKey`
+	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, serviceBusNamespaceDefaultAuthorizationRule)
+	if input := d.Get("auth_rule_id_of_the_alias").(string); input != "" {
+		ruleId, err := disasterrecoveryconfigs.ParseAuthorizationRuleID(input)
+		if err != nil {
+			return fmt.Errorf("parsing primary namespace auth rule id error: %+v", err)
+		}
+		authRuleId = *ruleId
+	}
+
 	keys, err := client.ListKeys(ctx, authRuleId)
 	if err != nil {
 		log.Printf("[WARN] listing default keys for %s: %+v", id, err)

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
@@ -51,7 +51,7 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 				AtLeastOneOf: []string{"namespace_id", "resource_group_name", "namespace_name"},
 			},
 
-			"auth_rule_id_of_the_alias": {
+			"alias_authorization_rule_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
@@ -133,7 +133,7 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.Resour
 
 	// the auth rule cannot be retrieved by dr config name, the shared access policy should either be specified by user or using the default one which is `RootManageSharedAccessKey`
 	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, serviceBusNamespaceDefaultAuthorizationRule)
-	if input := d.Get("auth_rule_id_of_the_alias").(string); input != "" {
+	if input := d.Get("alias_authorization_rule_id").(string); input != "" {
 		ruleId, err := disasterrecoveryconfigs.ParseAuthorizationRuleID(input)
 		if err != nil {
 			return fmt.Errorf("parsing primary namespace auth rule id error: %+v", err)

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
@@ -3,7 +3,6 @@ package servicebus
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"log"
 	"net/http"
 	"strconv"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
@@ -3,6 +3,7 @@ package servicebus
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"log"
 	"net/http"
 	"strconv"
@@ -57,6 +58,12 @@ func resourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ValidateFunc: azure.ValidateResourceIDOrEmpty,
+			},
+
+			"auth_rule_id_of_the_alias": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"primary_connection_string_alias": {
@@ -198,7 +205,15 @@ func resourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.Resource
 		}
 	}
 
-	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.Alias)
+	// the auth rule cannot be retrieved by dr config name, the shared access policy should either be specified by user or using the default one which is `RootManageSharedAccessKey`
+	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, serviceBusNamespaceDefaultAuthorizationRule)
+	if input := d.Get("auth_rule_id_of_the_alias").(string); input != "" {
+		ruleId, err := disasterrecoveryconfigs.ParseAuthorizationRuleID(input)
+		if err != nil {
+			return fmt.Errorf("parsing primary namespace auth rule id error: %+v", err)
+		}
+		authRuleId = *ruleId
+	}
 
 	keys, err := client.ListKeys(ctx, authRuleId)
 

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
@@ -60,7 +60,7 @@ func resourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 				ValidateFunc: azure.ValidateResourceIDOrEmpty,
 			},
 
-			"auth_rule_id_of_the_alias": {
+			"alias_authorization_rule_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
@@ -207,7 +207,7 @@ func resourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.Resource
 
 	// the auth rule cannot be retrieved by dr config name, the shared access policy should either be specified by user or using the default one which is `RootManageSharedAccessKey`
 	authRuleId := disasterrecoveryconfigs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, serviceBusNamespaceDefaultAuthorizationRule)
-	if input := d.Get("auth_rule_id_of_the_alias").(string); input != "" {
+	if input := d.Get("alias_authorization_rule_id").(string); input != "" {
 		ruleId, err := disasterrecoveryconfigs.ParseAuthorizationRuleID(input)
 		if err != nil {
 			return fmt.Errorf("parsing primary namespace auth rule id error: %+v", err)

--- a/internal/services/servicebus/servicebus_topic_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_resource_test.go
@@ -89,18 +89,21 @@ func TestAccServiceBusTopic_basicDisableEnable(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.basicDisabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -115,6 +118,7 @@ func TestAccServiceBusTopic_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -122,6 +126,7 @@ func TestAccServiceBusTopic_update(t *testing.T) {
 				check.That(data.ResourceName).Key("enable_express").HasValue("true"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -136,6 +141,7 @@ func TestAccServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.enablePartitioningStandard(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -174,6 +180,7 @@ func TestAccServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.enablePartitioningPremium(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -196,6 +203,7 @@ func TestAccServiceBusTopic_enableDuplicateDetection(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.enableDuplicateDetection(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -46,9 +46,9 @@ resource "azurerm_servicebus_namespace_authorization_rule" "example" {
 }
 
 resource "azurerm_servicebus_namespace_disaster_recovery_config" "example" {
-  name                      = "servicebus-alias-name"
-  primary_namespace_id      = azurerm_servicebus_namespace.primary.id
-  partner_namespace_id      = azurerm_servicebus_namespace.secondary.id
+  name                        = "servicebus-alias-name"
+  primary_namespace_id        = azurerm_servicebus_namespace.primary.id
+  partner_namespace_id        = azurerm_servicebus_namespace.secondary.id
   alias_authorization_rule_id = azurerm_servicebus_namespace_authorization_rule.example.id
 }
 

--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_servicebus_namespace_disaster_recovery_config" "example" {
   name                      = "servicebus-alias-name"
   primary_namespace_id      = azurerm_servicebus_namespace.primary.id
   partner_namespace_id      = azurerm_servicebus_namespace.secondary.id
-  auth_rule_id_of_the_alias = azurerm_servicebus_namespace_authorization_rule.example.id
+  alias_authorization_rule_id = azurerm_servicebus_namespace_authorization_rule.example.id
 }
 
 ```
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `partner_namespace_id` - (Required) The ID of the Service Bus Namespace to replicate to.
 
-* `auth_rule_id_of_the_alias` - (Optional) The Shared access policies used to access the connection string for the alias. Defaults to `RootManageSharedAccessKey`.
+* `alias_authorization_rule_id` - (Optional) The Shared access policies used to access the connection string for the alias. Defaults to `RootManageSharedAccessKey`.
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace_disaster_recovery_config"
 description: |-
-  Manages a Disaster Recovery Config for a Service Bus Namespace.
+Manages a Disaster Recovery Config for a Service Bus Namespace.
 ---
 
 # azurerm_servicebus_namespace_disaster_recovery_config
 
 Manages a Disaster Recovery Config for a Service Bus Namespace.
 
-~> **NOTE:** Disaster Recovery Config is a Premium SKU only capability. 
+~> **NOTE:** Disaster Recovery Config is a Premium SKU only capability.
 
 ## Example Usage
 
@@ -36,10 +36,20 @@ resource "azurerm_servicebus_namespace" "secondary" {
   capacity            = "1"
 }
 
+resource "azurerm_servicebus_namespace_authorization_rule" "example" {
+  name         = "examplerule"
+  namespace_id = azurerm_servicebus_namespace.example.id
+
+  listen = true
+  send   = true
+  manage = false
+}
+
 resource "azurerm_servicebus_namespace_disaster_recovery_config" "example" {
-  name                 = "servicebus-alias-name"
-  primary_namespace_id = azurerm_servicebus_namespace.primary.id
-  partner_namespace_id = azurerm_servicebus_namespace.secondary.id
+  name                      = "servicebus-alias-name"
+  primary_namespace_id      = azurerm_servicebus_namespace.primary.id
+  partner_namespace_id      = azurerm_servicebus_namespace.secondary.id
+  auth_rule_id_of_the_alias = azurerm_servicebus_namespace_authorization_rule.example.id
 }
 
 ```
@@ -54,6 +64,8 @@ The following arguments are supported:
 
 * `partner_namespace_id` - (Required) The ID of the Service Bus Namespace to replicate to.
 
+* `auth_rule_id_of_the_alias` - (Optional) The Shared access policies used to access the connection string for the alias. Defaults to `RootManageSharedAccessKey`.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -62,7 +74,7 @@ The following attributes are exported:
 
 * `primary_connection_string_alias` - The alias Primary Connection String for the ServiceBus Namespace.
 
-* `secondary_connection_string_alias` - The alias Secondary Connection String for the ServiceBus Namespace 
+* `secondary_connection_string_alias` - The alias Secondary Connection String for the ServiceBus Namespace
 
 * `default_primary_key` - The primary access key for the authorization rule `RootManageSharedAccessKey`.
 
@@ -70,7 +82,8 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+The `timeouts` block allows you to
+specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Service Bus Namespace Disaster Recovery Config.
 * `update` - (Defaults to 30 minutes) Used when updating the Service Bus Namespace Disaster Recovery Config.

--- a/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/servicebus_namespace_disaster_recovery_config.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace_disaster_recovery_config"
 description: |-
-Manages a Disaster Recovery Config for a Service Bus Namespace.
+  Manages a Disaster Recovery Config for a Service Bus Namespace.
 ---
 
 # azurerm_servicebus_namespace_disaster_recovery_config
@@ -82,8 +82,7 @@ The following attributes are exported:
 
 ## Timeouts
 
-The `timeouts` block allows you to
-specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Service Bus Namespace Disaster Recovery Config.
 * `update` - (Defaults to 30 minutes) Used when updating the Service Bus Namespace Disaster Recovery Config.


### PR DESCRIPTION
The dr alias connection string should be accessed by specifying the shared access policy which is having a default value `RootManageSharedAccessKey`, instead of using the alias name directly. 

fix failed acc tests"
`testcase.go:110: Step 1/1 error: Check failed: Check 4/7 error: data.azurerm_servicebus_namespace_disaster_recovery_config.test: Attribute 'primary_connection_string_alias' expected to be set`

in this pr, also add importSteps in test cases for servicebus

fix #18743 