### PR TITLE
`azurerm_fluid_relay_server` - add `primary_key` and `secondary_key` properties

### DIFF
--- a/internal/services/fluidrelay/fluid_relay_servers_resource.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource.go
@@ -116,13 +116,15 @@ func (s Server) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"primary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 
 		"secondary_key": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 	}
 }
@@ -272,7 +274,7 @@ func (s Server) Read() sdk.ResourceFunc {
 			keyRes, err := client.ListKeys(ctx, *id)
 			if err != nil {
 				// do not return if only list keys error
-				meta.Logger.Warnf("retrieving relay server keys err: %v", err)
+				meta.Logger.Warnf("retrieving keys for %s: %v", *id, err)
 			}
 			if keys := keyRes.Model; model != nil {
 				output.PrimaryKey = utils.NormalizeNilableString(keys.Key1)

--- a/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
@@ -48,6 +48,7 @@ func TestAccFluidRelay_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(f),
 				check.That(data.ResourceName).Key("frs_tenant_id").IsUUID(),
+				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("orderer_endpoints.0").Exists(),
 				check.That(data.ResourceName).Key("service_endpoints.#").Exists(),
 			),

--- a/website/docs/r/fluid_relay_servers.html.markdown
+++ b/website/docs/r/fluid_relay_servers.html.markdown
@@ -61,6 +61,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `frs_tenant_id` - The Fluid tenantId for this server.
 
+* `primary_key` - The primary key for this server.
+
+* `secondary_key` - The secondary key for this server.
+
 * `orderer_endpoints` - An array of the Fluid Relay Orderer endpoints.
 
 * `storage_endpoints` - An array of storage endpoints for this Fluid Relay Server.


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18755 

```
=== RUN   TestAccFluidRelay_basic
=== PAUSE TestAccFluidRelay_basic
=== CONT  TestAccFluidRelay_basic
--- PASS: TestAccFluidRelay_basic (142.01s)
PASS
```