### PR TITLE
Data Source: `azurerm_storage_management_policy` add supports for the `tier_to_archive_after_days_since_last_tier_change_greater_than`

### DIFF
--- a/internal/services/storage/storage_management_policy_data_source.go
+++ b/internal/services/storage/storage_management_policy_data_source.go
@@ -106,6 +106,10 @@ func dataSourceStorageManagementPolicy() *pluginsdk.Resource {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
 												},
+												"tier_to_archive_after_days_since_last_tier_change_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Computed: true,
+												},
 												"delete_after_days_since_last_access_time_greater_than": {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
@@ -123,6 +127,10 @@ func dataSourceStorageManagementPolicy() *pluginsdk.Resource {
 										Elem: &pluginsdk.Resource{
 											Schema: map[string]*pluginsdk.Schema{
 												"change_tier_to_archive_after_days_since_creation": {
+													Type:     pluginsdk.TypeInt,
+													Computed: true,
+												},
+												"tier_to_archive_after_days_since_last_tier_change_greater_than": {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
 												},
@@ -144,6 +152,10 @@ func dataSourceStorageManagementPolicy() *pluginsdk.Resource {
 										Elem: &pluginsdk.Resource{
 											Schema: map[string]*pluginsdk.Schema{
 												"change_tier_to_archive_after_days_since_creation": {
+													Type:     pluginsdk.TypeInt,
+													Computed: true,
+												},
+												"tier_to_archive_after_days_since_last_tier_change_greater_than": {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
 												},

--- a/internal/services/storage/storage_management_policy_data_source_test.go
+++ b/internal/services/storage/storage_management_policy_data_source_test.go
@@ -27,9 +27,12 @@ func TestAccDataSourceStorageManagementPolicy_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("rule.0.actions.0.base_blob.#").HasValue("1"),
 				check.That(data.ResourceName).Key("rule.0.actions.0.base_blob.0.tier_to_cool_after_days_since_modification_greater_than").HasValue("10"),
 				check.That(data.ResourceName).Key("rule.0.actions.0.base_blob.0.tier_to_archive_after_days_since_modification_greater_than").HasValue("50"),
+				check.That(data.ResourceName).Key("rule.0.actions.0.base_blob.0.tier_to_archive_after_days_since_last_tier_change_greater_than").HasValue("10"),
 				check.That(data.ResourceName).Key("rule.0.actions.0.base_blob.0.delete_after_days_since_modification_greater_than").HasValue("100"),
 				check.That(data.ResourceName).Key("rule.0.actions.0.snapshot.#").HasValue("1"),
 				check.That(data.ResourceName).Key("rule.0.actions.0.snapshot.0.delete_after_days_since_creation_greater_than").HasValue("30"),
+				check.That(data.ResourceName).Key("rule.0.actions.0.snapshot.0.tier_to_archive_after_days_since_last_tier_change_greater_than").HasValue("10"),
+				check.That(data.ResourceName).Key("rule.0.actions.0.snapshot.0.change_tier_to_archive_after_days_since_creation").HasValue("10"),
 			),
 		},
 	})
@@ -91,12 +94,15 @@ resource "azurerm_storage_management_policy" "test" {
     }
     actions {
       base_blob {
-        tier_to_cool_after_days_since_modification_greater_than    = 10
-        tier_to_archive_after_days_since_modification_greater_than = 50
-        delete_after_days_since_modification_greater_than          = 100
+        tier_to_cool_after_days_since_modification_greater_than        = 10
+        tier_to_archive_after_days_since_modification_greater_than     = 50
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 10
+        delete_after_days_since_modification_greater_than              = 100
       }
       snapshot {
-        delete_after_days_since_creation_greater_than = 30
+        delete_after_days_since_creation_greater_than                  = 30
+        change_tier_to_archive_after_days_since_creation               = 10
+        tier_to_archive_after_days_since_last_tier_change_greater_than = 10
       }
     }
   }

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier.
 * `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
 * `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
 * `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob.
 * `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob.
 
@@ -75,6 +76,7 @@ The following arguments are supported:
 `snapshot` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob snapshot to archive storage.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
 * `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob snapshot to cool storage.
 * `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob snapshot.
 
@@ -83,6 +85,7 @@ The following arguments are supported:
 `version` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob version to archive storage.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
 * `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob version to cool storage.
 * `delete_after_days_since_creation` - The age in days after creation to delete the blob version.
 


### PR DESCRIPTION
The flatten function is used in both the resouce and the data source, which means the newly added properties in resource would also need to be added in the data source, otherwise would get following panic:

```
panic: Invalid address to set: []string{"rule", "0", "actions", "0", "snapshot", "0", "tier_to_archive_after_days_since_last_tier_change_greater_than"}
```

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccDataSourceStorageManagementPolicy_'
=== RUN   TestAccDataSourceStorageManagementPolicy_basic
=== PAUSE TestAccDataSourceStorageManagementPolicy_basic
=== RUN   TestAccDataSourceStorageManagementPolicy_blobTypes
=== PAUSE TestAccDataSourceStorageManagementPolicy_blobTypes
=== CONT  TestAccDataSourceStorageManagementPolicy_basic
=== CONT  TestAccDataSourceStorageManagementPolicy_blobTypes
--- PASS: TestAccDataSourceStorageManagementPolicy_basic (86.64s)
--- PASS: TestAccDataSourceStorageManagementPolicy_blobTypes (94.56s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       94.572s
```