### PR TITLE
New resource: `azurerm_sentinel_data_connector_dynamics_365`

### DIFF
--- a/internal/services/sentinel/registration.go
+++ b/internal/services/sentinel/registration.go
@@ -63,5 +63,6 @@ func (r Registration) Resources() []sdk.Resource {
 		WatchlistResource{},
 		WatchlistItemResource{},
 		DataConnectorAwsS3Resource{},
+		DataConnectorDynamics365Resource{},
 	}
 }

--- a/internal/services/sentinel/sentinel_data_connector.go
+++ b/internal/services/sentinel/sentinel_data_connector.go
@@ -43,6 +43,8 @@ func assertDataConnectorKind(dc securityinsight.BasicDataConnector, expectKind s
 		kind = securityinsight.DataConnectorKindMicrosoftCloudAppSecurity
 	case securityinsight.TIDataConnector:
 		kind = securityinsight.DataConnectorKindThreatIntelligence
+	case securityinsight.Dynamics365DataConnector:
+		kind = securityinsight.DataConnectorKindDynamics365
 	case securityinsight.OfficeDataConnector:
 		kind = securityinsight.DataConnectorKindOffice365
 	case securityinsight.OfficeATPDataConnector:

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365.go
@@ -1,0 +1,194 @@
+package sentinel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/securityinsight/mgmt/2022-01-01-preview/securityinsight"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type DataConnectorDynamics365Resource struct{}
+
+var _ sdk.ResourceWithCustomImporter = DataConnectorDynamics365Resource{}
+
+type DataConnectorDynamics365Model struct {
+	Name                    string `tfschema:"name"`
+	LogAnalyticsWorkspaceId string `tfschema:"log_analytics_workspace_id"`
+	TenantId                string `tfschema:"tenant_id"`
+}
+
+func (r DataConnectorDynamics365Resource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"log_analytics_workspace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
+		},
+
+		"tenant_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+	}
+}
+
+func (r DataConnectorDynamics365Resource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r DataConnectorDynamics365Resource) ResourceType() string {
+	return "azurerm_sentinel_data_connector_dynamics_365"
+}
+
+func (r DataConnectorDynamics365Resource) ModelObject() interface{} {
+	return &DataConnectorDynamics365Model{}
+}
+
+func (r DataConnectorDynamics365Resource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.DataConnectorID
+}
+
+func (r DataConnectorDynamics365Resource) CustomImporter() sdk.ResourceRunFunc {
+	return func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+		_, err := importSentinelDataConnector(securityinsight.DataConnectorKindDynamics365)(ctx, metadata.ResourceData, metadata.Client)
+		return err
+	}
+}
+
+func (r DataConnectorDynamics365Resource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			var plan DataConnectorDynamics365Model
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			workspaceId, err := workspaces.ParseWorkspaceID(plan.LogAnalyticsWorkspaceId)
+			if err != nil {
+				return err
+			}
+
+			id := parse.NewDataConnectorID(workspaceId.SubscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, plan.Name)
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			tenantId := plan.TenantId
+			if tenantId == "" {
+				tenantId = metadata.Client.Account.TenantId
+			}
+
+			params := securityinsight.Dynamics365DataConnector{
+				Name: &plan.Name,
+				Dynamics365DataConnectorProperties: &securityinsight.Dynamics365DataConnectorProperties{
+					TenantID: &tenantId,
+					DataTypes: &securityinsight.Dynamics365DataConnectorDataTypes{
+						Dynamics365CdsActivities: &securityinsight.Dynamics365DataConnectorDataTypesDynamics365CdsActivities{
+							State: securityinsight.DataTypeStateEnabled,
+						},
+					},
+				},
+				Kind: securityinsight.KindBasicDataConnectorKindDynamics365,
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r DataConnectorDynamics365Resource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(existing.Response) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			dc, ok := existing.Value.(securityinsight.Dynamics365DataConnector)
+			if !ok {
+				return fmt.Errorf("%s was not an Dynamics 365 Data Connector", id)
+			}
+
+			var tenantId string
+			if props := dc.Dynamics365DataConnectorProperties; props != nil {
+				if props.TenantID != nil {
+					tenantId = *props.TenantID
+				}
+			}
+
+			model := DataConnectorDynamics365Model{
+				Name:                    id.Name,
+				LogAnalyticsWorkspaceId: workspaceId.ID(),
+				TenantId:                tenantId,
+			}
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r DataConnectorDynamics365Resource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
@@ -1,0 +1,153 @@
+package sentinel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type SentinelDataConnectorDynamics365Resource struct{}
+
+func TestAccSentinelDataConnectorDynamics365_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_dynamics_365", "test")
+	r := SentinelDataConnectorDynamics365Resource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelDataConnectorDynamics365_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_dynamics_365", "test")
+	r := SentinelDataConnectorDynamics365Resource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSentinelDataConnectorDynamics365_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_dynamics_365", "test")
+	r := SentinelDataConnectorDynamics365Resource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r SentinelDataConnectorDynamics365Resource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	client := clients.Sentinel.DataConnectorsClient
+
+	id, err := parse.DataConnectorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r SentinelDataConnectorDynamics365Resource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorDynamics365Resource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  tenant_id                  = data.azurerm_client_config.test.tenant_id
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorDynamics365Resource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_dynamics_365" "import" {
+  name                       = azurerm_sentinel_data_connector_dynamics_365.test.name
+  log_analytics_workspace_id = azurerm_sentinel_data_connector_dynamics_365.test.log_analytics_workspace_id
+}
+`, template)
+}
+
+func (r SentinelDataConnectorDynamics365Resource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sentinel-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "Sentinel"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sentinel_data_connector_dynamics_365"
+description: |-
+  Manages a Dynamics 365 Data Connector.
+---
+
+# azurerm_sentinel_data_connector_dynamics_365
+
+Manages a Dynamics 365 Data Connector.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
+
+resource "azurerm_sentinel_data_connector_dynamics_365" "example" {
+  name                       = "example"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace that this Dynamics 365 Data Connector resides in. Changing this forces a new Dynamics 365 Data Connector to be created.
+
+* `name` - (Required) The name which should be used for this Dynamics 365 Data Connector. Changing this forces a new Dynamics 365 Data Connector to be created.
+
+---
+
+* `tenant_id` - (Optional) The ID of the tenant that this Dynamics 365 Data Connector connects to. Changing this forces a new Dynamics 365 Data Connector to be created.
+
+-> **NOTE** Currently, only the same tenant as the running account is allowed. Cross-tenant scenario is not supported yet.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Dynamics 365 Data Connector.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Dynamics 365 Data Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dynamics 365 Data Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Dynamics 365 Data Connector.
+
+## Import
+
+Dynamics 365 Data Connectors can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sentinel_data_connector_dynamics_365.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/dataConnectors/dc1
+```


### PR DESCRIPTION
Relating to https://github.com/hashicorp/terraform-provider-azurerm/issues/18195.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel -run='TestAccSentinelDataConnectorDynamics365_'
=== RUN   TestAccSentinelDataConnectorDynamics365_basic
=== PAUSE TestAccSentinelDataConnectorDynamics365_basic
=== RUN   TestAccSentinelDataConnectorDynamics365_complete
=== PAUSE TestAccSentinelDataConnectorDynamics365_complete
=== RUN   TestAccSentinelDataConnectorDynamics365_requiresImport
=== PAUSE TestAccSentinelDataConnectorDynamics365_requiresImport
=== CONT  TestAccSentinelDataConnectorDynamics365_basic
=== CONT  TestAccSentinelDataConnectorDynamics365_requiresImport
=== CONT  TestAccSentinelDataConnectorDynamics365_complete
--- PASS: TestAccSentinelDataConnectorDynamics365_basic (79.53s)
--- PASS: TestAccSentinelDataConnectorDynamics365_complete (142.56s)
--- PASS: TestAccSentinelDataConnectorDynamics365_requiresImport (144.96s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      144.980s
```