### PR TITLE
`azurerm_network_interface_application_gateway_backend_address_pool_association`: Fix AccTest timeout

### DIFF
--- a/internal/services/network/network_interface_application_gateway_association_resource_test.go
+++ b/internal/services/network/network_interface_application_gateway_association_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -173,6 +174,9 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) d
 	}
 	config.InterfaceIPConfigurationPropertiesFormat.ApplicationGatewayBackendAddressPools = &updatedPools
 
+	// renew timeout value of ctx or it can be timeout
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*30)
+	defer cancel()
 	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.Name, read)
 	if err != nil {
 		return fmt.Errorf("removing Application Gateway Backend Address Pool Association for %s: %+v", nicID, err)


### PR DESCRIPTION
## Information
The ACC Test rarely failed because of the Ctx Timeout.

## Current Status

```
=== CONT  TestAccNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_deleted
    testcase.go:110: Step 1/1 error: Check failed: Check 2/2 error: Check 1/1 error: 
waiting for removal of Application Gateway Backend Address Pool Association for Network Interface: (Name "acctestni-221021013139847531" / Resource Group "acctestRG-221021013139847531"): 
Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
--- FAIL: TestAccNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_deleted (4722.21s)
```

![image](https://user-images.githubusercontent.com/2633022/197432391-b481f053-ceae-4ccc-b8d0-e836a9b0d445.png)

## Test Result


