### PR TITLE
`azurerm_fluid_relay_server` - support `service_endpoint` attribute

### DIFF
--- a/internal/services/fluidrelay/fluid_relay_servers_resource.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource.go
@@ -26,6 +26,7 @@ type ServerModel struct {
 	FrsTenantId      string                                     `tfschema:"frs_tenant_id"`
 	OrdererEndpoints []string                                   `tfschema:"orderer_endpoints"`
 	StorageEndpoints []string                                   `tfschema:"storage_endpoints"`
+	ServiceEndpoints []string                                   `tfschema:"service_endpoints"`
 	Tags             map[string]string                          `tfschema:"tags"`
 	Identity         []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
 }
@@ -87,6 +88,7 @@ func (s Server) Attributes() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
+
 		"orderer_endpoints": {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
@@ -94,7 +96,16 @@ func (s Server) Attributes() map[string]*pluginsdk.Schema {
 				Type: pluginsdk.TypeString,
 			},
 		},
+
 		"storage_endpoints": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"service_endpoints": {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
 			Elem: &pluginsdk.Schema{
@@ -235,6 +246,10 @@ func (s Server) Read() sdk.ResourceFunc {
 					}
 					if points.StorageEndpoints != nil {
 						output.StorageEndpoints = *points.StorageEndpoints
+					}
+
+					if points.ServiceEndpoints != nil {
+						output.ServiceEndpoints = *points.ServiceEndpoints
 					}
 				}
 			}

--- a/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
@@ -49,6 +49,7 @@ func TestAccFluidRelay_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(f),
 				check.That(data.ResourceName).Key("frs_tenant_id").IsUUID(),
 				check.That(data.ResourceName).Key("orderer_endpoints.0").Exists(),
+				check.That(data.ResourceName).Key("service_endpoints.#").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/fluid_relay_servers.html.markdown
+++ b/website/docs/r/fluid_relay_servers.html.markdown
@@ -65,6 +65,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `storage_endpoints` - An array of storage endpoints for this Fluid Relay Server.
 
+* `service_endpoints` - An array of service endpoints for this Fluid Relay Server.
+
 ---
 
 `identity` exports the following:


### PR DESCRIPTION
add missing attributes. relate issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/18755

```
=== RUN   TestAccFluidRelay_basic
=== PAUSE TestAccFluidRelay_basic
=== CONT  TestAccFluidRelay_basic
--- PASS: TestAccFluidRelay_basic (169.36s)
PASS
```