### PR TITLE
`azurerm_monitor_log_profile` - fix test config dependency resource

### DIFF
--- a/internal/services/monitor/monitor_log_profile_resource_test.go
+++ b/internal/services/monitor/monitor_log_profile_resource_test.go
@@ -227,8 +227,8 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "test" {
-  name                = "acctestsbrule-%s"
-  namespace_id        = azurerm_servicebus_namespace.test.id
+  name         = "acctestsbrule-%s"
+  namespace_id = azurerm_servicebus_namespace.test.id
 
   listen = true
   send   = true

--- a/internal/services/monitor/monitor_log_profile_resource_test.go
+++ b/internal/services/monitor/monitor_log_profile_resource_test.go
@@ -228,8 +228,7 @@ resource "azurerm_servicebus_namespace" "test" {
 
 resource "azurerm_servicebus_namespace_authorization_rule" "test" {
   name                = "acctestsbrule-%s"
-  namespace_name      = azurerm_servicebus_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  namespace_id        = azurerm_servicebus_namespace.test.id
 
   listen = true
   send   = true


### PR DESCRIPTION
original failure:
```
Error: Missing required argument
on terraform_plugin_test.tf line 18, in resource "azurerm_servicebus_namespace_authorization_rule" "test":
18: resource "azurerm_servicebus_namespace_authorization_rule" "test" {
The argument "namespace_id" is required, but no definition was found.
Error: Unsupported argument
on terraform_plugin_test.tf line 20, in resource "azurerm_servicebus_namespace_authorization_rule" "test":
20:   namespace_name      = azurerm_servicebus_namespace.test.name
An argument named "namespace_name" is not expected here.
Error: Unsupported argument
on terraform_plugin_test.tf line 21, in resource "azurerm_servicebus_namespace_authorization_rule" "test":
21:   resource_group_name = azurerm_resource_group.test.name
An argument named "resource_group_name" is not expected here.
```