### PR TITLE
Add resource_guid attribute to private_endpoint

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -271,6 +271,11 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 				},
 			},
 
+			"resource_guid": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -642,6 +647,7 @@ func resourcePrivateEndpointRead(d *pluginsdk.ResourceData, meta interface{}) er
 		}
 		d.Set("custom_network_interface_name", customNicName)
 
+		d.Set("resource_guid", props.ResourceGUID)
 	}
 
 	privateDnsZoneConfigs := make([]interface{}, 0)


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/issues/17011

Checks fail because of change needed in vendored `azure-sdk-for-go` library: https://github.com/Azure/azure-sdk-for-go/pull/19362