### PR TITLE
`azurerm_mysql_flexible_server` - Add `computed`  for  `zone` and `standby_availability_zone` properties as  the default value returned from API

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -463,8 +463,6 @@ func resourceMysqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	_, highAvailabilityConfigured := d.GetOk("high_availability")
-
 	// failover is only supported when `zone` and `standby_availability_zone` is exchanged
 	var requireFailover bool
 	switch {
@@ -488,9 +486,7 @@ func resourceMysqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta interface
 				return fmt.Errorf("`standby_availability_zone` cannot be added while changing `zone`")
 			}
 		}
-		// In fact, d.HasChange("high_availability.0.standby_availability_zone") return false when "high_availability" is removed.
-		// that means to disable high_availability
-	case d.HasChange("zone") && highAvailabilityConfigured && !d.HasChange("high_availability.0.standby_availability_zone"):
+	case d.HasChange("zone") && !d.HasChange("high_availability.0.standby_availability_zone"):
 		return fmt.Errorf("`zone` cannot be changed independently")
 	default:
 		// No need failover when only `standby_availability_zone` is changed and both `zone` and `standby_availability_zone` aren't changed

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -699,7 +699,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   name                   = "acctest-fs-%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
+  administrator_login    = "_admin_Terraform_892123456789312"
   administrator_password = "QAZwsx123"
   sku_name               = "MO_Standard_E2ds_v4"
   zone                   = "1"
@@ -718,6 +718,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
   sku_name               = "GP_Standard_D2ds_v4"
+  zone                   = "1"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zone.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zone.go
@@ -35,16 +35,6 @@ func ZoneSingleOptional() *schema.Schema {
 	}
 }
 
-// ZoneSingleOptionalComputed returns the schema used when a single Zone can be specified
-func ZoneSingleOptionalComputed() *schema.Schema {
-	return &schema.Schema{
-		Type:         schema.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ValidateFunc: validation.StringIsNotEmpty,
-	}
-}
-
 // ZoneSingleOptionalForceNew returns the schema used when a single Zone can be specified but cannot be changed
 func ZoneSingleOptionalForceNew() *schema.Schema {
 	return &schema.Schema{
@@ -60,5 +50,15 @@ func ZoneSingleComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
+	}
+}
+
+// ZoneSingleOptionalComputed returns the schema used when a single Zone can be specified
+func ZoneSingleOptionalComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
 	}
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zone.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema/zone.go
@@ -35,6 +35,16 @@ func ZoneSingleOptional() *schema.Schema {
 	}
 }
 
+// ZoneSingleOptionalComputed returns the schema used when a single Zone can be specified
+func ZoneSingleOptionalComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
+	}
+}
+
 // ZoneSingleOptionalForceNew returns the schema used when a single Zone can be specified but cannot be changed
 func ZoneSingleOptionalForceNew() *schema.Schema {
 	return &schema.Schema{


### PR DESCRIPTION
Fix acc tests failure, details are as following:

- Test case `TestAccMySqlFlexibleServer_updateMaintenanceWindow` failed with  "ResourceNotFound". That's because the flexible server could not be got  after the creation is complete.  I have filed an [API issue](https://github.com/Azure/azure-rest-api-specs/issues/21178) to track it. To sleep 30 seconds in terraform to resolve it  until the API issue is fixed.

- For test case `TestAccMySqlFlexibleServer_updateSku` , the `administrator_login` property should not be updated when updating Sku, because the `administrator_login` is `ForceNew`.

- For test case `TestAccMySqlFlexibleServer_updateHA` , after checking the behavior of API, it was found that the API returns the default values for the  `zone` and `standby_availability_zone` properties. For `zone` property,  the default value depends on the region, and the `high_availability.standby_availability_zone` default value depends on the value of `high_availability.mode`  and `zone`. The default values are not fixed. So adding computed for them to fix the test case failure. Also, the configure of 'zone'  property should be not removed as it could not be updated when HA is disabled. 