### PR TITLE
`azurerm_firewall_policy_rule_collection_group` - limit dnat rule destination port max number to 1

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -386,6 +386,8 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 									"destination_ports": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
+										// only support 1 destination port in one DNAT rule
+										MaxItems: 1,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
 											ValidateFunc: azValidate.PortOrPortRangeWithin(1, 64000),

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -192,7 +192,7 @@ A `rule` (NAT rule) block supports the following:
 
 * `destination_address` - (Optional) The destination IP address (including CIDR).
 
-* `destination_ports` - (Optional) Specifies a list of destination ports. Only one destination port is supported in DNAT rule.
+* `destination_ports` - (Optional) Specifies a list of destination ports. Only one destination port is supported in a NAT rule.
 
 * `translated_address` - (Optional) Specifies the translated address.
  

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "example" {
       protocols           = ["TCP", "UDP"]
       source_addresses    = ["10.0.0.1", "10.0.0.2"]
       destination_address = "192.168.1.1"
-      destination_ports   = ["80", "1000-2000"]
+      destination_ports   = ["80"]
       translated_address  = "192.168.0.1"
       translated_port     = "8080"
     }
@@ -192,7 +192,7 @@ A `rule` (NAT rule) block supports the following:
 
 * `destination_address` - (Optional) The destination IP address (including CIDR).
 
-* `destination_ports` - (Optional) Specifies a list of destination ports.
+* `destination_ports` - (Optional) Specifies a list of destination ports. Only one destination port is supported in DNAT rule.
 
 * `translated_address` - (Optional) Specifies the translated address.
  


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18725

I have reproduced this bug locally, looks like a server-side limitation on this parameter. the detailed error message is below. so I simply add a MaxItem limit to it so it is exposed in the `terraform plan` stage. This looks like **breaking change**, Or should we only update the document but not add the `MaxItems` limit in the code?

```json
{
    "error": {
        "code": "FirewallPolicyNatRuleInvalidDnatMultipleDestinationPortsExists",
        "message": "Firewall Policy Nat Rule Collection: nat_rule_collection1 Rule: nat_rule_collection1_rule1 has Multiple Destination Ports on a DNAT Rule. This is not supported, please set only 1 destination port on this rule."
    },
    "status": "Failed"
}
```

cc @neil-yechenwei if you know more context about this feature? I found you have worked on this before, Thanks.