### PR TITLE
`azurerm_mysql_flexible_server ` - Fix AccTest failure for resource azurerm_mysql_flexible_server

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -362,6 +362,9 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
+	// Take some time for resource to be visible after creating. Hence, sleep for 30 seconds until issue https://github.com/Azure/azure-rest-api-specs/issues/21178 is fixed.
+	time.Sleep(30 * time.Second)
+
 	// `maintenance_window` could only be updated with, could not be created with
 	if v, ok := d.GetOk("maintenance_window"); ok {
 		mwParams := mysqlflexibleservers.ServerForUpdate{

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -362,8 +363,22 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
-	// Take some time for resource to be visible after creating. Hence, sleep for 30 seconds until issue https://github.com/Azure/azure-rest-api-specs/issues/21178 is fixed.
-	time.Sleep(30 * time.Second)
+	// Add the state wait function until issue https://github.com/Azure/azure-rest-api-specs/issues/21178 is fixed.
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{
+			"Pending",
+		},
+		Target: []string{
+			"OK",
+		},
+		Refresh:    mySqlFlexibleServerCreationRefreshFunc(ctx, client, id),
+		MinTimeout: 10 * time.Second,
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for creation of Mysql Flexible Server %s: %+v", id, err)
+	}
 
 	// `maintenance_window` could only be updated with, could not be created with
 	if v, ok := d.GetOk("maintenance_window"); ok {
@@ -385,6 +400,19 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 	d.SetId(id.ID())
 
 	return resourceMysqlFlexibleServerRead(d, meta)
+}
+
+func mySqlFlexibleServerCreationRefreshFunc(ctx context.Context, client *mysqlflexibleservers.ServersClient, id parse.FlexibleServerId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return resp, "Pending", err
+			}
+			return resp, "Error", err
+		}
+		return "OK", "OK", nil
+	}
 }
 
 func resourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -699,7 +699,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   name                   = "acctest-fs-%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
+  administrator_login    = "_admin_Terraform_892123456789312"
   administrator_password = "QAZwsx123"
   sku_name               = "MO_Standard_E2ds_v4"
   zone                   = "1"
@@ -718,6 +718,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
   sku_name               = "GP_Standard_D2ds_v4"
+  zone                   = "1"
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -739,6 +740,12 @@ resource "azurerm_mysql_flexible_server" "test" {
 
   sku_name = "GP_Standard_D2ds_v4"
   zone     = "1"
+
+  lifecycle {
+    ignore_changes = [
+      high_availability.0.standby_availability_zone
+    ]
+  }
 }
 `, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
- Tests (TestAccMySqlFlexibleServer_updateSku and TestAccMySqlFlexibleServer_updateMaintenanceWindow) failed with "ResourceNotFound". That's because the flexible server could not be retrieved after the creation is complete. I have filed an [API issue](https://github.com/Azure/azure-rest-api-specs/issues/21178) to track it. Add a state wait function that calls the API till it is visible.
- For test case TestAccMySqlFlexibleServer_updateSku , since the purpose of test is to update sku, when the ForceNew property  `administrator_login ` changes, it means that creating a new resource. So update the value of `administrator_login ` to test updating sku.
- For test case TestAccMySqlFlexibleServer_updateHA , after checking the behavior of API, it is found that the API returns the deafult values when the  `zone` and `standby_availability_zone` are not specified in tf config.  For `zone` property, the default value depends on the region, and the `high_availability.standby_availability_zone` default value depends on the value of `high_availability.mode` and `zone`. The default values are not fixed. AFAIK, Optional & Computed is also not expected. So add `ignore_changes` for `high_availability.0.standby_availability_zone` to make the test pass.
