### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert_v2` - add `evaluation_frequency`, `window_duration`, `mute_actions_after_alert_duration`, and `query_time_range_override`validation and doc

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	helperValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -208,9 +207,23 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"evaluation_frequency": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: helperValidate.ISO8601Duration,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"PT1M",
+				"PT5M",
+				"PT10M",
+				"PT15M",
+				"PT30M",
+				"PT45M",
+				"PT1H",
+				"PT2H",
+				"PT3H",
+				"PT4H",
+				"PT5H",
+				"PT6H",
+				"P1D",
+			}, false),
 		},
 
 		"scopes": {
@@ -232,9 +245,23 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"window_duration": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: helperValidate.ISO8601Duration,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"PT5M",
+				"PT10M",
+				"PT15M",
+				"PT30M",
+				"PT45M",
+				"PT1H",
+				"PT2H",
+				"PT3H",
+				"PT4H",
+				"PT5H",
+				"PT6H",
+				"P1D",
+				"P2D",
+			}, false),
 		},
 
 		"action": {
@@ -293,15 +320,44 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"mute_actions_after_alert_duration": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: helperValidate.ISO8601Duration,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"PT5M",
+				"PT10M",
+				"PT15M",
+				"PT30M",
+				"PT45M",
+				"PT1H",
+				"PT2H",
+				"PT3H",
+				"PT4H",
+				"PT5H",
+				"PT6H",
+				"P1D",
+				"P2D",
+			}, false),
 		},
 
 		"query_time_range_override": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: helperValidate.ISO8601Duration,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"PT5M",
+				"PT10M",
+				"PT15M",
+				"PT20M",
+				"PT30M",
+				"PT45M",
+				"PT1H",
+				"PT2H",
+				"PT3H",
+				"PT4H",
+				"PT5H",
+				"PT6H",
+				"P1D",
+				"P2D",
+			}, false),
 		},
 
 		"skip_query_validation": {

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `severity` - (Required) Severity of the alert. Should be an integer between 0 and 4. Value of 0 is severest. 
 
-* `window_duration` - (Required) Specifies the period of time in ISO 8601 duration format on which the Scheduled Query Rule will be executed (bin size). Possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D` and `P2D`.
+* `window_duration` - (Required) Specifies the period of time in ISO 8601 duration format on which the Scheduled Query Rule will be executed (bin size). If `evaluation_frequency` is `PT1M`, possible values are `PT1M`, `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, and `PT6H`. Otherwise, possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D`, and `P2D`.
 
 * `action` - (Optional) An `action` block as defined below.
 

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -96,13 +96,17 @@ The following arguments are supported:
 
 * `criteria` - (Required) A `criteria` block as defined below.
 
-* `evaluation_frequency` - (Required) How often the scheduled query rule is evaluated, represented in ISO 8601 duration format. 
+* `evaluation_frequency` - (Required) How often the scheduled query rule is evaluated, represented in ISO 8601 duration format. Possible values are `PT1M`, `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D`.
+
+-> **Note** `evaluation_frequency` cannot be greater than the query look back which is `window_duration`*`number_of_evaluation_periods`.
+
+-> **Note** `evaluation_frequency` cannot be greater than the `mute_actions_after_alert_duration`.
 
 * `scopes` - (Required) Specifies the list of resource ids that this scheduled query rule is scoped to. Changing this forces a new resource to be created.
 
 * `severity` - (Required) Severity of the alert. Should be an integer between 0 and 4. Value of 0 is severest. 
 
-* `window_duration` - (Required) Specifies the period of time in ISO 8601 duration format on which the Scheduled Query Rule will be executed (bin size). Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D` and `P2D`.
+* `window_duration` - (Required) Specifies the period of time in ISO 8601 duration format on which the Scheduled Query Rule will be executed (bin size). Possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D` and `P2D`.
 
 * `action` - (Optional) An `action` block as defined below.
 
@@ -116,11 +120,13 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Specifies the flag which indicates whether this scheduled query rule is enabled. Value should be `true` or `false`. The default is `true`.
 
-* `mute_actions_after_alert_duration` - (Optional) Mute actions for the chosen period of time in ISO 8601 duration format after the alert is fired. 
+* `mute_actions_after_alert_duration` - (Optional) Mute actions for the chosen period of time in ISO 8601 duration format after the alert is fired. Possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D` and `P2D`.
 
 -> **NOTE** `auto_mitigation_enabled` and `mute_actions_after_alert_duration` are mutually exclusive and cannot both be set.
 
-* `query_time_range_override` - (Optional) If specified then overrides the query time range, default is `window_duration`*`number_of_evaluation_periods`.
+* `query_time_range_override` - (Optional) Set this if the alert evaluation period is different from the query time range. If not specified, the value is `window_duration`*`number_of_evaluation_periods`. Possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D` and `P2D`.
+
+-> **Note** `query_time_range_override` cannot be less than the query look back which is `window_duration`*`number_of_evaluation_periods`.
 
 * `skip_query_validation` - (Optional) Specifies the flag which indicates whether the provided query should be validated or not. The default is false.
 
@@ -173,6 +179,10 @@ A `failing_periods` block supports the following:
 * `minimum_failing_periods_to_trigger_alert` - (Required) Specifies the number of violations to trigger an alert. Should be smaller or equal to `number_of_evaluation_periods`. Possible value is integer between 1 and 6.
 
 * `number_of_evaluation_periods` - (Required) Specifies the number of aggregated look-back points. The look-back time window is calculated based on the aggregation granularity `window_duration` and the selected number of aggregated points. Possible value is integer between 1 and 6. 
+
+-> **Note** The query look back which is `window_duration`*`number_of_evaluation_periods` cannot exceed 48 hours.
+
+-> **Note** `number_of_evaluation_periods` must be `1` for queries that do not project timestamp column
 
 ## Attributes Reference
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18895

related to https://github.com/Azure/azure-rest-api-specs/issues/21258, actually the service API has more strict limitation than just ISO 8601 to those propties.