### PR TITLE
Docs: Use correct Resource Name in FrontDoor Route sample

### DIFF
--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -28,7 +28,7 @@ resource "azurerm_cdn_frontdoor_profile" "example" {
   resource_group_name = azurerm_resource_group.example.name
 }
 
-resource "frontdoor_origin_group" "example" {
+resource "azurerm_cdn_frontdoor_origin_group" "example" {
   name                     = "example-originGroup"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
 }


### PR DESCRIPTION
With this PR, the correct resource name `azurerm_cdn_frontdoor_origin_group` instead of `frontdoor_origin_group` is used in the `azurerm_cdn_frontdoor_route` sample