### PR TITLE
`azurerm_disk_pool` `azurerm_disk_pool_iscsi_target` `azurerm_disk_pool_iscsi_target_lun` `azurerm_disk_pool_managed_disk_attachment` - Remove registration for `Microsoft.StoragePool` and add deprecation message for affected resources

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -71,7 +71,6 @@ func Required() map[string]struct{} {
 		"Microsoft.ServiceFabricMesh":       {},
 		"Microsoft.Sql":                     {},
 		"Microsoft.Storage":                 {},
-		"Microsoft.StoragePool":             {},
 		"Microsoft.StreamAnalytics":         {},
 		"Microsoft.TimeSeriesInsights":      {},
 		"Microsoft.Web":                     {},

--- a/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
+++ b/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
@@ -22,12 +22,17 @@ import (
 )
 
 var _ sdk.Resource = DiskPoolIscsiTargetLunModel{}
+var _ sdk.ResourceWithDeprecationAndNoReplacement = DiskPoolIscsiTargetLunModel{}
 
 type DiskPoolIscsiTargetLunModel struct {
 	IscsiTargetId           string `tfschema:"iscsi_target_id"`
 	ManagedDiskAttachmentId string `tfschema:"disk_pool_managed_disk_attachment_id"`
 	Name                    string `tfschema:"name"`
 	Lun                     int64  `tfschema:"lun"`
+}
+
+func (DiskPoolIscsiTargetLunModel) DeprecationMessage() string {
+	return "The `azurerm_disk_pool_iscsi_target_lun` resource is deprecated and will be removed in v4.0 of the AzureRM Provider."
 }
 
 func (d DiskPoolIscsiTargetLunModel) Arguments() map[string]*schema.Schema {

--- a/internal/services/disks/disk_pool_iscsi_target_resource.go
+++ b/internal/services/disks/disk_pool_iscsi_target_resource.go
@@ -21,6 +21,7 @@ import (
 type DisksPoolIscsiTargetResource struct{}
 
 var _ sdk.Resource = DisksPoolIscsiTargetResource{}
+var _ sdk.ResourceWithDeprecationAndNoReplacement = DisksPoolIscsiTargetResource{}
 
 type DiskPoolIscsiTargetModel struct {
 	ACLMode     string   `tfschema:"acl_mode"`
@@ -29,6 +30,10 @@ type DiskPoolIscsiTargetModel struct {
 	Name        string   `tfschema:"name"`
 	Port        int      `tfschema:"port"`
 	TargetIqn   string   `tfschema:"target_iqn"`
+}
+
+func (DisksPoolIscsiTargetResource) DeprecationMessage() string {
+	return "The `azurerm_disk_pool_iscsi_target` resource is deprecated and will be removed in v4.0 of the AzureRM Provider."
 }
 
 func (d DisksPoolIscsiTargetResource) Arguments() map[string]*schema.Schema {

--- a/internal/services/disks/disk_pool_managed_disk_attachment_resource.go
+++ b/internal/services/disks/disk_pool_managed_disk_attachment_resource.go
@@ -19,10 +19,15 @@ import (
 type DiskPoolManagedDiskAttachmentResource struct{}
 
 var _ sdk.Resource = DiskPoolManagedDiskAttachmentResource{}
+var _ sdk.ResourceWithDeprecationAndNoReplacement = DiskPoolManagedDiskAttachmentResource{}
 
 type DiskPoolManagedDiskAttachmentModel struct {
 	DiskPoolId string `tfschema:"disk_pool_id"`
 	DiskId     string `tfschema:"managed_disk_id"`
+}
+
+func (DiskPoolManagedDiskAttachmentResource) DeprecationMessage() string {
+	return "The `azurerm_disk_pool_managed_disk_attachment` resource is deprecated and will be removed in v4.0 of the AzureRM Provider."
 }
 
 func (d DiskPoolManagedDiskAttachmentResource) Arguments() map[string]*schema.Schema {

--- a/internal/services/disks/disk_pool_resource.go
+++ b/internal/services/disks/disk_pool_resource.go
@@ -22,8 +22,13 @@ import (
 )
 
 var _ sdk.ResourceWithUpdate = DiskPoolResource{}
+var _ sdk.ResourceWithDeprecationAndNoReplacement = DiskPoolResource{}
 
 type DiskPoolResource struct{}
+
+func (DiskPoolResource) DeprecationMessage() string {
+	return "The `azurerm_disk_pool` resource is deprecated and will be removed in v4.0 of the AzureRM Provider."
+}
 
 type DiskPoolResourceModel struct {
 	Name              string                 `tfschema:"name"`


### PR DESCRIPTION
As #18820 pointed out, all new subscriptions will meet issue on plugin's startup because Azure has [halted](https://learn.microsoft.com/en-us/azure/azure-vmware/attach-disk-pools-to-azure-vmware-solution-hosts?tabs=azure-cli) the preview of Azure Disk Pools. The subscriptions which have registered `Microsoft.StoragePool` can still call the registration API and use disk pool API, and new subscriptions need an explicit `skip_provider_registration` to skip this registration.

This pr removed `Microsoft.StoragePool` from the required resource provider list to avoid such error so the new subscriptions don't need this `skip_provider_registration` anymore.