### PR TITLE
`azurerm_storage_management_policy` - Support for `tier_to_archive_after_days_since_last_tier_change_greater_than`

### DIFF
--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -845,19 +845,22 @@ resource "azurerm_storage_management_policy" "test" {
     }
     actions {
       base_blob {
-        tier_to_cool_after_days_since_modification_greater_than    = 10
-        tier_to_archive_after_days_since_modification_greater_than = 50
-        delete_after_days_since_modification_greater_than          = 100
+        tier_to_cool_after_days_since_modification_greater_than        = 10
+        tier_to_archive_after_days_since_modification_greater_than     = 50
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 10
+        delete_after_days_since_modification_greater_than              = 100
       }
       snapshot {
-        change_tier_to_archive_after_days_since_creation = 90
-        change_tier_to_cool_after_days_since_creation    = 23
-        delete_after_days_since_creation_greater_than    = 30
+        change_tier_to_archive_after_days_since_creation               = 90
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 10
+        change_tier_to_cool_after_days_since_creation                  = 23
+        delete_after_days_since_creation_greater_than                  = 30
       }
       version {
-        change_tier_to_archive_after_days_since_creation = 9
-        change_tier_to_cool_after_days_since_creation    = 90
-        delete_after_days_since_creation                 = 3
+        change_tier_to_archive_after_days_since_creation               = 9
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 10
+        change_tier_to_cool_after_days_since_creation                  = 90
+        delete_after_days_since_creation                               = 3
       }
     }
   }
@@ -898,19 +901,22 @@ resource "azurerm_storage_management_policy" "test" {
     }
     actions {
       base_blob {
-        tier_to_cool_after_days_since_modification_greater_than    = 11
-        tier_to_archive_after_days_since_modification_greater_than = 51
-        delete_after_days_since_modification_greater_than          = 101
+        tier_to_cool_after_days_since_modification_greater_than        = 11
+        tier_to_archive_after_days_since_modification_greater_than     = 51
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 20
+        delete_after_days_since_modification_greater_than              = 101
       }
       snapshot {
-        change_tier_to_archive_after_days_since_creation = 91
-        change_tier_to_cool_after_days_since_creation    = 24
-        delete_after_days_since_creation_greater_than    = 31
+        change_tier_to_archive_after_days_since_creation               = 91
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 20
+        change_tier_to_cool_after_days_since_creation                  = 24
+        delete_after_days_since_creation_greater_than                  = 31
       }
       version {
-        change_tier_to_archive_after_days_since_creation = 10
-        change_tier_to_cool_after_days_since_creation    = 91
-        delete_after_days_since_creation                 = 4
+        change_tier_to_archive_after_days_since_creation               = 10
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 20
+        change_tier_to_cool_after_days_since_creation                  = 91
+        delete_after_days_since_creation                               = 4
       }
     }
   }

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -130,6 +130,8 @@ The following arguments are supported:
 
 ~> **Note:** The `tier_to_archive_after_days_since_modification_greater_than` and `tier_to_archive_after_days_since_last_access_time_greater_than` can not be set at the same time.
 
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
+
 * `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob. Must be between 0 and 99999.
 * `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob. Must be between `0` and `99999`.
 
@@ -142,6 +144,7 @@ The following arguments are supported:
 `snapshot` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob snapshot to archive storage. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
 * `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob snapshot to cool storage. Must be between 0 and 99999.
 * `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob snapshot. Must be between 0 and 99999.
 
@@ -150,6 +153,7 @@ The following arguments are supported:
 `version` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob version to archive storage. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
 * `change_tier_to_cool_after_days_since_creation` - The age in days creation create to  tier blob version to cool storage. Must be between 0 and 99999.
 * `delete_after_days_since_creation` - The age in days after creation to delete the blob version. Must be between 0 and 99999.
 


### PR DESCRIPTION
Fix #18771.

## Test

```
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageManagementPolicy_update$'
=== RUN   TestAccStorageManagementPolicy_update
=== PAUSE TestAccStorageManagementPolicy_update
=== CONT  TestAccStorageManagementPolicy_update
--- PASS: TestAccStorageManagementPolicy_update (240.70s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       240.712s
```