### PR TITLE
fix: Removed invalid storage_account_type value

### DIFF
--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -115,7 +115,7 @@ The following arguments are supported:
 
 ~> **Note:** The default `sku_name` value may differ between Azure locations depending on local availability of Gen4/Gen5 capacity. When databases are replicated using the `creation_source_database_id` property, the source (primary) database cannot have a higher SKU service tier than any secondary databases. When changing the `sku_name` of a database having one or more secondary databases, this resource will first update any secondary databases as necessary. In such cases it's recommended to use the same `sku_name` in your configuration for all related databases, as not doing so may cause an unresolvable diff during subsequent plans.
 
-* `storage_account_type` - (Optional) Specifies the storage account type used to store backups for this database. Possible values are `Geo`, `GeoZone`, `Local` and `Zone`.  The default value is `Geo`.
+* `storage_account_type` - (Optional) Specifies the storage account type used to store backups for this database. Possible values are `Geo`, `Local` and `Zone`. The default value is `Geo`.
 
 * `threat_detection_policy` - (Optional) Threat detection policy configuration. The `threat_detection_policy` block supports fields documented below.
 


### PR DESCRIPTION
* `GeoZone` is not a valid value for the `storage_account_type` attribute.
* If you did happen to have provided `GeoZone` as an argument, you'd then receive this error response:
```
Error: expected storage_account_type to be one of [Geo Local Zone], got GeoZone
 
 with module.mssql_database.azurerm_mssql_database.mssql_db,
 on ../../main.tf line 58, in resource "azurerm_mssql_database" "mssql_db":
 58:   storage_account_type          = local.storage_account_type
``` 