### PR TITLE
Docs: Fix incorrect parameter description for data resource `azurerm_cosmosdb_sql_role_definition`

### DIFF
--- a/website/docs/d/cosmosdb_sql_role_definition.html.markdown
+++ b/website/docs/d/cosmosdb_sql_role_definition.html.markdown
@@ -16,7 +16,7 @@ Use this data source to access information about an existing Cosmos DB SQL Role 
 data "azurerm_cosmosdb_sql_role_definition" "example" {
   resource_group_name = "tfex-cosmosdb-sql-role-definition-rg"
   account_name        = "tfex-cosmosdb-sql-role-definition-account-name"
-  role_definition_id  = "00000000-0000-0000-0000-000000000002"
+  role_definition_id  = "00000000-0000-0000-0000-000000000000"
 }
 ```
 
@@ -35,6 +35,8 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Cosmos DB SQL Role Definition.
+
+* `name` - The role name of the Cosmos DB SQL Role Definition.
 
 * `assignable_scopes` - A list of fully qualified scopes at or below which Role Assignments may be created using this Cosmos DB SQL Role Definition.
 

--- a/website/docs/d/cosmosdb_sql_role_definition.html.markdown
+++ b/website/docs/d/cosmosdb_sql_role_definition.html.markdown
@@ -14,9 +14,9 @@ Use this data source to access information about an existing Cosmos DB SQL Role 
 
 ```hcl
 data "azurerm_cosmosdb_sql_role_definition" "example" {
-  name                = "tfex-cosmosdb-sql-role-definition"
   resource_group_name = "tfex-cosmosdb-sql-role-definition-rg"
   account_name        = "tfex-cosmosdb-sql-role-definition-account-name"
+  role_definition_id  = "00000000-0000-0000-0000-000000000002"
 }
 ```
 
@@ -24,13 +24,11 @@ data "azurerm_cosmosdb_sql_role_definition" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) An user-friendly name for the Cosmos DB SQL Role Definition.
-
 * `resource_group_name` - (Required) The name of the Resource Group in which the Cosmos DB SQL Role Definition is created.
 
 * `account_name` - (Required) The name of the Cosmos DB Account.
 
-* `role_definition_id` - (Optional) The GUID as the name of the Cosmos DB SQL Role Definition.
+* `role_definition_id` - (Required) The GUID as the name of the Cosmos DB SQL Role Definition.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Per the [SqlResources_GetSqlRoleDefinition](https://github.com/Azure/azure-rest-api-specs/blob/f459472a91a4b057f534ca82b0e560e4bcb50f0c/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/rbac.json#L39) Azure API, the [roleDefinitionIdParameter](https://github.com/Azure/azure-rest-api-specs/blob/f459472a91a4b057f534ca82b0e560e4bcb50f0c/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/rbac.json#L48) should be required property and the `name` should be a read-only property. So submitted this PR to keep the [terraform code implementation](https://github.com/hashicorp/terraform-provider-azurerm/blob/fdf25d668657d9162454a96d52d66b6a5109a1d1/internal/services/cosmos/cosmosdb_sql_role_definition_data_source.go#L34) and documentation consistent.

Fix #18776 .