### PR TITLE
`azurerm_app_configuration`  - fix testcase`TestAccAppConfigurationDataSource_basic`

### DIFF
--- a/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -510,6 +510,7 @@ resource "azurerm_app_configuration" "test" {
   location                   = azurerm_resource_group.test.location
   sku                        = "standard"
   local_auth_enabled         = true
+  public_network_access      = "Enabled"
   purge_protection_enabled   = false
   soft_delete_retention_days = 1
 


### PR DESCRIPTION
fix datasource test case `TestAccAppConfigurationDataSource_basic`

```
TF_ACC=1 go test -v ./internal/services/appconfiguration -parallel 1 -test.run=TestAccAppConfigurationData -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAppConfigurationDataSource_basic
=== PAUSE TestAccAppConfigurationDataSource_basic
=== CONT  TestAccAppConfigurationDataSource_basic
 --- PASS: TestAccAppConfigurationDataSource_basic (607.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration      607.766s

```