### PR TITLE
`azurerm_resource_**_policy_remediation`: suppress case diff in `policy_definition_reference_id` of policy remediation

### DIFF
--- a/internal/services/policy/remediation_management_group.go
+++ b/internal/services/policy/remediation_management_group.go
@@ -95,6 +95,8 @@ func resourceArmManagementGroupPolicyRemediation() *pluginsdk.Resource {
 			"policy_definition_reference_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 		},
 	}

--- a/internal/services/policy/remediation_resource.go
+++ b/internal/services/policy/remediation_resource.go
@@ -95,6 +95,8 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 			"policy_definition_reference_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"resource_discovery_mode": {

--- a/internal/services/policy/remediation_resource_group.go
+++ b/internal/services/policy/remediation_resource_group.go
@@ -95,6 +95,8 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 			"policy_definition_reference_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"resource_discovery_mode": {

--- a/internal/services/policy/remediation_resource_test.go
+++ b/internal/services/policy/remediation_resource_test.go
@@ -114,15 +114,20 @@ func (r ResourcePolicyRemediationResource) complete(data acceptance.TestData) st
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_policy_set_definition" "test" {
+  display_name = "Audit machines with insecure password security settings"
+}
+
 resource "azurerm_resource_policy_remediation" "test" {
-  name                    = "acctestremediation-%[2]s"
-  resource_id             = azurerm_virtual_network.test.id
-  policy_assignment_id    = azurerm_resource_policy_assignment.test.id
-  location_filters        = ["westus"]
-  resource_discovery_mode = "ReEvaluateCompliance"
-  failure_percentage      = 0.5
-  parallel_deployments    = 3
-  resource_count          = 3
+  name                           = "acctestremediation-%[2]s"
+  resource_id                    = azurerm_virtual_network.test.id
+  policy_assignment_id           = azurerm_resource_policy_assignment.test.id
+  location_filters               = ["westus"]
+  resource_discovery_mode        = "ReEvaluateCompliance"
+  failure_percentage             = 0.5
+  parallel_deployments           = 3
+  resource_count                 = 3
+  policy_definition_reference_id = data.azurerm_policy_set_definition.test.policy_definition_reference[0].reference_id
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/policy/remediation_subscription.go
+++ b/internal/services/policy/remediation_subscription.go
@@ -94,6 +94,8 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 			"policy_definition_reference_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"resource_discovery_mode": {


### PR DESCRIPTION
Try Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/18846

## Detail
I have tried the test locally which causes case-diff because the API responds to all IDs in lower-case even for this reference_id property. So add diffSuppress function and one test case for this property.

related issue: https://github.com/Azure/azure-rest-api-specs/issues/8353

## Test

```
--- PASS: TestAccAzureRMResourcePolicyRemediation_complete (445.26s)
PASS
```
