### PR TITLE
`azurerm_site_recovery_replicated_vm` - update disks sdk

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/disks"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -163,10 +163,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 							Required: true,
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(compute.DiskStorageAccountTypesStandardLRS),
-								string(compute.DiskStorageAccountTypesPremiumLRS),
-								string(compute.DiskStorageAccountTypesStandardSSDLRS),
-								string(compute.DiskStorageAccountTypesUltraSSDLRS),
+								string(disks.DiskStorageAccountTypesStandardLRS),
+								string(disks.DiskStorageAccountTypesPremiumLRS),
+								string(disks.DiskStorageAccountTypesStandardSSDLRS),
+								string(disks.DiskStorageAccountTypesUltraSSDLRS),
 							}, false),
 						},
 						"target_replica_disk_type": {
@@ -174,10 +174,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 							Required: true,
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(compute.DiskStorageAccountTypesStandardLRS),
-								string(compute.DiskStorageAccountTypesPremiumLRS),
-								string(compute.DiskStorageAccountTypesStandardSSDLRS),
-								string(compute.DiskStorageAccountTypesUltraSSDLRS),
+								string(disks.DiskStorageAccountTypesStandardLRS),
+								string(disks.DiskStorageAccountTypesPremiumLRS),
+								string(disks.DiskStorageAccountTypesStandardSSDLRS),
+								string(disks.DiskStorageAccountTypesUltraSSDLRS),
 							}, false),
 						},
 						"target_disk_encryption_set_id": {


### PR DESCRIPTION
`disks` has been migrated to pandora sdk, updating the constants from disks in `azurerm_site_recovery_replicated_vm` as well.