### PR TITLE
`azurerm_storage_account` - Modified to allow setting CMK for Premium-tier services

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1165,8 +1165,8 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// for encryption of blob, file, table and queue
 	var encryption *storage.Encryption
 	if v, ok := d.GetOk("customer_managed_key"); ok {
-		if accountKind != string(storage.KindStorageV2) {
-			return fmt.Errorf("customer managed key can only be used with account kind `StorageV2`")
+		if accountTier != string(storage.AccessTierPremium) && accountKind != string(storage.KindStorageV2) {
+			return fmt.Errorf("customer managed key can only be used with account kind `StorageV2` or account tier `Premium`")
 		}
 		if storageAccountIdentity.Type != storage.IdentityTypeUserAssigned {
 			return fmt.Errorf("customer managed key can only be used with identity type `UserAssigned`")

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -217,7 +217,7 @@ A `customer_managed_key` block supports the following:
 
 * `user_assigned_identity_id` - (Required) The ID of a user assigned identity.
 
-~> **NOTE:** `customer_managed_key` can only be set when the `account_kind` is set to `StorageV2` and the identity type is `UserAssigned`.
+~> **NOTE:** `customer_managed_key` can only be set when the `account_kind` is set to `StorageV2` or `account_tier` set to `Premium`, and the identity type is `UserAssigned`.
 
 ---
 


### PR DESCRIPTION
Description
------------
When creating Storage account with CMK enabled, it is hardcoded in Terraform to allow only StorageV2 kind. That does not allow using CMK with Premium accounts through Terraform.

Changes
---------
The change is checking for Premium account tier to allow CMK usage.

Tests
------

I have tested creation of Premium tier `BlockBlobStorage` and `FileStorage` and verified CMK is working as expected.

```shell
# go test -v -timeout 300000s -run ^TestAccStorageAccount_premium github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/
=== RUN   TestAccStorageAccount_premium
=== PAUSE TestAccStorageAccount_premium
=== RUN   TestAccStorageAccount_premiumBlobCustomerManagedKey
=== PAUSE TestAccStorageAccount_premiumBlobCustomerManagedKey
=== RUN   TestAccStorageAccount_premiumFileCustomerManagedKey
=== PAUSE TestAccStorageAccount_premiumFileCustomerManagedKey
=== CONT  TestAccStorageAccount_premium
=== CONT  TestAccStorageAccount_premiumFileCustomerManagedKey
=== CONT  TestAccStorageAccount_premiumBlobCustomerManagedKey
--- PASS: TestAccStorageAccount_premium (122.12s)
--- PASS: TestAccStorageAccount_premiumFileCustomerManagedKey (310.48s)
--- PASS: TestAccStorageAccount_premiumBlobCustomerManagedKey (321.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       321.068s
#
```