### PR TITLE
azurerm_dns_zone - Update SOA record ID parser for Microsoft's casing

### DIFF
--- a/internal/services/dns/parse/soa_record.go
+++ b/internal/services/dns/parse/soa_record.go
@@ -36,7 +36,7 @@ func (id SoaRecordId) String() string {
 }
 
 func (id SoaRecordId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/dnszones/%s/SOA/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/dnsZones/%s/SOA/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.SOAName)
 }
 

--- a/internal/services/dns/parse/soa_record.go
+++ b/internal/services/dns/parse/soa_record.go
@@ -60,7 +60,7 @@ func SoaRecordID(input string) (*SoaRecordId, error) {
 		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
 	}
 
-	if resourceId.DnszoneName, err = id.PopSegment("dnszones"); err != nil {
+	if resourceId.DnszoneName, err = id.PopSegment("dnsZones"); err != nil {
 		return nil, err
 	}
 	if resourceId.SOAName, err = id.PopSegment("SOA"); err != nil {


### PR DESCRIPTION
Microsoft is returning an ID with slightly different casing. This is causing replacements due to the changed ID.

```
  # module.aks_cluster.azurerm_management_lock.dns_zone_soa must be replaced
-/+ resource "azurerm_management_lock" "dns_zone_soa" {
      ~ id         = "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/dnszones/<dns-zone>/SOA/@/providers/Microsoft.Authorization/locks/<dns-zone>-lock" -> (known after apply)
        name       = "<dns-zone>-lock"
      ~ scope      = "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/dnszones/<dns-zone>/SOA/@" -> "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/dnsZones/<dns-zone>/SOA/@" # forces replacement
        # (2 unchanged attributes hidden)
    }

```
