### PR TITLE
sticky_settings should use "Windows Web App"

### DIFF
--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -518,9 +518,9 @@ A `status_code` block supports the following:
 
 A `sticky_settings` block exports the following:
 
-* `app_setting_names` - (Optional) A list of `app_setting` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
+* `app_setting_names` - (Optional) A list of `app_setting` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
-* `connection_string_names` - (Optional) A list of `connection_string` names that the Linux Web App will not swap between Slots when a swap operation is triggered.
+* `connection_string_names` - (Optional) A list of `connection_string` names that the Windows Web App will not swap between Slots when a swap operation is triggered.
 
 ---
 


### PR DESCRIPTION
The documentation for the `sticky_settings` block references "Linux Web App" in a couple places even though this is the documentation for a "Windows Web App".  This commit updates the documentation appropriately.