### PR TITLE
Docs: fix incorrect description for property `management_group_id` instead of `management_group_name`

### DIFF
--- a/website/docs/r/management_group_template_deployment.html.markdown
+++ b/website/docs/r/management_group_template_deployment.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Template should exist. Changing this forces a new Template to be created.
 
-* `management_group_name` - (Required) The Name of the Management Group to apply the Deployment Template to.
+* `management_group_id` - (Required) The ID of the Management Group to apply the Deployment Template to.
 
 * `name` - (Required) The name which should be used for this Template Deployment. Changing this forces a new Template Deployment to be created.
 


### PR DESCRIPTION
fix #18807