### PR TITLE
`document` - Fix `source_resource_id` description in `azurerm_managed_disk`

### DIFF
--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -127,7 +127,7 @@ The following arguments are supported:
 
 * `os_type` - (Optional) Specify a value when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Valid values are `Linux` or `Windows`.
 
-* `source_resource_id` - (Optional) The ID of an existing Managed Disk to copy `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore`
+* `source_resource_id` - (Optional) The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore`
 
 * `source_uri` - (Optional) URI to a valid VHD file to be used when `create_option` is `Import`.
 


### PR DESCRIPTION
Fix #18979
Snapshot can be used as `source_resource_id` too. https://github.com/hashicorp/terraform-provider-azurerm/blob/48a380cbf3ab9655c2ded1572d85f9a62cd9a2db/website/docs/r/managed_disk.html.markdown?plain=1#L88