### PR TITLE
`azurerm_network_connection_monitor` &`azurerm_network_watcher`: `TestAccNetworkWatcher` set delete os disk of virtual machine

### DIFF
--- a/internal/services/automation/automation_hybrid_runbook_worker_test.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_test.go
@@ -114,10 +114,6 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 
-  tags = {
-    azsecpack                                                                  = "nonprod"
-    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
-  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/network/network_connection_monitor_resource_test.go
+++ b/internal/services/network/network_connection_monitor_resource_test.go
@@ -398,6 +398,13 @@ resource "azurerm_virtual_machine" "dest" {
     managed_disk_type = "Standard_LRS"
   }
 
+  delete_os_disk_on_termination = true
+
+  tags = {
+    "azsecpack"                                                                = "nonprod"
+    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
+  }
+
   os_profile {
     computer_name  = "hostname%d"
     admin_username = "testadmin"

--- a/internal/services/network/network_connection_monitor_resource_test.go
+++ b/internal/services/network/network_connection_monitor_resource_test.go
@@ -334,11 +334,6 @@ resource "azurerm_virtual_machine" "src" {
 
   delete_os_disk_on_termination = true
 
-  tags = {
-    "azsecpack"                                                                = "nonprod"
-    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
-  }
-
   os_profile {
     computer_name  = "hostname%d"
     admin_username = "testadmin"
@@ -399,11 +394,6 @@ resource "azurerm_virtual_machine" "dest" {
   }
 
   delete_os_disk_on_termination = true
-
-  tags = {
-    "azsecpack"                                                                = "nonprod"
-    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
-  }
 
   os_profile {
     computer_name  = "hostname%d"

--- a/internal/services/network/network_connection_monitor_resource_test.go
+++ b/internal/services/network/network_connection_monitor_resource_test.go
@@ -332,6 +332,13 @@ resource "azurerm_virtual_machine" "src" {
     managed_disk_type = "Standard_LRS"
   }
 
+  delete_os_disk_on_termination = true
+
+  tags = {
+    "azsecpack"                                                                = "nonprod"
+    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
+  }
+
   os_profile {
     computer_name  = "hostname%d"
     admin_username = "testadmin"

--- a/internal/services/network/network_packet_capture_resource_test.go
+++ b/internal/services/network/network_packet_capture_resource_test.go
@@ -171,6 +171,14 @@ resource "azurerm_virtual_machine" "test" {
     managed_disk_type = "Standard_LRS"
   }
 
+  delete_os_disk_on_termination = true
+
+  tags = {
+    "azsecpack"                                                                = "nonprod"
+    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
+  }
+
+
   os_profile {
     computer_name  = "hostname%d"
     admin_username = "testadmin"

--- a/internal/services/network/network_packet_capture_resource_test.go
+++ b/internal/services/network/network_packet_capture_resource_test.go
@@ -173,12 +173,6 @@ resource "azurerm_virtual_machine" "test" {
 
   delete_os_disk_on_termination = true
 
-  tags = {
-    "azsecpack"                                                                = "nonprod"
-    "platformsettings.host_environment.service.platform_optedin_for_rootcerts" = "true"
-  }
-
-
   os_profile {
     computer_name  = "hostname%d"
     admin_username = "testadmin"

--- a/internal/services/network/network_watcher_flow_log_resource_test.go
+++ b/internal/services/network/network_watcher_flow_log_resource_test.go
@@ -384,6 +384,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
+  location             = azurerm_network_watcher.test.location
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id
@@ -412,6 +413,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
+  location             = azurerm_network_watcher.test.location
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id
@@ -447,6 +449,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
+  location             = azurerm_network_watcher.test.location
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id
@@ -483,6 +486,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
+  location             = azurerm_network_watcher.test.location
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id
@@ -518,6 +522,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
+  location             = azurerm_network_watcher.test.location
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id


### PR DESCRIPTION
## Information
1. There is a `delete_os_disk_on_termination` property of the virtual machine resource that has to be set as `true` to auto-remote the disk resource. or it will cause the destruction of the resource group falling.
2. PR #18364 try to fix the location property diff issue but forget to update the test code. we have to specify the location property or it will cause an execution plan after applying

This TestCase is very easy to fail because it only one network watcher is permitted in on a region of one subscription. So If one watcher instance deletes failed then all tests after it will fail.

## What to Fix
There are over 20 test cases that failed for the same reason. one example current error case message:

```
=== RUN   TestAccNetworkWatcher/ConnectionMonitor/vmUpdate
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "acctestRG-Watcher-220815051508682900": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        * `/subscriptions/*******/resourceGroups/ACCTESTRG-WATCHER-220815051508682900/providers/Microsoft.Compute/disks/osdisk-dest220815051508682900`
        * `/subscriptions/*******/resourceGroups/ACCTESTRG-WATCHER-220815051508682900/providers/Microsoft.Compute/disks/osdisk-src220815051508682900`
```

location property issue:

```
=== RUN   TestAccNetworkWatcher/FlowLog/retentionPolicy
    testcase.go:117: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # azurerm_network_watcher_flow_log.test must be replaced
        -/+ resource "azurerm_network_watcher_flow_log" "test" {
              ~ id                        = "/subscriptions/*******/resourceGroups/acctestRG-watcher-2209120990/providers/Microsoft.Network/networkWatchers/acctest-NW-220912095725314390/flowLogs/flowlog-220912095725314390" -> (known after apply)
              - location                  = "eastus2" -> null # forces replacement
                name                      = "flowlog-220912095725314390"
              ~ version                   = 1 -> (known after apply)
                # (5 unchanged attributes hidden)
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
```

## Test Result

![image](https://user-images.githubusercontent.com/2633022/197426590-7a4c962c-8b8a-4d4f-aaf9-e345d0bc8942.png)
