### PR TITLE
`azurerm_[linux|windows]_function_app` and `azurerm_[linux|windows]_function_app_slot` fix `app_settings` diff when `vnet_route_all_enabled = true` 

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1082,6 +1082,8 @@ func (m *LinuxFunctionAppModel) unpackLinuxFunctionAppSettings(input web.StringD
 				appSettings[k] = utils.NormalizeNilableString(v)
 			}
 
+		case "WEBSITE_VNET_ROUTE_ALL":
+			// Filter out - handled by site_config setting `vnet_route_all_enabled`
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -918,6 +918,9 @@ func (m *LinuxFunctionAppSlotModel) unpackLinuxFunctionAppSettings(input web.Str
 				appSettings[k] = utils.NormalizeNilableString(v)
 			}
 
+		case "WEBSITE_VNET_ROUTE_ALL":
+			// Filter out - handled by site_config setting `vnet_route_all_enabled`
+
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -1075,6 +1075,9 @@ func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input web.Str
 		case "AzureWebJobsDashboard__accountName":
 			m.BuiltinLogging = true
 
+		case "WEBSITE_VNET_ROUTE_ALL":
+			// Filter out - handled by site_config setting `vnet_route_all_enabled`
+
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -919,6 +919,9 @@ func (m *WindowsFunctionAppSlotModel) unpackWindowsFunctionAppSettings(input web
 		case "AzureWebJobsDashboard__accountName":
 			m.BuiltinLogging = true
 
+		case "WEBSITE_VNET_ROUTE_ALL":
+			// Filter out - handled by site_config setting `vnet_route_all_enabled`
+
 		default:
 			appSettings[k] = utils.NormalizeNilableString(v)
 		}


### PR DESCRIPTION
*`azurerm_linux_function_app` - fix an issue where `app_settings` would show a diff when setting `vnet_route_all_enabled` to true
*`azurerm_linux_function_app_slot` - fix an issue where `app_settings` would show a diff when setting `vnet_route_all_enabled` to true
*`azurerm_windows_function_app` - fix an issue where `app_settings` would show a diff when setting `vnet_route_all_enabled` to true
*`azurerm_windows_function_app_slot` - fix an issue where `app_settings` would show a diff when setting `vnet_route_all_enabled` to true