### PR TITLE
[Test Case]: Fix acctest for Log Analytics Workspace Data Source

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_data_source_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceLogAnalyticsWorkspace_basic(t *testing.T) {
 		{
 			Config: r.basicWithDataSource(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue("pergb2018"),
+				check.That(data.ResourceName).Key("sku").HasValue("PerGB2018"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("30"),
 				check.That(data.ResourceName).Key("daily_quota_gb").HasValue("-1"),
 			),
@@ -35,7 +35,7 @@ func TestAccDataSourceLogAnalyticsWorkspace_volumeCapWithDataSource(t *testing.T
 		{
 			Config: r.volumeCapWithDataSource(data, 4.5),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue("pergb2018"),
+				check.That(data.ResourceName).Key("sku").HasValue("PerGB2018"),
 				check.That(data.ResourceName).Key("retention_in_days").HasValue("30"),
 				check.That(data.ResourceName).Key("daily_quota_gb").HasValue("4.5"),
 			),


### PR DESCRIPTION
The service API returns standard sku name like "PerGB2018" but test case of Log Analytics Data Source expects lower case "pergb2018" so that the test case is failed. So submitted this PR to fix this issue.

--- PASS: TestAccDataSourceLogAnalyticsWorkspace_volumeCapWithDataSource (308.99s)
--- PASS: TestAccDataSourceLogAnalyticsWorkspace_basic (243.66s)

![image](https://user-images.githubusercontent.com/19754191/195751738-f258be60-7790-40e5-b8e6-625e59e1c1a1.png)
