### PR TITLE
`azurerm_point_to_site_vpn_gateway`: fix AccTest use default table id of virtual hub

### DIFF
--- a/internal/services/network/point_to_site_vpn_gateway_resource_test.go
+++ b/internal/services/network/point_to_site_vpn_gateway_resource_test.go
@@ -164,11 +164,6 @@ func (r PointToSiteVPNGatewayResource) updated(data acceptance.TestData) string 
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_virtual_hub_route_table" "test" {
-  name           = "acctest-RouteTable-%d"
-  virtual_hub_id = azurerm_virtual_hub.test.id
-}
-
 resource "azurerm_point_to_site_vpn_gateway" "test" {
   name                        = "acctestp2sVPNG-%d"
   location                    = azurerm_resource_group.test.location
@@ -185,16 +180,16 @@ resource "azurerm_point_to_site_vpn_gateway" "test" {
     }
 
     route {
-      associated_route_table_id = azurerm_virtual_hub_route_table.test.id
+      associated_route_table_id = azurerm_virtual_hub.test.default_route_table_id
 
       propagated_route_table {
-        ids    = [azurerm_virtual_hub_route_table.test.id]
+        ids    = [azurerm_virtual_hub.test.default_route_table_id]
         labels = ["label1", "label2"]
       }
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PointToSiteVPNGatewayResource) requiresImport(data acceptance.TestData) string {


### PR DESCRIPTION
## Information
Has to use the default table id of virtual hub instead of a custom route table.

## Current status

```
------- Stdout: -------
=== RUN   TestAccPointToSiteVPNGateway_update
=== PAUSE TestAccPointToSiteVPNGateway_update
=== CONT  TestAccPointToSiteVPNGateway_update
    testcase.go:110: Step 3/4 error: Error running apply: exit status 1
        
        Error: waiting for creation/update of Point To Site Vpn Gateway: (P2s Vpn Gateway Name "acctestp2sVPNG-221020035701892603" / Resource Group "acctestRG-221020035701892603"): Code="InvalidAssociatedRouteTable" Message="The specified associated route table '/subscriptions/*******/resourceGroups/acctestRG-221020035701892603/providers/Microsoft.Network/virtualHubs/acctestvhub-221020035701892603/hubRouteTables/acctest-RouteTable-221020035701892603' for connection '/subscriptions/*******/resourceGroups/acctestRG-221020035701892603/providers/Microsoft.Network/p2sVpnGateways/acctestp2sVPNG-221020035701892603/p2sConnectionConfigurations/first' is invalid 'Associated route table on branches can't be custom route table.'." Details=[]
```

## Test Result

![image](https://user-images.githubusercontent.com/2633022/197309179-2b1b947d-1ffd-46bc-93bc-efd6c2fe4b2f.png)
