### PR TITLE
`azurerm_netapp_volume`: set snapshot Id when `create_from_snapshot_resource_id` is specified

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -366,9 +366,12 @@ func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 
 		snapshotClient := meta.(*clients.Client).NetApp.SnapshotClient
-		_, err = snapshotClient.Get(ctx, *parsedSnapshotResourceID)
+		snapshotResponse, err := snapshotClient.Get(ctx, *parsedSnapshotResourceID)
 		if err != nil {
 			return fmt.Errorf("getting snapshot from %s: %+v", id, err)
+		}
+		if model := snapshotResponse.Model; model != nil && model.Id != nil {
+			snapshotID = *model.Id
 		}
 
 		sourceVolumeId := volumes.NewVolumeID(parsedSnapshotResourceID.SubscriptionId, parsedSnapshotResourceID.ResourceGroupName, parsedSnapshotResourceID.AccountName, parsedSnapshotResourceID.PoolName, parsedSnapshotResourceID.VolumeName)

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -104,6 +104,7 @@ func TestAccNetAppVolume_nfsv3FromSnapshot(t *testing.T) {
 			Config: r.nfsv3FromSnapshot(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("create_from_snapshot_resource_id").HasValue(fmt.Sprintf("/snapshots/acctest-Snapshot-%d", data.RandomInteger)),
 			),
 		},
 		data.ImportStep("create_from_snapshot_resource_id"),

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2021-10-01/volumes"
@@ -104,7 +105,7 @@ func TestAccNetAppVolume_nfsv3FromSnapshot(t *testing.T) {
 			Config: r.nfsv3FromSnapshot(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("create_from_snapshot_resource_id").HasValue(fmt.Sprintf("/snapshots/acctest-Snapshot-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("create_from_snapshot_resource_id").MatchesRegex(regexp.MustCompile(fmt.Sprintf("(.)/snapshots/acctest-Snapshot-%d", data.RandomInteger))),
 			),
 		},
 		data.ImportStep("create_from_snapshot_resource_id"),


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/18980

As the code snippet of setting snapshotId is deleted by this [PR 17465](https://github.com/hashicorp/terraform-provider-azurerm/pull/17465/files#diff-d193f61e6316f1a73de8bfe688c1abc0b068bf06213b8ed9fc824238b44a08f4L370), so it causes this issue. Hence, we have to add it back to resolve this issue.

![image](https://user-images.githubusercontent.com/19754191/198024644-e71b5aa0-02af-4e79-8dd5-78d13abba3d0.png)

--- PASS: TestAccNetAppVolume_nfsv3FromSnapshot (1355.06s)