### PR TITLE
`azurerm_express_route_port`:  `bandwidth_in_gbps` property set to 10

### DIFF
--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -139,7 +139,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Airtel-Chennai2-CLS"
-  bandwidth_in_gbps   = 1
+  bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   tags = {
     ENV = "Test"
@@ -158,7 +158,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "Area51-ERDirect"
-  bandwidth_in_gbps   = 1
+  bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   link1 {
     admin_enabled = true
@@ -199,7 +199,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra"
-  bandwidth_in_gbps   = 1
+  bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   identity {
     type         = "UserAssigned"
@@ -266,7 +266,7 @@ resource "azurerm_express_route_port" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   peering_location    = "CDC-Canberra2"
-  bandwidth_in_gbps   = 1
+  bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
## What to FIx

the `bandwidth_in_gbps` has to be 10 instead of 1 to pass the test..

>`        Error: creating Express Route Port "acctestERP-221020031220897182" (Resource Group "acctestRG-221020031220897182"): network.ExpressRoutePortsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ExpressRoutePortsNotAvailable" Message="ExpressRoutePorts /subscriptions/*******/resourceGroups/acctestRG-221020031220897182/providers/Microsoft.Network/expressRoutePorts/acctestERP-221020031220897182 cannot be created as requested bandwidth 1 is not available at peering location Airtel-Chennai2-CLS." Details=[]`

## Test result

![image](https://user-images.githubusercontent.com/2633022/197149572-256d0d11-fdf6-4bec-949f-cf3a07af87d5.png)
