### PR TITLE
`azurerm_public_ip`: fix AccTest `domain_name_label` has to be lowercase

### DIFF
--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -816,7 +817,7 @@ resource "azurerm_public_ip" "test" {
   allocation_method = "Static"
   domain_name_label = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomStringOfLength(63))
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, strings.ToLower(data.RandomStringOfLength(63)))
 }
 
 func (PublicIPResource) standard_IpTags(data acceptance.TestData) string {


### PR DESCRIPTION
fix randomly failure of TestAccPublicIpStatic_canLabelBe63 for `data.RandomStringOfLength` could generate with upper case letter.

## Current Status

```
=== CONT  TestAccPublicIpStatic_canLabelBe63
    testcase.go:110: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: domain_name_label must contain only lowercase alphanumeric characters, numbers and hyphens. It must start with a letter, end only with a number or letter and not exceed 63 characters in length
        
          with azurerm_public_ip.test,
          on terraform_plugin_test.tf line 17, in resource "azurerm_public_ip" "test":
          17:   domain_name_label = "1c8uc0txvh24plpqvvpv4ft2ovl8ozwyjlc9ztmi1d1zvuqt17wctbnej9rfz40"
        
--- FAIL: TestAccPublicIpStatic_canLabelBe63 (2.73s)

```

## Test Result

```
=== RUN   TestAccPublicIpStatic_canLabelBe63
=== PAUSE TestAccPublicIpStatic_canLabelBe63
=== CONT  TestAccPublicIpStatic_canLabelBe63
--- PASS: TestAccPublicIpStatic_canLabelBe63 (150.58s)
PASS
```