### PR TITLE
`azurerm_firewall_policy_rule_collection_group`- add `Mssql` as an option for `type` validation

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -111,6 +111,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 													ValidateFunc: validation.StringInSlice([]string{
 														string(network.FirewallPolicyRuleApplicationProtocolTypeHTTP),
 														string(network.FirewallPolicyRuleApplicationProtocolTypeHTTPS),
+														"Mssql",
 													}, false),
 												},
 												"port": {

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -242,6 +242,10 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
         type = "Https"
         port = 443
       }
+      protocols {
+        type = "Mssql"
+        port = 1443
+      }
       source_addresses      = ["10.0.0.1"]
       destination_fqdn_tags = ["WindowsDiagnostics"]
     }


### PR DESCRIPTION
fixes #13980