### PR TITLE
`azurerm_synapse_workspace` - remove sql password requirement for synapse

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -73,14 +73,14 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 
 			"sql_administrator_login": {
 				Type:         pluginsdk.TypeString,
-				Required:     false,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.SqlAdministratorLoginName,
 			},
 
 			"sql_administrator_login_password": {
 				Type:      pluginsdk.TypeString,
-				Required:  false,
+				Optional:  true,
 				Sensitive: true,
 			},
 

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -73,14 +73,14 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 
 			"sql_administrator_login": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Required:     false,
 				ForceNew:     true,
 				ValidateFunc: validate.SqlAdministratorLoginName,
 			},
 
 			"sql_administrator_login_password": {
 				Type:      pluginsdk.TypeString,
-				Required:  true,
+				Required:  false,
 				Sensitive: true,
 			},
 

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -403,6 +403,43 @@ resource "azurerm_synapse_workspace" "test" {
 `, template, data.RandomInteger)
 }
 
+func (r SynapseWorkspaceResource) withAadAdminsOnly(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_identity_control_enabled         = true
+  aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  sql_aad_admin {
+    login     = "AzureAD Admin"
+    object_id = data.azurerm_client_config.current.object_id
+    tenant_id = data.azurerm_client_config.current.tenant_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    ENV = "Test2"
+  }
+}
+`, template, data.RandomInteger)
+}
+
 func (r SynapseWorkspaceResource) azureDevOps(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -179,9 +179,9 @@ The following arguments are supported:
 
 * `storage_data_lake_gen2_filesystem_id` - (Required) Specifies the ID of storage data lake gen2 filesystem resource. Changing this forces a new resource to be created.
 
-* `sql_administrator_login` - (Required) Specifies The login name of the SQL administrator. Changing this forces a new resource to be created.
+* `sql_administrator_login` - (Optional) Specifies The login name of the SQL administrator. Changing this forces a new resource to be created. If this is not provided `aad_admin` or `customer_managed_key` must be provided.
 
-* `sql_administrator_login_password` - (Required) The Password associated with the `sql_administrator_login` for the SQL administrator.
+* `sql_administrator_login_password` - (Optional) The Password associated with the `sql_administrator_login` for the SQL administrator. If this is not provided `aad_admin` or `customer_managed_key` must be provided.
 
 ---
 


### PR DESCRIPTION
Please excuse any major mistakes. This is my first PR.

This PR removes the requirement for a local SQL User on Synapse as per Azure's constraints.

I am not sure how to add a validation to check either AAD auth or local SQL user enabled. Any direction is appreciated.