### PR TITLE
`azurerm_monitor_autoscale_setting` - add email string validation

### DIFF
--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -366,7 +366,8 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Elem: &pluginsdk.Schema{
-											Type: pluginsdk.TypeString,
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.StringIsNotEmpty,
 										},
 									},
 								},


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18810

 the provider returns an error `panic: interface conversion: interface {} is nil, not string` and crashes when passing `custom_emails = [""]` to [custom_emails](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting#custom_emails) property.