### PR TITLE
New resources: `azurerm_iothub_device_update_account` `azurerm_iothub_device_update_instance`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -78,6 +78,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // IoT Central is only available in certain locations
         "iotcentral" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "southeastasia", "eastus2", false)),
 
+        // IoT Hub Device Update is only available in certain locations
+        "iothub" to testConfiguration(locationOverride = LocationConfiguration("northeurope", "eastus2", "westus2", false)),
+
         // Log Analytics Clusters have a max deployments of 2 - parallelism set to 1 or `importTest` fails
         "loganalytics" to testConfiguration(parallelism = 1),
 

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -133,6 +133,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		domainservices.Registration{},
 		eventhub.Registration{},
 		fluidrelay.Registration{},
+		iothub.Registration{},
 		iotcentral.Registration{},
 		keyvault.Registration{},
 		loadbalancer.Registration{},

--- a/internal/services/iothub/client/client.go
+++ b/internal/services/iothub/client/client.go
@@ -4,12 +4,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/iothub/mgmt/2021-07-02/devices"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
 	ResourceClient          *devices.IotHubResourceClient
 	IotHubCertificateClient *devices.CertificatesClient
+	DeviceUpdatesClient     *deviceupdates.DeviceupdatesClient
 	DPSResourceClient       *iotdpsresource.IotDpsResourceClient
 	DPSCertificateClient    *dpscertificate.DpsCertificateClient
 }
@@ -21,6 +23,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	IotHubCertificateClient := devices.NewCertificatesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&IotHubCertificateClient.Client, o.ResourceManagerAuthorizer)
 
+	DeviceUpdatesClient := deviceupdates.NewDeviceupdatesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&DeviceUpdatesClient.Client, o.ResourceManagerAuthorizer)
+
 	DPSResourceClient := iotdpsresource.NewIotDpsResourceClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&DPSResourceClient.Client, o.ResourceManagerAuthorizer)
 
@@ -30,6 +35,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	return &Client{
 		ResourceClient:          &ResourceClient,
 		IotHubCertificateClient: &IotHubCertificateClient,
+		DeviceUpdatesClient:     &DeviceUpdatesClient,
 		DPSResourceClient:       &DPSResourceClient,
 		DPSCertificateClient:    &DPSCertificateClient,
 	}

--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -1,0 +1,284 @@
+package iothub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type IotHubDeviceUpdateAccountResource struct{}
+
+var (
+	_ sdk.ResourceWithUpdate = IotHubDeviceUpdateAccountResource{}
+)
+
+type IotHubDeviceUpdateAccountModel struct {
+	Name                string                            `tfschema:"name"`
+	ResourceGroupName   string                            `tfschema:"resource_group_name"`
+	Location            string                            `tfschema:"location"`
+	HostName            string                            `tfschema:"host_name"`
+	PublicNetworkAccess deviceupdates.PublicNetworkAccess `tfschema:"public_network_access"`
+	Sku                 deviceupdates.SKU                 `tfschema:"sku"`
+	Tags                map[string]string                 `tfschema:"tags"`
+}
+
+func (r IotHubDeviceUpdateAccountResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.IotHubDeviceUpdateAccountName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"location": commonschema.Location(),
+
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+
+		"public_network_access": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  deviceupdates.PublicNetworkAccessEnabled,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(deviceupdates.PublicNetworkAccessEnabled),
+				string(deviceupdates.PublicNetworkAccessDisabled),
+			}, false),
+		},
+
+		"sku": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  deviceupdates.SKUStandard,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(deviceupdates.SKUFree),
+				string(deviceupdates.SKUStandard),
+			}, false),
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r IotHubDeviceUpdateAccountResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"host_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateAccountResource) ResourceType() string {
+	return "azurerm_iothub_device_update_account"
+}
+
+func (r IotHubDeviceUpdateAccountResource) ModelObject() interface{} {
+	return &IotHubDeviceUpdateInstanceModel{}
+}
+
+func (r IotHubDeviceUpdateAccountResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return deviceupdates.ValidateAccountID
+}
+
+func (r IotHubDeviceUpdateAccountResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model IotHubDeviceUpdateAccountModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := deviceupdates.NewAccountID(subscriptionId, model.ResourceGroupName, model.Name)
+			existing, err := client.AccountsGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			identityValue, err := identity.ExpandLegacySystemAndUserAssignedMap(metadata.ResourceData.Get("identity").([]interface{}))
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			input := &deviceupdates.Account{
+				Location: location.Normalize(model.Location),
+				Identity: identityValue,
+				Properties: &deviceupdates.AccountProperties{
+					PublicNetworkAccess: &model.PublicNetworkAccess,
+					Sku:                 &model.Sku,
+				},
+				Tags: &model.Tags,
+			}
+
+			if err := client.AccountsCreateThenPoll(ctx, id, *input); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateAccountResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseAccountID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.AccountsGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
+			}
+
+			state := IotHubDeviceUpdateAccountModel{
+				Name:              id.AccountName,
+				ResourceGroupName: id.ResourceGroupName,
+				Location:          location.Normalize(model.Location),
+			}
+
+			identityValue, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
+			if err != nil {
+				return fmt.Errorf("flattening `identity`: %+v", err)
+			}
+
+			if err := metadata.ResourceData.Set("identity", identityValue); err != nil {
+				return fmt.Errorf("setting `identity`: %+v", err)
+			}
+
+			if properties := model.Properties; properties != nil {
+				if properties.HostName != nil {
+					state.HostName = *properties.HostName
+				}
+
+				if properties.PublicNetworkAccess != nil {
+					state.PublicNetworkAccess = *properties.PublicNetworkAccess
+				}
+
+				if properties.Sku != nil {
+					state.Sku = *properties.Sku
+				}
+			}
+			if model.Tags != nil {
+				state.Tags = *model.Tags
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateAccountResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseAccountID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model IotHubDeviceUpdateAccountModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.AccountsGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			existing := resp.Model
+			if existing == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			if existing.Properties == nil {
+				existing.Properties = &deviceupdates.AccountProperties{}
+			}
+
+			if metadata.ResourceData.HasChange("identity") {
+				identityValue, err := identity.ExpandLegacySystemAndUserAssignedMap(metadata.ResourceData.Get("identity").([]interface{}))
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+				existing.Identity = identityValue
+			}
+
+			if metadata.ResourceData.HasChange("public_network_access") {
+				existing.Properties.PublicNetworkAccess = &model.PublicNetworkAccess
+			}
+
+			if metadata.ResourceData.HasChange("sku") {
+				existing.Properties.Sku = &model.Sku
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				existing.Tags = &model.Tags
+			}
+
+			existing.Properties.HostName = nil
+			existing.Properties.Locations = nil
+			existing.SystemData = nil
+
+			if err := client.AccountsCreateThenPoll(ctx, *id, *existing); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateAccountResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseAccountID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.AccountsDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -250,8 +250,7 @@ func (r IotHubDeviceUpdateAccountResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
-			existing.Properties.HostName = nil
-			existing.Properties.Locations = nil
+			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
 			existing.SystemData = nil
 
 			if err := client.AccountsCreateThenPoll(ctx, *id, *existing); err != nil {

--- a/internal/services/iothub/iothub_device_update_account_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_account_resource_test.go
@@ -1,0 +1,412 @@
+package iothub_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type IotHubDeviceUpdateAccountResource struct{}
+
+func TestAccIotHubDeviceUpdateAccount_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
+				check.That(data.ResourceName).Key("host_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.identitySystemAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.identityUserAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.identitySystemAssignedUserAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_publicNetworkAccess(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.publicNetworkAccessDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccessEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_sku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateAccount_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_account", "test")
+	r := IotHubDeviceUpdateAccountResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.tags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tagsUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubDeviceUpdateAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := deviceupdates.ParseAccountID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := clients.IoTHub.DeviceUpdatesClient
+	resp, err := client.AccountsGet(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r IotHubDeviceUpdateAccountResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r IotHubDeviceUpdateAccountResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                  = "acc-dua-%s"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  public_network_access = "Disabled"
+  sku                   = "Free"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  tags = {
+    environment = "AccTest"
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "import" {
+  name                = azurerm_iothub_device_update_account.test.name
+  resource_group_name = azurerm_iothub_device_update_account.test.resource_group_name
+  location            = azurerm_iothub_device_update_account.test.location
+}
+`, config)
+}
+
+func (r IotHubDeviceUpdateAccountResource) identitySystemAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) identityUserAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) identitySystemAssignedUserAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+}
+`, template, data.RandomInteger, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) publicNetworkAccessDisabled(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  public_network_access = "Disabled"
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) publicNetworkAccessEnabled(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  public_network_access = "Enabled"
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) sku(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku = "Free"
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) skuUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku = "Standard"
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) tags(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  tags = {
+    environment = "AccTest"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateAccountResource) tagsUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  tags = {
+    environment = "AccTest2"
+    purpose     = "Testing"
+  }
+}
+`, template, data.RandomString)
+}

--- a/internal/services/iothub/iothub_device_update_instance_resource.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource.go
@@ -23,12 +23,12 @@ var (
 )
 
 type IotHubDeviceUpdateInstanceModel struct {
-	Name                        string                          `tfschema:"name"`
-	DiagnosticStorageAccount    []DiagnosticStorageAccountModel `tfschema:"diagnostic_storage_account"`
-	DiagnosticEnabled           bool                            `tfschema:"diagnostic_enabled"`
-	IotHubDeviceUpdateAccountId string                          `tfschema:"iothub_device_update_account_id"`
-	IotHubId                    string                          `tfschema:"iothub_id"`
-	Tags                        map[string]string               `tfschema:"tags"`
+	Name                     string                          `tfschema:"name"`
+	DeviceUpdateAccountId    string                          `tfschema:"device_update_account_id"`
+	DiagnosticStorageAccount []DiagnosticStorageAccountModel `tfschema:"diagnostic_storage_account"`
+	DiagnosticEnabled        bool                            `tfschema:"diagnostic_enabled"`
+	IotHubId                 string                          `tfschema:"iothub_id"`
+	Tags                     map[string]string               `tfschema:"tags"`
 }
 
 type DiagnosticStorageAccountModel struct {
@@ -45,7 +45,7 @@ func (r IotHubDeviceUpdateInstanceResource) Arguments() map[string]*pluginsdk.Sc
 			ValidateFunc: validate.IotHubDeviceUpdateInstanceName,
 		},
 
-		"iothub_device_update_account_id": {
+		"device_update_account_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
@@ -117,7 +117,7 @@ func (r IotHubDeviceUpdateInstanceResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.IoTHub.DeviceUpdatesClient
-			deviceUpdateAccountId, err := deviceupdates.ParseAccountID(model.IotHubDeviceUpdateAccountId)
+			deviceUpdateAccountId, err := deviceupdates.ParseAccountID(model.DeviceUpdateAccountId)
 			if err != nil {
 				return err
 			}
@@ -192,8 +192,8 @@ func (r IotHubDeviceUpdateInstanceResource) Read() sdk.ResourceFunc {
 			}
 
 			state := IotHubDeviceUpdateInstanceModel{
-				Name:                        *model.Name,
-				IotHubDeviceUpdateAccountId: deviceupdates.NewAccountID(id.SubscriptionId, id.ResourceGroupName, id.AccountName).ID(),
+				Name:                  *model.Name,
+				DeviceUpdateAccountId: deviceupdates.NewAccountID(id.SubscriptionId, id.ResourceGroupName, id.AccountName).ID(),
 			}
 
 			properties := model.Properties

--- a/internal/services/iothub/iothub_device_update_instance_resource.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource.go
@@ -260,6 +260,7 @@ func (r IotHubDeviceUpdateInstanceResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
+			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
 			existing.SystemData = nil
 
 			if err := client.InstancesCreateThenPoll(ctx, *id, *existing); err != nil {

--- a/internal/services/iothub/iothub_device_update_instance_resource.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource.go
@@ -1,0 +1,325 @@
+package iothub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
+	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type IotHubDeviceUpdateInstanceResource struct{}
+
+var (
+	_ sdk.ResourceWithUpdate = IotHubDeviceUpdateInstanceResource{}
+)
+
+type IotHubDeviceUpdateInstanceModel struct {
+	Name                        string                          `tfschema:"name"`
+	DiagnosticStorageAccount    []DiagnosticStorageAccountModel `tfschema:"diagnostic_storage_account"`
+	DiagnosticEnabled           bool                            `tfschema:"diagnostic_enabled"`
+	IotHubDeviceUpdateAccountId string                          `tfschema:"iothub_device_update_account_id"`
+	IotHubId                    string                          `tfschema:"iothub_id"`
+	Tags                        map[string]string               `tfschema:"tags"`
+}
+
+type DiagnosticStorageAccountModel struct {
+	ConnectionString string `tfschema:"connection_string"`
+	Id               string `tfschema:"id"`
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.IotHubDeviceUpdateInstanceName,
+		},
+
+		"iothub_device_update_account_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: deviceupdates.ValidateAccountID,
+		},
+
+		"iothub_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.IotHubID,
+		},
+
+		"diagnostic_storage_account": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"connection_string": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						Sensitive:    true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: storageValidate.StorageAccountID,
+					},
+				},
+			},
+		},
+
+		"diagnostic_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) ResourceType() string {
+	return "azurerm_iothub_device_update_instance"
+}
+
+func (r IotHubDeviceUpdateInstanceResource) ModelObject() interface{} {
+	return &IotHubDeviceUpdateInstanceModel{}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return deviceupdates.ValidateInstanceID
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model IotHubDeviceUpdateInstanceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+			deviceUpdateAccountId, err := deviceupdates.ParseAccountID(model.IotHubDeviceUpdateAccountId)
+			if err != nil {
+				return err
+			}
+
+			id := deviceupdates.NewInstanceID(deviceUpdateAccountId.SubscriptionId, deviceUpdateAccountId.ResourceGroupName, deviceUpdateAccountId.AccountName, model.Name)
+			existing, err := client.InstancesGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			deviceUpdateAccount, err := client.AccountsGet(ctx, *deviceUpdateAccountId)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *deviceUpdateAccountId, err)
+			}
+
+			if deviceUpdateAccount.Model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *deviceUpdateAccountId)
+			}
+
+			properties := &deviceupdates.Instance{
+				Location: location.Normalize(deviceUpdateAccount.Model.Location),
+				Properties: deviceupdates.InstanceProperties{
+					AccountName:                 &deviceUpdateAccountId.AccountName,
+					DiagnosticStorageProperties: expandDiagnosticStorageAccount(model.DiagnosticStorageAccount),
+					EnableDiagnostics:           &model.DiagnosticEnabled,
+					IotHubs: &[]deviceupdates.IotHubSettings{
+						{
+							ResourceId: model.IotHubId,
+						},
+					},
+				},
+				Tags: &model.Tags,
+			}
+
+			if err := client.InstancesCreateThenPoll(ctx, id, *properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseInstanceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.InstancesGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
+			}
+
+			state := IotHubDeviceUpdateInstanceModel{
+				Name:                        *model.Name,
+				IotHubDeviceUpdateAccountId: deviceupdates.NewAccountID(id.SubscriptionId, id.ResourceGroupName, id.AccountName).ID(),
+			}
+
+			properties := model.Properties
+
+			if iotHubs := properties.IotHubs; iotHubs != nil && len(*iotHubs) > 0 {
+				state.IotHubId = (*iotHubs)[0].ResourceId
+			}
+
+			diagnosticStorageAccount, err := flattenDiagnosticStorageAccount(properties.DiagnosticStorageProperties, metadata)
+			if err != nil {
+				return err
+			}
+			state.DiagnosticStorageAccount = diagnosticStorageAccount
+
+			diagnosticEnabled := false
+			if properties.EnableDiagnostics != nil {
+				diagnosticEnabled = *properties.EnableDiagnostics
+			}
+			state.DiagnosticEnabled = diagnosticEnabled
+
+			if model.Tags != nil {
+				state.Tags = *model.Tags
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseInstanceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model IotHubDeviceUpdateInstanceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.InstancesGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			existing := resp.Model
+			if existing == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			// connectionString is not returned by API, so always expands DiagnosticStorageAccount
+			existing.Properties.DiagnosticStorageProperties = expandDiagnosticStorageAccount(model.DiagnosticStorageAccount)
+
+			if metadata.ResourceData.HasChange("diagnostic_enabled") {
+				existing.Properties.EnableDiagnostics = &model.DiagnosticEnabled
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				existing.Tags = &model.Tags
+			}
+
+			existing.SystemData = nil
+
+			if err := client.InstancesCreateThenPoll(ctx, *id, *existing); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IoTHub.DeviceUpdatesClient
+
+			id, err := deviceupdates.ParseInstanceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.InstancesDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandDiagnosticStorageAccount(inputList []DiagnosticStorageAccountModel) *deviceupdates.DiagnosticStorageProperties {
+	if len(inputList) == 0 {
+		return nil
+	}
+
+	input := inputList[0]
+	output := deviceupdates.DiagnosticStorageProperties{
+		AuthenticationType: deviceupdates.AuthenticationTypeKeyBased,
+		ConnectionString:   &input.ConnectionString,
+		ResourceId:         input.Id,
+	}
+
+	return &output
+}
+
+func flattenDiagnosticStorageAccount(input *deviceupdates.DiagnosticStorageProperties, metadata sdk.ResourceMetaData) ([]DiagnosticStorageAccountModel, error) {
+	var outputList []DiagnosticStorageAccountModel
+	if input == nil {
+		return outputList, nil
+	}
+
+	output := DiagnosticStorageAccountModel{
+		Id: input.ResourceId,
+	}
+
+	// connectionString is not returned by API
+	if connectionString, ok := metadata.ResourceData.GetOk("diagnostic_storage_account.0.connection_string"); ok {
+		output.ConnectionString = connectionString.(string)
+	}
+
+	return append(outputList, output), nil
+}

--- a/internal/services/iothub/iothub_device_update_instance_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource_test.go
@@ -182,9 +182,9 @@ func (r IotHubDeviceUpdateInstanceResource) basic(data acceptance.TestData) stri
 %s
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 }
 `, template, data.RandomString)
 }
@@ -203,10 +203,10 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%[2]s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
-  diagnostic_enabled              = true
+  name                     = "acc-dui-%[2]s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
+  diagnostic_enabled       = true
 
   diagnostic_storage_account {
     connection_string = azurerm_storage_account.test.primary_connection_string
@@ -226,9 +226,9 @@ func (r IotHubDeviceUpdateInstanceResource) requiresImport(data acceptance.TestD
 %s
 
 resource "azurerm_iothub_device_update_instance" "import" {
-  name                            = azurerm_iothub_device_update_instance.test.name
-  iothub_device_update_account_id = azurerm_iothub_device_update_instance.test.iothub_device_update_account_id
-  iothub_id                       = azurerm_iothub_device_update_instance.test.iothub_id
+  name                     = azurerm_iothub_device_update_instance.test.name
+  device_update_account_id = azurerm_iothub_device_update_instance.test.device_update_account_id
+  iothub_id                = azurerm_iothub_device_update_instance.test.iothub_id
 }
 `, config)
 }
@@ -247,9 +247,9 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%[2]s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%[2]s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
 
   diagnostic_storage_account {
@@ -282,9 +282,9 @@ resource "azurerm_storage_account" "test2" {
 }
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%[2]s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%[2]s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
 
   diagnostic_storage_account {
@@ -301,9 +301,9 @@ func (r IotHubDeviceUpdateInstanceResource) diagnosticEnabled(data acceptance.Te
 %s
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
   diagnostic_enabled = true
 }
@@ -316,9 +316,9 @@ func (r IotHubDeviceUpdateInstanceResource) diagnosticDisabled(data acceptance.T
 %s
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
   diagnostic_enabled = false
 }
@@ -331,9 +331,9 @@ func (r IotHubDeviceUpdateInstanceResource) tags(data acceptance.TestData) strin
 %s
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
   tags = {
     environment = "AccTest"
@@ -348,9 +348,9 @@ func (r IotHubDeviceUpdateInstanceResource) tagsUpdated(data acceptance.TestData
 %s
 
 resource "azurerm_iothub_device_update_instance" "test" {
-  name                            = "acc-dui-%s"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
-  iothub_id                       = azurerm_iothub.test.id
+  name                     = "acc-dui-%s"
+  device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                = azurerm_iothub.test.id
 
   tags = {
     environment = "AccTest2"

--- a/internal/services/iothub/iothub_device_update_instance_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource_test.go
@@ -1,0 +1,361 @@
+package iothub_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type IotHubDeviceUpdateInstanceResource struct{}
+
+func TestAccIotHubDeviceUpdateInstance_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("diagnostic_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateInstance_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("diagnostic_storage_account.0.connection_string"),
+	})
+}
+
+func TestAccIotHubDeviceUpdateInstance_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccIotHubDeviceUpdateInstance_diagnosticStorageAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diagnosticStorageAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("diagnostic_storage_account.0.connection_string"),
+		{
+			Config: r.diagnosticStorageAccountUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("diagnostic_storage_account.0.connection_string"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateInstance_diagnosticEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diagnosticEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.diagnosticDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccIotHubDeviceUpdateInstance_tags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_device_update_instance", "test")
+	r := IotHubDeviceUpdateInstanceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.tags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tagsUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r IotHubDeviceUpdateInstanceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := deviceupdates.ParseInstanceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := clients.IoTHub.DeviceUpdatesClient
+	resp, err := client.InstancesGet(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r IotHubDeviceUpdateInstanceResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+}
+
+resource "azurerm_iothub_device_update_account" "test" {
+  name                = "acc-dua-%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%[2]s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+  diagnostic_enabled              = true
+
+  diagnostic_storage_account {
+    connection_string = azurerm_storage_account.test.primary_connection_string
+    id                = azurerm_storage_account.test.id
+  }
+
+  tags = {
+    environment = "AccTest"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "import" {
+  name                            = azurerm_iothub_device_update_instance.test.name
+  iothub_device_update_account_id = azurerm_iothub_device_update_instance.test.iothub_device_update_account_id
+  iothub_id                       = azurerm_iothub_device_update_instance.test.iothub_id
+}
+`, config)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) diagnosticStorageAccount(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%[2]s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+
+  diagnostic_storage_account {
+    connection_string = azurerm_storage_account.test.primary_connection_string
+    id                = azurerm_storage_account.test.id
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) diagnosticStorageAccountUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "acctestsa2%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%[2]s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+
+  diagnostic_storage_account {
+    connection_string = azurerm_storage_account.test2.primary_connection_string
+    id                = azurerm_storage_account.test2.id
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) diagnosticEnabled(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+  diagnostic_enabled = true
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) diagnosticDisabled(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+  diagnostic_enabled = false
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) tags(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+  tags = {
+    environment = "AccTest"
+  }
+}
+`, template, data.RandomString)
+}
+
+func (r IotHubDeviceUpdateInstanceResource) tagsUpdated(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_device_update_instance" "test" {
+  name                            = "acc-dui-%s"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.test.id
+  iothub_id                       = azurerm_iothub.test.id
+
+  tags = {
+    environment = "AccTest2"
+    purpose     = "Testing"
+  }
+}
+`, template, data.RandomString)
+}

--- a/internal/services/iothub/registration.go
+++ b/internal/services/iothub/registration.go
@@ -54,3 +54,14 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_iothub_shared_access_policy":       resourceIotHubSharedAccessPolicy(),
 	}
 }
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		IotHubDeviceUpdateAccountResource{},
+		IotHubDeviceUpdateInstanceResource{},
+	}
+}

--- a/internal/services/iothub/validate/iot_hub_device_update_account_name.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_account_name.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func IotHubDeviceUpdateAccountName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if len(value) < 3 || len(value) > 24 {
+		errors = append(errors, fmt.Errorf("%q must be between 3 and 24 characters long", k))
+	}
+
+	if matched := regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/iothub/validate/iot_hub_device_update_account_name.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_account_name.go
@@ -13,7 +13,7 @@ func IotHubDeviceUpdateAccountName(v interface{}, k string) (warnings []string, 
 	}
 
 	if matched := regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$`).Match([]byte(value)); !matched {
-		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
+		errors = append(errors, fmt.Errorf("%q must start with an alphanumeric, may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
 	}
 
 	return warnings, errors

--- a/internal/services/iothub/validate/iot_hub_device_update_account_name_test.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_account_name_test.go
@@ -1,0 +1,30 @@
+package validate
+
+import "testing"
+
+func TestIotHubDeviceUpdateAccountName(t *testing.T) {
+	validNames := []string{
+		"valid-name",
+		"Aa0",
+		"012345678901234567890123",
+	}
+	for _, v := range validNames {
+		_, errors := IotHubDeviceUpdateAccountName(v, "example")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid IoT Hub Device Update Account Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"invalid_name",
+		"double-hyphen--invalid",
+		"aa",
+		"0123456789012345678901234",
+	}
+	for _, v := range invalidNames {
+		_, errors := IotHubDeviceUpdateAccountName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid IoT Hub Device Update Account Name", v)
+		}
+	}
+}

--- a/internal/services/iothub/validate/iot_hub_device_update_instance_name.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_instance_name.go
@@ -13,7 +13,7 @@ func IotHubDeviceUpdateInstanceName(v interface{}, k string) (warnings []string,
 	}
 
 	if matched := regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$`).Match([]byte(value)); !matched {
-		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
+		errors = append(errors, fmt.Errorf("%q must start with an alphanumeric, may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
 	}
 
 	return warnings, errors

--- a/internal/services/iothub/validate/iot_hub_device_update_instance_name.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_instance_name.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func IotHubDeviceUpdateInstanceName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if len(value) < 3 || len(value) > 24 {
+		errors = append(errors, fmt.Errorf("%q must be between 3 and 24 characters long", k))
+	}
+
+	if matched := regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes, and consecutive dashes (-) are not allowed", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/iothub/validate/iot_hub_device_update_instance_name_test.go
+++ b/internal/services/iothub/validate/iot_hub_device_update_instance_name_test.go
@@ -1,0 +1,30 @@
+package validate
+
+import "testing"
+
+func TestIotHubDeviceUpdateInstanceName(t *testing.T) {
+	validNames := []string{
+		"valid-name",
+		"Aa0",
+		"012345678901234567890123",
+	}
+	for _, v := range validNames {
+		_, errors := IotHubDeviceUpdateInstanceName(v, "example")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid IoT Hub Device Update Instance Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"invalid_name",
+		"double-hyphen--invalid",
+		"aa",
+		"0123456789012345678901234",
+	}
+	for _, v := range invalidNames {
+		_, errors := IotHubDeviceUpdateInstanceName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid IoT Hub Device Update Instance Name", v)
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/README.md
@@ -1,0 +1,294 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates` Documentation
+
+The `deviceupdates` SDK allows for interaction with the Azure Resource Manager Service `deviceupdate` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
+```
+
+
+### Client Initialization
+
+```go
+client := deviceupdates.NewDeviceupdatesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsCreate`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+payload := deviceupdates.Account{
+	// ...
+}
+
+
+if err := client.AccountsCreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsDelete`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+if err := client.AccountsDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsGet`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+read, err := client.AccountsGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsHead`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+read, err := client.AccountsHead(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.AccountsListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.AccountsListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsListBySubscription`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.AccountsListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.AccountsListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.AccountsUpdate`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+payload := deviceupdates.AccountUpdate{
+	// ...
+}
+
+
+if err := client.AccountsUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.CheckNameAvailability`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+payload := deviceupdates.CheckNameAvailabilityRequest{
+	// ...
+}
+
+
+read, err := client.CheckNameAvailability(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesCreate`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "instanceValue")
+
+payload := deviceupdates.Instance{
+	// ...
+}
+
+
+if err := client.InstancesCreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesDelete`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "instanceValue")
+
+if err := client.InstancesDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesGet`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "instanceValue")
+
+read, err := client.InstancesGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesHead`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "instanceValue")
+
+read, err := client.InstancesHead(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesListByAccount`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+// alternatively `client.InstancesListByAccount(ctx, id)` can be used to do batched pagination
+items, err := client.InstancesListByAccountComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.InstancesUpdate`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "instanceValue")
+
+payload := deviceupdates.TagUpdate{
+	// ...
+}
+
+
+read, err := client.InstancesUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewPrivateEndpointConnectionProxyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "privateEndpointConnectionProxyIdValue")
+
+payload := deviceupdates.PrivateEndpointUpdate{
+	// ...
+}
+
+
+read, err := client.PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeviceupdatesClient.PrivateEndpointConnectionProxiesValidate`
+
+```go
+ctx := context.TODO()
+id := deviceupdates.NewPrivateEndpointConnectionProxyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "privateEndpointConnectionProxyIdValue")
+
+payload := deviceupdates.PrivateEndpointConnectionProxy{
+	// ...
+}
+
+
+read, err := client.PrivateEndpointConnectionProxiesValidate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/client.go
@@ -1,0 +1,18 @@
+package deviceupdates
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeviceupdatesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewDeviceupdatesClientWithBaseURI(endpoint string) DeviceupdatesClient {
+	return DeviceupdatesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/constants.go
@@ -1,0 +1,282 @@
+package deviceupdates
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AuthenticationType string
+
+const (
+	AuthenticationTypeKeyBased AuthenticationType = "KeyBased"
+)
+
+func PossibleValuesForAuthenticationType() []string {
+	return []string{
+		string(AuthenticationTypeKeyBased),
+	}
+}
+
+func parseAuthenticationType(input string) (*AuthenticationType, error) {
+	vals := map[string]AuthenticationType{
+		"keybased": AuthenticationTypeKeyBased,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AuthenticationType(input)
+	return &out, nil
+}
+
+type CheckNameAvailabilityReason string
+
+const (
+	CheckNameAvailabilityReasonAlreadyExists CheckNameAvailabilityReason = "AlreadyExists"
+	CheckNameAvailabilityReasonInvalid       CheckNameAvailabilityReason = "Invalid"
+)
+
+func PossibleValuesForCheckNameAvailabilityReason() []string {
+	return []string{
+		string(CheckNameAvailabilityReasonAlreadyExists),
+		string(CheckNameAvailabilityReasonInvalid),
+	}
+}
+
+func parseCheckNameAvailabilityReason(input string) (*CheckNameAvailabilityReason, error) {
+	vals := map[string]CheckNameAvailabilityReason{
+		"alreadyexists": CheckNameAvailabilityReasonAlreadyExists,
+		"invalid":       CheckNameAvailabilityReasonInvalid,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CheckNameAvailabilityReason(input)
+	return &out, nil
+}
+
+type PrivateEndpointConnectionProvisioningState string
+
+const (
+	PrivateEndpointConnectionProvisioningStateCreating  PrivateEndpointConnectionProvisioningState = "Creating"
+	PrivateEndpointConnectionProvisioningStateDeleting  PrivateEndpointConnectionProvisioningState = "Deleting"
+	PrivateEndpointConnectionProvisioningStateFailed    PrivateEndpointConnectionProvisioningState = "Failed"
+	PrivateEndpointConnectionProvisioningStateSucceeded PrivateEndpointConnectionProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForPrivateEndpointConnectionProvisioningState() []string {
+	return []string{
+		string(PrivateEndpointConnectionProvisioningStateCreating),
+		string(PrivateEndpointConnectionProvisioningStateDeleting),
+		string(PrivateEndpointConnectionProvisioningStateFailed),
+		string(PrivateEndpointConnectionProvisioningStateSucceeded),
+	}
+}
+
+func parsePrivateEndpointConnectionProvisioningState(input string) (*PrivateEndpointConnectionProvisioningState, error) {
+	vals := map[string]PrivateEndpointConnectionProvisioningState{
+		"creating":  PrivateEndpointConnectionProvisioningStateCreating,
+		"deleting":  PrivateEndpointConnectionProvisioningStateDeleting,
+		"failed":    PrivateEndpointConnectionProvisioningStateFailed,
+		"succeeded": PrivateEndpointConnectionProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointConnectionProvisioningState(input)
+	return &out, nil
+}
+
+type PrivateEndpointConnectionProxyProvisioningState string
+
+const (
+	PrivateEndpointConnectionProxyProvisioningStateCreating  PrivateEndpointConnectionProxyProvisioningState = "Creating"
+	PrivateEndpointConnectionProxyProvisioningStateDeleting  PrivateEndpointConnectionProxyProvisioningState = "Deleting"
+	PrivateEndpointConnectionProxyProvisioningStateFailed    PrivateEndpointConnectionProxyProvisioningState = "Failed"
+	PrivateEndpointConnectionProxyProvisioningStateSucceeded PrivateEndpointConnectionProxyProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForPrivateEndpointConnectionProxyProvisioningState() []string {
+	return []string{
+		string(PrivateEndpointConnectionProxyProvisioningStateCreating),
+		string(PrivateEndpointConnectionProxyProvisioningStateDeleting),
+		string(PrivateEndpointConnectionProxyProvisioningStateFailed),
+		string(PrivateEndpointConnectionProxyProvisioningStateSucceeded),
+	}
+}
+
+func parsePrivateEndpointConnectionProxyProvisioningState(input string) (*PrivateEndpointConnectionProxyProvisioningState, error) {
+	vals := map[string]PrivateEndpointConnectionProxyProvisioningState{
+		"creating":  PrivateEndpointConnectionProxyProvisioningStateCreating,
+		"deleting":  PrivateEndpointConnectionProxyProvisioningStateDeleting,
+		"failed":    PrivateEndpointConnectionProxyProvisioningStateFailed,
+		"succeeded": PrivateEndpointConnectionProxyProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointConnectionProxyProvisioningState(input)
+	return &out, nil
+}
+
+type PrivateEndpointServiceConnectionStatus string
+
+const (
+	PrivateEndpointServiceConnectionStatusApproved PrivateEndpointServiceConnectionStatus = "Approved"
+	PrivateEndpointServiceConnectionStatusPending  PrivateEndpointServiceConnectionStatus = "Pending"
+	PrivateEndpointServiceConnectionStatusRejected PrivateEndpointServiceConnectionStatus = "Rejected"
+)
+
+func PossibleValuesForPrivateEndpointServiceConnectionStatus() []string {
+	return []string{
+		string(PrivateEndpointServiceConnectionStatusApproved),
+		string(PrivateEndpointServiceConnectionStatusPending),
+		string(PrivateEndpointServiceConnectionStatusRejected),
+	}
+}
+
+func parsePrivateEndpointServiceConnectionStatus(input string) (*PrivateEndpointServiceConnectionStatus, error) {
+	vals := map[string]PrivateEndpointServiceConnectionStatus{
+		"approved": PrivateEndpointServiceConnectionStatusApproved,
+		"pending":  PrivateEndpointServiceConnectionStatusPending,
+		"rejected": PrivateEndpointServiceConnectionStatusRejected,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointServiceConnectionStatus(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateAccepted  ProvisioningState = "Accepted"
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
+	ProvisioningStateDeleted   ProvisioningState = "Deleted"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateAccepted),
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleted),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+	}
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"accepted":  ProvisioningStateAccepted,
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
+		"deleted":   ProvisioningStateDeleted,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type PublicNetworkAccess string
+
+const (
+	PublicNetworkAccessDisabled PublicNetworkAccess = "Disabled"
+	PublicNetworkAccessEnabled  PublicNetworkAccess = "Enabled"
+)
+
+func PossibleValuesForPublicNetworkAccess() []string {
+	return []string{
+		string(PublicNetworkAccessDisabled),
+		string(PublicNetworkAccessEnabled),
+	}
+}
+
+func parsePublicNetworkAccess(input string) (*PublicNetworkAccess, error) {
+	vals := map[string]PublicNetworkAccess{
+		"disabled": PublicNetworkAccessDisabled,
+		"enabled":  PublicNetworkAccessEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicNetworkAccess(input)
+	return &out, nil
+}
+
+type Role string
+
+const (
+	RoleFailover Role = "Failover"
+	RolePrimary  Role = "Primary"
+)
+
+func PossibleValuesForRole() []string {
+	return []string{
+		string(RoleFailover),
+		string(RolePrimary),
+	}
+}
+
+func parseRole(input string) (*Role, error) {
+	vals := map[string]Role{
+		"failover": RoleFailover,
+		"primary":  RolePrimary,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Role(input)
+	return &out, nil
+}
+
+type SKU string
+
+const (
+	SKUFree     SKU = "Free"
+	SKUStandard SKU = "Standard"
+)
+
+func PossibleValuesForSKU() []string {
+	return []string{
+		string(SKUFree),
+		string(SKUStandard),
+	}
+}
+
+func parseSKU(input string) (*SKU, error) {
+	vals := map[string]SKU{
+		"free":     SKUFree,
+		"standard": SKUStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SKU(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_account.go
@@ -1,0 +1,124 @@
+package deviceupdates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = AccountId{}
+
+// AccountId is a struct representing the Resource ID for a Account
+type AccountId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AccountName       string
+}
+
+// NewAccountID returns a new AccountId struct
+func NewAccountID(subscriptionId string, resourceGroupName string, accountName string) AccountId {
+	return AccountId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AccountName:       accountName,
+	}
+}
+
+// ParseAccountID parses 'input' into a AccountId
+func ParseAccountID(input string) (*AccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AccountId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseAccountIDInsensitively parses 'input' case-insensitively into a AccountId
+// note: this method should only be used for API response data and not user input
+func ParseAccountIDInsensitively(input string) (*AccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AccountId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateAccountID checks that 'input' can be parsed as a Account ID
+func ValidateAccountID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAccountID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Account ID
+func (id AccountId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DeviceUpdate/accounts/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Account ID
+func (id AccountId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDeviceUpdate", "Microsoft.DeviceUpdate", "Microsoft.DeviceUpdate"),
+		resourceids.StaticSegment("staticAccounts", "accounts", "accounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+	}
+}
+
+// String returns a human-readable description of this Account ID
+func (id AccountId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+	}
+	return fmt.Sprintf("Account (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_instance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_instance.go
@@ -1,0 +1,137 @@
+package deviceupdates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = InstanceId{}
+
+// InstanceId is a struct representing the Resource ID for a Instance
+type InstanceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AccountName       string
+	InstanceName      string
+}
+
+// NewInstanceID returns a new InstanceId struct
+func NewInstanceID(subscriptionId string, resourceGroupName string, accountName string, instanceName string) InstanceId {
+	return InstanceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AccountName:       accountName,
+		InstanceName:      instanceName,
+	}
+}
+
+// ParseInstanceID parses 'input' into a InstanceId
+func ParseInstanceID(input string) (*InstanceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(InstanceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := InstanceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.InstanceName, ok = parsed.Parsed["instanceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'instanceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseInstanceIDInsensitively parses 'input' case-insensitively into a InstanceId
+// note: this method should only be used for API response data and not user input
+func ParseInstanceIDInsensitively(input string) (*InstanceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(InstanceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := InstanceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.InstanceName, ok = parsed.Parsed["instanceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'instanceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateInstanceID checks that 'input' can be parsed as a Instance ID
+func ValidateInstanceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseInstanceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Instance ID
+func (id InstanceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DeviceUpdate/accounts/%s/instances/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName, id.InstanceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Instance ID
+func (id InstanceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDeviceUpdate", "Microsoft.DeviceUpdate", "Microsoft.DeviceUpdate"),
+		resourceids.StaticSegment("staticAccounts", "accounts", "accounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+		resourceids.StaticSegment("staticInstances", "instances", "instances"),
+		resourceids.UserSpecifiedSegment("instanceName", "instanceValue"),
+	}
+}
+
+// String returns a human-readable description of this Instance ID
+func (id InstanceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+		fmt.Sprintf("Instance Name: %q", id.InstanceName),
+	}
+	return fmt.Sprintf("Instance (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_privateendpointconnectionproxy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_privateendpointconnectionproxy.go
@@ -1,0 +1,137 @@
+package deviceupdates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = PrivateEndpointConnectionProxyId{}
+
+// PrivateEndpointConnectionProxyId is a struct representing the Resource ID for a Private Endpoint Connection Proxy
+type PrivateEndpointConnectionProxyId struct {
+	SubscriptionId                   string
+	ResourceGroupName                string
+	AccountName                      string
+	PrivateEndpointConnectionProxyId string
+}
+
+// NewPrivateEndpointConnectionProxyID returns a new PrivateEndpointConnectionProxyId struct
+func NewPrivateEndpointConnectionProxyID(subscriptionId string, resourceGroupName string, accountName string, privateEndpointConnectionProxyId string) PrivateEndpointConnectionProxyId {
+	return PrivateEndpointConnectionProxyId{
+		SubscriptionId:                   subscriptionId,
+		ResourceGroupName:                resourceGroupName,
+		AccountName:                      accountName,
+		PrivateEndpointConnectionProxyId: privateEndpointConnectionProxyId,
+	}
+}
+
+// ParsePrivateEndpointConnectionProxyID parses 'input' into a PrivateEndpointConnectionProxyId
+func ParsePrivateEndpointConnectionProxyID(input string) (*PrivateEndpointConnectionProxyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PrivateEndpointConnectionProxyId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PrivateEndpointConnectionProxyId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.PrivateEndpointConnectionProxyId, ok = parsed.Parsed["privateEndpointConnectionProxyId"]; !ok {
+		return nil, fmt.Errorf("the segment 'privateEndpointConnectionProxyId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParsePrivateEndpointConnectionProxyIDInsensitively parses 'input' case-insensitively into a PrivateEndpointConnectionProxyId
+// note: this method should only be used for API response data and not user input
+func ParsePrivateEndpointConnectionProxyIDInsensitively(input string) (*PrivateEndpointConnectionProxyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PrivateEndpointConnectionProxyId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PrivateEndpointConnectionProxyId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.PrivateEndpointConnectionProxyId, ok = parsed.Parsed["privateEndpointConnectionProxyId"]; !ok {
+		return nil, fmt.Errorf("the segment 'privateEndpointConnectionProxyId' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidatePrivateEndpointConnectionProxyID checks that 'input' can be parsed as a Private Endpoint Connection Proxy ID
+func ValidatePrivateEndpointConnectionProxyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePrivateEndpointConnectionProxyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Private Endpoint Connection Proxy ID
+func (id PrivateEndpointConnectionProxyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DeviceUpdate/accounts/%s/privateEndpointConnectionProxies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName, id.PrivateEndpointConnectionProxyId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Private Endpoint Connection Proxy ID
+func (id PrivateEndpointConnectionProxyId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDeviceUpdate", "Microsoft.DeviceUpdate", "Microsoft.DeviceUpdate"),
+		resourceids.StaticSegment("staticAccounts", "accounts", "accounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+		resourceids.StaticSegment("staticPrivateEndpointConnectionProxies", "privateEndpointConnectionProxies", "privateEndpointConnectionProxies"),
+		resourceids.UserSpecifiedSegment("privateEndpointConnectionProxyId", "privateEndpointConnectionProxyIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Private Endpoint Connection Proxy ID
+func (id PrivateEndpointConnectionProxyId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+		fmt.Sprintf("Private Endpoint Connection Proxy: %q", id.PrivateEndpointConnectionProxyId),
+	}
+	return fmt.Sprintf("Private Endpoint Connection Proxy (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountscreate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountscreate_autorest.go
@@ -1,0 +1,79 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsCreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// AccountsCreate ...
+func (c DeviceupdatesClient) AccountsCreate(ctx context.Context, id AccountId, input Account) (result AccountsCreateOperationResponse, err error) {
+	req, err := c.preparerForAccountsCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsCreate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForAccountsCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsCreate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// AccountsCreateThenPoll performs AccountsCreate then polls until it's completed
+func (c DeviceupdatesClient) AccountsCreateThenPoll(ctx context.Context, id AccountId, input Account) error {
+	result, err := c.AccountsCreate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AccountsCreate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after AccountsCreate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForAccountsCreate prepares the AccountsCreate request.
+func (c DeviceupdatesClient) preparerForAccountsCreate(ctx context.Context, id AccountId, input Account) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForAccountsCreate sends the AccountsCreate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeviceupdatesClient) senderForAccountsCreate(ctx context.Context, req *http.Request) (future AccountsCreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsdelete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsdelete_autorest.go
@@ -1,0 +1,78 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsDeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// AccountsDelete ...
+func (c DeviceupdatesClient) AccountsDelete(ctx context.Context, id AccountId) (result AccountsDeleteOperationResponse, err error) {
+	req, err := c.preparerForAccountsDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForAccountsDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// AccountsDeleteThenPoll performs AccountsDelete then polls until it's completed
+func (c DeviceupdatesClient) AccountsDeleteThenPoll(ctx context.Context, id AccountId) error {
+	result, err := c.AccountsDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing AccountsDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after AccountsDelete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForAccountsDelete prepares the AccountsDelete request.
+func (c DeviceupdatesClient) preparerForAccountsDelete(ctx context.Context, id AccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForAccountsDelete sends the AccountsDelete request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeviceupdatesClient) senderForAccountsDelete(ctx context.Context, req *http.Request) (future AccountsDeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsget_autorest.go
@@ -1,0 +1,68 @@
+package deviceupdates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Account
+}
+
+// AccountsGet ...
+func (c DeviceupdatesClient) AccountsGet(ctx context.Context, id AccountId) (result AccountsGetOperationResponse, err error) {
+	req, err := c.preparerForAccountsGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAccountsGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAccountsGet prepares the AccountsGet request.
+func (c DeviceupdatesClient) preparerForAccountsGet(ctx context.Context, id AccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAccountsGet handles the response to the AccountsGet request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForAccountsGet(resp *http.Response) (result AccountsGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountshead_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountshead_autorest.go
@@ -1,0 +1,66 @@
+package deviceupdates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsHeadOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// AccountsHead ...
+func (c DeviceupdatesClient) AccountsHead(ctx context.Context, id AccountId) (result AccountsHeadOperationResponse, err error) {
+	req, err := c.preparerForAccountsHead(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsHead", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsHead", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAccountsHead(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsHead", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAccountsHead prepares the AccountsHead request.
+func (c DeviceupdatesClient) preparerForAccountsHead(ctx context.Context, id AccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsHead(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAccountsHead handles the response to the AccountsHead request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForAccountsHead(resp *http.Response) (result AccountsHeadOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountslistbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountslistbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Account
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (AccountsListByResourceGroupOperationResponse, error)
+}
+
+type AccountsListByResourceGroupCompleteResult struct {
+	Items []Account
+}
+
+func (r AccountsListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r AccountsListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp AccountsListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// AccountsListByResourceGroup ...
+func (c DeviceupdatesClient) AccountsListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp AccountsListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForAccountsListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForAccountsListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForAccountsListByResourceGroup prepares the AccountsListByResourceGroup request.
+func (c DeviceupdatesClient) preparerForAccountsListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.DeviceUpdate/accounts", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForAccountsListByResourceGroupWithNextLink prepares the AccountsListByResourceGroup request with the given nextLink token.
+func (c DeviceupdatesClient) preparerForAccountsListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAccountsListByResourceGroup handles the response to the AccountsListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForAccountsListByResourceGroup(resp *http.Response) (result AccountsListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []Account `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result AccountsListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForAccountsListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForAccountsListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// AccountsListByResourceGroupComplete retrieves all of the results into a single object
+func (c DeviceupdatesClient) AccountsListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (AccountsListByResourceGroupCompleteResult, error) {
+	return c.AccountsListByResourceGroupCompleteMatchingPredicate(ctx, id, AccountOperationPredicate{})
+}
+
+// AccountsListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DeviceupdatesClient) AccountsListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate AccountOperationPredicate) (resp AccountsListByResourceGroupCompleteResult, err error) {
+	items := make([]Account, 0)
+
+	page, err := c.AccountsListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := AccountsListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountslistbysubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountslistbysubscription_autorest.go
@@ -1,0 +1,187 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Account
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (AccountsListBySubscriptionOperationResponse, error)
+}
+
+type AccountsListBySubscriptionCompleteResult struct {
+	Items []Account
+}
+
+func (r AccountsListBySubscriptionOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r AccountsListBySubscriptionOperationResponse) LoadMore(ctx context.Context) (resp AccountsListBySubscriptionOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// AccountsListBySubscription ...
+func (c DeviceupdatesClient) AccountsListBySubscription(ctx context.Context, id commonids.SubscriptionId) (resp AccountsListBySubscriptionOperationResponse, err error) {
+	req, err := c.preparerForAccountsListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForAccountsListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForAccountsListBySubscription prepares the AccountsListBySubscription request.
+func (c DeviceupdatesClient) preparerForAccountsListBySubscription(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.DeviceUpdate/accounts", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForAccountsListBySubscriptionWithNextLink prepares the AccountsListBySubscription request with the given nextLink token.
+func (c DeviceupdatesClient) preparerForAccountsListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAccountsListBySubscription handles the response to the AccountsListBySubscription request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForAccountsListBySubscription(resp *http.Response) (result AccountsListBySubscriptionOperationResponse, err error) {
+	type page struct {
+		Values   []Account `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result AccountsListBySubscriptionOperationResponse, err error) {
+			req, err := c.preparerForAccountsListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForAccountsListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// AccountsListBySubscriptionComplete retrieves all of the results into a single object
+func (c DeviceupdatesClient) AccountsListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (AccountsListBySubscriptionCompleteResult, error) {
+	return c.AccountsListBySubscriptionCompleteMatchingPredicate(ctx, id, AccountOperationPredicate{})
+}
+
+// AccountsListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DeviceupdatesClient) AccountsListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate AccountOperationPredicate) (resp AccountsListBySubscriptionCompleteResult, err error) {
+	items := make([]Account, 0)
+
+	page, err := c.AccountsListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := AccountsListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_accountsupdate_autorest.go
@@ -1,0 +1,79 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountsUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// AccountsUpdate ...
+func (c DeviceupdatesClient) AccountsUpdate(ctx context.Context, id AccountId, input AccountUpdate) (result AccountsUpdateOperationResponse, err error) {
+	req, err := c.preparerForAccountsUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForAccountsUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "AccountsUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// AccountsUpdateThenPoll performs AccountsUpdate then polls until it's completed
+func (c DeviceupdatesClient) AccountsUpdateThenPoll(ctx context.Context, id AccountId, input AccountUpdate) error {
+	result, err := c.AccountsUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AccountsUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after AccountsUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForAccountsUpdate prepares the AccountsUpdate request.
+func (c DeviceupdatesClient) preparerForAccountsUpdate(ctx context.Context, id AccountId, input AccountUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForAccountsUpdate sends the AccountsUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeviceupdatesClient) senderForAccountsUpdate(ctx context.Context, req *http.Request) (future AccountsUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_checknameavailability_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_checknameavailability_autorest.go
@@ -1,0 +1,71 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckNameAvailabilityOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *CheckNameAvailabilityResponse
+}
+
+// CheckNameAvailability ...
+func (c DeviceupdatesClient) CheckNameAvailability(ctx context.Context, id commonids.SubscriptionId, input CheckNameAvailabilityRequest) (result CheckNameAvailabilityOperationResponse, err error) {
+	req, err := c.preparerForCheckNameAvailability(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "CheckNameAvailability", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "CheckNameAvailability", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCheckNameAvailability(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "CheckNameAvailability", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCheckNameAvailability prepares the CheckNameAvailability request.
+func (c DeviceupdatesClient) preparerForCheckNameAvailability(ctx context.Context, id commonids.SubscriptionId, input CheckNameAvailabilityRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.DeviceUpdate/checknameavailability", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCheckNameAvailability handles the response to the CheckNameAvailability request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForCheckNameAvailability(resp *http.Response) (result CheckNameAvailabilityOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancescreate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancescreate_autorest.go
@@ -1,0 +1,79 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesCreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// InstancesCreate ...
+func (c DeviceupdatesClient) InstancesCreate(ctx context.Context, id InstanceId, input Instance) (result InstancesCreateOperationResponse, err error) {
+	req, err := c.preparerForInstancesCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesCreate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForInstancesCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesCreate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// InstancesCreateThenPoll performs InstancesCreate then polls until it's completed
+func (c DeviceupdatesClient) InstancesCreateThenPoll(ctx context.Context, id InstanceId, input Instance) error {
+	result, err := c.InstancesCreate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing InstancesCreate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after InstancesCreate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForInstancesCreate prepares the InstancesCreate request.
+func (c DeviceupdatesClient) preparerForInstancesCreate(ctx context.Context, id InstanceId, input Instance) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForInstancesCreate sends the InstancesCreate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeviceupdatesClient) senderForInstancesCreate(ctx context.Context, req *http.Request) (future InstancesCreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesdelete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesdelete_autorest.go
@@ -1,0 +1,78 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesDeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// InstancesDelete ...
+func (c DeviceupdatesClient) InstancesDelete(ctx context.Context, id InstanceId) (result InstancesDeleteOperationResponse, err error) {
+	req, err := c.preparerForInstancesDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForInstancesDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// InstancesDeleteThenPoll performs InstancesDelete then polls until it's completed
+func (c DeviceupdatesClient) InstancesDeleteThenPoll(ctx context.Context, id InstanceId) error {
+	result, err := c.InstancesDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing InstancesDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after InstancesDelete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForInstancesDelete prepares the InstancesDelete request.
+func (c DeviceupdatesClient) preparerForInstancesDelete(ctx context.Context, id InstanceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForInstancesDelete sends the InstancesDelete request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeviceupdatesClient) senderForInstancesDelete(ctx context.Context, req *http.Request) (future InstancesDeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesget_autorest.go
@@ -1,0 +1,68 @@
+package deviceupdates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Instance
+}
+
+// InstancesGet ...
+func (c DeviceupdatesClient) InstancesGet(ctx context.Context, id InstanceId) (result InstancesGetOperationResponse, err error) {
+	req, err := c.preparerForInstancesGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForInstancesGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForInstancesGet prepares the InstancesGet request.
+func (c DeviceupdatesClient) preparerForInstancesGet(ctx context.Context, id InstanceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForInstancesGet handles the response to the InstancesGet request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForInstancesGet(resp *http.Response) (result InstancesGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instanceshead_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instanceshead_autorest.go
@@ -1,0 +1,66 @@
+package deviceupdates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesHeadOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// InstancesHead ...
+func (c DeviceupdatesClient) InstancesHead(ctx context.Context, id InstanceId) (result InstancesHeadOperationResponse, err error) {
+	req, err := c.preparerForInstancesHead(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesHead", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesHead", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForInstancesHead(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesHead", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForInstancesHead prepares the InstancesHead request.
+func (c DeviceupdatesClient) preparerForInstancesHead(ctx context.Context, id InstanceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsHead(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForInstancesHead handles the response to the InstancesHead request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForInstancesHead(resp *http.Response) (result InstancesHeadOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instanceslistbyaccount_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instanceslistbyaccount_autorest.go
@@ -1,0 +1,186 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesListByAccountOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Instance
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (InstancesListByAccountOperationResponse, error)
+}
+
+type InstancesListByAccountCompleteResult struct {
+	Items []Instance
+}
+
+func (r InstancesListByAccountOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r InstancesListByAccountOperationResponse) LoadMore(ctx context.Context) (resp InstancesListByAccountOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// InstancesListByAccount ...
+func (c DeviceupdatesClient) InstancesListByAccount(ctx context.Context, id AccountId) (resp InstancesListByAccountOperationResponse, err error) {
+	req, err := c.preparerForInstancesListByAccount(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForInstancesListByAccount(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForInstancesListByAccount prepares the InstancesListByAccount request.
+func (c DeviceupdatesClient) preparerForInstancesListByAccount(ctx context.Context, id AccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/instances", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForInstancesListByAccountWithNextLink prepares the InstancesListByAccount request with the given nextLink token.
+func (c DeviceupdatesClient) preparerForInstancesListByAccountWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForInstancesListByAccount handles the response to the InstancesListByAccount request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForInstancesListByAccount(resp *http.Response) (result InstancesListByAccountOperationResponse, err error) {
+	type page struct {
+		Values   []Instance `json:"value"`
+		NextLink *string    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result InstancesListByAccountOperationResponse, err error) {
+			req, err := c.preparerForInstancesListByAccountWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForInstancesListByAccount(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesListByAccount", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// InstancesListByAccountComplete retrieves all of the results into a single object
+func (c DeviceupdatesClient) InstancesListByAccountComplete(ctx context.Context, id AccountId) (InstancesListByAccountCompleteResult, error) {
+	return c.InstancesListByAccountCompleteMatchingPredicate(ctx, id, InstanceOperationPredicate{})
+}
+
+// InstancesListByAccountCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DeviceupdatesClient) InstancesListByAccountCompleteMatchingPredicate(ctx context.Context, id AccountId, predicate InstanceOperationPredicate) (resp InstancesListByAccountCompleteResult, err error) {
+	items := make([]Instance, 0)
+
+	page, err := c.InstancesListByAccount(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := InstancesListByAccountCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_instancesupdate_autorest.go
@@ -1,0 +1,69 @@
+package deviceupdates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstancesUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Instance
+}
+
+// InstancesUpdate ...
+func (c DeviceupdatesClient) InstancesUpdate(ctx context.Context, id InstanceId, input TagUpdate) (result InstancesUpdateOperationResponse, err error) {
+	req, err := c.preparerForInstancesUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForInstancesUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "InstancesUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForInstancesUpdate prepares the InstancesUpdate request.
+func (c DeviceupdatesClient) preparerForInstancesUpdate(ctx context.Context, id InstanceId, input TagUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForInstancesUpdate handles the response to the InstancesUpdate request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForInstancesUpdate(resp *http.Response) (result InstancesUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_privateendpointconnectionproxiesupdateprivateendpointproperties_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_privateendpointconnectionproxiesupdateprivateendpointproperties_autorest.go
@@ -1,0 +1,68 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProxiesUpdatePrivateEndpointPropertiesOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties ...
+func (c DeviceupdatesClient) PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(ctx context.Context, id PrivateEndpointConnectionProxyId, input PrivateEndpointUpdate) (result PrivateEndpointConnectionProxiesUpdatePrivateEndpointPropertiesOperationResponse, err error) {
+	req, err := c.preparerForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties prepares the PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties request.
+func (c DeviceupdatesClient) preparerForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(ctx context.Context, id PrivateEndpointConnectionProxyId, input PrivateEndpointUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/updatePrivateEndpointProperties", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties handles the response to the PrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForPrivateEndpointConnectionProxiesUpdatePrivateEndpointProperties(resp *http.Response) (result PrivateEndpointConnectionProxiesUpdatePrivateEndpointPropertiesOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_privateendpointconnectionproxiesvalidate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/method_privateendpointconnectionproxiesvalidate_autorest.go
@@ -1,0 +1,68 @@
+package deviceupdates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProxiesValidateOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// PrivateEndpointConnectionProxiesValidate ...
+func (c DeviceupdatesClient) PrivateEndpointConnectionProxiesValidate(ctx context.Context, id PrivateEndpointConnectionProxyId, input PrivateEndpointConnectionProxy) (result PrivateEndpointConnectionProxiesValidateOperationResponse, err error) {
+	req, err := c.preparerForPrivateEndpointConnectionProxiesValidate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesValidate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesValidate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateEndpointConnectionProxiesValidate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deviceupdates.DeviceupdatesClient", "PrivateEndpointConnectionProxiesValidate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateEndpointConnectionProxiesValidate prepares the PrivateEndpointConnectionProxiesValidate request.
+func (c DeviceupdatesClient) preparerForPrivateEndpointConnectionProxiesValidate(ctx context.Context, id PrivateEndpointConnectionProxyId, input PrivateEndpointConnectionProxy) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/validate", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateEndpointConnectionProxiesValidate handles the response to the PrivateEndpointConnectionProxiesValidate request. The method always
+// closes the http.Response Body.
+func (c DeviceupdatesClient) responderForPrivateEndpointConnectionProxiesValidate(resp *http.Response) (result PrivateEndpointConnectionProxiesValidateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_account.go
@@ -1,0 +1,20 @@
+package deviceupdates
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Account struct {
+	Id         *string                                  `json:"id,omitempty"`
+	Identity   *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Location   string                                   `json:"location"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *AccountProperties                       `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                   `json:"systemData,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_accountproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_accountproperties.go
@@ -1,0 +1,13 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountProperties struct {
+	HostName                   *string                      `json:"hostName,omitempty"`
+	Locations                  *[]Location                  `json:"locations,omitempty"`
+	PrivateEndpointConnections *[]PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState          *ProvisioningState           `json:"provisioningState,omitempty"`
+	PublicNetworkAccess        *PublicNetworkAccess         `json:"publicNetworkAccess,omitempty"`
+	Sku                        *SKU                         `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_accountupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_accountupdate.go
@@ -1,0 +1,14 @@
+package deviceupdates
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccountUpdate struct {
+	Identity *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Location *string                                  `json:"location,omitempty"`
+	Tags     *map[string]string                       `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_checknameavailabilityrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_checknameavailabilityrequest.go
@@ -1,0 +1,9 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckNameAvailabilityRequest struct {
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_checknameavailabilityresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_checknameavailabilityresponse.go
@@ -1,0 +1,10 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckNameAvailabilityResponse struct {
+	Message       *string                      `json:"message,omitempty"`
+	NameAvailable *bool                        `json:"nameAvailable,omitempty"`
+	Reason        *CheckNameAvailabilityReason `json:"reason,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_connectiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_connectiondetails.go
@@ -1,0 +1,12 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectionDetails struct {
+	GroupId          *string `json:"groupId,omitempty"`
+	Id               *string `json:"id,omitempty"`
+	LinkIdentifier   *string `json:"linkIdentifier,omitempty"`
+	MemberName       *string `json:"memberName,omitempty"`
+	PrivateIPAddress *string `json:"privateIpAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_diagnosticstorageproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_diagnosticstorageproperties.go
@@ -1,0 +1,10 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiagnosticStorageProperties struct {
+	AuthenticationType AuthenticationType `json:"authenticationType"`
+	ConnectionString   *string            `json:"connectionString,omitempty"`
+	ResourceId         string             `json:"resourceId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_groupconnectivityinformation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_groupconnectivityinformation.go
@@ -1,0 +1,13 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GroupConnectivityInformation struct {
+	CustomerVisibleFqdns        *[]string `json:"customerVisibleFqdns,omitempty"`
+	GroupId                     *string   `json:"groupId,omitempty"`
+	InternalFqdn                *string   `json:"internalFqdn,omitempty"`
+	MemberName                  *string   `json:"memberName,omitempty"`
+	PrivateLinkServiceArmRegion *string   `json:"privateLinkServiceArmRegion,omitempty"`
+	RedirectMapId               *string   `json:"redirectMapId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_instance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_instance.go
@@ -1,0 +1,18 @@
+package deviceupdates
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Instance struct {
+	Id         *string                `json:"id,omitempty"`
+	Location   string                 `json:"location"`
+	Name       *string                `json:"name,omitempty"`
+	Properties InstanceProperties     `json:"properties"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Tags       *map[string]string     `json:"tags,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_instanceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_instanceproperties.go
@@ -1,0 +1,12 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InstanceProperties struct {
+	AccountName                 *string                      `json:"accountName,omitempty"`
+	DiagnosticStorageProperties *DiagnosticStorageProperties `json:"diagnosticStorageProperties,omitempty"`
+	EnableDiagnostics           *bool                        `json:"enableDiagnostics,omitempty"`
+	IotHubs                     *[]IotHubSettings            `json:"iotHubs,omitempty"`
+	ProvisioningState           *ProvisioningState           `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_iothubsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_iothubsettings.go
@@ -1,0 +1,8 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IotHubSettings struct {
+	ResourceId string `json:"resourceId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_location.go
@@ -1,0 +1,9 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Location struct {
+	Name *string `json:"name,omitempty"`
+	Role *Role   `json:"role,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpoint.go
@@ -1,0 +1,8 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpoint struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnection.go
@@ -1,0 +1,16 @@
+package deviceupdates
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnection struct {
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties PrivateEndpointConnectionProperties `json:"properties"`
+	SystemData *systemdata.SystemData              `json:"systemData,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproperties.go
@@ -1,0 +1,11 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	GroupIds                          *[]string                                   `json:"groupIds,omitempty"`
+	PrivateEndpoint                   *PrivateEndpoint                            `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState PrivateLinkServiceConnectionState           `json:"privateLinkServiceConnectionState"`
+	ProvisioningState                 *PrivateEndpointConnectionProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproxy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproxy.go
@@ -1,0 +1,19 @@
+package deviceupdates
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProxy struct {
+	ETag                  *string                                   `json:"eTag,omitempty"`
+	Id                    *string                                   `json:"id,omitempty"`
+	Name                  *string                                   `json:"name,omitempty"`
+	Properties            *PrivateEndpointConnectionProxyProperties `json:"properties,omitempty"`
+	RemotePrivateEndpoint *RemotePrivateEndpoint                    `json:"remotePrivateEndpoint,omitempty"`
+	Status                *string                                   `json:"status,omitempty"`
+	SystemData            *systemdata.SystemData                    `json:"systemData,omitempty"`
+	Type                  *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproxyproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointconnectionproxyproperties.go
@@ -1,0 +1,8 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProxyProperties struct {
+	ProvisioningState *PrivateEndpointConnectionProxyProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privateendpointupdate.go
@@ -1,0 +1,12 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointUpdate struct {
+	Id                      *string `json:"id,omitempty"`
+	ImmutableResourceId     *string `json:"immutableResourceId,omitempty"`
+	ImmutableSubscriptionId *string `json:"immutableSubscriptionId,omitempty"`
+	Location                *string `json:"location,omitempty"`
+	VnetTrafficTag          *string `json:"vnetTrafficTag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceconnection.go
@@ -1,0 +1,10 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnection struct {
+	GroupIds       *[]string `json:"groupIds,omitempty"`
+	Name           *string   `json:"name,omitempty"`
+	RequestMessage *string   `json:"requestMessage,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionState struct {
+	ActionsRequired *string                                 `json:"actionsRequired,omitempty"`
+	Description     *string                                 `json:"description,omitempty"`
+	Status          *PrivateEndpointServiceConnectionStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceproxy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_privatelinkserviceproxy.go
@@ -1,0 +1,11 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceProxy struct {
+	GroupConnectivityInformation            *[]GroupConnectivityInformation    `json:"groupConnectivityInformation,omitempty"`
+	Id                                      *string                            `json:"id,omitempty"`
+	RemotePrivateEndpointConnection         *RemotePrivateEndpointConnection   `json:"remotePrivateEndpointConnection,omitempty"`
+	RemotePrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"remotePrivateLinkServiceConnectionState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_remoteprivateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_remoteprivateendpoint.go
@@ -1,0 +1,16 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemotePrivateEndpoint struct {
+	ConnectionDetails                   *[]ConnectionDetails            `json:"connectionDetails,omitempty"`
+	Id                                  *string                         `json:"id,omitempty"`
+	ImmutableResourceId                 *string                         `json:"immutableResourceId,omitempty"`
+	ImmutableSubscriptionId             *string                         `json:"immutableSubscriptionId,omitempty"`
+	Location                            *string                         `json:"location,omitempty"`
+	ManualPrivateLinkServiceConnections *[]PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+	PrivateLinkServiceConnections       *[]PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
+	PrivateLinkServiceProxies           *[]PrivateLinkServiceProxy      `json:"privateLinkServiceProxies,omitempty"`
+	VnetTrafficTag                      *string                         `json:"vnetTrafficTag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_remoteprivateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_remoteprivateendpointconnection.go
@@ -1,0 +1,8 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemotePrivateEndpointConnection struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_tagupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/model_tagupdate.go
@@ -1,0 +1,8 @@
+package deviceupdates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagUpdate struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/predicates.go
@@ -1,0 +1,57 @@
+package deviceupdates
+
+type AccountOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p AccountOperationPredicate) Matches(input Account) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type InstanceOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p InstanceOperationPredicate) Matches(input Instance) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/version.go
@@ -1,0 +1,12 @@
+package deviceupdates
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/deviceupdates/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -231,6 +231,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace
 github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate
 github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource
+github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates
 github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01
 github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/dns
 github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets

--- a/website/docs/r/iothub_device_update_account.html.markdown
+++ b/website/docs/r/iothub_device_update_account.html.markdown
@@ -1,0 +1,97 @@
+---
+subcategory: "IoT Hub"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_iothub_device_update_account"
+description: |-
+  Manages an IoT Hub Device Update Account.
+---
+
+# azurerm_iothub_device_update_account
+
+Manages an IoT Hub Device Update Account.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "East US"
+}
+
+resource "azurerm_iothub_device_update_account" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    key = "value"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this IoT Hub Device Update Account. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the IoT Hub Device Update Account should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) Specifies the Azure Region where the IoT Hub Device Update Account should exist. Changing this forces a new resource to be created.
+
+* `identity` - (Optional) An `identity` block as defined below.
+
+* `public_network_access` - (Optional) The Public Network Access setting of the IoT Hub Device Update Account. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+
+* `sku` - (Optional) Sku of the IoT Hub Device Update Account. Possible values are `Free` and `Standard`. Defaults to `Standard`.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the IoT Hub Device Update Account.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this IoT Hub Device Update Account. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned` (to enable both).
+
+* `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this IoT Hub Device Update Account.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the IoT Hub Device Update Account.
+
+* `host_name` - The API host name of the IoT Hub Device Update Account.
+
+* `identity` - An `identity` block as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this IoT Hub Device Update Account.
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this IoT Hub Device Update Account.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the IoT Hub Device Update Account.
+* `read` - (Defaults to 5 minutes) Used when retrieving the IoT Hub Device Update Account.
+* `update` - (Defaults to 30 minutes) Used when updating the IoT Hub Device Update Account.
+* `delete` - (Defaults to 30 minutes) Used when deleting the IoT Hub Device Update Account.
+
+## Import
+
+IoT Hub Device Update Account can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_iothub_device_update_account.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.DeviceUpdate/accounts/account1
+```

--- a/website/docs/r/iothub_device_update_account.html.markdown
+++ b/website/docs/r/iothub_device_update_account.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `public_network_access` - (Optional) The Public Network Access setting of the IoT Hub Device Update Account. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+* `public_network_access_enabled` - (Optional) Specifies whether the public network access is enabled for the IoT Hub Device Update Account. Possible values are `true` and `false`. Defaults to `true`.
 
 * `sku` - (Optional) Sku of the IoT Hub Device Update Account. Possible values are `Free` and `Standard`. Defaults to `Standard`.
 

--- a/website/docs/r/iothub_device_update_instance.html.markdown
+++ b/website/docs/r/iothub_device_update_instance.html.markdown
@@ -44,10 +44,10 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_iothub_device_update_instance" "example" {
-  name                            = "example"
-  iothub_device_update_account_id = azurerm_iothub_device_update_account.example.id
-  iothub_id                       = azurerm_iothub.example.id
-  diagnostic_enabled              = true
+  name                     = "example"
+  device_update_account_id = azurerm_iothub_device_update_account.example.id
+  iothub_id                = azurerm_iothub.example.id
+  diagnostic_enabled       = true
 
   diagnostic_storage_account {
     connection_string = azurerm_storage_account.example.primary_connection_string
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name which should be used for this IoT Hub Device Update Instance. Changing this forces a new resource to be created.
 
-* `iothub_device_update_account_id` - (Required) Specifies the ID of the IoT Hub Device Update Account where the IoT Hub Device Update Instance exists. Changing this forces a new resource to be created.
+* `device_update_account_id` - (Required) Specifies the ID of the IoT Hub Device Update Account where the IoT Hub Device Update Instance exists. Changing this forces a new resource to be created.
 
 * `iothub_id` - (Required) Specifies the ID of the IoT Hub associated with the IoT Hub Device Update Instance. Changing this forces a new resource to be created.
 

--- a/website/docs/r/iothub_device_update_instance.html.markdown
+++ b/website/docs/r/iothub_device_update_instance.html.markdown
@@ -1,0 +1,108 @@
+---
+subcategory: "IoT Hub"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_iothub_device_update_instance"
+description: |-
+  Manages an IoT Hub Device Update Instance.
+---
+
+# azurerm_iothub_device_update_instance
+
+Manages an IoT Hub Device Update Instance.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "East US"
+}
+
+resource "azurerm_iothub_device_update_account" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_iothub" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_iothub_device_update_instance" "example" {
+  name                            = "example"
+  iothub_device_update_account_id = azurerm_iothub_device_update_account.example.id
+  iothub_id                       = azurerm_iothub.example.id
+  diagnostic_enabled              = true
+
+  diagnostic_storage_account {
+    connection_string = azurerm_storage_account.example.primary_connection_string
+    id                = azurerm_storage_account.example.id
+  }
+
+  tags = {
+    key = "value"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this IoT Hub Device Update Instance. Changing this forces a new resource to be created.
+
+* `iothub_device_update_account_id` - (Required) Specifies the ID of the IoT Hub Device Update Account where the IoT Hub Device Update Instance exists. Changing this forces a new resource to be created.
+
+* `iothub_id` - (Required) Specifies the ID of the IoT Hub associated with the IoT Hub Device Update Instance. Changing this forces a new resource to be created.
+
+* `diagnostic_storage_account` - (Optional) A `diagnostic_storage_account` block as defined below.
+
+* `diagnostic_enabled` - (Optional) Whether the diagnostic log collection is enabled. Possible values are `true` and `false`. Defaults to `false`.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the IoT Hub Device Update Instance.
+
+---
+
+A `diagnostic_storage_account` block supports the following:
+
+* `connection_string` - (Required) Connection String of the Diagnostic Storage Account.
+
+* `id` - (Required) Resource ID of the Diagnostic Storage Account.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the IoT Hub Device Update Instance.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the IoT Hub Device Update Instance.
+* `read` - (Defaults to 5 minutes) Used when retrieving the IoT Hub Device Update Instance.
+* `update` - (Defaults to 30 minutes) Used when updating the IoT Hub Device Update Instance.
+* `delete` - (Defaults to 30 minutes) Used when deleting the IoT Hub Device Update Instance.
+
+## Import
+
+IoT Hub Device Update Instance can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_iothub_device_update_instance.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.DeviceUpdate/accounts/account1/instances/instance1
+```


### PR DESCRIPTION
- Adding the support for these two new resources for IoT Hub Resource Management: https://learn.microsoft.com/azure/iot-hub-device-update/create-device-update-account
- Swagger: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/deviceupdate/resource-manager/Microsoft.DeviceUpdate/stable/2022-10-01/deviceupdate.json
- These two resources are part of IoT Hub Management, so I put them under the `iothub` directory
- IoT Hub Device Update is not available in `westeurope`, so updating the teamcity locations with `northeurope` instead