### PR TITLE
`azurerm_sentinel_data_connector_aws_s3` - fix import

### DIFF
--- a/internal/services/sentinel/sentinel_data_connector.go
+++ b/internal/services/sentinel/sentinel_data_connector.go
@@ -51,6 +51,8 @@ func assertDataConnectorKind(dc securityinsight.BasicDataConnector, expectKind s
 		kind = securityinsight.DataConnectorKindAmazonWebServicesCloudTrail
 	case securityinsight.MDATPDataConnector:
 		kind = securityinsight.DataConnectorKindMicrosoftDefenderAdvancedThreatProtection
+	case securityinsight.AwsS3DataConnector:
+		kind = securityinsight.DataConnectorKindAmazonWebServicesS3
 	}
 	if expectKind != kind {
 		return fmt.Errorf("Sentinel Data Connector has mismatched kind, expected: %q, got %q", expectKind, kind)


### PR DESCRIPTION
The data connector kind was not recognized and failed with the following error:

> Error: Sentinel Data Connector has mismatched kind, expected: "AmazonWebServicesS3", got ""