### PR TITLE
`azurerm_network_security_{group|rule}` - Setting correct casing `protocol` to state

### DIFF
--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -394,6 +395,13 @@ func expandAzureRmSecurityRules(d *pluginsdk.ResourceData) ([]network.SecurityRu
 func flattenNetworkSecurityRules(rules *[]network.SecurityRule) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 
+	// For fixing the case insensitive issue for the NSR protocol in Azure
+	// See: https://github.com/hashicorp/terraform-provider-azurerm/issues/16092
+	protocolMap := map[string]network.SecurityRuleProtocol{}
+	for _, protocol := range network.PossibleSecurityRuleProtocolValues() {
+		protocolMap[strings.ToLower(string(protocol))] = protocol
+	}
+
 	if rules != nil {
 		for _, rule := range *rules {
 			sgRule := make(map[string]interface{})
@@ -447,7 +455,7 @@ func flattenNetworkSecurityRules(rules *[]network.SecurityRule) []map[string]int
 					sgRule["source_port_ranges"] = set.FromStringSlice(*props.SourcePortRanges)
 				}
 
-				sgRule["protocol"] = string(props.Protocol)
+				sgRule["protocol"] = string(protocolMap[strings.ToLower(string(props.Protocol))])
 				sgRule["priority"] = int(*props.Priority)
 				sgRule["access"] = string(props.Access)
 				sgRule["direction"] = string(props.Direction)

--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
@@ -316,9 +317,16 @@ func resourceNetworkSecurityRuleRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("network_security_group_name", id.NetworkSecurityGroupName)
 
+	// For fixing the case insensitive issue for the NSR protocol in Azure
+	// See: https://github.com/hashicorp/terraform-provider-azurerm/issues/16092
+	protocolMap := map[string]network.SecurityRuleProtocol{}
+	for _, protocol := range network.PossibleSecurityRuleProtocolValues() {
+		protocolMap[strings.ToLower(string(protocol))] = protocol
+	}
+
 	if props := resp.SecurityRulePropertiesFormat; props != nil {
 		d.Set("description", props.Description)
-		d.Set("protocol", string(props.Protocol))
+		d.Set("protocol", string(protocolMap[strings.ToLower(string(props.Protocol))]))
 		d.Set("destination_address_prefix", props.DestinationAddressPrefix)
 		d.Set("destination_address_prefixes", props.DestinationAddressPrefixes)
 		d.Set("destination_port_range", props.DestinationPortRange)


### PR DESCRIPTION
Fix #16092