### PR TITLE
`azurerm_logic_app_action_http` - support for the `queries` property

### DIFF
--- a/internal/services/logic/logic_app_action_http_resource_test.go
+++ b/internal/services/logic/logic_app_action_http_resource_test.go
@@ -76,6 +76,21 @@ func TestAccLogicAppActionHttp_headers(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppActionHttp_queries(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_action_http", "test")
+	r := LogicAppActionHttpResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.queries(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppActionHttp_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_action_http", "test")
 	r := LogicAppActionHttpResource{}
@@ -189,6 +204,24 @@ resource "azurerm_logic_app_action_http" "test" {
   uri          = "http://example.com/hello"
 
   headers = {
+    "Hello"     = "World"
+    "Something" = "New"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogicAppActionHttpResource) queries(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_action_http" "test" {
+  name         = "action%d"
+  logic_app_id = azurerm_logic_app_workflow.test.id
+  method       = "GET"
+  uri          = "http://example.com/hello"
+
+  queries = {
     "Hello"     = "World"
     "Something" = "New"
   }

--- a/website/docs/r/logic_app_action_http.html.markdown
+++ b/website/docs/r/logic_app_action_http.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 
 * `headers` - (Optional) Specifies a Map of Key-Value Pairs that should be sent to the `uri` when this HTTP Action is triggered.
 
+* `queries` - (Optional) Specifies a Map of Key-Value Pairs that should be sent to the `uri` when this HTTP Action is triggered.
+
 * `run_after` - (Optional) Specifies the place of the HTTP Action in the Logic App Workflow. If not specified, the HTTP Action is right after the Trigger. A `run_after` block is as defined below.
 
 ---


### PR DESCRIPTION
fix #18896

Test
---
```
 TF_ACC=1 go test -v ./internal/services/logic -run=TestAccLogicAppActionHttp_queries -timeout=60m        
=== RUN   TestAccLogicAppActionHttp_queries
=== PAUSE TestAccLogicAppActionHttp_queries
=== CONT  TestAccLogicAppActionHttp_queries
--- PASS: TestAccLogicAppActionHttp_queries (380.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 381.650s
```