### PR TITLE
Update azurerm_private_endpoint resource documentation

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -189,7 +189,7 @@ A `private_service_connection` supports the following:
 | Web App / Function App        | sites            |                            |
 | Web App / Function App Slots  | sites-&lt;slotName&gt; |                            |
 
-See the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) for more information.
+Some resource types (such as Storage Account) only support 1 subresource per private endpoint. See the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) for more information.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
 


### PR DESCRIPTION
Updating documentation for azurerm_private_endpoint to note that not all resource types support multiple subresources per private endpoint. 

https://github.com/hashicorp/terraform-provider-azurerm/issues/5820 