### PR TITLE
`azurerm_stream_analytics_stream_input_eventhub` - Mark `shared_access_policy_key` and `shared_access_policy_name` as optional

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
@@ -72,14 +72,14 @@ func resourceStreamAnalyticsStreamInputEventHub() *pluginsdk.Resource {
 
 			"shared_access_policy_key": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"shared_access_policy_name": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -132,12 +132,18 @@ func resourceStreamAnalyticsStreamInputEventHubCreateUpdate(d *pluginsdk.Resourc
 	}
 
 	eventHubDataSourceProps := &streamanalytics.EventHubStreamInputDataSourceProperties{
-		EventHubName:           utils.String(d.Get("eventhub_name").(string)),
-		ServiceBusNamespace:    utils.String(d.Get("servicebus_namespace").(string)),
-		SharedAccessPolicyKey:  utils.String(d.Get("shared_access_policy_key").(string)),
-		SharedAccessPolicyName: utils.String(d.Get("shared_access_policy_name").(string)),
-		ConsumerGroupName:      utils.String(d.Get("eventhub_consumer_group_name").(string)),
-		AuthenticationMode:     streamanalytics.AuthenticationMode(d.Get("authentication_mode").(string)),
+		EventHubName:        utils.String(d.Get("eventhub_name").(string)),
+		ServiceBusNamespace: utils.String(d.Get("servicebus_namespace").(string)),
+		ConsumerGroupName:   utils.String(d.Get("eventhub_consumer_group_name").(string)),
+		AuthenticationMode:  streamanalytics.AuthenticationMode(d.Get("authentication_mode").(string)),
+	}
+
+	if v, ok := d.GetOk("shared_access_policy_key"); ok {
+		eventHubDataSourceProps.SharedAccessPolicyKey = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("shared_access_policy_name"); ok {
+		eventHubDataSourceProps.SharedAccessPolicyName = utils.String(v.(string))
 	}
 
 	props := streamanalytics.Input{
@@ -204,7 +210,6 @@ func resourceStreamAnalyticsStreamInputEventHubRead(d *pluginsdk.ResourceData, m
 
 		d.Set("eventhub_name", eventHub.EventHubName)
 		d.Set("servicebus_namespace", eventHub.ServiceBusNamespace)
-		d.Set("shared_access_policy_name", eventHub.SharedAccessPolicyName)
 		d.Set("authentication_mode", eventHub.AuthenticationMode)
 
 		consumerGroupName := ""
@@ -213,6 +218,13 @@ func resourceStreamAnalyticsStreamInputEventHubRead(d *pluginsdk.ResourceData, m
 		}
 
 		d.Set("eventhub_consumer_group_name", consumerGroupName)
+
+		sharedAccessPolicyName := ""
+		if eventHub.SharedAccessPolicyName != nil {
+			sharedAccessPolicyName = *eventHub.SharedAccessPolicyName
+		}
+
+		d.Set("shared_access_policy_name", sharedAccessPolicyName)
 
 		partitionKey := ""
 		if v.PartitionKey != nil {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
@@ -362,6 +362,27 @@ resource "azurerm_stream_analytics_stream_input_eventhub" "test" {
 `, template, data.RandomInteger)
 }
 
+func (r StreamAnalyticsStreamInputEventHubResource) msiWithoutSharedAccessPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_eventhub" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = azurerm_stream_analytics_job.test.name
+  resource_group_name          = azurerm_stream_analytics_job.test.resource_group_name
+  eventhub_consumer_group_name = azurerm_eventhub_consumer_group.test.name
+  eventhub_name                = azurerm_eventhub.test.name
+  servicebus_namespace         = azurerm_eventhub_namespace.test.name
+  authentication_mode          = "Msi"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (r StreamAnalyticsStreamInputEventHubResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -416,25 +437,4 @@ QUERY
 
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (r StreamAnalyticsStreamInputEventHubResource) msiWithoutSharedAccessPolicy(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_stream_analytics_stream_input_eventhub" "test" {
-  name                         = "acctestinput-%d"
-  stream_analytics_job_name    = azurerm_stream_analytics_job.test.name
-  resource_group_name          = azurerm_stream_analytics_job.test.resource_group_name
-  eventhub_consumer_group_name = azurerm_eventhub_consumer_group.test.name
-  eventhub_name                = azurerm_eventhub.test.name
-  servicebus_namespace         = azurerm_eventhub_namespace.test.name
-  authentication_mode          = "Msi"
-
-  serialization {
-    type     = "Json"
-    encoding = "UTF8"
-  }
-}
-`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
@@ -127,13 +127,28 @@ func TestAccStreamAnalyticsStreamInputEventHub_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccStreamAnalyticsInputEventhub_authenticationMode(t *testing.T) {
+func TestAccStreamAnalyticsStreamInputEventHub_authenticationMode(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_stream_input_eventhub", "test")
 	r := StreamAnalyticsStreamInputEventHubResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authenticationMode(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("shared_access_policy_key"),
+	})
+}
+
+func TestAccStreamAnalyticsStreamInputEventHub_msiWithoutSharedAccessPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_stream_input_eventhub", "test")
+	r := StreamAnalyticsStreamInputEventHubResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.msiWithoutSharedAccessPolicy(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -401,4 +416,25 @@ QUERY
 
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r StreamAnalyticsStreamInputEventHubResource) msiWithoutSharedAccessPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_eventhub" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = azurerm_stream_analytics_job.test.name
+  resource_group_name          = azurerm_stream_analytics_job.test.resource_group_name
+  eventhub_consumer_group_name = azurerm_eventhub_consumer_group.test.name
+  eventhub_name                = azurerm_eventhub.test.name
+  servicebus_namespace         = azurerm_eventhub_namespace.test.name
+  authentication_mode          = "Msi"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
@@ -352,7 +352,7 @@ resource "azurerm_stream_analytics_stream_input_eventhub" "test" {
   shared_access_policy_key     = azurerm_eventhub_namespace.test.default_primary_key
   shared_access_policy_name    = "RootManagedSharedAccessKey"
   partition_key                = "partitionKey"
-  authentication_mode          = "Msi"
+  authentication_mode          = "ConnectionString"
 
   serialization {
     type     = "Json"

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -77,10 +77,6 @@ The following arguments are supported:
 
 * `servicebus_namespace` - (Required) The namespace that is associated with the desired Event Hub, Service Bus Queue, Service Bus Topic, etc.
 
-* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy.
-
-* `shared_access_policy_name` - (Required) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
-
 * `serialization` - (Required) A `serialization` block as defined below.
 
 * `partition_key` - (Optional) The property the input Event Hub has been partitioned by.
@@ -88,6 +84,10 @@ The following arguments are supported:
 * `authentication_mode` - (Optional) The authentication mode for the Stream Output. Possible values are `Msi` and `ConnectionString`. Defaults to `ConnectionString`.
 
 * `eventhub_consumer_group_name` - (Optional) The name of an Event Hub Consumer Group that should be used to read events from the Event Hub. Specifying distinct consumer group names for multiple inputs allows each of those inputs to receive the same events from the Event Hub. If not set the input will use the Event Hub's default consumer group. 
+
+* `shared_access_policy_key` - (Optional) The shared access policy key for the specified shared access policy.
+
+* `shared_access_policy_name` - (Optional) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
 
 ---
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/18940

--- PASS: TestAccStreamAnalyticsStreamInputEventHub_csv (382.21s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_avro (426.81s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_json (441.21s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_noOptional (441.21s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_requiresImport (478.98s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_update (804.22s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_authenticationMode (419.38s)
--- PASS: TestAccStreamAnalyticsStreamInputEventHub_msiWithoutSharedAccessPolicy (432.19s)

![image](https://user-images.githubusercontent.com/19754191/197690395-4f42bfe0-f7e5-4f0d-b60d-226640b0523e.png)
