### PR TITLE
`azurerm_vpn_gateway_connection`: fix `TestAccVpnGatewayConnection_customRouteTable` routing table

### DIFF
--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -235,5 +235,5 @@ resource "azurerm_express_route_gateway" "test" {
   virtual_hub_id      = azurerm_virtual_hub.test.id
   scale_units         = 1
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -129,8 +129,6 @@ resource "azurerm_express_route_connection" "test" {
   name                             = "acctest-ExpressRouteConnection-%d"
   express_route_gateway_id         = azurerm_express_route_gateway.test.id
   express_route_circuit_peering_id = azurerm_express_route_circuit_peering.test.id
-
-  depends_on = [azurerm_virtual_hub_route_table.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -161,11 +159,11 @@ resource "azurerm_express_route_connection" "test" {
   enable_internet_security         = true
 
   routing {
-    associated_route_table_id = azurerm_virtual_hub_route_table.test.id
+    associated_route_table_id = azurerm_virtual_hub.test.default_route_table_id
 
     propagated_route_table {
       labels          = ["label1"]
-      route_table_ids = [azurerm_virtual_hub_route_table.test.id]
+      route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
     }
   }
 }
@@ -179,25 +177,25 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-erconnection-%d"
-  location = "%s"
+  name     = "acctestRG-erconnection-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_express_route_port" "test" {
-  name                = "acctest-erp-%d"
+  name                = "acctest-erp-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra"
-  bandwidth_in_gbps   = 1
+  bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
 }
 
 resource "azurerm_express_route_circuit" "test" {
-  name                  = "acctest-erc-%d"
+  name                  = "acctest-erc-%[1]d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   express_route_port_id = azurerm_express_route_port.test.id
-  bandwidth_in_gbps     = 1
+  bandwidth_in_gbps     = 5
 
   sku {
     tier   = "Premium"
@@ -217,13 +215,13 @@ resource "azurerm_express_route_circuit_peering" "test" {
 }
 
 resource "azurerm_virtual_wan" "test" {
-  name                = "acctest-vwan-%d"
+  name                = "acctest-vwan-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_virtual_hub" "test" {
-  name                = "acctest-vhub-%d"
+  name                = "acctest-vhub-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   virtual_wan_id      = azurerm_virtual_wan.test.id
@@ -231,16 +229,11 @@ resource "azurerm_virtual_hub" "test" {
 }
 
 resource "azurerm_express_route_gateway" "test" {
-  name                = "acctest-ergw-%d"
+  name                = "acctest-ergw-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   virtual_hub_id      = azurerm_virtual_hub.test.id
   scale_units         = 1
 }
-
-resource "azurerm_virtual_hub_route_table" "test" {
-  name           = "acctest-vhubrt-%d"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/point_to_site_vpn_gateway_resource_test.go
+++ b/internal/services/network/point_to_site_vpn_gateway_resource_test.go
@@ -164,11 +164,6 @@ func (r PointToSiteVPNGatewayResource) updated(data acceptance.TestData) string 
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_virtual_hub_route_table" "test" {
-  name           = "acctest-RouteTable-%d"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-
 resource "azurerm_point_to_site_vpn_gateway" "test" {
   name                        = "acctestp2sVPNG-%d"
   location                    = azurerm_resource_group.test.location
@@ -185,16 +180,16 @@ resource "azurerm_point_to_site_vpn_gateway" "test" {
     }
 
     route {
-      associated_route_table_id = azurerm_virtual_hub_route_table.test.id
+      associated_route_table_id = azurerm_virtual_hub.test.default_route_table_id
 
       propagated_route_table {
-        ids    = [azurerm_virtual_hub_route_table.test.id]
+        ids    = [azurerm_virtual_hub.test.default_route_table_id]
         labels = ["label1", "label2"]
       }
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PointToSiteVPNGatewayResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/network/vpn_gateway_connection_resource.go
+++ b/internal/services/network/vpn_gateway_connection_resource.go
@@ -419,6 +419,8 @@ func resourceVpnGatewayConnectionResourceCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		// try to delete the resource, or it will exist as failed status. we could simply ignore the result and error
+		_, _ = client.Delete(ctx, gatewayId.ResourceGroup, gatewayId.Name, name)
 		return fmt.Errorf("waiting for creation of Vpn Gateway Connection Resource %q (Resource Group %q / VPN Gateway %q): %+v", name, gatewayId.ResourceGroup, gatewayId.Name, err)
 	}
 

--- a/internal/services/network/vpn_gateway_connection_resource.go
+++ b/internal/services/network/vpn_gateway_connection_resource.go
@@ -419,8 +419,6 @@ func resourceVpnGatewayConnectionResourceCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		// try to delete the resource, or it will exist as failed status. we could simply ignore the result and error
-		_, _ = client.Delete(ctx, gatewayId.ResourceGroup, gatewayId.Name, name)
 		return fmt.Errorf("waiting for creation of Vpn Gateway Connection Resource %q (Resource Group %q / VPN Gateway %q): %+v", name, gatewayId.ResourceGroup, gatewayId.Name, err)
 	}
 

--- a/internal/services/network/vpn_gateway_connection_resource_test.go
+++ b/internal/services/network/vpn_gateway_connection_resource_test.go
@@ -293,20 +293,15 @@ func (r VPNGatewayConnectionResource) customRouteTable(data acceptance.TestData)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_virtual_hub_route_table" "test" {
-  name           = "acctest-RouteTable-%[2]d"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-
 resource "azurerm_vpn_gateway_connection" "test" {
   name               = "acctest-VpnGwConn-%[2]d"
   vpn_gateway_id     = azurerm_vpn_gateway.test.id
   remote_vpn_site_id = azurerm_vpn_site.test.id
   routing {
-    associated_route_table = azurerm_virtual_hub_route_table.test.id
+    associated_route_table = azurerm_virtual_hub.test.default_route_table_id
 
     propagated_route_table {
-      route_table_ids = [azurerm_virtual_hub_route_table.test.id]
+      route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
       labels          = ["label1"]
     }
   }
@@ -344,25 +339,15 @@ func (r VPNGatewayConnectionResource) customRouteTableUpdate(data acceptance.Tes
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_virtual_hub_route_table" "test" {
-  name           = "acctest-RouteTable-%[2]d"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-
-resource "azurerm_virtual_hub_route_table" "test2" {
-  name           = "acctest-RouteTable-%[2]d-2"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-
 resource "azurerm_vpn_gateway_connection" "test" {
   name               = "acctest-VpnGwConn-%[2]d"
   vpn_gateway_id     = azurerm_vpn_gateway.test.id
   remote_vpn_site_id = azurerm_vpn_site.test.id
   routing {
-    associated_route_table = azurerm_virtual_hub_route_table.test2.id
+    associated_route_table = azurerm_virtual_hub.test.default_route_table_id
 
     propagated_route_table {
-      route_table_ids = [azurerm_virtual_hub_route_table.test2.id]
+      route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
       labels          = ["label2"]
     }
   }


### PR DESCRIPTION
## Background Information
1. We can not use a custom route table but use the default route table of the virtualhub

## What Try to fix
**TestAccVpnGatewayConnection_customRouteTable**
> ```Error: waiting for creation of Vpn Gateway Connection Resource "acctest-VpnGwConn-221019074830357563" (Resource Group "acctestRG-vpn-221019074830357563" / VPN Gateway "acctest-vpngw-221019074830357563"): Code="InvalidAssociatedRouteTable" Message="The specified associated route table '/subscriptions/*******/resourceGroups/acctestRG-vpn-221019074830357563/providers/Microsoft.Network/virtualHubs/acctest-vhub-221019074830357563/hubRouteTables/acctest-RouteTable-221019074830357563' for connection '/subscriptions/*******/resourceGroups/acctestRG-vpn-221019074830357563/providers/Microsoft.Network/vpnGateways/acctest-vpngw-221019074830357563/vpnConnections/acctest-VpnGwConn-221019074830357563' is invalid 'Associated route table on branches can't be custom route table.'." Details=[]```

## Test Result

```
=== RUN   TestAccVpnGatewayConnection_customRouteTable
=== PAUSE TestAccVpnGatewayConnection_customRouteTable
=== CONT  TestAccVpnGatewayConnection_customRouteTable
--- PASS: TestAccVpnGatewayConnection_customRouteTable (5284.45s)
```

![image](https://user-images.githubusercontent.com/2633022/197541846-e0c2967c-00c3-4698-9551-eb06e4367c97.png)

