### PR TITLE
Allow php version 8.1

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -1167,6 +1167,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						"7.4",
 						"8.0",
+						"8.1",
 					}, false),
 					AtLeastOneOf: []string{
 						"site_config.0.application_stack.0.docker_image",


### PR DESCRIPTION
php 8.1 now supported, see https://azure.github.io/AppService/2022/10/12/New-Language-Stacks-available-on-AppService.html