### PR TITLE
Docs: fix automation software update configuration `timezone` typo

### DIFF
--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -169,7 +169,7 @@ A `schedule` block supports the following:
 
 * `expiry_time` -  (Optional) The end time of the schedule.
 
-* `timezone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
+* `time_zone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
 
 * `advanced_week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`.
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18773