### PR TITLE
`azurerm_automation_software_update_configuration` - fix validation for subscription id

### DIFF
--- a/internal/services/automation/automation_software_update_configuration.go
+++ b/internal/services/automation/automation_software_update_configuration.go
@@ -9,10 +9,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/automation/mgmt/2020-01-13-preview/automation"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	validate4 "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	validate3 "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/validate"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
@@ -628,7 +628,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 											if len(e) == 0 {
 												return w, e
 											}
-											w, e = validate3.SubscriptionID(i, s)
+											w, e = commonids.ValidateSubscriptionID(i, s)
 											return w, e
 										},
 									},

--- a/internal/services/automation/automation_software_update_configuration_test.go
+++ b/internal/services/automation/automation_software_update_configuration_test.go
@@ -161,6 +161,8 @@ func (a SoftwareUpdateConfigurationResource) update(data acceptance.TestData) st
 
 %s
 
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
@@ -178,7 +180,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
   target {
     azure_query {
-      scope     = [azurerm_resource_group.test.id]
+      scope     = ["/subscriptions/${data.azurerm_client_config.current.subscription_id}"]
       locations = [azurerm_resource_group.test.location]
       tags {
         tag    = "foo"
@@ -268,7 +270,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
 // software update need log analytic location map correct, if use a random location like `East US` will cause
 // error like `chosen Azure Automation does not have a Log Analytics workspace linked for operation to succeed`.
-//  so location hardcode as `West US`
+// so location hardcode as `West US`
 // see more https://learn.microsoft.com/en-us/azure/automation/how-to/region-mappings
 func (a SoftwareUpdateConfigurationResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION

## Detail
fixing of using a wrong validation function for subscription id.

## Fixes
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18835

## Test

```
--- PASS: TestAccSoftwareUpdateConfiguration_update (250.93s)
PASS
```

