### PR TITLE
`azurerm_postgresql_server` - Fixed issue with creating Postgres server in `Replica` mode

### DIFF
--- a/internal/services/postgres/postgresql_server_key_resource_test.go
+++ b/internal/services/postgres/postgresql_server_key_resource_test.go
@@ -63,7 +63,22 @@ func TestAccPostgreSQLServerKey_requiresImport(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.RequiresImportErrorStep(r.requiresImport),
+		data.ImportStep(),
+	})
+}
+
+func TestAccPostgreSQLServerKey_replica(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_server_key", "test")
+	r := PostgreSQLServerKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.replica(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -171,17 +186,6 @@ resource "azurerm_postgresql_server_key" "test" {
 `, r.template(data))
 }
 
-func (r PostgreSQLServerKeyResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_postgresql_server_key" "import" {
-  server_id        = azurerm_postgresql_server_key.test.server_id
-  key_vault_key_id = azurerm_postgresql_server_key.test.key_vault_key_id
-}
-`, r.basic(data))
-}
-
 func (r PostgreSQLServerKeyResource) updated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -204,4 +208,50 @@ resource "azurerm_postgresql_server_key" "test" {
   key_vault_key_id = azurerm_key_vault_key.second.id
 }
 `, r.template(data))
+}
+
+func (r PostgreSQLServerKeyResource) replica(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_server_key" "test" {
+  server_id        = azurerm_postgresql_server.test.id
+  key_vault_key_id = azurerm_key_vault_key.first.id
+}
+
+resource "azurerm_key_vault_access_policy" "replica" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_postgresql_server.replica.identity.0.principal_id
+
+  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
+  secret_permissions = ["Get"]
+}
+
+resource "azurerm_resource_group" "replica" {
+  name     = "acctestRG-psql-%d-replica"
+  location = "%s"
+}
+
+resource "azurerm_postgresql_server" "replica" {
+  name                = "acctest-postgre-replica-%d"
+  location            = azurerm_resource_group.replica.location
+  resource_group_name = azurerm_resource_group.replica.name
+
+  create_mode               = "Replica"
+  creation_source_server_id = azurerm_postgresql_server.test.id
+
+  sku_name   = "GP_Gen5_2"
+  version    = "11"
+  storage_mb = 51200
+
+  ssl_enforcement_enabled = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
+`, r.template(data), data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Description
------------
This PR fixes few linked issues:

1. When creating Postgres server with `Replica` mode, and the master server has enabled CMK - Replica server will be created successfully, but will stay with `Inaccessible` state, waiting for keys revalidation.

2. When Replica server is created - provided `Identity` is ignored by API, so we need to Update the server with `Identity` value to apply it.

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/10480
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/10489
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/16413


Changes
---------

1. The change is detecting a situation where we create `Replica` server, with BYOK enabled, `Inaccessible` state, and so requiring a revalidation of the key. In a normal situation, we would finish creating a server, then create a KeyVault access policy for created SystemAssigned identity, then create a key, that would re-validate it on the server.

2. Change in the `azurerm_postgresql_server_key` logic to avoid throwing an error if the key with same name already exists. API allows to `PUT` same keys, that situation is triggering key revalidation.

3. Adding `Identity` to Update call, like we do for `publicNetworkAccess` property.

Tests
-----

```sh
# go test -v -timeout 300000s -run ^TestAccPostgreSQLServerKey_ github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/
=== RUN   TestAccPostgreSQLServerKey_basic
=== PAUSE TestAccPostgreSQLServerKey_basic
=== RUN   TestAccPostgreSQLServerKey_updateKey
=== PAUSE TestAccPostgreSQLServerKey_updateKey
=== RUN   TestAccPostgreSQLServerKey_requiresImport
=== PAUSE TestAccPostgreSQLServerKey_requiresImport
=== RUN   TestAccPostgreSQLServerKey_replica
=== PAUSE TestAccPostgreSQLServerKey_replica
=== CONT  TestAccPostgreSQLServerKey_basic
=== CONT  TestAccPostgreSQLServerKey_requiresImport
=== CONT  TestAccPostgreSQLServerKey_replica
=== CONT  TestAccPostgreSQLServerKey_updateKey
--- PASS: TestAccPostgreSQLServerKey_requiresImport (342.65s)
--- PASS: TestAccPostgreSQLServerKey_basic (417.49s)
--- PASS: TestAccPostgreSQLServerKey_updateKey (523.52s)
--- PASS: TestAccPostgreSQLServerKey_replica (816.12s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres      816.139s
#
```