### PR TITLE
[Documentation]: Rebrand the old FrontDoor resources as `classic` and the new CDN FrontDoor resources as `standard/premium`

### DIFF
--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -24,9 +24,9 @@ data "azurerm_cdn_frontdoor_endpoint" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the FrontDoor Endpoint.
+* `name` - (Required) Specifies the name of the Front Door Endpoint.
 
-* `profile_name` - (Required) The name of the FrontDoor Profile within which Front Door Endpoint exists.
+* `profile_name` - (Required) The name of the Front Door Profile within which Front Door Endpoint exists.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Front Door Profile exists.
 
@@ -46,4 +46,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Endpoint.

--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
+  Gets information about an existing Front Door(standard/premium) Endpoint.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_endpoint
 
-Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
+Use this data source to access information about an existing Front Door (standard/premium) Endpoint.
 
 ## Example Usage
 
@@ -26,21 +26,21 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the FrontDoor Endpoint.
 
-* `profile_name` - (Required) The name of the FrontDoor Profile within which CDN FrontDoor Endpoint exists.
+* `profile_name` - (Required) The name of the FrontDoor Profile within which Front Door Endpoint exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the CDN FrontDoor Profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the Front Door Profile exists.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of this CDN FrontDoor Endpoint.
+* `id` - The ID of this Front Door Endpoint.
 
-* `enabled` - Specifies whether this CDN FrontDoor Endpoint is enabled or not.
+* `enabled` - Specifies whether this Front Door Endpoint is enabled or not.
 
-* `host_name` - Specifies the host name of the CDN FrontDoor Endpoint, in the format `{endpointName}.{dnsZone}` (for example, `contoso.azureedge.net`).
+* `host_name` - Specifies the host name of the Front Door Endpoint, in the format `{endpointName}.{dnsZone}` (for example, `contoso.azureedge.net`).
 
-* `tags` - Specifies a mapping of Tags assigned to this CDN FrontDoor Endpoint.
+* `tags` - Specifies a mapping of Tags assigned to this Front Door Endpoint.
 
 ## Timeouts
 

--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_cdn_frontdoor_endpoint
 
-Use this data source to access information about an existing Front Door (standard/premium) Endpoint.
+Use this data source to access information about an existing Front Door(standard/premium) Endpoint.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -46,4 +46,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Endpoint.

--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Endpoint.
+  Gets information about an existing Front Door (standard/premium) Endpoint.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_endpoint
 
-Use this data source to access information about an existing Front Door(standard/premium) Endpoint.
+Use this data source to access information about an existing Front Door (standard/premium) Endpoint.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/d/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Gets information about an existing CDN FrontDoor Endpoint.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_endpoint
 
-Use this data source to access information about an existing CDN FrontDoor Endpoint.
+Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -35,7 +35,7 @@ The following attributes are exported:
 
 * `enabled` - The enabled state of the CDN FrontDoor Firewall Policy.
 
-* `frontend_endpoint_ids` - The CDN Frontend Endpoints associated with this CDN FrontDoor Firewall Policy.
+* `frontend_endpoint_ids` - The CDN FrontDoor Profiles frontend endpoints associated with this CDN FrontDoor Firewall Policy.
 
 * `mode` - The CDN FrontDoor Firewall Policy mode.
 

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Firewall Policy.
+  Gets information about an existing Front Door (standard/premium) Firewall Policy.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_firewall_policy
 
-Use this data source to access information about an existing Front Door(standard/premium) Firewall Policy.
+Use this data source to access information about an existing Front Door (standard/premium) Firewall Policy.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Gets information about an existing CDN Front Door Firewall Policy.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_firewall_policy
 
-Gets information about an existing CDN Front Door Firewall Policy.
+Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy.
+  Gets information about an existing Front Door(standard/premium) Firewall Policy.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_firewall_policy
 
-Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy.
+Gets information about an existing Front Door(standard/premium) Firewall Policy.
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ data "azurerm_cdn_frontdoor_firewall_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the CDN FrontDoor Firewall Policy.
+* `name` - (Required) The name of the Front Door Firewall Policy.
 
 * `resource_group_name` - (Required) The name of the resource group.
 
@@ -31,17 +31,17 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Firewall Policy.
+* `id` - The ID of the Front Door Firewall Policy.
 
-* `enabled` - The enabled state of the CDN FrontDoor Firewall Policy.
+* `enabled` - The enabled state of the Front Door Firewall Policy.
 
-* `frontend_endpoint_ids` - The CDN FrontDoor Profiles frontend endpoints associated with this CDN FrontDoor Firewall Policy.
+* `frontend_endpoint_ids` - The Front Door Profiles frontend endpoints associated with this Front Door Firewall Policy.
 
-* `mode` - The CDN FrontDoor Firewall Policy mode.
+* `mode` - The Front Door Firewall Policy mode.
 
 * `redirect_url` - The redirect URL for the client.
 
-* `sku_name` - The sku's pricing tier for this CDN FrontDoor Firewall Policy.
+* `sku_name` - The sku's pricing tier for this Front Door Firewall Policy.
 
 ## Timeouts
 

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -47,4 +47,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Firewall Policy.

--- a/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_firewall_policy.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_cdn_frontdoor_firewall_policy
 
-Gets information about an existing Front Door(standard/premium) Firewall Policy.
+Use this data source to access information about an existing Front Door(standard/premium) Firewall Policy.
 
 ## Example Usage
 
@@ -47,4 +47,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Firewall Policy.

--- a/website/docs/d/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/d/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Origin Group.
+  Gets information about an existing Front Door (standard/premium) Origin Group.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_origin_group
 
-Use this data source to access information about an existing Front Door(standard/premium) Origin Group.
+Use this data source to access information about an existing Front Door (standard/premium) Origin Group.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/d/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Gets information about an existing CDN FrontDoor Origin Group.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_origin_group
 
-Use this data source to access information about an existing CDN FrontDoor Origin Group.
+Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/d/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
+  Gets information about an existing Front Door(standard/premium) Origin Group.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_origin_group
 
-Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
+Use this data source to access information about an existing Front Door(standard/premium) Origin Group.
 
 ## Example Usage
 
@@ -24,19 +24,19 @@ data "azurerm_cdn_frontdoor_origin_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the FrontDoor Origin Group.
+* `name` - (Required) Specifies the name of the Front Door Origin Group.
 
-* `profile_name` - (Required) The name of the FrontDoor Profile within which CDN FrontDoor Origin Group exists.
+* `profile_name` - (Required) The name of the Front Door Profile within which Front Door Origin Group exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the CDN FrontDoor Profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the Front Door Profile exists.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Origin Group.
+* `id` - The ID of the Front Door Origin Group.
 
-* `cdn_frontdoor_profile_id` - Specifies the ID of the CDN FrontDoor Profile within which this CDN FrontDoor Origin Group exists.
+* `cdn_frontdoor_profile_id` - Specifies the ID of the Front Door Profile within which this Front Door Origin Group exists.
 
 * `health_probe` - A `health_probe` block as defined below.
 

--- a/website/docs/d/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/d/cdn_frontdoor_origin_group.html.markdown
@@ -70,4 +70,4 @@ A `load_balancing` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Origin Group.

--- a/website/docs/d/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/d/cdn_frontdoor_origin_group.html.markdown
@@ -70,4 +70,4 @@ A `load_balancing` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Origin Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin Group.

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Profile.
+  Gets information about an existing Front Door(standard/premium) Profile.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_profile
 
-Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Profile.
+Gets information about an existing Front Door(standard/premium) Profile.
 
 ## Example Usage
 
@@ -23,23 +23,23 @@ data "azurerm_cdn_frontdoor_profile" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CDN FrontDoor Profile.
+* `name` - (Required) Specifies the name of the Front Door Profile.
 
-* `resource_group_name` - (Required) The name of the Resource Group where this CDN FrontDoor Profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where this Front Door Profile exists.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of this CDN FrontDoor Profile.
+* `id` - The ID of this Front Door Profile.
 
-* `resource_guid` - The UUID of the CDN FrontDoor Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
+* `resource_guid` - The UUID of the Front Door Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
 
-* `sku_name` - Specifies the SKU for this CDN FrontDoor Profile.
+* `sku_name` - Specifies the SKU for this Front Door Profile.
 
 * `response_timeout_seconds` - Specifies the maximum response timeout in seconds.
 
-* `tags` - Specifies a mapping of Tags assigned to this CDN FrontDoor Profile.
+* `tags` - Specifies a mapping of Tags assigned to this Front Door Profile.
 
 ## Timeouts
 

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Gets information about an existing CDN FrontDoor Profile.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Profile.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_profile
 
-Use this data source to access information about an existing CDN FrontDoor Profile.
+Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Profile.
 
 ## Example Usage
 
@@ -23,9 +23,9 @@ data "azurerm_cdn_frontdoor_profile" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the FrontDoor Profile.
+* `name` - (Required) Specifies the name of the CDN FrontDoor Profile.
 
-* `resource_group_name` - (Required) The name of the Resource Group where this FrontDoor Profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where this CDN FrontDoor Profile exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Profile.
+  Gets information about an existing Front Door (standard/premium) Profile.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_profile
 
-Use this data source to access information about an existing Front Door(standard/premium) Profile.
+Use this data source to access information about an existing Front Door (standard/premium) Profile.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -45,4 +45,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Profile.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Profile.

--- a/website/docs/d/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/d/cdn_frontdoor_profile.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_cdn_frontdoor_profile
 
-Gets information about an existing Front Door(standard/premium) Profile.
+Use this data source to access information about an existing Front Door(standard/premium) Profile.
 
 ## Example Usage
 
@@ -45,4 +45,4 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Profile.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Profile.

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Rule Set.
+  Gets information about an existing Front Door (standard/premium) Rule Set.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_rule_set
 
-Use this data source to access information about an existing Front Door(standard/premium) Rule Set.
+Use this data source to access information about an existing Front Door (standard/premium) Rule Set.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Gets information about an existing CDN FrontDoor Rule Set.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_rule_set
 
-Gets information about an existing CDN FrontDoor Rule Set.
+Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
+  Gets information about an existing Front Door(standard/premium) Rule Set.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_rule_set
 
-Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
+Gets information about an existing Front Door(standard/premium) Rule Set.
 
 ## Example Usage
 
@@ -24,19 +24,19 @@ data "azurerm_cdn_frontdoor_rule_set" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CDN FrontDoor Rule Set to retrieve.
+* `name` - (Required) Specifies the name of the Front Door Rule Set to retrieve.
 
-* `profile_name` - (Required) Specifies the name of the CDN FrontDoor Profile where this CDN FrontDoor Rule Set exists.
+* `profile_name` - (Required) Specifies the name of the Front Door Profile where this Front Door Rule Set exists.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the CDN FrontDoor Profile exists.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Front Door Profile exists.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Rule Set.
+* `id` - The ID of the Front Door Rule Set.
 
-* `cdn_frontdoor_profile_id` - The ID of the CDN FrontDoor Profile within which this CDN FrontDoor Rule Set exists.
+* `cdn_frontdoor_profile_id` - The ID of the Front Door Profile within which this Front Door Rule Set exists.
 
 ## Timeouts
 

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -42,4 +42,4 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule Set.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Rule Set.

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_cdn_frontdoor_rule_set
 
-Gets information about an existing Front Door(standard/premium) Rule Set.
+Use this data source to access information about an existing Front Door(standard/premium) Rule Set.
 
 ## Example Usage
 
@@ -42,4 +42,4 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Rule Set.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule Set.

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_cdn_frontdoor_secret
 
-Gets information about an existing Front Door(standard/premium) Secret.
+Use this data source to access information about an existing Front Door(standard/premium) Secret.
 
 ## Example Usage
 
@@ -60,4 +60,4 @@ A `customer_certificate` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Secret.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Secret.

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Gets information about an existing Front Door(standard/premium) Secret.
+  Gets information about an existing Front Door (standard/premium) Secret.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_secret
 
-Use this data source to access information about an existing Front Door(standard/premium) Secret.
+Use this data source to access information about an existing Front Door (standard/premium) Secret.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Secret.
+  Gets information about an existing Front Door(standard/premium) Secret.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_secret
 
-Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Secret.
+Gets information about an existing Front Door(standard/premium) Secret.
 
 ## Example Usage
 
@@ -24,19 +24,19 @@ data "azurerm_cdn_frontdoor_secret" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CDN FrontDoor Secret.
+* `name` - (Required) Specifies the name of the Front Door Secret.
 
-* `profile_name` - (Required) The name of the CDN FrontDoor Profile within which the CDN FrontDoor Secret exists.
+* `profile_name` - (Required) The name of the Front Door Profile within which the Front Door Secret exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the CDN FrontDoor Profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the Front Door Profile exists.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Secret.
+* `id` - The ID of the Front Door Secret.
 
-* `cdn_frontdoor_profile_id` - Specifies the ID of the CDN FrontDoor Profile within which this CDN FrontDoor Secret exists.
+* `cdn_frontdoor_profile_id` - Specifies the ID of the Front Door Profile within which this Front Door Secret exists.
 
 * `secret` - A `secret` block as defined below.
 

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -60,4 +60,4 @@ A `customer_certificate` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Secret.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Secret.

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Gets information about an existing CDN FrontDoor Secret.
+  Gets information about an existing CDN FrontDoor (Azure Front Door standard/premium) Secret.
 ---
 
 # Data Source: azurerm_cdn_frontdoor_secret
 
-Use this data source to access information about an existing CDN FrontDoor Secret.
+Use this data source to access information about an existing CDN FrontDoor (Azure Front Door standard/premium) Secret.
 
 ## Example Usage
 
@@ -24,9 +24,9 @@ data "azurerm_cdn_frontdoor_secret" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the FrontDoor Secret.
+* `name` - (Required) Specifies the name of the CDN FrontDoor Secret.
 
-* `profile_name` - (Required) The name of the FrontDoor Profile within which CDN FrontDoor Secret exists.
+* `profile_name` - (Required) The name of the CDN FrontDoor Profile within which CDN FrontDoor Secret exists.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the CDN FrontDoor Profile exists.
 

--- a/website/docs/d/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/d/cdn_frontdoor_secret.html.markdown
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the CDN FrontDoor Secret.
 
-* `profile_name` - (Required) The name of the CDN FrontDoor Profile within which CDN FrontDoor Secret exists.
+* `profile_name` - (Required) The name of the CDN FrontDoor Profile within which the CDN FrontDoor Secret exists.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the CDN FrontDoor Profile exists.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -122,10 +122,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 12 hours) Used when creating the CDN Front Door Custom Domain.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Custom Domain.
-* `update` - (Defaults to 24 hours) Used when updating the CDN Front Door Custom Domain.
-* `delete` - (Defaults to 12 hours) Used when deleting the CDN Front Door Custom Domain.
+* `create` - (Defaults to 12 hours) Used when creating the Front Door Custom Domain.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Custom Domain.
+* `update` - (Defaults to 24 hours) Used when updating the Front Door Custom Domain.
+* `delete` - (Defaults to 12 hours) Used when deleting the Front Door Custom Domain.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain"
 description: |-
-  Manages a Front Door(standard/premium) Custom Domain.
+  Manages a Front Door (standard/premium) Custom Domain.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain
 
-Manages a Front Door(standard/premium) Custom Domain.
+Manages a Front Door (standard/premium) Custom Domain.
 
 !>**IMPORTANT:** If you are using Terraform to manage your DNS Auth and DNS CNAME records for your Custom Domain you will need to add configuration blocks for both the `azurerm_dns_txt_record`(see the `Example DNS Auth TXT Record Usage` below) and the `azurerm_dns_cname_record`(see the `Example CNAME Record Usage` below) to your configuration file.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -62,7 +62,7 @@ resource "azurerm_dns_txt_record" "example" {
 
 ## Example CNAME Record Usage
 
-!>**IMPORTANT:** You **must** include the `depends_on` meta-argument which references both the `azurerm_cdn_frontdoor_route` and the `azurerm_cdn_frontdoor_security_policy` that are associated with your Custom Domain. The reason for these `depends_on` meta-arguments is because all of the resources for the Custom Domain need to be associated within FrontDoor before the CNAME record can be written to the domains DNS, else the CNAME validation will fail and FrontDoor will not enable traffic to the Domain.
+!>**IMPORTANT:** You **must** include the `depends_on` meta-argument which references both the `azurerm_cdn_frontdoor_route` and the `azurerm_cdn_frontdoor_security_policy` that are associated with your Custom Domain. The reason for these `depends_on` meta-arguments is because all of the resources for the Custom Domain need to be associated within Front Door before the CNAME record can be written to the domains DNS, else the CNAME validation will fail and Front Door will not enable traffic to the Domain.
 
 ```hcl
 resource "azurerm_dns_cname_record" "example" {
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Front Door Custom Domain. Possible values must be between 2 and 260 characters in length, must begin with a letter or number, end with a letter or number and contain only letters, numbers and hyphens. Changing this forces a new Front Door Custom Domain to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the Frontdoor Profile. Changing this forces a new Frontdoor Profile to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile. Changing this forces a new Front Door Profile to be created.
 
 * `host_name` - (Required) The host name of the domain. The `host_name` field must be the FQDN of your domain(e.g. `contoso.fabrikam.com`). Changing this forces a new Front Door Custom Domain to be created.
 
@@ -100,11 +100,11 @@ A `tls` block supports the following:
 
 * `certificate_type` - (Optional) Defines the source of the SSL certificate. Possible values include `CustomerCertificate` and `ManagedCertificate`. Defaults to `ManagedCertificate`.
 
-->**NOTE:** It may take up to 15 minutes for the Frontdoor Service to validate the state and Domain ownership of the Custom Domain.
+->**NOTE:** It may take up to 15 minutes for the Front Door Service to validate the state and Domain ownership of the Custom Domain.
 
 * `minimum_tls_version` - (Optional) TLS protocol version that will be used for Https. Possible values include `TLS10` and `TLS12`. Defaults to `TLS12`.
 
-* `cdn_frontdoor_secret_id` - (Optional) Resource ID of the Frontdoor Secret.
+* `cdn_frontdoor_secret_id` - (Optional) Resource ID of the Front Door Secret.
 
 ---
 
@@ -122,10 +122,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 12 hours) Used when creating the CDN FrontDoor Custom Domain.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Custom Domain.
-* `update` - (Defaults to 24 hours) Used when updating the CDN FrontDoor Custom Domain.
-* `delete` - (Defaults to 12 hours) Used when deleting the CDN FrontDoor Custom Domain.
+* `create` - (Defaults to 12 hours) Used when creating the CDN Front Door Custom Domain.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Custom Domain.
+* `update` - (Defaults to 24 hours) Used when updating the CDN Front Door Custom Domain.
+* `delete` - (Defaults to 12 hours) Used when deleting the CDN Front Door Custom Domain.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain.
+  Manages a Front Door(standard/premium) Custom Domain.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain.
+Manages a Front Door(standard/premium) Custom Domain.
 
 !>**IMPORTANT:** If you are using Terraform to manage your DNS Auth and DNS CNAME records for your Custom Domain you will need to add configuration blocks for both the `azurerm_dns_txt_record`(see the `Example DNS Auth TXT Record Usage` below) and the `azurerm_dns_cname_record`(see the `Example CNAME Record Usage` below) to your configuration file.
 
@@ -45,7 +45,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "example" {
 ```
 ## Example DNS Auth TXT Record Usage
 
-The name of your DNS TXT record should be in the format of `_dnsauth.<your_subdomain>`. So, for example, if we use the `host_name` in the example usage above you would create a DNS TXT record with the name of `_dnsauth.contoso` which contains the value of the CDN FrontDoor Custom Domains `validation_token` field. See the [product documentation](https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-add-custom-domain) for more information.
+The name of your DNS TXT record should be in the format of `_dnsauth.<your_subdomain>`. So, for example, if we use the `host_name` in the example usage above you would create a DNS TXT record with the name of `_dnsauth.contoso` which contains the value of the Front Door Custom Domains `validation_token` field. See the [product documentation](https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-add-custom-domain) for more information.
 
 ```hcl
 resource "azurerm_dns_txt_record" "example" {
@@ -80,15 +80,15 @@ resource "azurerm_dns_cname_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Custom Domain. Possible values must be between 2 and 260 characters in length, must begin with a letter or number, end with a letter or number and contain only letters, numbers and hyphens. Changing this forces a new CDN FrontDoor Custom Domain to be created.
+* `name` - (Required) The name which should be used for this Front Door Custom Domain. Possible values must be between 2 and 260 characters in length, must begin with a letter or number, end with a letter or number and contain only letters, numbers and hyphens. Changing this forces a new Front Door Custom Domain to be created.
 
 * `cdn_frontdoor_profile_id` - (Required) The ID of the Frontdoor Profile. Changing this forces a new Frontdoor Profile to be created.
 
-* `host_name` - (Required) The host name of the domain. The `host_name` field must be the FQDN of your domain(e.g. `contoso.fabrikam.com`). Changing this forces a new CDN FrontDoor Custom Domain to be created.
+* `host_name` - (Required) The host name of the domain. The `host_name` field must be the FQDN of your domain(e.g. `contoso.fabrikam.com`). Changing this forces a new Front Door Custom Domain to be created.
 
-* `dns_zone_id` - (Optional) The ID of the Azure DNS Zone which should be used for this CDN FrontDoor Custom Domain. If you are using Azure to host your [DNS domains](https://learn.microsoft.com/azure/dns/dns-overview), you must delegate the domain provider's domain name system (DNS) to an Azure DNS Zone. For more information, see [Delegate a domain to Azure DNS](https://learn.microsoft.com/azure/dns/dns-delegate-domain-azure-dns). Otherwise, if you're using your own domain provider to handle your DNS, you must validate the CDN FrontDoor Custom Domain by creating the DNS TXT records manually.
+* `dns_zone_id` - (Optional) The ID of the Azure DNS Zone which should be used for this Front Door Custom Domain. If you are using Azure to host your [DNS domains](https://learn.microsoft.com/azure/dns/dns-overview), you must delegate the domain provider's domain name system (DNS) to an Azure DNS Zone. For more information, see [Delegate a domain to Azure DNS](https://learn.microsoft.com/azure/dns/dns-delegate-domain-azure-dns). Otherwise, if you're using your own domain provider to handle your DNS, you must validate the Front Door Custom Domain by creating the DNS TXT records manually.
 
-<!-- * `pre_validated_cdn_frontdoor_custom_domain_id` - (Optional) The resource ID of the pre-validated CDN FrontDoor Custom Domain. This domain type is used when you wish to onboard a validated Azure service domain, and then configure the Azure service behind an Azure Front Door.
+<!-- * `pre_validated_cdn_frontdoor_custom_domain_id` - (Optional) The resource ID of the pre-validated Front Door Custom Domain. This domain type is used when you wish to onboard a validated Azure service domain, and then configure the Azure service behind an Azure Front Door.
 
 ->**NOTE:** Currently `pre_validated_cdn_frontdoor_custom_domain_id` only supports domains validated by Static Web App. -->
 
@@ -112,7 +112,7 @@ A `tls` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Custom Domain.
+* `id` - The ID of the Front Door Custom Domain.
 
 * `expiration_date` - The date time that the token expires.
 
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-CDN FrontDoor Custom Domains can be imported using the `resource id`, e.g.
+Front Door Custom Domains can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_custom_domain.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/customDomains/customDomain1

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain"
 description: |-
-  Manages a CDN FrontDoor Custom Domain.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain
 
-Manages a CDN FrontDoor Custom Domain.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain.
 
 !>**IMPORTANT:** If you are using Terraform to manage your DNS Auth and DNS CNAME records for your Custom Domain you will need to add configuration blocks for both the `azurerm_dns_txt_record`(see the `Example DNS Auth TXT Record Usage` below) and the `azurerm_dns_cname_record`(see the `Example CNAME Record Usage` below) to your configuration file.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -41,10 +41,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Custom Domain Association.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Custom Domain Association.
-* `update` - (Defaults to 30 minutes) Used when retrieving the CDN Front Door Custom Domain Association.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Custom Domain Association.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Custom Domain Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Custom Domain Association.
+* `update` - (Defaults to 30 minutes) Used when retrieving the Front Door Custom Domain Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Custom Domain Association.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -41,10 +41,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Custom Domain Association.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Custom Domain Association.
-* `update` - (Defaults to 30 minutes) Used when retrieving the CDN FrontDoor Custom Domain Association.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Custom Domain Association.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Custom Domain Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Custom Domain Association.
+* `update` - (Defaults to 30 minutes) Used when retrieving the CDN Front Door Custom Domain Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Custom Domain Association.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain_association"
 description: |-
-  Manages the association between a CDN FrontDoor Custom Domain and one or more CDN FrontDoor Routes.
+  Manages the association between a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain and one or more CDN FrontDoor (Azure Front Door standard/premium) Routes.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain_association
 
-Manages the association between a CDN FrontDoor Custom Domain and one or more CDN FrontDoor Routes.
+Manages the association between a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain and one or more CDN FrontDoor (Azure Front Door standard/premium) Routes.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain_association"
 description: |-
-  Manages the association between a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain and one or more CDN FrontDoor (Azure Front Door standard/premium) Routes.
+  Manages the association between a Front Door(standard/premium) Custom Domain and one or more Front Door(standard/premium) Routes.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain_association
 
-Manages the association between a CDN FrontDoor (Azure Front Door standard/premium) Custom Domain and one or more CDN FrontDoor (Azure Front Door standard/premium) Routes.
+Manages the association between a Front Door(standard/premium) Custom Domain and one or more Front Door(standard/premium) Routes.
 
 ## Example Usage
 
@@ -23,17 +23,17 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "example" {
 
 The following arguments are supported:
 
-* `cdn_frontdoor_custom_domain_id` - (Required) The ID of the CDN FrontDoor Custom Domain that should be managed by the association resource. Changing this forces a new association resource to be created.
+* `cdn_frontdoor_custom_domain_id` - (Required) The ID of the Front Door Custom Domain that should be managed by the association resource. Changing this forces a new association resource to be created.
 
-* `cdn_frontdoor_route_ids` - (Required) One or more IDs of the CDN FrontDoor Route to which the CDN FrontDoor Custom Domain is associated with.
+* `cdn_frontdoor_route_ids` - (Required) One or more IDs of the Front Door Route to which the Front Door Custom Domain is associated with.
 
--> **NOTE:** This should include all of the CDN FrontDoor Route resources that the CDN FrontDoor Custom Domain is associated with. If the list of CDN FrontDoor Routes is not complete you will receive the service side error `This resource is still associated with a route. Please delete the association with the route first before deleting this resource` when you attempt to `destroy`/`delete` your CDN FrontDoor Custom Domain.
+-> **NOTE:** This should include all of the Front Door Route resources that the Front Door Custom Domain is associated with. If the list of Front Door Routes is not complete you will receive the service side error `This resource is still associated with a route. Please delete the association with the route first before deleting this resource` when you attempt to `destroy`/`delete` your Front Door Custom Domain.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Custom Domain Association.
+* `id` - The ID of the Front Door Custom Domain Association.
 
 ---
 
@@ -48,7 +48,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Frontdoor Routes can be imported using the `resource id`, e.g.
+Front Door Custom Domain Associations can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_custom_domain_association.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain_association"
 description: |-
-  Manages the association between a Front Door(standard/premium) Custom Domain and one or more Front Door(standard/premium) Routes.
+  Manages the association between a Front Door (standard/premium) Custom Domain and one or more Front Door (standard/premium) Routes.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain_association
 
-Manages the association between a Front Door(standard/premium) Custom Domain and one or more Front Door(standard/premium) Routes.
+Manages the association between a Front Door (standard/premium) Custom Domain and one or more Front Door (standard/premium) Routes.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/r/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Manages a Front Door(standard/premium) Endpoint.
+  Manages a Front Door (standard/premium) Endpoint.
 ---
 
 # azurerm_cdn_frontdoor_endpoint
 
-Manages a Front Door(standard/premium) Endpoint.
+Manages a Front Door (standard/premium) Endpoint.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/r/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Manages a FrontDoor Endpoint.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
 ---
 
 # azurerm_cdn_frontdoor_endpoint
 
-Manages a FrontDoor Endpoint.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
 
 ## Example Usage
 
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this CDN FrontDoor Endpoint. Changing this forces a new CDN FrontDoor Endpoint to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the FrontDoor Profile within which this FrontDoor Endpoint should exist. Changing this forces a new CDN FrontDoor Endpoint to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile within which this CDN FrontDoor Endpoint should exist. Changing this forces a new CDN FrontDoor Endpoint to be created.
 
 ---
 

--- a/website/docs/r/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/r/cdn_frontdoor_endpoint.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_endpoint"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
+  Manages a Front Door(standard/premium) Endpoint.
 ---
 
 # azurerm_cdn_frontdoor_endpoint
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Endpoint.
+Manages a Front Door(standard/premium) Endpoint.
 
 ## Example Usage
 
@@ -38,23 +38,23 @@ resource "azurerm_cdn_frontdoor_endpoint" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Endpoint. Changing this forces a new CDN FrontDoor Endpoint to be created.
+* `name` - (Required) The name which should be used for this Front Door Endpoint. Changing this forces a new Front Door Endpoint to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile within which this CDN FrontDoor Endpoint should exist. Changing this forces a new CDN FrontDoor Endpoint to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile within which this Front Door Endpoint should exist. Changing this forces a new Front Door Endpoint to be created.
 
 ---
 
-* `enabled` - (Optional) Specifies if this CDN FrontDoor Endpoint is enabled? Defaults to `true`.
+* `enabled` - (Optional) Specifies if this Front Door Endpoint is enabled? Defaults to `true`.
 
-* `tags` - (Optional) Specifies a mapping of tags which should be assigned to the CDN FrontDoor Endpoint.
+* `tags` - (Optional) Specifies a mapping of tags which should be assigned to the Front Door Endpoint.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of this CDN FrontDoor Endpoint.
+* `id` - The ID of this Front Door Endpoint.
 
-* `host_name` - The host name of the CDN FrontDoor Endpoint, in the format `{endpointName}.{dnsZone}` (for example, `contoso.azureedge.net`).
+* `host_name` - The host name of the Front Door Endpoint, in the format `{endpointName}.{dnsZone}` (for example, `contoso.azureedge.net`).
 
 ## Timeouts
 
@@ -67,7 +67,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-CDN FrontDoor Endpoints can be imported using the `resource id`, e.g.
+Front Door Endpoints can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1

--- a/website/docs/r/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/r/cdn_frontdoor_endpoint.html.markdown
@@ -60,10 +60,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Endpoint.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Endpoint.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Endpoint.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Endpoint.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Endpoint.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Endpoint.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Endpoint.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_endpoint.html.markdown
+++ b/website/docs/r/cdn_frontdoor_endpoint.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Front Door Endpoint. Changing this forces a new Front Door Endpoint to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile within which this Front Door Endpoint should exist. Changing this forces a new Front Door Endpoint to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile within which this Front Door Endpoint should exist. Changing this forces a new Front Door Endpoint to be created.
 
 ---
 
@@ -60,10 +60,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Endpoint.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Endpoint.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Endpoint.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Endpoint.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Endpoint.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Endpoint.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Endpoint.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 * `mode` - (Optional) The CDN FrontDoor Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
 
--> **NOTE:** When run in `Detection` mode, the CDN FrontDoor Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched CDN FrontDoor rule to the Web Application Firewall logs.
+-> **NOTE:** When run in `Detection` mode, the CDN FrontDoor Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched CDN FrontDoor Rule to the Web Application Firewall logs.
 
 * `redirect_url` - (Optional) If action type is redirect, this field represents redirect URL for the client.
 
@@ -249,7 +249,7 @@ The following attributes are exported:
 
 * `location` - The Azure Region where this CDN FrontDoor Firewall Policy exists.
 
-* `frontend_endpoint_ids` - The Cdn Frontend Endpoints associated with this CDN FrontDoor Firewall Policy.
+* `frontend_endpoint_ids` - The CDN FrontDoor Profiles frontend endpoints associated with this CDN FrontDoor Firewall Policy.
 
 ## Timeouts
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy instance.
+  Manages a Front Door(standard/premium) Firewall Policy instance.
 ---
 
 # azurerm_cdn_frontdoor_firewall_policy
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy instance.
+Manages a Front Door(standard/premium) Firewall Policy instance.
 
 ## Example Usage
 
@@ -135,15 +135,15 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The sku's pricing tier for this CDN FrontDoor Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`.
+* `sku_name` - (Required) The sku's pricing tier for this Front Door Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`.
 
--> **NOTE:** The `Standard_AzureFrontDoor` CDN FrontDoor Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` CDN FrontDoor Firewall Policy skus may contain both `custom` and `managed` rules.
+-> **NOTE:** The `Standard_AzureFrontDoor` Front Door Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` Front Door Firewall Policy skus may contain both `custom` and `managed` rules.
 
-* `enabled` - (Optional) Is the CDN FrontDoor Firewall Policy enabled? Defaults to `true`.
+* `enabled` - (Optional) Is the Front Door Firewall Policy enabled? Defaults to `true`.
 
-* `mode` - (Optional) The CDN FrontDoor Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
+* `mode` - (Optional) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
 
--> **NOTE:** When run in `Detection` mode, the CDN FrontDoor Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched CDN FrontDoor Rule to the Web Application Firewall logs.
+-> **NOTE:** When run in `Detection` mode, the Front Door Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched Front Door Rule to the Web Application Firewall logs.
 
 * `redirect_url` - (Optional) If action type is redirect, this field represents redirect URL for the client.
 
@@ -155,7 +155,7 @@ The following arguments are supported:
 
 * `managed_rule` - (Optional) One or more `managed_rule` blocks as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the CDN FrontDoor Firewall Policy.
+* `tags` - (Optional) A mapping of tags to assign to the Front Door Firewall Policy.
 
 ---
 
@@ -245,11 +245,11 @@ An `exclusion` block supports the following:
 
 The following attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Firewall Policy.
+* `id` - The ID of the Front Door Firewall Policy.
 
-* `location` - The Azure Region where this CDN FrontDoor Firewall Policy exists.
+* `location` - The Azure Region where this Front Door Firewall Policy exists.
 
-* `frontend_endpoint_ids` - The CDN FrontDoor Profiles frontend endpoints associated with this CDN FrontDoor Firewall Policy.
+* `frontend_endpoint_ids` - The Front Door Profiles frontend endpoints associated with this Front Door Firewall Policy.
 
 ## Timeouts
 
@@ -262,7 +262,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Frontdoor Firewall Policy can be imported using the `resource id`, e.g.
+Front Door Firewall Policies can be imported using the `resource id`, e.g.
 
 ```shell
 $ terraform import azurerm_cdn_frontdoor_firewall_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/firewallPolicy1

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -255,10 +255,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Firewall Policy.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Firewall Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Firewall Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Firewall Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Firewall Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Firewall Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Firewall Policy.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Manages an Azure CDN Front Door Firewall Policy instance.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy instance.
 ---
 
 # azurerm_cdn_frontdoor_firewall_policy
 
-Manages an Azure CDN Front Door Firewall Policy instance.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Firewall Policy instance.
 
 ## Example Usage
 
@@ -135,15 +135,15 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The sku's pricing tier for this Cdn Frontdoor firewall policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`.
+* `sku_name` - (Required) The sku's pricing tier for this CDN FrontDoor Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`.
 
--> **NOTE:** The `Standard_AzureFrontDoor` Cdn Frontdoor firewall policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` Cdn Frontdoor firewall policy skus may contain both `custom` and `managed` rules.
+-> **NOTE:** The `Standard_AzureFrontDoor` CDN FrontDoor Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` CDN FrontDoor Firewall Policy skus may contain both `custom` and `managed` rules.
 
-* `enabled` - (Optional) Is the Cdn Frontdoor firewall policy enabled? Defaults to `true`.
+* `enabled` - (Optional) Is the CDN FrontDoor Firewall Policy enabled? Defaults to `true`.
 
-* `mode` - (Optional) The Cdn Frontdoor firewall policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
+* `mode` - (Optional) The CDN FrontDoor Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
 
--> **NOTE:** When run in `Detection` mode, the Cdn Frontdoor firewall policy doesn't take any other actions other than monitoring and loging the request and its matched Cdn Frontdoor rule to the Web Application Firewall logs.
+-> **NOTE:** When run in `Detection` mode, the CDN FrontDoor Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched CDN FrontDoor rule to the Web Application Firewall logs.
 
 * `redirect_url` - (Optional) If action type is redirect, this field represents redirect URL for the client.
 
@@ -155,7 +155,7 @@ The following arguments are supported:
 
 * `managed_rule` - (Optional) One or more `managed_rule` blocks as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the Cdn Frontdoor firewall policy.
+* `tags` - (Optional) A mapping of tags to assign to the CDN FrontDoor Firewall Policy.
 
 ---
 
@@ -245,20 +245,20 @@ An `exclusion` block supports the following:
 
 The following attributes are exported:
 
-* `id` - The ID of the Cdn Frontdoor Firewall Policy.
+* `id` - The ID of the CDN FrontDoor Firewall Policy.
 
-* `location` - The Azure Region where this Cdn Frontdoor Firewall Policy exists.
+* `location` - The Azure Region where this CDN FrontDoor Firewall Policy exists.
 
-* `frontend_endpoint_ids` - The Cdn Frontend Endpoints associated with this Cdn Frontdoor Firewall policy.
+* `frontend_endpoint_ids` - The Cdn Frontend Endpoints associated with this CDN FrontDoor Firewall Policy.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Cdn Frontdoor Firewall Policy.
-* `update` - (Defaults to 30 minutes) Used when updating the Cdn Frontdoor Firewall Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Cdn Frontdoor Firewall Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Cdn Frontdoor Firewall Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Firewall Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Firewall Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Firewall Policy.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_firewall_policy"
 description: |-
-  Manages a Front Door(standard/premium) Firewall Policy instance.
+  Manages a Front Door (standard/premium) Firewall Policy instance.
 ---
 
 # azurerm_cdn_frontdoor_firewall_policy
 
-Manages a Front Door(standard/premium) Firewall Policy instance.
+Manages a Front Door (standard/premium) Firewall Policy instance.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -255,10 +255,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Firewall Policy.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Firewall Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Firewall Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Firewall Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Firewall Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Firewall Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Firewall Policy.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -234,7 +234,7 @@ A `private_link` block supports the following:
 
 !> **IMPORTANT:** To associate a Load Balancer with a Front Door Origin via Private Link you must stand up your own `azurerm_private_link_service` - and ensure that a `depends_on` exists on the `azurerm_cdn_frontdoor_origin` resource to ensure it's destroyed before the `azurerm_private_link_service` resource (e.g. `depends_on = [azurerm_private_link_service.example]`) due to the design of the Front Door Service. 
 
-* `request_message` - (Optional) Specifies the request message that will be submitted to the `private_link_target_id` when requesting the private link endpoint connection. Values must be between `1` and `140` characters in length. Defaults to `Access request for CDN Front Door Private Link Origin`.
+* `request_message` - (Optional) Specifies the request message that will be submitted to the `private_link_target_id` when requesting the private link endpoint connection. Values must be between `1` and `140` characters in length. Defaults to `Access request for Front Door Private Link Origin`.
 
 * `target_type` - (Optional) Specifies the type of target for this Private Link Endpoint. Possible values are `blob`, `blob_secondary`, `web` and `sites`.
 
@@ -263,10 +263,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Origin.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Origin.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Origin.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Origin.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Origin.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Origin.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Origin.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -3,14 +3,14 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin"
 description: |-
-  Manages a `CDN FrontDoor Origin.`
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin.
 ---
 
 # azurerm_cdn_frontdoor_origin
 
-Manages a CDN FrontDoor Origin.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin.
 
-!>**IMPORTANT:** If you are attempting to implement an Origin that uses its own Private Link Service with a Load Balancer the Profile resource in your configuration file **must** hava a `depends_on` meta-argument which references the `azurerm_private_link_service`, see `Example Usage With Private Link Service` below.
+!>**IMPORTANT:** If you are attempting to implement an Origin that uses its own Private Link Service with a Load Balancer the Profile resource in your configuration file **must** have a `depends_on` meta-argument which references the `azurerm_private_link_service`, see `Example Usage With Private Link Service` below.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin.
+  Manages a Front Door(standard/premium) Origin.
 ---
 
 # azurerm_cdn_frontdoor_origin
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin.
+Manages a Front Door(standard/premium) Origin.
 
 !>**IMPORTANT:** If you are attempting to implement an Origin that uses its own Private Link Service with a Load Balancer the Profile resource in your configuration file **must** have a `depends_on` meta-argument which references the `azurerm_private_link_service`, see `Example Usage With Private Link Service` below.
 
@@ -194,13 +194,13 @@ resource "azurerm_private_link_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Origin. Changing this forces a new CDN FrontDoor Origin to be created.
+* `name` - (Required) The name which should be used for this Front Door Origin. Changing this forces a new Front Door Origin to be created.
 
-* `cdn_frontdoor_origin_group_id` - (Required) The ID of the CDN FrontDoor Origin Group within which this CDN FrontDoor Origin should exist. Changing this forces a new CDN FrontDoor Origin to be created.
+* `cdn_frontdoor_origin_group_id` - (Required) The ID of the Front Door Origin Group within which this Front Door Origin should exist. Changing this forces a new Front Door Origin to be created.
 
 * `host_name` - (Required) The IPv4 address, IPv6 address or Domain name of the Origin.
 
-!> **IMPORTANT:** This must be unique across all CDN FrontDoor Origins within a CDN FrontDoor Endpoint.
+!> **IMPORTANT:** This must be unique across all Front Door Origins within a Front Door Endpoint.
 
 * `certificate_name_check_enabled` - (Required) Specifies whether certificate name checks are enabled for this origin.
 
@@ -220,7 +220,7 @@ The following arguments are supported:
 
 * `private_link` - (Optional) A `private_link` block as defined below.
 
--> **NOTE:** Private Link requires that the CDN FrontDoor Profile this Origin is hosted within is using the SKU `Premium_AzureFrontDoor` and that the `certificate_name_check_enabled` field is set to `true`.
+-> **NOTE:** Private Link requires that the Front Door Profile this Origin is hosted within is using the SKU `Premium_AzureFrontDoor` and that the `certificate_name_check_enabled` field is set to `true`.
 
 * `weight` - (Optional) The weight of the origin in a given origin group for load balancing. Must be between `1` and `1000`. Defaults to `500`.
 
@@ -232,7 +232,7 @@ A `private_link` block supports the following:
 
 !> **IMPORTANT:** Origin support for direct private end point connectivity is limited to `Storage (Azure Blobs)`, `App Services` and `internal load balancers`. The Azure Front Door Private Link feature is region agnostic but for the best latency, you should always pick an Azure region closest to your origin when choosing to enable Azure Front Door Private Link endpoint.
 
-!> **IMPORTANT:** To associate a Load Balancer with a CDN FrontDoor Origin via Private LInk you must stand up your own `azurerm_private_link_service` - and ensure that a `depends_on` exists on the `azurerm_cdn_frontdoor_origin` resource to ensure it's destroyed before the `azurerm_private_link_service` resource (e.g. `depends_on = [azurerm_private_link_service.example]`) due to the design of the CDN FrontDoor Service. 
+!> **IMPORTANT:** To associate a Load Balancer with a Front Door Origin via Private Link you must stand up your own `azurerm_private_link_service` - and ensure that a `depends_on` exists on the `azurerm_cdn_frontdoor_origin` resource to ensure it's destroyed before the `azurerm_private_link_service` resource (e.g. `depends_on = [azurerm_private_link_service.example]`) due to the design of the Front Door Service. 
 
 * `request_message` - (Optional) Specifies the request message that will be submitted to the `private_link_target_id` when requesting the private link endpoint connection. Values must be between `1` and `140` characters in length. Defaults to `Access request for CDN Frontdoor Private Link Origin`.
 
@@ -257,7 +257,7 @@ A `private_link` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Origin.
+* `id` - The ID of the Front Door Origin.
 
 ## Timeouts
 
@@ -270,7 +270,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-CDN FrontDoor Origin can be imported using the `resource id`, e.g.
+Front Door Origins can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_origin.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/originGroups/originGroup1/origins/origin1

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin"
 description: |-
-  Manages a Front Door(standard/premium) Origin.
+  Manages a Front Door (standard/premium) Origin.
 ---
 
 # azurerm_cdn_frontdoor_origin
 
-Manages a Front Door(standard/premium) Origin.
+Manages a Front Door (standard/premium) Origin.
 
 !>**IMPORTANT:** If you are attempting to implement an Origin that uses its own Private Link Service with a Load Balancer the Profile resource in your configuration file **must** have a `depends_on` meta-argument which references the `azurerm_private_link_service`, see `Example Usage With Private Link Service` below.
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -206,7 +206,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should the origin be enabled? Possible values are `true` or `false`. Defaults to `true`.
 
--> **NOTE:** Due to the deprecation of the `health_probes_enabled` property in version 3.x of the AzureRM Provider this value will need to be explicitly set until the 4.0 provider is released where it will default to `true`.
+-> **NOTE:** The `enabled` field will need to be explicitly set until the 4.0 provider is released due to the deprecation of the `health_probes_enabled` property in version 3.x of the AzureRM Provider.
 
 * `http_port` - (Optional) The value of the HTTP port. Must be between `1` and `65535`. Defaults to `80`.
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -214,7 +214,7 @@ The following arguments are supported:
 
 * `origin_host_header` - (Optional) The host header value (an IPv4 address, IPv6 address or Domain name) which is sent to the origin with each request. If unspecified the hostname from the request will be used. 
 
--> Azure FrontDoor Origins, such as Web Apps, Blob Storage, and Cloud Services require this host header value to match the origin's hostname. This field's value overrides the host header defined in the FrontDoor Endpoint. For more information on how to properly set the origin host header value please see the [product documentation](https://docs.microsoft.com/azure/frontdoor/origin?pivots=front-door-standard-premium#origin-host-header).
+-> Azure Front Door Origins, such as Web Apps, Blob Storage, and Cloud Services require this host header value to match the origin's hostname. This field's value overrides the host header defined in the Front Door Endpoint. For more information on how to properly set the origin host header value please see the [product documentation](https://docs.microsoft.com/azure/frontdoor/origin?pivots=front-door-standard-premium#origin-host-header).
 
 * `priority` - (Optional) Priority of origin in given origin group for load balancing. Higher priorities will not be used for load balancing if any lower priority origin is healthy. Must be between `1` and `5` (inclusive). Defaults to `1`.
 
@@ -234,7 +234,7 @@ A `private_link` block supports the following:
 
 !> **IMPORTANT:** To associate a Load Balancer with a Front Door Origin via Private Link you must stand up your own `azurerm_private_link_service` - and ensure that a `depends_on` exists on the `azurerm_cdn_frontdoor_origin` resource to ensure it's destroyed before the `azurerm_private_link_service` resource (e.g. `depends_on = [azurerm_private_link_service.example]`) due to the design of the Front Door Service. 
 
-* `request_message` - (Optional) Specifies the request message that will be submitted to the `private_link_target_id` when requesting the private link endpoint connection. Values must be between `1` and `140` characters in length. Defaults to `Access request for CDN Frontdoor Private Link Origin`.
+* `request_message` - (Optional) Specifies the request message that will be submitted to the `private_link_target_id` when requesting the private link endpoint connection. Values must be between `1` and `140` characters in length. Defaults to `Access request for CDN Front Door Private Link Origin`.
 
 * `target_type` - (Optional) Specifies the type of target for this Private Link Endpoint. Possible values are `blob`, `blob_secondary`, `web` and `sites`.
 
@@ -263,10 +263,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Origin.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Origin.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Origin.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Origin.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Origin.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Origin.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Origin.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -99,10 +99,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Origin Group.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin Group.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Origin Group.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Origin Group.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Origin Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Origin Group.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Origin Group.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Origin Group.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Manages a Front Door(standard/premium) Origin Group.
+  Manages a Front Door (standard/premium) Origin Group.
 ---
 
 # azurerm_cdn_frontdoor_origin_group
 
-Manages a Front Door(standard/premium) Origin Group.
+Manages a Front Door (standard/premium) Origin Group.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -99,10 +99,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Origin Group.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Origin Group.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Origin Group.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Origin Group.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Origin Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Origin Group.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Origin Group.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Origin Group.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Manages a CDN FrontDoor Origin Group.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
 ---
 
 # azurerm_cdn_frontdoor_origin_group
 
-Manages a CDN FrontDoor Origin Group.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_origin_group"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
+  Manages a Front Door(standard/premium) Origin Group.
 ---
 
 # azurerm_cdn_frontdoor_origin_group
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Origin Group.
+Manages a Front Door(standard/premium) Origin Group.
 
 ## Example Usage
 
@@ -49,9 +49,9 @@ resource "azurerm_cdn_frontdoor_origin_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Origin Group. Changing this forces a new CDN FrontDoor Origin Group to be created.
+* `name` - (Required) The name which should be used for this Front Door Origin Group. Changing this forces a new Front Door Origin Group to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile within which this CDN FrontDoor Origin Group should exist. Changing this forces a new CDN FrontDoor Origin Group to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile within which this Front Door Origin Group should exist. Changing this forces a new Front Door Origin Group to be created.
 
 * `load_balancing` - (Required) A `load_balancing` block as defined below.
 
@@ -93,7 +93,7 @@ A `load_balancing` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Origin Group.
+* `id` - The ID of the Front Door Origin Group.
 
 ## Timeouts
 
@@ -106,7 +106,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-CDN FrontDoor Origin Groups can be imported using the `resource id`, e.g.
+Front Door Origin Groups can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_origin_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/originGroups/originGroup1

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Profile, which contains a collection of endpoints and origin groups.
+  Manages a Front Door(standard/premium) Profile, which contains a collection of endpoints and origin groups.
 ---
 
 # azurerm_cdn_frontdoor_profile
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Profile, which contains a collection of endpoints and origin groups.
+Manages a Front Door(standard/premium) Profile, which contains a collection of endpoints and origin groups.
 
 ## Example Usage
 
@@ -33,11 +33,11 @@ resource "azurerm_cdn_frontdoor_profile" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CDN FrontDoor Profile. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Front Door Profile. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where this CDN FrontDoor Profile should exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where this Front Door Profile should exist. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) Specifies the SKU for this CDN FrontDoor Profile. Possible values include `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) Specifies the SKU for this Front Door Profile. Possible values include `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
 * `response_timeout_seconds` - Specifies the maximum response timeout in seconds. Possible values are between `16` and `240` seconds (inclusive). Defaults to `120` seconds.
 
@@ -47,9 +47,9 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of this CDN FrontDoor Profile.
+* `id` - The ID of this Front Door Profile.
 
-* `resource_guid` - The UUID of this CDN FrontDoor Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
+* `resource_guid` - The UUID of this Front Door Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
 
 ## Timeouts
 
@@ -62,7 +62,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-CDN FrontDoor Profiles can be imported using the `resource id`, e.g.
+Front Door Profiles can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_profile.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Cdn/profiles/myprofile1

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Manages a Front Door(standard/premium) Profile, which contains a collection of endpoints and origin groups.
+  Manages a Front Door(standard/premium) Profile.
 ---
 
 # azurerm_cdn_frontdoor_profile
 
-Manages a Front Door(standard/premium) Profile, which contains a collection of endpoints and origin groups.
+Manages a Front Door(standard/premium) Profile which contains a collection of endpoints and origin groups.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Manages a CDN FrontDoor Profile which contains a collection of CDN FrontDoor Endpoints.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Profile, which contains a collection of endpoints and origin groups.
 ---
 
 # azurerm_cdn_frontdoor_profile
 
-Manages a CDN FrontDoor Profile which contains a collection of CDN FrontDoor Endpoints.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Profile, which contains a collection of endpoints and origin groups.
 
 ## Example Usage
 
@@ -33,9 +33,9 @@ resource "azurerm_cdn_frontdoor_profile" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the FrontDoor Profile. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the CDN FrontDoor Profile. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where this FrontDoor Profile should exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where this CDN FrontDoor Profile should exist. Changing this forces a new resource to be created.
 
 * `sku_name` - (Required) Specifies the SKU for this CDN FrontDoor Profile. Possible values include `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
@@ -49,7 +49,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of this CDN FrontDoor Profile.
 
-* `resource_guid` - The UUID of this CDN FrontDoor Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
+* `resource_guid` - The UUID of this CDN FrontDoor Profile.
 
 ## Timeouts
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -49,7 +49,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of this CDN FrontDoor Profile.
 
-* `resource_guid` - The UUID of this CDN FrontDoor Profile.
+* `resource_guid` - The UUID of this CDN FrontDoor Profile which will be sent in the HTTP Header as the `X-Azure-FDID` attribute.
 
 ## Timeouts
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -55,10 +55,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Profile.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Profile.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Profile.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Profile.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Profile.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Profile.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Profile.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Profile.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -55,10 +55,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Profile.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Profile.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Profile.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Profile.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Profile.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Profile.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Profile.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Profile.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_profile"
 description: |-
-  Manages a Front Door(standard/premium) Profile.
+  Manages a Front Door (standard/premium) Profile.
 ---
 
 # azurerm_cdn_frontdoor_profile
 
-Manages a Front Door(standard/premium) Profile which contains a collection of endpoints and origin groups.
+Manages a Front Door (standard/premium) Profile which contains a collection of endpoints and origin groups.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route"
 description: |-
-  Manages a CDN FrontDoor Route.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_route
 
-Manages a CDN FrontDoor Route.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Route.
 
 ## Example Usage
 
@@ -115,19 +115,19 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "fabrikam" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Frontdoor Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new Frontdoor Route to be created.
+* `name` - (Required) The name which should be used for this CDN FrontDoor Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new CDN FrontDoor Route to be created.
 
-* `cdn_frontdoor_endpoint_id` - (Required) The resource ID of the CDN FrontDoor Endpoint where this CDN FrontDoor Route should exist. Changing this forces a new Frontdoor Route to be created.
+* `cdn_frontdoor_endpoint_id` - (Required) The resource ID of the CDN FrontDoor Endpoint where this CDN FrontDoor Route should exist. Changing this forces a new CDN FrontDoor Route to be created.
 
 * `cdn_frontdoor_origin_group_id` - (Required) The resource ID of the CDN FrontDoor Origin Group where this CDN FrontDoor Route should be created.
 
-* `cdn_frontdoor_origin_ids` - (Required) One or more Frontdoor Origin resource IDs that this Frontdoor Route will link to.
+* `cdn_frontdoor_origin_ids` - (Required) One or more CDN FrontDoor Origin resource IDs that this CDN FrontDoor Route will link to.
 
 * `forwarding_protocol` - (Required) The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
 
 * `patterns_to_match` - (Required) The route patterns of the rule.
 
-* `supported_protocols` - (Required) One or more Protocols supported by this Frontdoor Route. Possible values are `Http` or `Https`.
+* `supported_protocols` - (Required) One or more Protocols supported by this CDN FrontDoor Route. Possible values are `Http` or `Https`.
 
 ~> **NOTE:** If `https_redirect_enabled` is set to `true` the `supported_protocols` field must contain both `Http` and `Https` values.
 
@@ -137,11 +137,11 @@ The following arguments are supported:
 
 * `cdn_frontdoor_custom_domain_ids` - (Optional) The IDs of the CDN FrontDoor Custom Domains which are associated with this CDN FrontDoor Route.
 
-* `cdn_frontdoor_origin_path` - (Optional) A directory path on the origin that Frontdoor can use to retrieve content from (e.g. `contoso.cloudapp.net/originpath`).
+* `cdn_frontdoor_origin_path` - (Optional) A directory path on the CDN FrontDoor Origin that can use to retrieve content from (e.g. `contoso.cloudapp.net/originpath`).
 
 * `cdn_frontdoor_rule_set_ids` - (Optional) A list of the CDN FrontDoor Rule Set IDs which should be assigned to this CDN FrontDoor Route.
 
-* `enabled` - (Optional) Is this Frontdoor Route enabled? Possible values are `true` or `false`. Defaults to `true`.
+* `enabled` - (Optional) Is this CDN FrontDoor Route enabled? Possible values are `true` or `false`. Defaults to `true`.
 
 * `https_redirect_enabled` - (Optional) Automatically redirect HTTP traffic to HTTPS traffic? Possible values are `true` or `false`. Defaults to `true`.
 
@@ -153,7 +153,7 @@ The following arguments are supported:
 
 A `cache` block supports the following:
 
-* `query_string_caching_behavior` - (Optional) Defines how the Frontdoor will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
+* `query_string_caching_behavior` - (Optional) Defines how the CDN FrontDoor Route will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
 
 ~> **NOTE:** The value of the `query_string_caching_behavior` determines if the `query_strings` field will be used as an include list or an ignore list.
 
@@ -169,7 +169,7 @@ A `cache` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Frontdoor Route.
+* `id` - The ID of the CDN FrontDoor Route.
 
 ---
 
@@ -177,10 +177,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Frontdoor Route.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Frontdoor Route.
-* `update` - (Defaults to 30 minutes) Used when updating the Frontdoor Route.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Frontdoor Route.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Route.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Route.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Route.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Route.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route"
 description: |-
-  Manages a Front Door(standard/premium) Route.
+  Manages a Front Door (standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_route
 
-Manages a Front Door(standard/premium) Route.
+Manages a Front Door (standard/premium) Route.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -137,7 +137,7 @@ The following arguments are supported:
 
 * `cdn_frontdoor_custom_domain_ids` - (Optional) The IDs of the CDN FrontDoor Custom Domains which are associated with this CDN FrontDoor Route.
 
-* `cdn_frontdoor_origin_path` - (Optional) A directory path on the CDN FrontDoor Origin that can use to retrieve content from (e.g. `contoso.cloudapp.net/originpath`).
+* `cdn_frontdoor_origin_path` - (Optional) A directory path on the CDN FrontDoor Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
 
 * `cdn_frontdoor_rule_set_ids` - (Optional) A list of the CDN FrontDoor Rule Set IDs which should be assigned to this CDN FrontDoor Route.
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -177,10 +177,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Route.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Route.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Route.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Route.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Route.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Route.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Route.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Route.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Route.
+  Manages a Front Door(standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_route
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Route.
+Manages a Front Door(standard/premium) Route.
 
 ## Example Usage
 
@@ -115,19 +115,19 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "fabrikam" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new CDN FrontDoor Route to be created.
+* `name` - (Required) The name which should be used for this Front Door Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new Front Door Route to be created.
 
-* `cdn_frontdoor_endpoint_id` - (Required) The resource ID of the CDN FrontDoor Endpoint where this CDN FrontDoor Route should exist. Changing this forces a new CDN FrontDoor Route to be created.
+* `cdn_frontdoor_endpoint_id` - (Required) The resource ID of the Front Door Endpoint where this Front Door Route should exist. Changing this forces a new Front Door Route to be created.
 
-* `cdn_frontdoor_origin_group_id` - (Required) The resource ID of the CDN FrontDoor Origin Group where this CDN FrontDoor Route should be created.
+* `cdn_frontdoor_origin_group_id` - (Required) The resource ID of the Front Door Origin Group where this Front Door Route should be created.
 
-* `cdn_frontdoor_origin_ids` - (Required) One or more CDN FrontDoor Origin resource IDs that this CDN FrontDoor Route will link to.
+* `cdn_frontdoor_origin_ids` - (Required) One or more Front Door Origin resource IDs that this Front Door Route will link to.
 
 * `forwarding_protocol` - (Required) The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
 
 * `patterns_to_match` - (Required) The route patterns of the rule.
 
-* `supported_protocols` - (Required) One or more Protocols supported by this CDN FrontDoor Route. Possible values are `Http` or `Https`.
+* `supported_protocols` - (Required) One or more Protocols supported by this Front Door Route. Possible values are `Http` or `Https`.
 
 ~> **NOTE:** If `https_redirect_enabled` is set to `true` the `supported_protocols` field must contain both `Http` and `Https` values.
 
@@ -135,25 +135,25 @@ The following arguments are supported:
 
 ~> **NOTE:** To disable caching, do not provide the `cache` block in the configuration file.
 
-* `cdn_frontdoor_custom_domain_ids` - (Optional) The IDs of the CDN FrontDoor Custom Domains which are associated with this CDN FrontDoor Route.
+* `cdn_frontdoor_custom_domain_ids` - (Optional) The IDs of the Front Door Custom Domains which are associated with this Front Door Route.
 
-* `cdn_frontdoor_origin_path` - (Optional) A directory path on the CDN FrontDoor Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
+* `cdn_frontdoor_origin_path` - (Optional) A directory path on the Front Door Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
 
-* `cdn_frontdoor_rule_set_ids` - (Optional) A list of the CDN FrontDoor Rule Set IDs which should be assigned to this CDN FrontDoor Route.
+* `cdn_frontdoor_rule_set_ids` - (Optional) A list of the Front Door Rule Set IDs which should be assigned to this Front Door Route.
 
-* `enabled` - (Optional) Is this CDN FrontDoor Route enabled? Possible values are `true` or `false`. Defaults to `true`.
+* `enabled` - (Optional) Is this Front Door Route enabled? Possible values are `true` or `false`. Defaults to `true`.
 
 * `https_redirect_enabled` - (Optional) Automatically redirect HTTP traffic to HTTPS traffic? Possible values are `true` or `false`. Defaults to `true`.
 
 ~> **NOTE:** The `https_redirect_enabled` rule is the first rule that will be executed.
 
-* `link_to_default_domain` - (Optional) Should this CDN FrontDoor Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
+* `link_to_default_domain` - (Optional) Should this Front Door Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
 
 ---
 
 A `cache` block supports the following:
 
-* `query_string_caching_behavior` - (Optional) Defines how the CDN FrontDoor Route will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
+* `query_string_caching_behavior` - (Optional) Defines how the Front Door Route will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
 
 ~> **NOTE:** The value of the `query_string_caching_behavior` determines if the `query_strings` field will be used as an include list or an ignore list.
 
@@ -169,7 +169,7 @@ A `cache` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Route.
+* `id` - The ID of the Front Door Route.
 
 ---
 
@@ -184,7 +184,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Frontdoor Routes can be imported using the `resource id`, e.g.
+Front Door Routes can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_route.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -177,10 +177,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Route.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Route.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Route.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Route.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Route.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Route.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Route.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Route.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route_disable_link_to_default_domain"
 description: |-
-  Manages the Link To Default Domain property of a CDN FrontDoor Route.
+  Manages the Link To Default Domain property of a Front Door(standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_route_disable_link_to_default_domain
 
-Manages the Link To Default Domain property of a CDN FrontDoor Route.
+Manages the Link To Default Domain property of a Front Door(standard/premium) Route.
 
 !>**IMPORTANT:** This resource has been deprecated and should not be used for new deployments. The `azurerm_cdn_frontdoor_route_disable_link_to_default_domain` resource will be removed from the 4.0 AzureRM provider. Please use the `link_to_default_domain` field in the `azurerm_cdn_frontdoor_route` resource to control this value.
 
@@ -25,15 +25,15 @@ resource "azurerm_cdn_frontdoor_route_disable_link_to_default_domain" "example" 
 
 The following arguments are supported:
 
-* `cdn_frontdoor_route_id` - (Required) The resource ID of the CDN FrontDoor Route where the Link To Default Domain property should be `disabled`. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
+* `cdn_frontdoor_route_id` - (Required) The resource ID of the Front Door Route where the Link To Default Domain property should be `disabled`. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
 
-* `cdn_frontdoor_custom_domain_ids` - (Required) The resource IDs of the CDN FrontDoor Custom Domains which are associated with this CDN FrontDoor Route. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
+* `cdn_frontdoor_custom_domain_ids` - (Required) The resource IDs of the Front Door Custom Domains which are associated with this Front Door Route. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the FrontDoor Route Disable Link To Default Domain.
+* `id` - The ID of the Front Door Route Disable Link To Default Domain.
 
 ---
 
@@ -41,9 +41,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the FrontDoor Route Disable Link To Default Domain.
-* `read` - (Defaults to 5 minutes) Used when retrieving the FrontDoor Route Disable Link To Default Domain.
-* `delete` - (Defaults to 30 minutes) Used when deleting the FrontDoor Route Disable Link To Default Domain.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Route Disable Link To Default Domain.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Route Disable Link To Default Domain.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Route Disable Link To Default Domain.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route_disable_link_to_default_domain"
 description: |-
-  Manages the Link To Default Domain property of a Front Door(standard/premium) Route.
+  Manages the Link To Default Domain property of a Front Door (standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_route_disable_link_to_default_domain
 
-Manages the Link To Default Domain property of a Front Door(standard/premium) Route.
+Manages the Link To Default Domain property of a Front Door (standard/premium) Route.
 
 !>**IMPORTANT:** This resource has been deprecated and should not be used for new deployments. The `azurerm_cdn_frontdoor_route_disable_link_to_default_domain` resource will be removed from the 4.0 AzureRM provider. Please use the `link_to_default_domain` field in the `azurerm_cdn_frontdoor_route` resource to control this value.
 

--- a/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
@@ -25,9 +25,9 @@ resource "azurerm_cdn_frontdoor_route_disable_link_to_default_domain" "example" 
 
 The following arguments are supported:
 
-* `cdn_frontdoor_route_id` - (Required) The resource ID of the Front Door Route where the Link To Default Domain property should be `disabled`. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
+* `cdn_frontdoor_route_id` - (Required) The resource ID of the Front Door Route where the Link To Default Domain property should be `disabled`. Changing this forces a new Front Door Route Disable Link To Default Domain to be created.
 
-* `cdn_frontdoor_custom_domain_ids` - (Required) The resource IDs of the Front Door Custom Domains which are associated with this Front Door Route. Changing this forces a new FrontDoor Route Disable Link To Default Domain to be created.
+* `cdn_frontdoor_custom_domain_ids` - (Required) The resource IDs of the Front Door Custom Domains which are associated with this Front Door Route. Changing this forces a new Front Door Route Disable Link To Default Domain to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule"
 description: |-
-  Manages a Front Door(standard/premium) Rule.
+  Manages a Front Door (standard/premium) Rule.
 ---
 
 # azurerm_cdn_frontdoor_rule
 
-Manages a Front Door(standard/premium) Rule.
+Manages a Front Door (standard/premium) Rule.
 
 !>**IMPORTANT:** The Rules resource **must** include a `depends_on` meta-argument which references the `azurerm_cdn_frontdoor_origin` and the `azurerm_cdn_frontdoor_origin_group`.
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -145,7 +145,7 @@ resource "azurerm_cdn_frontdoor_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Front Door Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Frontdoor Rule to be created.
+* `name` - (Required) The name which should be used for this Front Door Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Front Door Rule to be created.
 
 * `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the Front Door Rule Set for this Front Door Rule. Changing this forces a new Front Door Rule to be created.
 
@@ -696,10 +696,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Rule.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Rule.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Rule.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Rule.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -587,7 +587,7 @@ Rule Set server variables provide access to structured information about the req
 
 | Variable name | Description |
 |---------------|-------------|
-| `socket_ip`      | The IP address of the direct connection to CDN Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of `socket_ip` is the IP address of the proxy or load balancer. |
+| `socket_ip`      | The IP address of the direct connection to Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of `socket_ip` is the IP address of the proxy or load balancer. |
 | `client_ip`      | The IP address of the client that made the original request. If there was an `X-Forwarded-For` header in the request, then the client IP address is picked from the header. |
 | `client_port`    | The IP port of the client that made the request. |
 | `hostname`       | The host name in the request from the client. |
@@ -696,10 +696,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Rule.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the CDN Front Door Rule.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Rule.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Rule.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule"
 description: |-
-  Manages a Frontdoor Rule.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule.
 ---
 
 # azurerm_cdn_frontdoor_rule
 
-Manages a Frontdoor Rule.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule.
 
 !>**IMPORTANT:** The Rules resource **must** include a `depends_on` meta-argument which references the `azurerm_cdn_frontdoor_origin` and the `azurerm_cdn_frontdoor_origin_group`.
 
@@ -145,13 +145,13 @@ resource "azurerm_cdn_frontdoor_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Frontdoor Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Frontdoor Rule to be created.
+* `name` - (Required) The name which should be used for this CDN FrontDoor Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Frontdoor Rule to be created.
 
-* `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the Frontdoor Rule Set for this Frontdoor Rule. Changing this forces a new Frontdoor Rule to be created.
+* `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the CDN FrontDoor Rule Set for this CDN FrontDoor Rule. Changing this forces a new CDN FrontDoor Rule to be created.
 
-* `order` - (Required) The order in which the rules will be applied for the Frontdoor Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A Frontdoor Rule with a lesser order value will be applied before a rule with a greater order value.
+* `order` - (Required) The order in which the rules will be applied for the CDN FrontDoor Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A CDN FrontDoor Rule with a lesser order value will be applied before a rule with a greater order value.
 
-->**NOTE:** If the Frontdoor Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
+->**NOTE:** If the CDN FrontDoor Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
 
 * `actions` - (Required) An `actions` block as defined below.
 
@@ -163,7 +163,7 @@ The following arguments are supported:
 
 An `actions` block supports the following:
 
-->**NOTE:** You may include upto 5 separate actions in the `actions` block.
+->**NOTE:** You may include up to 5 separate actions in the `actions` block.
 
 Some actions support `Action Server Variables` which provide access to structured information about the request. For more information about `Action Server Variables` see the `Action Server Variables` as defined below.
 
@@ -197,23 +197,25 @@ An `url_redirect_action` block supports the following:
 
 A `route_configuration_override_action` block supports the following:
 
-* `cdn_frontdoor_origin_group_id` - (Required) The origin group resource ID that the request should be routed to. This overrides the configuration specified in the Frontdoor endpoint route.
-
 * `cache_duration` - (Required) When Cache behavior is set to `Override` or `SetIfMissing`, this field specifies the cache duration to use. The maximum duration is 366 days specified in the `d.HH:MM:SS` format(e.g. `365.23:59:59`). If the desired maximum cache duration is less than 1 day then the maximum cache duration should be specified in the `HH:MM:SS` format(e.g. `23:59:59`).
 
-* `forwarding_protocol` - (Optional)  The forwarding protocol the request will be redirected as. This overrides the configuration specified in the route to be associated with. Possible values include `MatchRequest`, `HttpOnly` or `HttpsOnly`. Defaults to `MatchRequest`. Possible values include `HttpOnly`, `HttpsOnly` or `MatchRequest`. Defaults to `MatchRequest`.
+* `cdn_frontdoor_origin_group_id` - (Optional) The CDN FrontDoor Origin Group resource ID that the request should be routed to. This overrides the configuration specified in the CDN FrontDoor Endpoint route.
 
-* `query_string_caching_behavior` - (Optional)  `IncludeSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get included when the cache key gets generated. `UseQueryString` cache every unique URL, each unique URL will have its own cache key. `IgnoreSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get excluded when the cache key gets generated. `IgnoreQueryString` query strings aren't considered when the cache key gets generated. Possible values include `IgnoreQueryString`, `UseQueryString`, `IgnoreSpecifiedQueryStrings` or `IncludeSpecifiedQueryStrings`. Defaults to `IgnoreQueryString`.
+* `forwarding_protocol` - (Optional) The forwarding protocol the request will be redirected as. This overrides the configuration specified in the route to be associated with. Possible values include `MatchRequest`, `HttpOnly` or `HttpsOnly`. Defaults to `MatchRequest`. Possible values include `HttpOnly`, `HttpsOnly` or `MatchRequest`. Defaults to `MatchRequest`.
+
+->**NOTE:** If the `cdn_frontdoor_origin_group_id` is not defined you cannot set the `forwarding_protocol`.
+
+* `query_string_caching_behavior` - (Optional) `IncludeSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get included when the cache key gets generated. `UseQueryString` cache every unique URL, each unique URL will have its own cache key. `IgnoreSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get excluded when the cache key gets generated. `IgnoreQueryString` query strings aren't considered when the cache key gets generated. Possible values include `IgnoreQueryString`, `UseQueryString`, `IgnoreSpecifiedQueryStrings` or `IncludeSpecifiedQueryStrings`. Defaults to `IgnoreQueryString`.
 
 * `query_string_parameters` - (Optional) A list of query string parameter names.
 
 ->**NOTE:** `query_string_parameters` is a required field when the `query_string_caching_behavior` is set to `IncludeSpecifiedQueryStrings` or `IgnoreSpecifiedQueryStrings`.
 
-* `compression_enabled` - (Optional) Should Frontdoor dynamically compress the content? Possible values include `true` or `false`. Defaults to `false`.
+* `compression_enabled` - (Optional) Should the CDN FrontDoor Profile dynamically compress the content? Possible values include `true` or `false`. Defaults to `false`.
 
 ->**NOTE:** Content won't be compressed on AzureFrontDoor when requested content is smaller than `1 byte` or larger than `1 MB`.
 
-* `cache_behavior` - (Optional) `HonorOrigin` Frontdoor will always honor origin response header directive. If the origin directive is missing, Frontdoor will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. Possible values include `HonorOrigin`, `OverrideAlways` or `OverrideIfOriginMissing`. Defaults to `HonorOrigin`.
+* `cache_behavior` - (Optional) `HonorOrigin` the CDN FrontDoor Profile will always honor origin response header directive. If the origin directive is missing, CDN FrontDoor Profile will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your CDN FrontDoor Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your CDN FrontDoor Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. Possible values include `HonorOrigin`, `OverrideAlways` or `OverrideIfOriginMissing`. Defaults to `HonorOrigin`.
 
 ---
 
@@ -257,7 +259,7 @@ A `request_header_action` block supports the following:
 
 A `conditions` block supports the following:
 
-->**NOTE:** You may include upto 10 separate conditions in the `conditions` block.
+->**NOTE:** You may include up to 10 separate conditions in the `conditions` block.
 
 * `remote_address_condition` - (Optional) A `remote_address_condition` block as defined below.
 
@@ -319,13 +321,13 @@ A `host_name_condition` block supports the following:
 
 * `match_values` - (Required) A list of one or more string values representing the value of the request hostname to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
 A `server_port_condition` block supports the following:
 
-->The `server_port_condition` identifies requests based on which port of the Frontdoor server accepted the request on.
+->The `server_port_condition` identifies requests based on which port of the CDN Frontdoor Profile server accepted the request on.
 
 * `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual` or `RegEx`. Details can be found in the `Condition Operator List` below.
 
@@ -349,7 +351,7 @@ A `client_port_condition` block supports the following:
 
 A `socket_address_condition` block supports the following:
 
-->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the Frontdoors edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer. 
+->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the CDN FrontDoor Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer. 
 
 ->Remote Address represents the original client IP that is either from the network connection or typically the `X-Forwarded-For` request header if the user is behind a proxy.
 
@@ -401,7 +403,7 @@ A `query_string_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the query string to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -417,7 +419,7 @@ A `post_args_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the `POST` argument to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -431,7 +433,7 @@ A `request_uri_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the request URL to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -447,7 +449,7 @@ A `request_header_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the request header to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -463,7 +465,7 @@ A `request_body_condition` block supports the following:
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -489,7 +491,7 @@ An `url_path_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the request path to match. Don't include the leading slash (`/`). If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -503,7 +505,7 @@ An `url_file_extension_condition` block supports the following:
 
 * `match_values` - (Required) A list of one or more string or integer values(e.g. "1") representing the value of the request file extension to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -517,7 +519,7 @@ An `url_filename_condition` block supports the following:
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -545,7 +547,7 @@ A `cookies_condition` block supports the following:
 
 * `match_values` - (Optional) One or more string or integer values(e.g. "1") representing the value of the request header to match. If multiple values are specified, they're evaluated using `OR` logic.
 
-* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`.  Details can be found in the `Condition Transform List` below.
+* `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
 ---
 
@@ -585,7 +587,7 @@ Rule Set server variables provide access to structured information about the req
 
 | Variable name | Description |
 |---------------|-------------|
-| `socket_ip`      | The IP address of the direct connection to Azure Front Door edge. If the client used an HTTP proxy or a load balancer to send the request, the value of `socket_ip` is the IP address of the proxy or load balancer. |
+| `socket_ip`      | The IP address of the direct connection to CDN Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of `socket_ip` is the IP address of the proxy or load balancer. |
 | `client_ip`      | The IP address of the client that made the original request. If there was an `X-Forwarded-For` header in the request, then the client IP address is picked from the header. |
 | `client_port`    | The IP port of the client that made the request. |
 | `hostname`       | The host name in the request from the client. |
@@ -686,22 +688,22 @@ For rules that can transform strings, the following transforms are valid:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Frontdoor Rule.
+* `id` - The ID of the CDN FrontDoor Rule.
 
-* `cdn_frontdoor_rule_set_name` - The name of the Frontdoor Rule Set containing this Frontdoor Rule.
+* `cdn_frontdoor_rule_set_name` - The name of the CDN FrontDoor Rule Set containing this CDN FrontDoor Rule.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the cdn Rule.
-* `read` - (Defaults to 5 minutes) Used when retrieving the cdn Rule.
-* `update` - (Defaults to 30 minutes) Used when updating the cdn Rule.
-* `delete` - (Defaults to 30 minutes) Used when deleting the cdn Rule.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the CDN FrontDoor Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Rule.
 
 ## Import
 
-cdn Rules can be imported using the `resource id`, e.g.
+CDN FrontDoor Rules can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_rule.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/ruleSets/ruleSet1/rules/rule1

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule.
+  Manages a Front Door(standard/premium) Rule.
 ---
 
 # azurerm_cdn_frontdoor_rule
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule.
+Manages a Front Door(standard/premium) Rule.
 
 !>**IMPORTANT:** The Rules resource **must** include a `depends_on` meta-argument which references the `azurerm_cdn_frontdoor_origin` and the `azurerm_cdn_frontdoor_origin_group`.
 
@@ -145,13 +145,13 @@ resource "azurerm_cdn_frontdoor_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Frontdoor Rule to be created.
+* `name` - (Required) The name which should be used for this Front Door Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Frontdoor Rule to be created.
 
-* `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the CDN FrontDoor Rule Set for this CDN FrontDoor Rule. Changing this forces a new CDN FrontDoor Rule to be created.
+* `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the Front Door Rule Set for this Front Door Rule. Changing this forces a new Front Door Rule to be created.
 
-* `order` - (Required) The order in which the rules will be applied for the CDN FrontDoor Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A CDN FrontDoor Rule with a lesser order value will be applied before a rule with a greater order value.
+* `order` - (Required) The order in which the rules will be applied for the Front Door Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A Front Door Rule with a lesser order value will be applied before a rule with a greater order value.
 
-->**NOTE:** If the CDN FrontDoor Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
+->**NOTE:** If the Front Door Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
 
 * `actions` - (Required) An `actions` block as defined below.
 
@@ -199,7 +199,7 @@ A `route_configuration_override_action` block supports the following:
 
 * `cache_duration` - (Required) When Cache behavior is set to `Override` or `SetIfMissing`, this field specifies the cache duration to use. The maximum duration is 366 days specified in the `d.HH:MM:SS` format(e.g. `365.23:59:59`). If the desired maximum cache duration is less than 1 day then the maximum cache duration should be specified in the `HH:MM:SS` format(e.g. `23:59:59`).
 
-* `cdn_frontdoor_origin_group_id` - (Optional) The CDN FrontDoor Origin Group resource ID that the request should be routed to. This overrides the configuration specified in the CDN FrontDoor Endpoint route.
+* `cdn_frontdoor_origin_group_id` - (Optional) The Front Door Origin Group resource ID that the request should be routed to. This overrides the configuration specified in the Front Door Endpoint route.
 
 * `forwarding_protocol` - (Optional) The forwarding protocol the request will be redirected as. This overrides the configuration specified in the route to be associated with. Possible values include `MatchRequest`, `HttpOnly` or `HttpsOnly`. Defaults to `MatchRequest`. Possible values include `HttpOnly`, `HttpsOnly` or `MatchRequest`. Defaults to `MatchRequest`.
 
@@ -211,11 +211,11 @@ A `route_configuration_override_action` block supports the following:
 
 ->**NOTE:** `query_string_parameters` is a required field when the `query_string_caching_behavior` is set to `IncludeSpecifiedQueryStrings` or `IgnoreSpecifiedQueryStrings`.
 
-* `compression_enabled` - (Optional) Should the CDN FrontDoor Profile dynamically compress the content? Possible values include `true` or `false`. Defaults to `false`.
+* `compression_enabled` - (Optional) Should the Front Door Profile dynamically compress the content? Possible values include `true` or `false`. Defaults to `false`.
 
 ->**NOTE:** Content won't be compressed on AzureFrontDoor when requested content is smaller than `1 byte` or larger than `1 MB`.
 
-* `cache_behavior` - (Optional) `HonorOrigin` the CDN FrontDoor Profile will always honor origin response header directive. If the origin directive is missing, CDN FrontDoor Profile will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your CDN FrontDoor Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your CDN FrontDoor Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. Possible values include `HonorOrigin`, `OverrideAlways` or `OverrideIfOriginMissing`. Defaults to `HonorOrigin`.
+* `cache_behavior` - (Optional) `HonorOrigin` the Front Door Profile will always honor origin response header directive. If the origin directive is missing, Front Door Profile will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your Front Door Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your Front Door Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. Possible values include `HonorOrigin`, `OverrideAlways` or `OverrideIfOriginMissing`. Defaults to `HonorOrigin`.
 
 ---
 
@@ -327,7 +327,7 @@ A `host_name_condition` block supports the following:
 
 A `server_port_condition` block supports the following:
 
-->The `server_port_condition` identifies requests based on which port of the CDN Frontdoor Profile server accepted the request on.
+->The `server_port_condition` identifies requests based on which port of the Front Door Profile server accepted the request on.
 
 * `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual` or `RegEx`. Details can be found in the `Condition Operator List` below.
 
@@ -351,7 +351,7 @@ A `client_port_condition` block supports the following:
 
 A `socket_address_condition` block supports the following:
 
-->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the CDN FrontDoor Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer. 
+->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer. 
 
 ->Remote Address represents the original client IP that is either from the network connection or typically the `X-Forwarded-For` request header if the user is behind a proxy.
 
@@ -688,9 +688,9 @@ For rules that can transform strings, the following transforms are valid:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Rule.
+* `id` - The ID of the Front Door Rule.
 
-* `cdn_frontdoor_rule_set_name` - The name of the CDN FrontDoor Rule Set containing this CDN FrontDoor Rule.
+* `cdn_frontdoor_rule_set_name` - The name of the Front Door Rule Set containing this Front Door Rule.
 
 ## Timeouts
 
@@ -703,7 +703,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-CDN FrontDoor Rules can be imported using the `resource id`, e.g.
+Front Door Rules can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_rule.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/ruleSets/ruleSet1/rules/rule1

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -48,9 +48,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Rule Set.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule Set.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Rule Set.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Rule Set.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Rule Set.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Rule Set.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Manages a Front Door(standard/premium) Rule Set.
+  Manages a Front Door (standard/premium) Rule Set.
 ---
 
 # azurerm_cdn_frontdoor_rule_set
 
-Manages a Front Door(standard/premium) Rule Set.
+Manages a Front Door (standard/premium) Rule Set.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -48,9 +48,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Rule Set.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Rule Set.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Rule Set.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Rule Set.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Rule Set.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Rule Set.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
+  Manages a Front Door(standard/premium) Rule Set.
 ---
 
 # azurerm_cdn_frontdoor_rule_set
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
+Manages a Front Door(standard/premium) Rule Set.
 
 ## Example Usage
 
@@ -34,15 +34,15 @@ resource "azurerm_cdn_frontdoor_rule_set" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Rule Set. Changing this forces a new CDN FrontDoor Rule Set to be created.
+* `name` - (Required) The name which should be used for this Front Door Rule Set. Changing this forces a new Front Door Rule Set to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The ID of the CDN FrontDoor Profile. Changing this forces a new CDN FrontDoor Rule Set to be created.
+* `cdn_frontdoor_profile_id` - (Required) The ID of the Front Door Profile. Changing this forces a new Front Door Rule Set to be created.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Rule Set.
+* `id` - The ID of the Front Door Rule Set.
 
 ## Timeouts
 
@@ -54,7 +54,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-CDN FrontDoor Rule Sets can be imported using the `resource id`, e.g.
+Front Door Rule Sets can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_rule_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/ruleSets/ruleSet1

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_rule_set"
 description: |-
-  Manages a CDN FrontDoor Rule Set.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
 ---
 
 # azurerm_cdn_frontdoor_rule_set
 
-Manages a CDN FrontDoor Rule Set.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Rule Set.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Secret.
+  Manages a Front Door(standard/premium) Secret.
 ---
 
 # azurerm_cdn_frontdoor_secret
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Secret.
+Manages a Front Door(standard/premium) Secret.
 
 ## Required Key Vault Permissions
 
@@ -44,7 +44,7 @@ resource "azurerm_key_vault" "example" {
     ip_rules       = ["10.0.0.0/24"]
   }
 
-  # CDN FrontDoor Enterprise Application Object ID(e.g. Microsoft.AzureFrontDoor-Cdn)
+  # CDN Front Door Enterprise Application Object ID(e.g. Microsoft.AzureFrontDoor-Cdn)
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azuread_service_principal.frontdoor.object_id
@@ -97,23 +97,23 @@ resource "azurerm_cdn_frontdoor_secret" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Secret. Possible values must start with a letter or a number, only contain letters, numbers and hyphens and have a length of between 2 and 260 characters. Changing this forces a new CDN FrontDoor Secret to be created.
+* `name` - (Required) The name which should be used for this Front Door Secret. Possible values must start with a letter or a number, only contain letters, numbers and hyphens and have a length of between 2 and 260 characters. Changing this forces a new Front Door Secret to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The Resource ID of the CDN FrontDoor Profile. Changing this forces a new CDN FrontDoor Secret to be created.
+* `cdn_frontdoor_profile_id` - (Required) The Resource ID of the Front Door Profile. Changing this forces a new Front Door Secret to be created.
 
-* `secret` - (Required) A `secret` block as defined below. Changing this forces a new CDN FrontDoor Secret to be created.
+* `secret` - (Required) A `secret` block as defined below. Changing this forces a new Front Door Secret to be created.
 
 ---
 
 A `secret` block supports the following:
 
-* `customer_certificate` - (Required) A `customer_certificate` block as defined below. Changing this forces a new CDN FrontDoor Secret to be created.
+* `customer_certificate` - (Required) A `customer_certificate` block as defined below. Changing this forces a new Front Door Secret to be created.
 
 ---
 
 A `customer_certificate` block supports the following:
 
-* `key_vault_certificate_id` - (Required) The ID of the Key Vault certificate resource to use. Changing this forces a new CDN FrontDoor Secret to be created.
+* `key_vault_certificate_id` - (Required) The ID of the Key Vault certificate resource to use. Changing this forces a new Front Door Secret to be created.
 
 ->**NOTE:** If you would like to use the **latest version** of the Key Vault Certificate use the Key Vault Certificates `versionless_id` attribute as the `key_vault_certificate_id` fields value(e.g. `key_vault_certificate_id = azurerm_key_vault_certificate.example.versionless_id`).
 
@@ -125,9 +125,9 @@ A `customer_certificate` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Secret.
+* `id` - The ID of the Front Door Secret.
 
-* `cdn_frontdoor_profile_name` - The name of the CDN FrontDoor Profile containing this CDN FrontDoor Secret.
+* `cdn_frontdoor_profile_name` - The name of the Front Door Profile containing this Front Door Secret.
 
 ## Timeouts
 
@@ -139,7 +139,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Frontdoor Secrets can be imported using the `resource id`, e.g.
+Front Door Secrets can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_secret.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/secrets/secrets1

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Manages a Frontdoor Secret.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Secret.
 ---
 
 # azurerm_cdn_frontdoor_secret
 
-Manages a Frontdoor Secret.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Secret.
 
 ## Required Key Vault Permissions
 
@@ -44,7 +44,7 @@ resource "azurerm_key_vault" "example" {
     ip_rules       = ["10.0.0.0/24"]
   }
 
-  # Frontdoor Enterprise Application Object ID(e.g. Microsoft.AzureFrontDoor-Cdn)
+  # CDN FrontDoor Enterprise Application Object ID(e.g. Microsoft.AzureFrontDoor-Cdn)
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azuread_service_principal.frontdoor.object_id
@@ -97,23 +97,23 @@ resource "azurerm_cdn_frontdoor_secret" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Frontdoor Secret. Possible values must start with a letter or a number, only contain letters, numbers and hyphens and have a length of between 2 and 260 characters. Changing this forces a new Frontdoor Secret to be created.
+* `name` - (Required) The name which should be used for this CDN FrontDoor Secret. Possible values must start with a letter or a number, only contain letters, numbers and hyphens and have a length of between 2 and 260 characters. Changing this forces a new CDN FrontDoor Secret to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The Resource ID of the Frontdoor Profile. Changing this forces a new Frontdoor Secret to be created.
+* `cdn_frontdoor_profile_id` - (Required) The Resource ID of the CDN FrontDoor Profile. Changing this forces a new CDN FrontDoor Secret to be created.
 
-* `secret` - (Required) A `secret` block as defined below. Changing this forces a new Frontdoor Secret to be created.
+* `secret` - (Required) A `secret` block as defined below. Changing this forces a new CDN FrontDoor Secret to be created.
 
 ---
 
 A `secret` block supports the following:
 
-* `customer_certificate` - (Required) A `customer_certificate` block as defined below. Changing this forces a new Frontdoor Secret to be created.
+* `customer_certificate` - (Required) A `customer_certificate` block as defined below. Changing this forces a new CDN FrontDoor Secret to be created.
 
 ---
 
 A `customer_certificate` block supports the following:
 
-* `key_vault_certificate_id` - (Required) The ID of the Key Vault certificate resource to use. Changing this forces a new Frontdoor Secret to be created.
+* `key_vault_certificate_id` - (Required) The ID of the Key Vault certificate resource to use. Changing this forces a new CDN FrontDoor Secret to be created.
 
 ->**NOTE:** If you would like to use the **latest version** of the Key Vault Certificate use the Key Vault Certificates `versionless_id` attribute as the `key_vault_certificate_id` fields value(e.g. `key_vault_certificate_id = azurerm_key_vault_certificate.example.versionless_id`).
 
@@ -125,17 +125,17 @@ A `customer_certificate` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Frontdoor Secret.
+* `id` - The ID of the CDN FrontDoor Secret.
 
-* `cdn_frontdoor_profile_name` - The name of the Frontdoor Profile containing this Frontdoor Secret.
+* `cdn_frontdoor_profile_name` - The name of the CDN FrontDoor Profile containing this CDN FrontDoor Secret.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Frontdoor Secret.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Frontdoor Secret.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Frontdoor Secret.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Secret.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Secret.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Secret.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_secret"
 description: |-
-  Manages a Front Door(standard/premium) Secret.
+  Manages a Front Door (standard/premium) Secret.
 ---
 
 # azurerm_cdn_frontdoor_secret
 
-Manages a Front Door(standard/premium) Secret.
+Manages a Front Door (standard/premium) Secret.
 
 ## Required Key Vault Permissions
 

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -133,9 +133,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Secret.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Secret.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Secret.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Secret.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Secret.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Secret.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -133,9 +133,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Secret.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Secret.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Secret.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Secret.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Secret.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Secret.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -123,9 +123,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Security Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Security Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Security Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Security Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Security Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Security Policy.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_security_policy"
 description: |-
-  Manages a CDN FrontDoor (Azure Front Door standard/premium) Security Policy.
+  Manages a Front Door(standard/premium) Security Policy.
 ---
 
 # azurerm_cdn_frontdoor_security_policy
 
-Manages a CDN FrontDoor (Azure Front Door standard/premium) Security Policy.
+Manages a Front Door(standard/premium) Security Policy.
 
 ## Example Usage
 
@@ -73,43 +73,43 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this CDN FrontDoor Security Policy. Possible values must not be an empty string. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `name` - (Required) The name which should be used for this Front Door Security Policy. Possible values must not be an empty string. Changing this forces a new Front Door Security Policy to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The CDN FrontDoor Profile Resource Id that is linked to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `cdn_frontdoor_profile_id` - (Required) The Front Door Profile Resource Id that is linked to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
 
-* `security_policies` - (Required) An `security_policies` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `security_policies` - (Required) An `security_policies` block as defined below. Changing this forces a new Front Door Security Policy to be created.
 
 ---
 
 A `security_policies` block supports the following:
 
-* `firewall` - (Required) An `firewall` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `firewall` - (Required) An `firewall` block as defined below. Changing this forces a new Front Door Security Policy to be created.
 
 ---
 
 A `firewall` block supports the following:
 
-* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the CDN FrontDoor Firewall Policy that should be linked to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the Front Door Firewall Policy that should be linked to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
 
-* `association` - (Required) An `association` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `association` - (Required) An `association` block as defined below. Changing this forces a new Front Door Security Policy to be created.
 
 ---
 
 An `association` block supports the following:
 
-* `domain` - (Required) One or more `domain` blocks as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `domain` - (Required) One or more `domain` blocks as defined below. Changing this forces a new Front Door Security Policy to be created.
 
-* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. Possible value includes `/*`. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. Possible value includes `/*`. Changing this forces a new Front Door Security Policy to be created.
 
 ---
 
 A `domain` block supports the following:
 
-~> **NOTE:** The number of `domain` blocks that maybe included in the configuration file varies depending on the `sku_name` field of the linked CDN FrontDoor Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
+~> **NOTE:** The number of `domain` blocks that maybe included in the configuration file varies depending on the `sku_name` field of the linked Front Door Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
 
-* `cdn_frontdoor_domain_id` - (Required) The Resource Id of the **CDN FrontDoor Custom Domain** or **CDN FrontDoor Endpoint** that should be bound to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
+* `cdn_frontdoor_domain_id` - (Required) The Resource Id of the **Front Door Custom Domain** or **Front Door Endpoint** that should be bound to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
 
-* `active` - (Computed) Is the CDN FrontDoor Custom Domain/Endpoint activated?
+* `active` - (Computed) Is the Front Door Custom Domain/Endpoint activated?
 
 ---
 
@@ -117,7 +117,7 @@ A `domain` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the CDN FrontDoor Security Policy.
+* `id` - The ID of the Front Door Security Policy.
 
 ## Timeouts
 
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Frontdoor Security Policies can be imported using the `resource id`, e.g.
+Front Door Security Policies can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_security_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/securityPolicies/policy1

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -123,9 +123,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Security Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Security Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Security Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN Front Door Security Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Front Door Security Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN Front Door Security Policy.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_security_policy"
 description: |-
-  Manages a Front Door(standard/premium) Security Policy.
+  Manages a Front Door (standard/premium) Security Policy.
 ---
 
 # azurerm_cdn_frontdoor_security_policy
 
-Manages a Front Door(standard/premium) Security Policy.
+Manages a Front Door (standard/premium) Security Policy.
 
 ## Example Usage
 

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_security_policy"
 description: |-
-  Manages a Frontdoor Security Policy.
+  Manages a CDN FrontDoor (Azure Front Door standard/premium) Security Policy.
 ---
 
 # azurerm_cdn_frontdoor_security_policy
 
-Manages a Frontdoor Security Policy.
+Manages a CDN FrontDoor (Azure Front Door standard/premium) Security Policy.
 
 ## Example Usage
 
@@ -73,43 +73,43 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Frontdoor Security Policy. Possible values must not be an empty string. Changing this forces a new Frontdoor Security Policy to be created.
+* `name` - (Required) The name which should be used for this CDN FrontDoor Security Policy. Possible values must not be an empty string. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The Frontdoor Profile Resource Id that is linked to this Frontdoor Security Policy. Changing this forces a new Frontdoor Security Policy to be created.
+* `cdn_frontdoor_profile_id` - (Required) The CDN FrontDoor Profile Resource Id that is linked to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
-* `security_policies` - (Required) An `security_policies` block as defined below. Changing this forces a new Frontdoor Security Policy to be created.
+* `security_policies` - (Required) An `security_policies` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
 ---
 
 A `security_policies` block supports the following:
 
-* `firewall` - (Required) An `firewall` block as defined below. Changing this forces a new Frontdoor Security Policy to be created.
+* `firewall` - (Required) An `firewall` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
 ---
 
 A `firewall` block supports the following:
 
-* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the Frontdoor Firewall Policy that should be linked to this Frontdoor Security Policy. Changing this forces a new Frontdoor Security Policy to be created.
+* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the CDN FrontDoor Firewall Policy that should be linked to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
-* `association` - (Required) An `association` block as defined below. Changing this forces a new Frontdoor Security Policy to be created.
+* `association` - (Required) An `association` block as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
 ---
 
 An `association` block supports the following:
 
-* `domain` - (Required) One or more `domain` blocks as defined below. Changing this forces a new Frontdoor Security Policy to be created.
+* `domain` - (Required) One or more `domain` blocks as defined below. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
-* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. Possilbe value includes `/*`. Changing this forces a new Frontdoor Security Policy to be created.
+* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. Possible value includes `/*`. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
 ---
 
 A `domain` block supports the following:
 
-~> **NOTE:** The number of `domain` blocks that maybe included in the configuration file varies depending on the `sku_name` field of the linked Frontdoor Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
+~> **NOTE:** The number of `domain` blocks that maybe included in the configuration file varies depending on the `sku_name` field of the linked CDN FrontDoor Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
 
-* `cdn_frontdoor_domain_id` - (Required) The Resource Id of the **Frontdoor Custom Domain** or **Frontdoor Endpoint** that should be bound to this Frontdoor Security Policy. Changing this forces a new Frontdoor Security Policy to be created.
+* `cdn_frontdoor_domain_id` - (Required) The Resource Id of the **CDN FrontDoor Custom Domain** or **CDN FrontDoor Endpoint** that should be bound to this CDN FrontDoor Security Policy. Changing this forces a new CDN FrontDoor Security Policy to be created.
 
-* `active` - (Computed) Is the Frontdoor Custom Domain/Endpoint activated?
+* `active` - (Computed) Is the CDN FrontDoor Custom Domain/Endpoint activated?
 
 ---
 
@@ -117,15 +117,15 @@ A `domain` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Frontdoor Security Policy.
+* `id` - The ID of the CDN FrontDoor Security Policy.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Frontdoor Security Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Frontdoor Security Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Frontdoor Security Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the CDN FrontDoor Security Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN FrontDoor Security Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the CDN FrontDoor Security Policy.
 
 ## Import
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor"
 description: |-
-  Manages an Azure Front Door (classic) instance.
+  Manages an Azure Front Door(classic) instance.
 ---
 
 # azurerm_frontdoor
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN Front Door (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
-Manages an Azure Front Door (classic) instance.
+Manages an Azure Front Door(classic) instance.
 
 Azure Front Door Service is Microsoft's highly available and scalable web application acceleration platform and global HTTP(S) load balancer. It provides built-in DDoS protection and application layer security and caching. Front Door enables you to build applications that maximize and automate high-availability and performance for your end-users. Use Front Door with Azure services including Web/Mobile Apps, Cloud Services and Virtual Machines – or combine it with on-premises services for hybrid deployments and smooth cloud migration.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -3,12 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor"
 description: |-
-  Manages an Azure Front Door instance.
+  Manages an Azure Front Door (classic) instance.
 ---
 
 # azurerm_frontdoor
 
-Manages an Azure Front Door instance.
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
+
+Manages an Azure Front Door (classic) instance.
 
 Azure Front Door Service is Microsoft's highly available and scalable web application acceleration platform and global HTTP(S) load balancer. It provides built-in DDoS protection and application layer security and caching. Front Door enables you to build applications that maximize and automate high-availability and performance for your end-users. Use Front Door with Azure services including Web/Mobile Apps, Cloud Services and Virtual Machines – or combine it with on-premises services for hybrid deployments and smooth cloud migration.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_frontdoor
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 Manages an Azure Front Door (classic) instance.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor"
 description: |-
-  Manages an Azure Front Door(classic) instance.
+  Manages an Azure Front Door (classic) instance.
 ---
 
 # azurerm_frontdoor
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Front Door (standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
-Manages an Azure Front Door(classic) instance.
+Manages an Azure Front Door (classic) instance.
 
 Azure Front Door Service is Microsoft's highly available and scalable web application acceleration platform and global HTTP(S) load balancer. It provides built-in DDoS protection and application layer security and caching. Front Door enables you to build applications that maximize and automate high-availability and performance for your end-users. Use Front Door with Azure services including Web/Mobile Apps, Cloud Services and Virtual Machines – or combine it with on-premises services for hybrid deployments and smooth cloud migration.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_frontdoor
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN Front Door (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 Manages an Azure Front Door (classic) instance.
 
@@ -19,7 +19,7 @@ Below are some of the key scenarios that Azure Front Door Service addresses:
 * Use Front Door to improve application performance with SSL offload and routing requests to the fastest available application backend.
 * Use Front Door for application layer security and DDoS protection for your application.
 
-!> **Be Aware:** Microsoft rolled out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+!> **Be Aware:** Microsoft rolled out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and Front Door resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 
 !> **BREAKING CHANGE:** The `custom_https_provisioning_enabled` field and the `custom_https_configuration` block have been removed from the `azurerm_frontdoor` resource in the `v2.58.0` provider due to changes made by the service team. If you wish to enable the custom HTTPS configuration functionality within your `azurerm_frontdoor` resource moving forward you will need to define a separate `azurerm_frontdoor_custom_https_configuration` block in your configuration file.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages the Custom HTTPS Configuration for an Azure Front Door (classic) Frontend Endpoint.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 -> **NOTE:** Defining custom HTTPS configurations using a separate `azurerm_frontdoor_custom_https_configuration` resource allows for parallel creation/update.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -18,7 +18,7 @@ Manages the Custom HTTPS Configuration for an Azure Front Door(classic) Frontend
 
 !> **BREAKING CHANGE:** The `resource_group_name` field has been removed as of the `v2.58.0` provider release. If the `resource_group_name` field has been defined in your current `azurerm_frontdoor_custom_https_configuration` resource configuration file please remove it else you will receive a `An argument named "resource_group_name" is not expected here.` error. If your pre-existing Front Door instance contained inline `custom_https_configuration` blocks there are additional steps that will need to be completed to successfully migrate your Front Door onto the `v2.58.0` provider which [can be found in this guide](../guides/2.58.0-frontdoor-upgrade-guide.html).
 
-!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and Front Door resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 
 ```hcl
 resource "azurerm_resource_group" "example" {
@@ -99,7 +99,7 @@ resource "azurerm_frontdoor_custom_https_configuration" "example_custom_https_1"
 
 The `custom_https_configuration` block is also valid inside an `azurerm_frontdoor_custom_https_configuration`, which supports the following arguments: 
 
-* `frontend_endpoint_id` - (Required) The ID of the FrontDoor Frontend Endpoint which this configuration refers to.
+* `frontend_endpoint_id` - (Required) The ID of the Front Door Frontend Endpoint which this configuration refers to.
 
 * `custom_https_provisioning_enabled` - (Required) Should the HTTPS protocol be enabled for this custom domain associated with the Front Door?
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_custom_https_configuration"
 description: |-
-  Manages the Custom Https Configuration for an Azure Front Door (classic) Frontend Endpoint.
+  Manages the Custom Https Configuration for an Azure Front Door(classic) Frontend Endpoint.
 ---
 
 # azurerm_frontdoor_custom_https_configuration
 
-Manages the Custom HTTPS Configuration for an Azure Front Door (classic) Frontend Endpoint.
+Manages the Custom HTTPS Configuration for an Azure Front Door(classic) Frontend Endpoint.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 -> **NOTE:** Defining custom HTTPS configurations using a separate `azurerm_frontdoor_custom_https_configuration` resource allows for parallel creation/update.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_custom_https_configuration"
 description: |-
-  Manages the Custom Https Configuration for an Azure Front Door(classic) Frontend Endpoint.
+  Manages the Custom Https Configuration for an Azure Front Door (classic) Frontend Endpoint.
 ---
 
 # azurerm_frontdoor_custom_https_configuration
 
-Manages the Custom HTTPS Configuration for an Azure Front Door(classic) Frontend Endpoint.
+Manages the Custom HTTPS Configuration for an Azure Front Door (classic) Frontend Endpoint.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure Front Door (standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 -> **NOTE:** Defining custom HTTPS configurations using a separate `azurerm_frontdoor_custom_https_configuration` resource allows for parallel creation/update.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -3,12 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_custom_https_configuration"
 description: |-
-  Manages the Custom Https Configuration for an Azure Front Door Frontend Endpoint.
+  Manages the Custom Https Configuration for an Azure Front Door (classic) Frontend Endpoint.
 ---
 
 # azurerm_frontdoor_custom_https_configuration
 
-Manages the Custom HTTPS Configuration for an Azure Front Door Frontend Endpoint..
+Manages the Custom HTTPS Configuration for an Azure Front Door (classic) Frontend Endpoint.
+
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
 
 -> **NOTE:** Defining custom HTTPS configurations using a separate `azurerm_frontdoor_custom_https_configuration` resource allows for parallel creation/update.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_firewall_policy"
 description: |-
-  Manages an Azure Front Door(classic) Web Application Firewall Policy instance.
+  Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
 ---
 
 # azurerm_frontdoor_firewall_policy
 
-Manages an Azure Front Door(classic) Web Application Firewall Policy instance.
+Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure Front Door (standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 !> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and Front Door resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -3,12 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_firewall_policy"
 description: |-
-  Manages an Azure Front Door Web Application Firewall Policy instance.
+  Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
 ---
 
 # azurerm_frontdoor_firewall_policy
 
-Manages an Azure Front Door Web Application Firewall Policy instance.
+Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
+
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
 
 !> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 !> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -12,7 +12,7 @@ Manages an Azure Front Door(classic) Web Application Firewall Policy instance.
 
 !> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
-!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and Front Door resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 
 ## Example Usage
 
@@ -231,9 +231,9 @@ The `exclusion` block supports the following:
 
 The following attributes are exported:
 
-* `id` - The ID of the FrontDoor Firewall Policy.
+* `id` - The ID of the Front Door Firewall Policy.
 
-* `location` - The Azure Region where this FrontDoor Firewall Policy exists.
+* `location` - The Azure Region where this Front Door Firewall Policy exists.
 
 * `frontend_endpoint_ids` - The Frontend Endpoints associated with this Front Door Web Application Firewall policy.
 
@@ -241,10 +241,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the FrontDoor Web Application Firewall Policy.
-* `update` - (Defaults to 30 minutes) Used when updating the FrontDoor Web Application Firewall Policy.
-* `read` - (Defaults to 5 minutes) Used when retrieving the FrontDoor Web Application Firewall Policy.
-* `delete` - (Defaults to 30 minutes) Used when deleting the FrontDoor Web Application Firewall Policy.
+* `create` - (Defaults to 30 minutes) Used when creating the Front Door Web Application Firewall Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Front Door Web Application Firewall Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Web Application Firewall Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Web Application Firewall Policy.
 
 ## Import
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_firewall_policy"
 description: |-
-  Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
+  Manages an Azure Front Door(classic) Web Application Firewall Policy instance.
 ---
 
 # azurerm_frontdoor_firewall_policy
 
-Manages an Azure Front Door (classic) Web Application Firewall Policy instance.
+Manages an Azure Front Door(classic) Web Application Firewall Policy instance.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 !> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April 2021 which may cause issues with the CDN/FrontDoor resources. [More information is available in this GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Azure Front Door (classic) Rules Engine configuration and rules.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 ## Example Usage
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -3,12 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_rules_engine"
 description: |-
-  Manages an Azure Front Door Rules Engine configuration and rules.
+  Manages an Azure Front Door (classic) Rules Engine configuration and rules.
 ---
 
 # azurerm_frontdoor_rules_engine
 
-Manages an Azure Front Door Rules Engine configuration and rules.
+Manages an Azure Front Door (classic) Rules Engine configuration and rules.
+
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_endpoint).
 
 ## Example Usage
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_rules_engine"
 description: |-
-  Manages an Azure Front Door (classic) Rules Engine configuration and rules.
+  Manages an Azure Front Door(classic) Rules Engine configuration and rules.
 ---
 
 # azurerm_frontdoor_rules_engine
 
-Manages an Azure Front Door (classic) Rules Engine configuration and rules.
+Manages an Azure Front Door(classic) Rules Engine configuration and rules.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure CDN FrontDoor (Azure Front Door standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 ## Example Usage
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -3,14 +3,14 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_rules_engine"
 description: |-
-  Manages an Azure Front Door(classic) Rules Engine configuration and rules.
+  Manages an Azure Front Door (classic) Rules Engine configuration and rules.
 ---
 
 # azurerm_frontdoor_rules_engine
 
-Manages an Azure Front Door(classic) Rules Engine configuration and rules.
+Manages an Azure Front Door (classic) Rules Engine configuration and rules.
 
-!> **IMPORTANT** This resource deploys an Azure Front Door(classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door(classic) deployments to the new [Azure Front Door(standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
+!> **IMPORTANT** This resource deploys an Azure Front Door (classic) resource which is being deprecated in v4.0 of the AzureRM Provider. Please migrate your existing Azure Front Door (classic) deployments to the new [Azure Front Door (standard/premium) resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint).
 
 ## Example Usage
 


### PR DESCRIPTION
Update the Terraform documentation to be consistent with the Microsoft branding guidelines for the Front Door resources, per the Service team and Customer Engineering. 