### PR TITLE
`azurerm_automation_webhook`: remove a AccTest case with uri property

### DIFF
--- a/internal/services/automation/automation_webhook_test.go
+++ b/internal/services/automation/automation_webhook_test.go
@@ -75,29 +75,6 @@ func TestAccAutomationWebhook_WithParameters(t *testing.T) {
 	})
 }
 
-func TestAccAutomationWebhook_ChangeUri(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_automation_webhook", "test")
-	r := AutomationWebhookResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.WebhookURIChange(data, "https://12345678-9012-3456-7890-123456789012.webhook.we.azure-automation.net/webhooks?token=abcdefghijklmnoprstuwxyz1234567890abcdefghijklm"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("uri").HasValue("https://12345678-9012-3456-7890-123456789012.webhook.we.azure-automation.net/webhooks?token=abcdefghijklmnoprstuwxyz1234567890abcdefghijklm"),
-			),
-		},
-		data.ImportStep("uri"),
-		{
-			Config: r.WebhookURIChange(data, "https://12345678-9012-3456-7890-123456789012.webhook.we.azure-automation.net/webhooks?token=abcdefghijklmnoprstuwxyz1234567890abcdefg313377"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("uri").HasValue("https://12345678-9012-3456-7890-123456789012.webhook.we.azure-automation.net/webhooks?token=abcdefghijklmnoprstuwxyz1234567890abcdefg313377"),
-			),
-		},
-	})
-}
-
 func TestAccAutomationWebhook_WithWorkerGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_webhook", "test")
 	r := AutomationWebhookResource{}
@@ -228,21 +205,4 @@ resource "azurerm_automation_webhook" "test" {
   run_on_worker_group     = "workergroup"
 }
 `, template)
-}
-
-func (AutomationWebhookResource) WebhookURIChange(data acceptance.TestData, uri string) string {
-	template := AutomationWebhookResource{}.ParentResources(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_automation_webhook" "test" {
-  name                    = "TestRunbook_webhook"
-  resource_group_name     = azurerm_resource_group.test.name
-  automation_account_name = azurerm_automation_account.test.name
-  expiry_time             = "%s"
-  enabled                 = true
-  runbook_name            = azurerm_automation_runbook.test.name
-  uri                     = "%s"
-}
-`, template, time.Now().UTC().Add(time.Hour).Format(time.RFC3339), uri)
 }

--- a/website/docs/r/automation_webhook.html.markdown
+++ b/website/docs/r/automation_webhook.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) Map of input parameters passed to runbook.
 
-* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation. Changing this forces a Webhook resource to be created.
+* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_webhook.html.markdown
+++ b/website/docs/r/automation_webhook.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) Map of input parameters passed to runbook.
 
-* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation.
+* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation. Changing this forces a Webhook resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`TestAccAutomationWebhook_ChangeUri` starts failing from #18380 because the old logic did not use the URI property in create but only set it back to the state file. The URI value provided in the test case is invalid by the server side(because the URI has to be generated by API [webhook/generate-uri](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri) of a valid automation account), so we do not need such a case to check the change of URI.

Test Failure message: 

>`=== CONT  TestAccAutomationWebhook_ChangeUri
    testcase.go:110: Step 1/3 error: Error running apply: exit status 1
 Error: creating Webhook: (Name "TestRunbook_webhook" / Automation Account Name "acctest-220916024554817583" / Resource Group "acctestRG-auto-220916024554817583"): automation.WebhookClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="" Message="Invalid uri."
`