### PR TITLE
`iothub` - Update test location to fit Device Update resource

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -78,6 +78,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // IoT Central is only available in certain locations
         "iotcentral" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "southeastasia", "eastus2", false)),
 
+        // IoT Hub Device Update is only available in certain locations
+        "iothub" to testConfiguration(locationOverride = LocationConfiguration("northeurope", "eastus2", "westus2", false)),
+
         // Log Analytics Clusters have a max deployments of 2 - parallelism set to 1 or `importTest` fails
         "loganalytics" to testConfiguration(parallelism = 1),
 


### PR DESCRIPTION
This is to split out the test location fix from #18789. It only takes effect after merging.