### PR TITLE
Fix broken AccTests - `azurerm_api_management`

### DIFF
--- a/internal/services/apimanagement/api_management_resource_test.go
+++ b/internal/services/apimanagement/api_management_resource_test.go
@@ -120,12 +120,6 @@ func TestAccApiManagement_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("hostname_configuration.0.portal.0.expiry").Exists(),
 				check.That(data.ResourceName).Key("hostname_configuration.0.portal.0.subject").Exists(),
 				check.That(data.ResourceName).Key("hostname_configuration.0.portal.0.thumbprint").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.0.expiry").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.0.subject").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.0.thumbprint").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.1.expiry").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.1.subject").Exists(),
-				check.That(data.ResourceName).Key("hostname_configuration.0.proxy.1.thumbprint").Exists(),
 			),
 		},
 		{
@@ -143,10 +137,10 @@ func TestAccApiManagement_complete(t *testing.T) {
 				"hostname_configuration.0.portal.0.certificate_password",           // not returned from API, sensitive
 				"hostname_configuration.0.developer_portal.0.certificate",          // not returned from API, sensitive
 				"hostname_configuration.0.developer_portal.0.certificate_password", // not returned from API, sensitive
-				"hostname_configuration.0.proxy.0.certificate",                     // not returned from API, sensitive
-				"hostname_configuration.0.proxy.0.certificate_password",            // not returned from API, sensitive
 				"hostname_configuration.0.proxy.1.certificate",                     // not returned from API, sensitive
 				"hostname_configuration.0.proxy.1.certificate_password",            // not returned from API, sensitive
+				"hostname_configuration.0.proxy.2.certificate",                     // not returned from API, sensitive
+				"hostname_configuration.0.proxy.2.certificate_password",            // not returned from API, sensitive
 			},
 		},
 	})
@@ -168,10 +162,10 @@ func TestAccApiManagement_completeUpdateAdditionalLocations(t *testing.T) {
 			"hostname_configuration.0.portal.0.certificate_password",           // not returned from API, sensitive
 			"hostname_configuration.0.developer_portal.0.certificate",          // not returned from API, sensitive
 			"hostname_configuration.0.developer_portal.0.certificate_password", // not returned from API, sensitive
-			"hostname_configuration.0.proxy.0.certificate",                     // not returned from API, sensitive
-			"hostname_configuration.0.proxy.0.certificate_password",            // not returned from API, sensitive
 			"hostname_configuration.0.proxy.1.certificate",                     // not returned from API, sensitive
 			"hostname_configuration.0.proxy.1.certificate_password",            // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate",                     // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate_password",            // not returned from API, sensitive
 		),
 		{
 			Config: r.completeUpdateAdditionalLocations(data),
@@ -184,10 +178,10 @@ func TestAccApiManagement_completeUpdateAdditionalLocations(t *testing.T) {
 			"hostname_configuration.0.portal.0.certificate_password",           // not returned from API, sensitive
 			"hostname_configuration.0.developer_portal.0.certificate",          // not returned from API, sensitive
 			"hostname_configuration.0.developer_portal.0.certificate_password", // not returned from API, sensitive
-			"hostname_configuration.0.proxy.0.certificate",                     // not returned from API, sensitive
-			"hostname_configuration.0.proxy.0.certificate_password",            // not returned from API, sensitive
 			"hostname_configuration.0.proxy.1.certificate",                     // not returned from API, sensitive
 			"hostname_configuration.0.proxy.1.certificate_password",            // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate",                     // not returned from API, sensitive
+			"hostname_configuration.0.proxy.2.certificate_password",            // not returned from API, sensitive
 		),
 	})
 }
@@ -1154,10 +1148,12 @@ resource "azurerm_api_management" "test" {
   sku_name = "Premium_2"
 
   additional_location {
+    zones    = []
     location = azurerm_resource_group.test2.location
   }
 
   additional_location {
+    zones    = []
     location = azurerm_resource_group.test3.location
   }
 
@@ -1208,6 +1204,11 @@ resource "azurerm_api_management" "test" {
 
   hostname_configuration {
     proxy {
+      host_name                    = "acctestAM-%d.azure-api.net"
+      negotiate_client_certificate = true
+    }
+
+    proxy {
       host_name                    = "api.terraform.io"
       certificate                  = filebase64("testdata/api_management_api_test.pfx")
       certificate_password         = "terraform"
@@ -1242,7 +1243,7 @@ resource "azurerm_api_management" "test" {
   location            = azurerm_resource_group.test1.location
   resource_group_name = azurerm_resource_group.test1.name
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.Locations.Ternary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.Locations.Ternary, data.RandomInteger, data.RandomInteger)
 }
 
 func (ApiManagementResource) completeUpdateAdditionalLocations(data acceptance.TestData) string {
@@ -1325,6 +1326,11 @@ resource "azurerm_api_management" "test" {
   }
 
   hostname_configuration {
+	proxy {
+      host_name                    = "acctestAM-%d.azure-api.net"
+      negotiate_client_certificate = true
+    }
+
     proxy {
       host_name                    = "api.terraform.io"
       certificate                  = filebase64("testdata/api_management_api_test.pfx")
@@ -1360,7 +1366,7 @@ resource "azurerm_api_management" "test" {
   location            = azurerm_resource_group.test1.location
   resource_group_name = azurerm_resource_group.test1.name
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.Locations.Ternary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.Locations.Ternary, data.RandomInteger, data.RandomInteger)
 }
 
 func (ApiManagementResource) virtualNetworkTemplate(data acceptance.TestData) string {

--- a/internal/services/apimanagement/api_management_resource_test.go
+++ b/internal/services/apimanagement/api_management_resource_test.go
@@ -1326,7 +1326,7 @@ resource "azurerm_api_management" "test" {
   }
 
   hostname_configuration {
-	proxy {
+    proxy {
       host_name                    = "acctestAM-%d.azure-api.net"
       negotiate_client_certificate = true
     }
@@ -1886,6 +1886,11 @@ resource "azurerm_api_management" "test" {
 
   hostname_configuration {
     proxy {
+      host_name                    = "acctestAM-%d.azure-api.net"
+      negotiate_client_certificate = true
+    }
+
+    proxy {
       host_name                    = "api.pluginsdk.io"
       key_vault_id                 = azurerm_key_vault_certificate.test.versionless_secret_id
       default_ssl_binding          = true
@@ -1893,7 +1898,7 @@ resource "azurerm_api_management" "test" {
     }
   }
 }
-`, r.identitySystemAssignedUpdateHostnameConfigurationsTemplate(data), data.RandomInteger)
+`, r.identitySystemAssignedUpdateHostnameConfigurationsTemplate(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApiManagementResource) identitySystemAssignedUpdateHostnameConfigurationsVersionedKeyVaultIdUpdateCD(data acceptance.TestData) string {
@@ -1915,6 +1920,11 @@ resource "azurerm_api_management" "test" {
 
   hostname_configuration {
     proxy {
+      host_name                    = "acctestAM-%d.azure-api.net"
+      negotiate_client_certificate = true
+    }
+
+    proxy {
       host_name                    = "api.pluginsdk.io"
       key_vault_id                 = azurerm_key_vault_certificate.test.secret_id
       default_ssl_binding          = true
@@ -1922,7 +1932,7 @@ resource "azurerm_api_management" "test" {
     }
   }
 }
-`, r.identitySystemAssignedUpdateHostnameConfigurationsTemplate(data), data.RandomInteger)
+`, r.identitySystemAssignedUpdateHostnameConfigurationsTemplate(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (ApiManagementResource) identityUserAssignedHostnameConfigurationsKeyVaultId(data acceptance.TestData) string {
@@ -2037,6 +2047,11 @@ resource "azurerm_api_management" "test" {
   sku_name = "Developer_1"
 
   hostname_configuration {
+    proxy {
+      host_name                    = "acctestAM-%[1]d.azure-api.net"
+      negotiate_client_certificate = true
+    }
+
     proxy {
       host_name                       = "api.terraform.io"
       key_vault_id                    = azurerm_key_vault_certificate.test.secret_id


### PR DESCRIPTION
```log
=== RUN   TestAccApiManagement_complete
=== PAUSE TestAccApiManagement_complete
=== RUN   TestAccApiManagement_completeUpdateAdditionalLocations
=== PAUSE TestAccApiManagement_completeUpdateAdditionalLocations
=== CONT  TestAccApiManagement_complete
=== CONT  TestAccApiManagement_completeUpdateAdditionalLocations
--- PASS: TestAccApiManagement_complete (2828.65s)
--- PASS: TestAccApiManagement_completeUpdateAdditionalLocations (3225.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 3274.302s

=== RUN   TestAccApiManagement_identityUserAssignedHostnameConfigurationsKeyVaultId
=== PAUSE TestAccApiManagement_identityUserAssignedHostnameConfigurationsKeyVaultId
=== RUN   TestAccApiManagement_identityUserAssigned
=== PAUSE TestAccApiManagement_identityUserAssigned
=== RUN   TestAccApiManagement_identityUserAssignedUpdateNone
=== PAUSE TestAccApiManagement_identityUserAssignedUpdateNone
=== CONT  TestAccApiManagement_identityUserAssignedHostnameConfigurationsKeyVaultId
=== CONT  TestAccApiManagement_identityUserAssignedUpdateNone
=== CONT  TestAccApiManagement_identityUserAssigned
--- PASS: TestAccApiManagement_identityUserAssignedUpdateNone (5477.81s)
--- PASS: TestAccApiManagement_identityUserAssigned (5530.66s)
--- PASS: TestAccApiManagement_identityUserAssignedHostnameConfigurationsKeyVaultId (5567.10s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 5616.752s
```