### PR TITLE
refactor: removing most usages of `resourceid.Formatter`

### DIFF
--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+// TODO: @tombuildsstuff: this wants refactoring and fixing into sub-ID parsers
+
+var _ resourceid.Formatter = RoleAssignmentId{}
 
 type RoleAssignmentId struct {
 	SubscriptionID      string

--- a/internal/services/authorization/parse/role_assignment_test.go
+++ b/internal/services/authorization/parse/role_assignment_test.go
@@ -2,11 +2,7 @@ package parse
 
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
-
-var _ resourceid.Formatter = RoleAssignmentId{}
 
 func TestRoleAssignmentIDFormatter(t *testing.T) {
 	testData := []struct {

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+// TODO: this wants splitting into virtual resources with Virtual IDs
+
 func resourceArmRoleAssignment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceArmRoleAssignmentCreate,

--- a/internal/services/billing/parse/enrollment.go
+++ b/internal/services/billing/parse/enrollment.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = EnrollmentId{}
 
 type EnrollmentId struct {
 	EnrollmentAccountName string

--- a/internal/services/billing/parse/enrollment_billing_scope.go
+++ b/internal/services/billing/parse/enrollment_billing_scope.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = EnrollmentBillingScopeId{}
 
 type EnrollmentBillingScopeId struct {
 	BillingAccountName    string

--- a/internal/services/billing/parse/enrollment_billing_scope_test.go
+++ b/internal/services/billing/parse/enrollment_billing_scope_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = EnrollmentBillingScopeId{}
+import "testing"
 
 func TestEnrollmentBillingScopeIDFormatter(t *testing.T) {
 	actual := NewEnrollmentBillingScopeID("12345678", "123456").ID()

--- a/internal/services/billing/parse/enrollment_test.go
+++ b/internal/services/billing/parse/enrollment_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = EnrollmentId{}
+import "testing"
 
 func TestEnrollmentIDFormatter(t *testing.T) {
 	actual := NewEnrollmentID("12345678-1234-9876-4563-123456789012").ID()

--- a/internal/services/billing/parse/mca_billing_scope.go
+++ b/internal/services/billing/parse/mca_billing_scope.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = MicrosoftCustomerAccountBillingScopeId{}
 
 type MicrosoftCustomerAccountBillingScopeId struct {
 	BillingAccountName string

--- a/internal/services/billing/parse/mca_billing_scope_test.go
+++ b/internal/services/billing/parse/mca_billing_scope_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = MicrosoftCustomerAccountBillingScopeId{}
+import "testing"
 
 func TestMicrosoftCustomerAccountBillingScopeIDFormatter(t *testing.T) {
 	actual := NewMCABillingScopeID("e879cf0f-2b4d-5431-109a-f72fc9868693:024cabf4-7321-4cf9-be59-df0c77ca51de_2019-05-31", "PE2Q-NOIT-BG7-TGB", "MTT4-OBS7-PJA-TGB").ID()

--- a/internal/services/billing/parse/mpa_billing_scope.go
+++ b/internal/services/billing/parse/mpa_billing_scope.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = MicrosoftPartnerAccountBillingScopeId{}
 
 type MicrosoftPartnerAccountBillingScopeId struct {
 	BillingAccountName string

--- a/internal/services/billing/parse/mpa_billing_scope_test.go
+++ b/internal/services/billing/parse/mpa_billing_scope_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = MicrosoftPartnerAccountBillingScopeId{}
+import "testing"
 
 func TestMicrosoftPartnerAccountBillingScopeIDFormatter(t *testing.T) {
 	actual := NewMPABillingScopeID("e879cf0f-2b4d-5431-109a-f72fc9868693:024cabf4-7321-4cf9-be59-df0c77ca51de_2019-05-31", "2281f543-7321-4cf9-1e23-edb4Oc31a31c").ID()

--- a/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
+++ b/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
@@ -4,16 +4,24 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
 
-var _ resourceid.Formatter = WorkspaceApplicationGroupAssociationId{}
+var _ resourceids.Id = WorkspaceApplicationGroupAssociationId{}
 
 type WorkspaceApplicationGroupAssociationId struct {
 	Workspace        workspace.WorkspaceId
 	ApplicationGroup applicationgroup.ApplicationGroupId
+}
+
+func (id WorkspaceApplicationGroupAssociationId) String() string {
+	components := []string{
+		fmt.Sprintf("Workspace %s", id.Workspace.String()),
+		fmt.Sprintf("Application Group %s", id.ApplicationGroup.String()),
+	}
+	return fmt.Sprintf("Workspace Application Group Association %s", strings.Join(components, " / "))
 }
 
 func (id WorkspaceApplicationGroupAssociationId) ID() string {

--- a/internal/services/keyvault/parse/nested_item.go
+++ b/internal/services/keyvault/parse/nested_item.go
@@ -5,10 +5,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
-var _ resourceid.Formatter = NestedItemId{}
+var _ resourceids.Id = NestedItemId{}
 
 type NestedItemId struct {
 	KeyVaultBaseUrl string
@@ -35,25 +35,35 @@ func NewNestedItemID(keyVaultBaseUrl, nestedItemType, name, version string) (*Ne
 	}, nil
 }
 
-func (n NestedItemId) ID() string {
+func (id NestedItemId) ID() string {
 	// example: https://tharvey-keyvault.vault.azure.net/type/bird/fdf067c93bbb4b22bff4d8b7a9a56217
 	segments := []string{
-		strings.TrimSuffix(n.KeyVaultBaseUrl, "/"),
-		n.NestedItemType,
-		n.Name,
+		strings.TrimSuffix(id.KeyVaultBaseUrl, "/"),
+		id.NestedItemType,
+		id.Name,
 	}
-	if n.Version != "" {
-		segments = append(segments, n.Version)
+	if id.Version != "" {
+		segments = append(segments, id.Version)
 	}
 	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
 }
 
-func (n NestedItemId) VersionlessID() string {
+func (id NestedItemId) String() string {
+	components := []string{
+		fmt.Sprintf("Base Url %q", id.KeyVaultBaseUrl),
+		fmt.Sprintf("Nested Item Type %q", id.NestedItemType),
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Version %q", id.Version),
+	}
+	return fmt.Sprintf("Key Vault Nested Item %s", strings.Join(components, " / "))
+}
+
+func (id NestedItemId) VersionlessID() string {
 	// example: https://tharvey-keyvault.vault.azure.net/type/bird
 	segments := []string{
-		strings.TrimSuffix(n.KeyVaultBaseUrl, "/"),
-		n.NestedItemType,
-		n.Name,
+		strings.TrimSuffix(id.KeyVaultBaseUrl, "/"),
+		id.NestedItemType,
+		id.Name,
 	}
 	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
 }

--- a/internal/services/monitor/parse/monitor_aad_diagnostic_setting.go
+++ b/internal/services/monitor/parse/monitor_aad_diagnostic_setting.go
@@ -3,9 +3,13 @@ package parse
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 const aadDiagnosticSettingIdPrefix = "/providers/Microsoft.AADIAM/diagnosticSettings/"
+
+var _ resourceids.Id = MonitorAADDiagnosticSettingId{}
 
 type MonitorAADDiagnosticSettingId struct {
 	Name string

--- a/internal/services/monitor/parse/monitor_aad_diagnostic_setting_test.go
+++ b/internal/services/monitor/parse/monitor_aad_diagnostic_setting_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = MonitorAADDiagnosticSettingId{}
+import "testing"
 
 func TestMonitorAADDiagnosticSettingIDFormatter(t *testing.T) {
 	actual := NewMonitorAADDiagnosticSettingID("setting1").ID()

--- a/internal/services/network/parse/application_gateway_private_link_configuration_test.go
+++ b/internal/services/network/parse/application_gateway_private_link_configuration_test.go
@@ -5,14 +5,14 @@ package parse
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
-var _ resourceid.Formatter = ApplicationGatewayPrivateLinkConfigurationId{}
+var _ resourceids.Id = ApplicationGatewayPrivateLinkConfigurationId{}
 
 func TestApplicationGatewayPrivateLinkConfigurationIDFormatter(t *testing.T) {
-	actual := NewApplicationGatewayPrivateLinkConfigurationID("00d16aa6-089c-400f-98eb-926adb838ee1", "cbuk-core-testoce-appgatewayshared-uksouth", "cbuk-core-testoce-appgatewayshared-uksouth", "hbtest").ID()
-	expected := "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/privateLinkConfigurations/hbtest"
+	actual := NewApplicationGatewayPrivateLinkConfigurationID("12345678-1234-9876-4563-123456789012", "group1", "applicationGateway1", "privateLinkConfiguration1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/privateLinkConfiguration1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -24,6 +24,7 @@ func TestApplicationGatewayPrivateLinkConfigurationID(t *testing.T) {
 		Error    bool
 		Expected *ApplicationGatewayPrivateLinkConfigurationId
 	}{
+
 		{
 			// empty
 			Input: "",
@@ -44,54 +45,54 @@ func TestApplicationGatewayPrivateLinkConfigurationID(t *testing.T) {
 
 		{
 			// missing ResourceGroup
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
 			Error: true,
 		},
 
 		{
 			// missing value for ResourceGroup
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
 			Error: true,
 		},
 
 		{
 			// missing ApplicationGatewayName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/",
 			Error: true,
 		},
 
 		{
 			// missing value for ApplicationGatewayName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/",
 			Error: true,
 		},
 
 		{
 			// missing PrivateLinkConfigurationName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/",
 			Error: true,
 		},
 
 		{
 			// missing value for PrivateLinkConfigurationName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/privateLinkConfigurations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/privateLinkConfigurations/hbtest",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/privateLinkConfiguration1",
 			Expected: &ApplicationGatewayPrivateLinkConfigurationId{
-				SubscriptionId:               "00d16aa6-089c-400f-98eb-926adb838ee1",
-				ResourceGroup:                "cbuk-core-testoce-appgatewayshared-uksouth",
-				ApplicationGatewayName:       "cbuk-core-testoce-appgatewayshared-uksouth",
-				PrivateLinkConfigurationName: "hbtest",
+				SubscriptionId:               "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:                "group1",
+				ApplicationGatewayName:       "applicationGateway1",
+				PrivateLinkConfigurationName: "privateLinkConfiguration1",
 			},
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/00D16AA6-089C-400F-98EB-926ADB838EE1/RESOURCEGROUPS/CBUK-CORE-TESTOCE-APPGATEWAYSHARED-UKSOUTH/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/CBUK-CORE-TESTOCE-APPGATEWAYSHARED-UKSOUTH/PRIVATELINKCONFIGURATIONS/HBTEST",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/APPLICATIONGATEWAY1/PRIVATELINKCONFIGURATIONS/PRIVATELINKCONFIGURATION1",
 			Error: true,
 		},
 	}

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -24,6 +24,7 @@ package network
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=LocalNetworkGateway -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/localNetworkGateways/localNetworkGateway1
 
 // Application Gateway
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ApplicationGatewayPrivateLinkConfiguration -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/privateLinkConfiguration1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FrontendPort -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/frontendPorts/feport1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FrontendIPConfiguration -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/frontendIPConfigurations/feipconfig1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BackendAddressPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/backendAddressPools/beap1

--- a/internal/services/network/validate/application_gateway_private_link_configuration_id_test.go
+++ b/internal/services/network/validate/application_gateway_private_link_configuration_id_test.go
@@ -9,6 +9,7 @@ func TestApplicationGatewayPrivateLinkConfigurationID(t *testing.T) {
 		Input string
 		Valid bool
 	}{
+
 		{
 			// empty
 			Input: "",
@@ -29,49 +30,49 @@ func TestApplicationGatewayPrivateLinkConfigurationID(t *testing.T) {
 
 		{
 			// missing ResourceGroup
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
 			Valid: false,
 		},
 
 		{
 			// missing value for ResourceGroup
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
 			Valid: false,
 		},
 
 		{
 			// missing ApplicationGatewayName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/",
 			Valid: false,
 		},
 
 		{
 			// missing value for ApplicationGatewayName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/",
 			Valid: false,
 		},
 
 		{
 			// missing PrivateLinkConfigurationName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/",
 			Valid: false,
 		},
 
 		{
 			// missing value for PrivateLinkConfigurationName
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/privateLinkConfigurations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/00d16aa6-089c-400f-98eb-926adb838ee1/resourceGroups/cbuk-core-testoce-appgatewayshared-uksouth/providers/Microsoft.Network/applicationGateways/cbuk-core-testoce-appgatewayshared-uksouth/privateLinkConfigurations/hbtest",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/applicationGateway1/privateLinkConfigurations/privateLinkConfiguration1",
 			Valid: true,
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/00D16AA6-089C-400F-98EB-926ADB838EE1/RESOURCEGROUPS/CBUK-CORE-TESTOCE-APPGATEWAYSHARED-UKSOUTH/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/CBUK-CORE-TESTOCE-APPGATEWAYSHARED-UKSOUTH/PRIVATELINKCONFIGURATIONS/HBTEST",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/GROUP1/PROVIDERS/MICROSOFT.NETWORK/APPLICATIONGATEWAYS/APPLICATIONGATEWAY1/PRIVATELINKCONFIGURATIONS/PRIVATELINKCONFIGURATION1",
 			Valid: false,
 		},
 	}

--- a/internal/services/policy/parse/management_group_assignment.go
+++ b/internal/services/policy/parse/management_group_assignment.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = ManagementGroupAssignmentId{}
 
 type ManagementGroupAssignmentId struct {
 	ManagementGroupName  string

--- a/internal/services/policy/parse/management_group_assignment_test.go
+++ b/internal/services/policy/parse/management_group_assignment_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = ManagementGroupAssignmentId{}
+import "testing"
 
 func TestManagementGroupAssignmentIDFormatter(t *testing.T) {
 	actual := NewManagementGroupAssignmentID("managementGroup1", "assignment1").ID()

--- a/internal/services/portal/parse/portal_tenant_configuration.go
+++ b/internal/services/portal/parse/portal_tenant_configuration.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = PortalTenantConfigurationId{}
 
 type PortalTenantConfigurationId struct {
 	Name string

--- a/internal/services/portal/parse/portal_tenant_configuration_test.go
+++ b/internal/services/portal/parse/portal_tenant_configuration_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = PortalTenantConfigurationId{}
+import "testing"
 
 func TestPortalTenantConfigurationIDFormatter(t *testing.T) {
 	actual := NewPortalTenantConfigurationID("default").ID()

--- a/internal/services/resource/parse/feature.go
+++ b/internal/services/resource/parse/feature.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = FeatureId{}
 
 type FeatureId struct {
 	SubscriptionId    string

--- a/internal/services/resource/parse/feature_test.go
+++ b/internal/services/resource/parse/feature_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = FeatureId{}
+import "testing"
 
 func TestFeatureIDFormatter(t *testing.T) {
 	actual := NewFeatureID("12345678-1234-9876-4563-123456789012", "Microsoft.Test", "Feature1").ID()

--- a/internal/services/resource/parse/management_group_template_deployment.go
+++ b/internal/services/resource/parse/management_group_template_deployment.go
@@ -5,8 +5,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = ManagementGroupTemplateDeploymentId{}
 
 type ManagementGroupTemplateDeploymentId struct {
 	ManagementGroupName string

--- a/internal/services/resource/parse/management_group_template_deployment_test.go
+++ b/internal/services/resource/parse/management_group_template_deployment_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = ManagementGroupTemplateDeploymentId{}
+import "testing"
 
 func TestManagementGroupTemplateDeploymentIDFormatter(t *testing.T) {
 	actual := NewManagementGroupTemplateDeploymentID("my-management-group-id", "deploy1").ID()

--- a/internal/services/resource/parse/resource_provider.go
+++ b/internal/services/resource/parse/resource_provider.go
@@ -3,8 +3,11 @@ package parse
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = ResourceProviderId{}
 
 type ResourceProviderId struct {
 	SubscriptionId   string
@@ -21,6 +24,10 @@ func NewResourceProviderID(subscriptionId, resourceProvider string) ResourceProv
 func (id ResourceProviderId) ID() string {
 	fmtString := "/subscriptions/%s/providers/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceProvider)
+}
+
+func (id ResourceProviderId) String() string {
+	return fmt.Sprintf("Resource Provider %q", id.ResourceProvider)
 }
 
 // ResourceProviderID parses a ResourceProvider ID into an ResourceProviderId struct

--- a/internal/services/resource/parse/resource_provider_test.go
+++ b/internal/services/resource/parse/resource_provider_test.go
@@ -1,14 +1,8 @@
 package parse
 
-// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
-
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
-
-var _ resourceid.Formatter = ResourceProviderId{}
 
 func TestResourceProviderIDFormatter(t *testing.T) {
 	actual := NewResourceProviderID("12345678-1234-9876-4563-123456789012", "Instruments.Didgeridoo").ID()

--- a/internal/services/resource/parse/tenant_template_deployment.go
+++ b/internal/services/resource/parse/tenant_template_deployment.go
@@ -5,8 +5,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = TenantTemplateDeploymentId{}
 
 type TenantTemplateDeploymentId struct {
 	DeploymentName string

--- a/internal/services/resource/parse/tenant_template_deployment_test.go
+++ b/internal/services/resource/parse/tenant_template_deployment_test.go
@@ -1,12 +1,6 @@
 package parse
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
-)
-
-var _ resourceid.Formatter = TenantTemplateDeploymentId{}
+import "testing"
 
 func TestTenantTemplateDeploymentIDFormatter(t *testing.T) {
 	actual := NewTenantTemplateDeploymentID("deploy1").ID()

--- a/internal/services/securitycenter/parse/advanced_threat_protection.go
+++ b/internal/services/securitycenter/parse/advanced_threat_protection.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
 
-var _ resourceid.Formatter = AdvancedThreatProtectionId{}
+var _ resourceids.Id = AdvancedThreatProtectionId{}
 
 type AdvancedThreatProtectionId struct {
 	TargetResourceID string
@@ -25,6 +25,14 @@ func NewAdvancedThreatProtectionId(targetResourceId string) AdvancedThreatProtec
 func (id AdvancedThreatProtectionId) ID() string {
 	fmtString := "%s/providers/Microsoft.Security/advancedThreatProtectionSettings/%s"
 	return fmt.Sprintf(fmtString, id.TargetResourceID, id.SettingName)
+}
+
+func (id AdvancedThreatProtectionId) String() string {
+	components := []string{
+		fmt.Sprintf("Target Resource ID %q", id.TargetResourceID),
+		fmt.Sprintf("Setting Name %q", id.SettingName),
+	}
+	return fmt.Sprintf("Advanced Protection %s", strings.Join(components, " / "))
 }
 
 func AdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionId, error) {

--- a/internal/services/securitycenter/parse/assessment.go
+++ b/internal/services/securitycenter/parse/assessment.go
@@ -4,12 +4,23 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
+
+var _ resourceids.Id = AssessmentId{}
 
 type AssessmentId struct {
 	TargetResourceID string
 	Name             string
+}
+
+func (id AssessmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Target Resource %q", id.TargetResourceID),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return fmt.Sprintf("Assessment %s", strings.Join(components, " / "))
 }
 
 func NewAssessmentID(targetResourceID, name string) AssessmentId {

--- a/internal/services/securitycenter/parse/assessment_test.go
+++ b/internal/services/securitycenter/parse/assessment_test.go
@@ -2,11 +2,7 @@ package parse
 
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
-
-var _ resourceid.Formatter = AssessmentId{}
 
 func TestAssessmentIDFormatter(t *testing.T) {
 	actual := NewAssessmentID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1", "assessment1").ID()

--- a/internal/services/storage/parse/object_replication.go
+++ b/internal/services/storage/parse/object_replication.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2021-04-01/objectreplicationpolicies"
 )
 
 // This is manual for concat two ids are not supported in auto-generation
+
+var _ resourceids.Id = ObjectReplicationId{}
 
 type ObjectReplicationId struct {
 	Src objectreplicationpolicies.ObjectReplicationPolicyId

--- a/internal/services/storage/parse/object_replication_test.go
+++ b/internal/services/storage/parse/object_replication_test.go
@@ -6,10 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2021-04-01/objectreplicationpolicies"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
-
-var _ resourceid.Formatter = ObjectReplicationId{}
 
 func TestObjectReplicationIDFormatter(t *testing.T) {
 	actual := NewObjectReplicationID(

--- a/internal/services/storage/parse/storage_container_data_plane.go
+++ b/internal/services/storage/parse/storage_container_data_plane.go
@@ -5,13 +5,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/containers"
 )
 
-// TODO: tests for this
-
-var _ resourceid.Formatter = StorageContainerDataPlaneId{}
+var _ resourceids.Id = StorageContainerDataPlaneId{}
 
 type StorageContainerDataPlaneId struct {
 	AccountName  string
@@ -19,7 +17,15 @@ type StorageContainerDataPlaneId struct {
 	Name         string
 }
 
-// only present to comply with the interface
+func (id StorageContainerDataPlaneId) String() string {
+	components := []string{
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Domain Suffix %q", id.DomainSuffix),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return fmt.Sprintf("Storage Container %s", strings.Join(components, " / "))
+}
+
 func (id StorageContainerDataPlaneId) ID() string {
 	return fmt.Sprintf("https://%s.blob.%s/%s", id.AccountName, id.DomainSuffix, id.Name)
 }

--- a/internal/services/storage/parse/storage_queue_data_plane.go
+++ b/internal/services/storage/parse/storage_queue_data_plane.go
@@ -5,12 +5,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/queue/queues"
 )
 
-// TODO: tests for this
-var _ resourceid.Formatter = StorageQueueDataPlaneId{}
+var _ resourceids.Id = StorageQueueDataPlaneId{}
 
 type StorageQueueDataPlaneId struct {
 	AccountName  string
@@ -18,7 +17,15 @@ type StorageQueueDataPlaneId struct {
 	Name         string
 }
 
-// only present to comply with the interface
+func (id StorageQueueDataPlaneId) String() string {
+	components := []string{
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Domain Suffix %q", id.DomainSuffix),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return fmt.Sprintf("Storage Queue %s", strings.Join(components, " / "))
+}
+
 func (id StorageQueueDataPlaneId) ID() string {
 	return fmt.Sprintf("https://%s.queue.%s/%s", id.AccountName, id.DomainSuffix, id.Name)
 }

--- a/internal/services/storage/parse/storage_share_data_plane.go
+++ b/internal/services/storage/parse/storage_share_data_plane.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/tombuildsstuff/giovanni/storage/2020-08-04/file/shares"
 )
 
 // TODO: tests for this
-var _ resourceid.Formatter = StorageShareDataPlaneId{}
+var _ resourceids.Id = StorageShareDataPlaneId{}
 
 type StorageShareDataPlaneId struct {
 	AccountName  string
@@ -18,7 +18,15 @@ type StorageShareDataPlaneId struct {
 	Name         string
 }
 
-// only present to comply with the interface
+func (id StorageShareDataPlaneId) String() string {
+	components := []string{
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Domain Suffix %q", id.DomainSuffix),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return fmt.Sprintf("Storage Share (%s)", strings.Join(components, " / "))
+}
+
 func (id StorageShareDataPlaneId) ID() string {
 	return fmt.Sprintf("https://%s.file.%s/%s", id.AccountName, id.DomainSuffix, id.Name)
 }

--- a/internal/services/storage/parse/storage_table_data_plane.go
+++ b/internal/services/storage/parse/storage_table_data_plane.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/table/tables"
 )
 
 // TODO: tests for this
-var _ resourceid.Formatter = StorageTableDataPlaneId{}
+var _ resourceids.Id = StorageTableDataPlaneId{}
 
 type StorageTableDataPlaneId struct {
 	AccountName  string
@@ -18,7 +18,15 @@ type StorageTableDataPlaneId struct {
 	Name         string
 }
 
-// only present to comply with the interface
+func (id StorageTableDataPlaneId) String() string {
+	components := []string{
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Domain Suffix %q", id.DomainSuffix),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return fmt.Sprintf("Storage Table %s", strings.Join(components, " / "))
+}
+
 func (id StorageTableDataPlaneId) ID() string {
 	return fmt.Sprintf("https://%s.table.%s/Tables('%s')", id.AccountName, id.DomainSuffix, id.Name)
 }

--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+// TODO: @tombuildsstuff: this wants a state migration to move the ID to `{id1}|{id2}` to match other resources
+
 func resourceStorageObjectReplication() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceStorageObjectReplicationCreate,

--- a/internal/services/synapse/parse/role_assignment.go
+++ b/internal/services/synapse/parse/role_assignment.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
-var _ resourceid.Formatter = RoleAssignmentId{}
+var _ resourceids.Id = RoleAssignmentId{}
 
 type RoleAssignmentId struct {
 	Scope                 string
@@ -19,6 +19,14 @@ func NewRoleAssignmentId(scope string, dataPlaneAssignmentId string) RoleAssignm
 		Scope:                 scope,
 		DataPlaneAssignmentId: dataPlaneAssignmentId,
 	}
+}
+
+func (id RoleAssignmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Scope %q", id.Scope),
+		fmt.Sprintf("Data Plane Assignment ID %q", id.DataPlaneAssignmentId),
+	}
+	return fmt.Sprintf("Role Assignment %s", strings.Join(components, " / "))
 }
 
 func (id RoleAssignmentId) ID() string {

--- a/internal/services/web/parse/certificate_binding.go
+++ b/internal/services/web/parse/certificate_binding.go
@@ -3,9 +3,13 @@ package parse
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
 // This is a special case ID for a meta resource that links a web certificate to a Web App or Function App
+
+var _ resourceids.Id = CertificateBindingId{}
 
 type CertificateBindingId struct {
 	HostnameBindingId
@@ -22,6 +26,14 @@ func NewCertificateBindingId(hostnameBindingId HostnameBindingId, certificateId 
 func (id CertificateBindingId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/sites/%s/hostNameBindings/%s|/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/certificates/%s"
 	return fmt.Sprintf(fmtString, id.HostnameBindingId.SubscriptionId, id.HostnameBindingId.ResourceGroup, id.HostnameBindingId.SiteName, id.HostnameBindingId.Name, id.CertificateId.SubscriptionId, id.CertificateId.ResourceGroup, id.CertificateId.Name)
+}
+
+func (id CertificateBindingId) String() string {
+	components := []string{
+		fmt.Sprintf("Hostname Binding ID %q", id.HostnameBindingId.String()),
+		fmt.Sprintf("Certificate ID %q", id.CertificateId.String()),
+	}
+	return fmt.Sprintf("Certificate Binding %s", strings.Join(components, " / "))
 }
 
 func CertificateBindingID(input string) (*CertificateBindingId, error) {

--- a/internal/services/web/parse/certificate_binding_test.go
+++ b/internal/services/web/parse/certificate_binding_test.go
@@ -3,11 +3,7 @@ package parse
 import (
 	"reflect"
 	"testing"
-
-	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceid"
 )
-
-var _ resourceid.Formatter = CertificateBindingId{}
 
 func TestCertificateBindingIDFormatter(t *testing.T) {
 	hostnameBindingId := HostnameBindingId{


### PR DESCRIPTION
This PR removes the majority (but not all) of the references to `resourceid.Formatter` - since this type should now be sourced from `resourceids.Id` in `go-azure-helpers`.

Whilst the `resourceids.Id` type within `go-azure-helpers` will be removed at some point in the future in favour of the `resourceids.ResourceId` interface, this refactor means that we have a single deprecated interface method for now, as opposed to two.

I'll send a separate PR to update the `disks` package to use `go-azure-sdk`, which it appears is the last Embedded Resource Manager SDK.