### PR TITLE
[Document] `azurerm_disk_pool` `azurerm_disk_pool_iscsi_target` `azurerm_disk_pool_iscsi_target_lun` `azurerm_disk_pool_managed_disk_attachment` - Add halting on Azure Disk Pools preview's warning

### DIFF
--- a/website/docs/r/disk_pool.html.markdown
+++ b/website/docs/r/disk_pool.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Disk Pool.
 
+!> **Note:** Azure are officially [halting](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools, and it **will not** be made generally available. New customers will not be able to register the Microsoft.StoragePool resource provider on their subscription and deploy new Disk Pools. Existing subscriptions registered with Microsoft.StoragePool may continue to deploy and manage disk pools for the time being.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/disk_pool_iscsi_target.html.markdown
+++ b/website/docs/r/disk_pool_iscsi_target.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an iSCSI Target.
 
+!> **Note:** Azure are officially [halting](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools, and it **will not** be made generally available. New customers will not be able to register the Microsoft.StoragePool resource provider on their subscription and deploy new Disk Pools. Existing subscriptions registered with Microsoft.StoragePool may continue to deploy and manage disk pools for the time being.
+
 !> **Note:** Each Disk Pool can have a maximum of 1 iSCSI Target.
 
 ## Example Usage

--- a/website/docs/r/disk_pool_iscsi_target_lun.html.markdown
+++ b/website/docs/r/disk_pool_iscsi_target_lun.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an iSCSI Target lun.
 
+!> **Note:** Azure are officially [halting](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools, and it **will not** be made generally available. New customers will not be able to register the Microsoft.StoragePool resource provider on their subscription and deploy new Disk Pools. Existing subscriptions registered with Microsoft.StoragePool may continue to deploy and manage disk pools for the time being.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/disk_pool_managed_disk_attachment.html.markdown
+++ b/website/docs/r/disk_pool_managed_disk_attachment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Disk Pool Managed Disk Attachment.
 
+!> **Note:** Azure are officially [halting](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools, and it **will not** be made generally available. New customers will not be able to register the Microsoft.StoragePool resource provider on their subscription and deploy new Disk Pools. Existing subscriptions registered with Microsoft.StoragePool may continue to deploy and manage disk pools for the time being.
+
 ~> **Note:** Must be either a premium SSD, standard SSD, or an ultra disk in the same region and availability zone as the disk pool.
 
 ~> **Note:** Ultra disks must have a disk sector size of 512 bytes.


### PR DESCRIPTION
As #18820 pointed out, Azure has [halted](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools, and it will not be made generally available. This pr updated the document to warn the new users not to use this resource.