### PR TITLE
`azurerm_monitor_data_collection_rule` -  correctly support streams

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source.go
@@ -197,6 +197,13 @@ func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema 
 										Type: pluginsdk.TypeString,
 									},
 								},
+								"streams": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
 							},
 						},
 					},

--- a/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccMonitorDataCollectionRuleDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("data_flow.2.streams.0").HasValue("Microsoft-Event"),
 				check.That(data.ResourceName).Key("data_flow.2.destinations.0").HasValue("test-destination-log1"),
 				check.That(data.ResourceName).Key("data_sources.0.syslog.0.facility_names.#").HasValue("5"),
+				check.That(data.ResourceName).Key("data_sources.0.syslog.0.streams.#").HasValue("2"),
 				check.That(data.ResourceName).Key("data_sources.0.performance_counter.#").HasValue("2"),
 				check.That(data.ResourceName).Key("data_sources.0.performance_counter.1.sampling_frequency_in_seconds").HasValue("20"),
 				check.That(data.ResourceName).Key("data_sources.0.performance_counter.1.name").HasValue("test-datasource-perfcounter2"),

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -3,7 +3,6 @@ package monitor
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -66,6 +67,7 @@ type Syslog struct {
 	FacilityNames []string `tfschema:"facility_names"`
 	LogLevels     []string `tfschema:"log_levels"`
 	Name          string   `tfschema:"name"`
+	Streams       []string `tfschema:"streams"`
 }
 
 type WindowsEventLog struct {
@@ -118,9 +120,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 						Required: true,
 						MinItems: 1,
 						Elem: &pluginsdk.Schema{
-							Type: pluginsdk.TypeString,
-							ValidateFunc: validation.StringInSlice(
-								datacollectionrules.PossibleValuesForKnownDataFlowStreams(), false),
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 					},
 				},
@@ -198,10 +199,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 									Required: true,
 									MinItems: 1,
 									Elem: &pluginsdk.Schema{
-										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice(
-											datacollectionrules.PossibleValuesForKnownExtensionDataSourceStreams(),
-											false),
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
 								"extension_json": {
@@ -241,10 +240,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 									Required: true,
 									MinItems: 1,
 									Elem: &pluginsdk.Schema{
-										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice(
-											datacollectionrules.PossibleValuesForKnownPerfCounterDataSourceStreams(),
-											false),
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
 								"counter_specifiers": {
@@ -290,6 +287,16 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 											datacollectionrules.PossibleValuesForKnownSyslogDataSourceLogLevels(), false),
 									},
 								},
+								"streams": {
+									Type:     pluginsdk.TypeList,
+									Optional: !features.FourPointOhBeta(),
+									Required: features.FourPointOhBeta(),
+									MinItems: 1,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
 							},
 						},
 					},
@@ -308,10 +315,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 									Required: true,
 									MinItems: 1,
 									Elem: &pluginsdk.Schema{
-										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice(
-											datacollectionrules.PossibleValuesForKnownWindowsEventLogDataSourceStreams(),
-											false),
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
 								"x_path_queries": {
@@ -692,8 +697,23 @@ func expandDataCollectionRuleDataSourceSyslog(input []Syslog) *[]datacollectionr
 			FacilityNames: expandDataCollectionRuleDataSourceSyslogFacilityNames(v.FacilityNames),
 			LogLevels:     expandDataCollectionRuleDataSourceSyslogLogLevels(v.LogLevels),
 			Name:          utils.String(v.Name),
-			Streams:       &[]datacollectionrules.KnownSyslogDataSourceStreams{datacollectionrules.KnownSyslogDataSourceStreamsMicrosoftNegativeSyslog},
+			Streams:       expandDataCollectionRuleDataSourceSyslogStreams(v.Streams),
 		})
+	}
+	return &result
+}
+
+func expandDataCollectionRuleDataSourceSyslogStreams(input []string) *[]datacollectionrules.KnownSyslogDataSourceStreams {
+	if len(input) == 0 {
+		if !features.FourPointOhBeta() {
+			return &[]datacollectionrules.KnownSyslogDataSourceStreams{datacollectionrules.KnownSyslogDataSourceStreamsMicrosoftNegativeSyslog}
+		}
+		return nil
+	}
+
+	result := make([]datacollectionrules.KnownSyslogDataSourceStreams, 0)
+	for _, v := range input {
+		result = append(result, datacollectionrules.KnownSyslogDataSourceStreams(v))
 	}
 	return &result
 }
@@ -922,6 +942,7 @@ func flattenDataCollectionRuleDataSourceSyslog(input *[]datacollectionrules.Sysl
 			Name:          flattenStringPtr(v.Name),
 			FacilityNames: flattenDataCollectionRuleDataSourceSyslogFacilityNames(v.FacilityNames),
 			LogLevels:     flattenDataCollectionRuleDataSourceSyslogLogLevels(v.LogLevels),
+			Streams:       flattenDataCollectionRuleSyslogStreams(v.Streams),
 		})
 	}
 	return result
@@ -940,6 +961,18 @@ func flattenDataCollectionRuleDataSourceSyslogFacilityNames(input *[]datacollect
 }
 
 func flattenDataCollectionRuleDataSourceSyslogLogLevels(input *[]datacollectionrules.KnownSyslogDataSourceLogLevels) []string {
+	if input == nil {
+		return make([]string, 0)
+	}
+
+	result := make([]string, 0)
+	for _, v := range *input {
+		result = append(result, string(v))
+	}
+	return result
+}
+
+func flattenDataCollectionRuleSyslogStreams(input *[]datacollectionrules.KnownSyslogDataSourceStreams) []string {
 	if input == nil {
 		return make([]string, 0)
 	}

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -290,6 +290,7 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 								"streams": {
 									Type:     pluginsdk.TypeList,
 									Optional: !features.FourPointOhBeta(),
+									Computed: !features.FourPointOhBeta(),
 									Required: features.FourPointOhBeta(),
 									MinItems: 1,
 									Elem: &pluginsdk.Schema{

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -174,6 +174,7 @@ resource "azurerm_monitor_data_collection_rule" "test" {
       facility_names = ["*"]
       log_levels     = ["*"]
       name           = "test-datasource-syslog"
+      streams        = ["Microsoft-CiscoAsa"]
     }
     performance_counter {
       streams                       = ["Microsoft-Perf", "Microsoft-InsightsMetrics"]
@@ -283,6 +284,7 @@ resource "azurerm_monitor_data_collection_rule" "test" {
         "Notice",
       ]
       name = "test-datasource-syslog"
+      streams = ["Microsoft-Syslog", "Microsoft-CiscoAsa"]
     }
 
     performance_counter {

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -324,7 +324,7 @@ resource "azurerm_monitor_data_collection_rule" "test" {
     }
 
     extension {
-      streams            = ["Microsoft-WindowsEvent"]
+      streams            = ["Microsoft-WindowsEvent", "Microsoft-ServiceMap"]
       input_data_sources = ["test-datasource-wineventlog"]
       extension_name     = "test-extension-name"
       extension_json = jsonencode({

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -283,7 +283,7 @@ resource "azurerm_monitor_data_collection_rule" "test" {
         "Info",
         "Notice",
       ]
-      name = "test-datasource-syslog"
+      name    = "test-datasource-syslog"
       streams = ["Microsoft-Syslog", "Microsoft-CiscoAsa"]
     }
 
@@ -348,6 +348,8 @@ resource "azurerm_monitor_data_collection_rule" "test" {
     azurerm_log_analytics_solution.test2,
   ]
 }
+
+
 
 
 `, r.template(data), data.RandomInteger)

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -140,7 +140,7 @@ A `data_flow` block supports the following:
 
 * `destinations` - (Required) Specifies a list of destination names. A `azure_monitor_metrics` data source only allows for stream of kind `Microsoft-InsightsMetrics`.
 
-* `streams` - (Required) Specifies a list of streams. Possible values are `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`,and `Microsoft-WindowsEvent`.
+* `streams` - (Required) Specifies a list of streams. Possible values include but not limited to `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`,and `Microsoft-WindowsEvent`.
 
 ---
 
@@ -172,7 +172,7 @@ A `extension` block supports the following:
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 
-* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`,and `Microsoft-WindowsEvent`.
+* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values include but not limited to `Microsoft-Event`, `Microsoft-InsightsMetrics`, `Microsoft-Perf`, `Microsoft-Syslog`, `Microsoft-WindowsEvent`.
 
 * `extension_json` - (Optional) A JSON String which specifies the extension setting.
 
@@ -196,7 +196,7 @@ A `performance_counter` block supports the following:
 
 * `sampling_frequency_in_seconds` - (Required) The number of seconds between consecutive counter measurements (samples). The value should be integer between `1` and `300` inclusive.
 
-* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-InsightsMetrics`,and `Microsoft-Perf`.
+* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values include but not limited to `Microsoft-InsightsMetrics`,and `Microsoft-Perf`.
 
 ---
 
@@ -208,7 +208,9 @@ A `syslog` block supports the following:
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 
--> **Note:** Syslog data source has only one possible streams value which is `Microsoft-Syslog`.
+* `streams` - (Optional) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values include but not limited to `Microsoft-Syslog`,and `Microsoft-CiscoAsa`, and `Microsoft-CommonSecurityLog`.
+
+-> **Note:** In 4.0 or later version of the provider, `streams` will be required. In 3.x version of provider, if `streams` is not specified, it is default to `["Microsoft-Syslog"]`. if `streams` need to be modified (include change other value to the default value), it must be explicitly specified.
 
 ---
 
@@ -216,7 +218,7 @@ A `windows_event_log` block supports the following:
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 
-* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values are `Microsoft-Event`,and `Microsoft-WindowsEvent`.
+* `streams` - (Required) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values include but not limited to `Microsoft-Event`,and `Microsoft-WindowsEvent`, `Microsoft-RomeDetectionEvent`, and `Microsoft-SecurityEvent`.
 
 * `x_path_queries` - (Required) Specifies a list of Windows Event Log queries in XPath expression.
 

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -210,7 +210,7 @@ A `syslog` block supports the following:
 
 * `streams` - (Optional) Specifies a list of streams that this data source will be sent to. A stream indicates what schema will be used for this data and usually what table in Log Analytics the data will be sent to. Possible values include but not limited to `Microsoft-Syslog`,and `Microsoft-CiscoAsa`, and `Microsoft-CommonSecurityLog`.
 
--> **Note:** In 4.0 or later version of the provider, `streams` will be required. In 3.x version of provider, if `streams` is not specified, it is default to `["Microsoft-Syslog"]`. if `streams` need to be modified (include change other value to the default value), it must be explicitly specified.
+-> **Note:** In 4.0 or later version of the provider, `streams` will be required. In 3.x version of provider, if `streams` is not specified in creation, it is default to `["Microsoft-Syslog"]`. if `streams` need to be modified (include change other value to the default value), it must be explicitly specified.
 
 ---
 


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18481

relaterd to https://github.com/Azure/azure-rest-api-specs/issues/21200, lots of possible `streams` values are shown in response.

confirmed with service team that new `streams` are added on a weekly basis. So here we change the validation func to simply `StringIsNotEmpty` .


```
make acctests SERVICE="monitor" TESTARGS="-parallel 10 -test.run=TestAccMonitorDataCollectionRule_" TESTTIMEOUT='1440m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -parallel 10 -test.run=TestAccMonitorDataCollectionRule_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDataCollectionRule_basic
=== PAUSE TestAccMonitorDataCollectionRule_basic
=== RUN   TestAccMonitorDataCollectionRule_requiresImport
=== PAUSE TestAccMonitorDataCollectionRule_requiresImport
=== RUN   TestAccMonitorDataCollectionRule_update
=== PAUSE TestAccMonitorDataCollectionRule_update
=== RUN   TestAccMonitorDataCollectionRule_complete
=== PAUSE TestAccMonitorDataCollectionRule_complete
=== CONT  TestAccMonitorDataCollectionRule_basic
=== CONT  TestAccMonitorDataCollectionRule_update
=== CONT  TestAccMonitorDataCollectionRule_requiresImport
=== CONT  TestAccMonitorDataCollectionRule_complete
--- PASS: TestAccMonitorDataCollectionRule_basic (192.65s)
--- PASS: TestAccMonitorDataCollectionRule_requiresImport (208.63s)
--- PASS: TestAccMonitorDataCollectionRule_complete (234.82s)
--- PASS: TestAccMonitorDataCollectionRule_update (545.41s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       545.444s

```