### PR TITLE
`azurerm_kubernetes_cluster`: Add support for KEDA Autoscaler

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1036,6 +1036,22 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
+			"workload_autoscaler_profile": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"keda_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
 			"workload_identity_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -1128,6 +1144,9 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	windowsProfileRaw := d.Get("windows_profile").([]interface{})
 	windowsProfile := expandKubernetesClusterWindowsProfile(windowsProfileRaw)
 
+	workloadAutoscalerProfileRaw := d.Get("workload_autoscaler_profile").([]interface{})
+	workloadAutoscalerProfile := expandKubernetesClusterWorkloadAutoscalerProfile(workloadAutoscalerProfileRaw)
+
 	apiServerAuthorizedIPRangesRaw := d.Get("api_server_authorized_ip_ranges").(*pluginsdk.Set).List()
 	apiServerAuthorizedIPRanges := utils.ExpandStringSlice(apiServerAuthorizedIPRangesRaw)
 
@@ -1200,23 +1219,24 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 			Tier: utils.ToPtr(managedclusters.ManagedClusterSKUTier(d.Get("sku_tier").(string))),
 		},
 		Properties: &managedclusters.ManagedClusterProperties{
-			ApiServerAccessProfile: &apiAccessProfile,
-			AadProfile:             azureADProfile,
-			AddonProfiles:          addonProfiles,
-			AgentPoolProfiles:      agentProfiles,
-			AutoScalerProfile:      autoScalerProfile,
-			DnsPrefix:              utils.String(dnsPrefix),
-			EnableRBAC:             utils.Bool(d.Get("role_based_access_control_enabled").(bool)),
-			KubernetesVersion:      utils.String(kubernetesVersion),
-			LinuxProfile:           linuxProfile,
-			WindowsProfile:         windowsProfile,
-			NetworkProfile:         networkProfile,
-			NodeResourceGroup:      utils.String(nodeResourceGroup),
-			PublicNetworkAccess:    &publicNetworkAccess,
-			DisableLocalAccounts:   utils.Bool(d.Get("local_account_disabled").(bool)),
-			HTTPProxyConfig:        httpProxyConfig,
-			OidcIssuerProfile:      oidcIssuerProfile,
-			SecurityProfile:        securityProfile,
+			ApiServerAccessProfile:    &apiAccessProfile,
+			AadProfile:                azureADProfile,
+			AddonProfiles:             addonProfiles,
+			AgentPoolProfiles:         agentProfiles,
+			AutoScalerProfile:         autoScalerProfile,
+			DnsPrefix:                 utils.String(dnsPrefix),
+			EnableRBAC:                utils.Bool(d.Get("role_based_access_control_enabled").(bool)),
+			KubernetesVersion:         utils.String(kubernetesVersion),
+			LinuxProfile:              linuxProfile,
+			WindowsProfile:            windowsProfile,
+			NetworkProfile:            networkProfile,
+			NodeResourceGroup:         utils.String(nodeResourceGroup),
+			PublicNetworkAccess:       &publicNetworkAccess,
+			DisableLocalAccounts:      utils.Bool(d.Get("local_account_disabled").(bool)),
+			HTTPProxyConfig:           httpProxyConfig,
+			OidcIssuerProfile:         oidcIssuerProfile,
+			SecurityProfile:           securityProfile,
+			WorkloadAutoScalerProfile: workloadAutoscalerProfile,
 		},
 		Tags: tags.Expand(t),
 	}
@@ -1616,6 +1636,13 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		existing.Model.Properties.WindowsProfile = windowsProfile
 	}
 
+	if d.HasChange("workload_autoscaler_profile") {
+		updateCluster = true
+		workloadAutoscalerProfileRaw := d.Get("workload_autoscaler_profile").([]interface{})
+		workloadAutoscalerProfile := expandKubernetesClusterWorkloadAutoscalerProfile(workloadAutoscalerProfileRaw)
+		existing.Model.Properties.WorkloadAutoScalerProfile = workloadAutoscalerProfile
+	}
+
 	if d.HasChange("identity") {
 		updateCluster = true
 		managedClusterIdentityRaw := d.Get("identity").([]interface{})
@@ -1957,6 +1984,11 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("setting `windows_profile`: %+v", err)
 		}
 
+		workloadAutoscalerProfile := flattenKubernetesClusterWorkloadAutoscalerProfile(props.WorkloadAutoScalerProfile, d)
+		if err := d.Set("workload_autoscaler_profile", workloadAutoscalerProfile); err != nil {
+			return fmt.Errorf("setting `workload_autoscaler_profile`: %+v", err)
+		}
+
 		httpProxyConfig := flattenKubernetesClusterHttpProxyConfig(props)
 		if err := d.Set("http_proxy_config", httpProxyConfig); err != nil {
 			return fmt.Errorf("setting `http_proxy_config`: %+v", err)
@@ -2234,6 +2266,22 @@ func expandKubernetesClusterWindowsProfile(input []interface{}) *managedclusters
 	}
 }
 
+func expandKubernetesClusterWorkloadAutoscalerProfile(input []interface{}) *managedclusters.ManagedClusterWorkloadAutoScalerProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	config := input[0].(map[string]interface{})
+	kedaEnabled := managedclusters.ManagedClusterWorkloadAutoScalerProfileKeda{}
+	if v := config["keda_enabled"].(bool); v {
+		kedaEnabled.Enabled = v
+	}
+
+	return &managedclusters.ManagedClusterWorkloadAutoScalerProfile{
+		Keda: &kedaEnabled,
+	}
+}
+
 func expandGmsaProfile(input []interface{}) *managedclusters.WindowsGmsaProfile {
 	if len(input) == 0 {
 		return nil
@@ -2274,6 +2322,23 @@ func flattenKubernetesClusterWindowsProfile(profile *managedclusters.ManagedClus
 			"admin_username": adminUsername,
 			"license":        license,
 			"gmsa":           gmsaProfile,
+		},
+	}
+}
+
+func flattenKubernetesClusterWorkloadAutoscalerProfile(profile *managedclusters.ManagedClusterWorkloadAutoScalerProfile, d *pluginsdk.ResourceData) []interface{} {
+	if profile == nil {
+		return []interface{}{}
+	}
+
+	kedaEnabled := false
+	if v := profile.Keda; v != nil {
+		kedaEnabled = profile.Keda.Enabled
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"keda_enabled": kedaEnabled,
 		},
 	}
 }

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -75,7 +75,7 @@ func TestAccKubernetesCluster_runCommand(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_workloadAutoscalerProfileKeda(t *testing.T) {
+func TestAccKubernetesCluster_workloadAutoscalerProfileKedaOnOff(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
@@ -94,6 +94,28 @@ func TestAccKubernetesCluster_workloadAutoscalerProfileKeda(t *testing.T) {
 				check.That(data.ResourceName).Key("workload_autoscaler_profile.0.keda_enabled").HasValue("false"),
 			),
 		},
+	})
+}
+
+func TestAccKubernetesCluster_workloadAutoscalerProfileKedaOnAbsent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadAutoscalerProfileKeda(data, currentKubernetesVersion, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("workload_autoscaler_profile.0.keda_enabled").HasValue("true"),
+			),
+		},
+		{
+			Config: r.basicVMSSConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -84,14 +84,14 @@ func TestAccKubernetesCluster_workloadAutoscalerProfileKeda(t *testing.T) {
 			Config: r.workloadAutoscalerProfileKeda(data, currentKubernetesVersion, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("run_command_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("workload_autoscaler_profile.0.keda_enabled").HasValue("true"),
 			),
 		},
 		{
 			Config: r.workloadAutoscalerProfileKeda(data, currentKubernetesVersion, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("run_command_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("workload_autoscaler_profile.0.keda_enabled").HasValue("false"),
 			),
 		},
 	})

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -161,6 +161,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **Note:** If you use BYO DNS Zone, AKS cluster should either use a User Assigned Identity or a service principal (which is deprecated) with the `Private DNS Zone Contributor` role and access to this Private DNS Zone. If `UserAssigned` identity is used - to prevent improper resource order destruction - cluster should depend on the role assignment, like in this example:
 
+* `workload_autoscaler_profile` - (Optional) A `workload_autoscaler_profile` block defined below.
+
 * `workload_identity_enabled` - (Optional) Specifies whether Azure AD Workload Identity should be enabled for the Cluster. Defaults to `false`.
 
 -> **Note** To enable Azure AD Workload Identity `oidc_issuer_enabled` must be set to `true`.
@@ -707,6 +709,11 @@ A `gmsa` block supports the following:
 * `root_domain` - (Required) Specifies the root domain name for Windows gMSA. Set this to an empty string if you have configured the DNS server in the VNet which was used to create the managed cluster.
 
 -> **Note:** The properties `dns_server` and `root_domain` must both either be set or unset, i.e. empty.
+
+---
+A `workload_autoscaler_profile` block supports the following:
+
+* `keda_enabled` - (Optional) Specifies whether KEDA Autoscaler can be used for workloads.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -715,6 +715,8 @@ A `workload_autoscaler_profile` block supports the following:
 
 * `keda_enabled` - (Optional) Specifies whether KEDA Autoscaler can be used for workloads.
 
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AKS-KedaPreview` is enabled and the Resource Provider is re-registered, see [the documentation](Microsoft.ContainerService/AKS-KedaPreview) for more information.
+
 ---
 
 A `http_proxy_config` block supports the following:


### PR DESCRIPTION
The reason I made it a block in schema is cause it also supports VPA, but since I'm selfish and time-deprived atm, I just implemented KEDA for now. Making this a block will allow for adding VPA in the future.

`AKS-KedaPreview` feature needs to be enabled in `Microsoft.ContainerService` namespace for this to work.