### PR TITLE
`azurerm_recovery_services_vault` - fix acctest

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -187,40 +187,6 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for creation of %q: %+v", id, err)
 	}
-	cfg := backup.ResourceVaultConfigResource{
-		Properties: &backup.ResourceVaultConfig{
-			EnhancedSecurityState: backup.EnhancedSecurityStateEnabled, // always enabled
-		},
-	}
-
-	if sd := d.Get("soft_delete_enabled").(bool); sd {
-		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateEnabled
-	} else {
-		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateDisabled
-	}
-
-	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{"syncing"},
-		Target:     []string{"success"},
-		MinTimeout: 30 * time.Second,
-		Refresh: func() (interface{}, string, error) {
-			resp, err := cfgsClient.Update(ctx, id.Name, id.ResourceGroup, cfg)
-			if err != nil {
-				if strings.Contains(err.Error(), "ResourceNotYetSynced") {
-					return resp, "syncing", nil
-				}
-				return resp, "error", fmt.Errorf("updating Recovery Service Vault Cfg %s: %+v", id.String(), err)
-			}
-
-			return resp, "success", nil
-		},
-	}
-
-	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
-
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
-	}
 
 	storageCfg := backup.ResourceConfigResource{
 		Properties: &backup.ResourceConfig{
@@ -229,7 +195,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		},
 	}
 
-	err = pluginsdk.Retry(stateConf.Timeout, func() *pluginsdk.RetryError {
+	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if resp, err := storageCfgsClient.Update(ctx, id.Name, id.ResourceGroup, storageCfg); err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return pluginsdk.RetryableError(fmt.Errorf("updating Recovery Service Storage Cfg %s: %+v", id.String(), err))
@@ -247,7 +213,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	// storage type is not updated instantaneously, so we wait until storage type is correct
-	err = pluginsdk.Retry(stateConf.Timeout, func() *pluginsdk.RetryError {
+	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if resp, err := storageCfgsClient.Get(ctx, id.Name, id.ResourceGroup); err == nil {
 			if resp.Properties == nil {
 				return pluginsdk.NonRetryableError(fmt.Errorf("updating %s Storage Config: `properties` was nil", id))
@@ -281,6 +247,40 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for update encryption of %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
 		}
+	}
+
+	// an update on the vault will reset the vault config to default, so we handle it at last.
+	cfg := backup.ResourceVaultConfigResource{
+		Properties: &backup.ResourceVaultConfig{
+			EnhancedSecurityState: backup.EnhancedSecurityStateEnabled, // always enabled
+		},
+	}
+	if sd := d.Get("soft_delete_enabled").(bool); sd {
+		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateEnabled
+	} else {
+		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateDisabled
+	}
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"syncing"},
+		Target:     []string{"success"},
+		MinTimeout: 30 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+			resp, err := cfgsClient.Update(ctx, id.Name, id.ResourceGroup, cfg)
+			if err != nil {
+				if strings.Contains(err.Error(), "ResourceNotYetSynced") {
+					return resp, "syncing", nil
+				}
+				return resp, "error", fmt.Errorf("updating Recovery Service Vault Cfg %s: %+v", id.String(), err)
+			}
+
+			return resp, "success", nil
+		},
+	}
+
+	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
 	}
 
 	d.SetId(id.ID())
@@ -333,37 +333,6 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 		Properties: &backup.ResourceVaultConfig{
 			EnhancedSecurityState: backup.EnhancedSecurityStateEnabled, // always enabled
 		},
-	}
-
-	if d.HasChange("soft_delete_enabled") {
-		if sd := d.Get("soft_delete_enabled").(bool); sd {
-			cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateEnabled
-		} else {
-			cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateDisabled
-		}
-
-		stateConf := &pluginsdk.StateChangeConf{
-			Pending:    []string{"syncing"},
-			Target:     []string{"success"},
-			MinTimeout: 30 * time.Second,
-			Refresh: func() (interface{}, string, error) {
-				resp, err := cfgsClient.Update(ctx, id.Name, id.ResourceGroup, cfg)
-				if err != nil {
-					if strings.Contains(err.Error(), "ResourceNotYetSynced") {
-						return resp, "syncing", nil
-					}
-					return resp, "error", fmt.Errorf("updating Recovery Service Vault Cfg %s: %+v", id.String(), err)
-				}
-
-				return resp, "success", nil
-			},
-		}
-
-		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
-
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
-		}
 	}
 
 	if d.HasChanges("storage_mode_type", "cross_region_restore_enabled") {
@@ -463,6 +432,36 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 	if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for update encryption of %s: %+v", id, err)
+	}
+
+	// an update on vault will cause the vault config reset to default, so whether the config has change or not, it needs to be updated.
+	if sd := d.Get("soft_delete_enabled").(bool); sd {
+		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateEnabled
+	} else {
+		cfg.Properties.SoftDeleteFeatureState = backup.SoftDeleteFeatureStateDisabled
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"syncing"},
+		Target:     []string{"success"},
+		MinTimeout: 30 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+			resp, err := cfgsClient.Update(ctx, id.Name, id.ResourceGroup, cfg)
+			if err != nil {
+				if strings.Contains(err.Error(), "ResourceNotYetSynced") {
+					return resp, "syncing", nil
+				}
+				return resp, "error", fmt.Errorf("updating Recovery Service Vault Cfg %s: %+v", id.String(), err)
+			}
+
+			return resp, "success", nil
+		},
+	}
+
+	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for on update for Recovery Service  %s: %+v", id.String(), err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -187,6 +187,13 @@ func TestAccRecoveryServicesVault_softDelete(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.softDeleteDisabledWithEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -658,6 +665,93 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                 = "Standard"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) softDeleteDisabledWithEncryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctest-key-vault-%[3]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctest-key-vault-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  soft_delete_enabled = false
+
+  encryption {
+    key_id                            = azurerm_key_vault_key.test.id
+    infrastructure_encryption_enabled = false
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (RecoveryServicesVaultResource) softDeleteDisabled(data acceptance.TestData) string {


### PR DESCRIPTION
fix a bug that `soft_delete_enabled` will be reset to default when `identity` block changed or create with `identity`

Test
---
```
TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccRecoveryServicesVault_softDelete -timeout=600m
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== CONT  TestAccRecoveryServicesVault_softDelete
--- PASS: TestAccRecoveryServicesVault_softDelete (1023.09s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      1023.104s
```