### PR TITLE
`azurerm_virtual_network_gateway` - `TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2Sfix` fix public ip resource zone property

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -687,7 +687,7 @@ resource "azurerm_public_ip" "first" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_public_ip" "second" {
@@ -697,7 +697,7 @@ resource "azurerm_public_ip" "second" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_public_ip" "thirth" {
@@ -707,7 +707,7 @@ resource "azurerm_public_ip" "thirth" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_virtual_network_gateway" "test" {


### PR DESCRIPTION
public ip zone need all zones listed.


current failure message:

```
TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
=== PAUSE TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
=== CONT  TestAccVirtualNetworkGateway_activeActiveZoneRedundantWithP2S
    testcase.go:110: Step 1/1 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # azurerm_public_ip.first must be replaced
        -/+ resource "azurerm_public_ip" "first" {
              + fqdn                    = (known after apply)
              ~ id                      = "/subscriptions/*******/resourceGroups/acctestRG-221017080640493888/providers/Microsoft.Network/publicIPAddresses/acctestpip1-221017080640493888" -> (known after apply)
              ~ ip_address              = "20.69.220.152" -> (known after apply)
              - ip_tags                 = {} -> null
                name                    = "acctestpip1-221017080640493888"
              - tags                    = {} -> null
              ~ zones                   = [ # forces replacement
                  - "3",   <- response from creating with additional 3
                    # (2 unchanged elements hidden)
                ]
                # (7 unchanged attributes hidden)
            }
        
````

Test pass now:

![image](https://user-images.githubusercontent.com/2633022/196587027-aea43d23-0dc4-4504-ab22-76a8d964406c.png)
