### PR TITLE
`azurerm_express_route_circuit`: `TestAccExpressRouteCircuit` change `peer_location` property for bandwith issue

### DIFF
--- a/internal/services/network/express_route_circuit_connection_resource_test.go
+++ b/internal/services/network/express_route_circuit_connection_resource_test.go
@@ -198,7 +198,7 @@ resource "azurerm_express_route_port" "peer_test" {
   name                = "acctest-erp2-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "CDC-Canberra"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }

--- a/internal/services/network/express_route_circuit_resource_test.go
+++ b/internal/services/network/express_route_circuit_resource_test.go
@@ -557,7 +557,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctest-ERP-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Airtel-Chennai2-CLS"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }
@@ -592,7 +592,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctest-ERP-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Airtel-Chennai2-CLS"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
 }

--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -138,7 +138,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctestERP-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Airtel-Chennai2-CLS"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   tags = {
@@ -157,7 +157,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctestERP-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Area51-ERDirect"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   link1 {
@@ -198,7 +198,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctestERP-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "CDC-Canberra"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   identity {
@@ -265,7 +265,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctestERP-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "CDC-Canberra2"
+  peering_location    = "Silicon Valley"
   bandwidth_in_gbps   = 1
   encapsulation       = "Dot1Q"
   identity {


### PR DESCRIPTION
missed some cases of peering_location if pr https://github.com/hashicorp/terraform-provider-azurerm/pull/18442