### PR TITLE
`azurerm_postgresql_server`: allow to set `public_network_access_enabled` when the PITR is enabled

### DIFF
--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -798,7 +798,8 @@ resource "azurerm_postgresql_server" "restore" {
   creation_source_server_id = azurerm_postgresql_server.test.id
   restore_point_in_time     = "%[3]s"
 
-  ssl_enforcement_enabled = true
+  ssl_enforcement_enabled       = true
+  public_network_access_enabled = false
 }
 `, r.gp(data, version), data.RandomInteger, restoreTime, version)
 }

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -78,8 +78,6 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this server. Defaults to `true`.
 
--> **NOTE:** `public_network_access_enabled` doesn't support PointInTimeRestore mode.
-
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore` the point in time to restore from `creation_source_server_id`. It should be provided in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format, e.g. `2013-11-08T22:00:40Z`.
 
 * `ssl_enforcement_enabled` - (Required) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/18812

Service team confirmed that `public_network_access_enabled` is allowed to be changed when the PointInTimeRestore mode is enabled. And `public_network_access_enabled` only can be updated after the PITR server is created.

![image](https://user-images.githubusercontent.com/19754191/197747093-68f2aac3-3ab8-4652-8573-4b5d7dad4a66.png)
