### PR TITLE
`azurerm_linux_virtual_machine_scale_set` `azurerm_windows_virtual_machine_scale_set` - rename `gallery_applications`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -755,10 +755,10 @@ func TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationBasic(t *testing.
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherGalleryApplicationsBasic(data),
+			Config: r.otherGalleryApplicationBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_applications.0.order").HasValue("0"),
+				check.That(data.ResourceName).Key("gallery_application.0.order").HasValue("0"),
 			),
 		},
 		data.ImportStep("admin_password"),
@@ -771,7 +771,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationComplete(t *testi
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherGalleryApplicationsComplete(data),
+			Config: r.otherGalleryApplicationComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -3067,7 +3067,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationsBasic(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -3105,14 +3105,14 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 
-  gallery_applications {
-    package_reference_id = azurerm_gallery_application_version.test.id
+  gallery_application {
+    version_id = azurerm_gallery_application_version.test.id
   }
 }
-`, r.otherGalleryApplicationsTemplate(data), data.RandomInteger)
+`, r.otherGalleryApplicationTemplate(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationsComplete(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationComplete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -3150,17 +3150,17 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     }
   }
 
-  gallery_applications {
-    package_reference_id             = azurerm_gallery_application_version.test.id
-    configuration_reference_blob_uri = azurerm_storage_blob.test2.id
-    order                            = 1
-    tag                              = "app"
+  gallery_application {
+    version_id             = azurerm_gallery_application_version.test.id
+    configuration_blob_uri = azurerm_storage_blob.test2.id
+    order                  = 1
+    tag                    = "app"
   }
 }
-`, r.otherGalleryApplicationsTemplate(data), data.RandomInteger)
+`, r.otherGalleryApplicationTemplate(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationsTemplate(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) otherGalleryApplicationTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -178,14 +178,21 @@ func VirtualMachineScaleSetNetworkInterfaceSchema() *pluginsdk.Schema {
 	}
 }
 
-func VirtualMachineScaleSetGalleryApplicationsSchema() *pluginsdk.Schema {
+func VirtualMachineScaleSetGalleryApplicationSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MaxItems: 100,
+		Computed: !features.FourPointOhBeta(),
+		ConflictsWith: func() []string {
+			if !features.FourPointOhBeta() {
+				return []string{"gallery_applications"}
+			}
+			return []string{}
+		}(),
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
-				"package_reference_id": {
+				"version_id": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
 					ForceNew:     true,
@@ -193,7 +200,7 @@ func VirtualMachineScaleSetGalleryApplicationsSchema() *pluginsdk.Schema {
 				},
 
 				// Example: https://mystorageaccount.blob.core.windows.net/configurations/settings.config
-				"configuration_reference_blob_uri": {
+				"configuration_blob_uri": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ForceNew:     true,
@@ -218,6 +225,119 @@ func VirtualMachineScaleSetGalleryApplicationsSchema() *pluginsdk.Schema {
 			},
 		},
 	}
+}
+
+func VirtualMachineScaleSetGalleryApplicationsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:          pluginsdk.TypeList,
+		Optional:      true,
+		MaxItems:      100,
+		Computed:      !features.FourPointOhBeta(),
+		ConflictsWith: []string{"gallery_application"},
+		Deprecated:    "`gallery_applications` has been renamed to `gallery_application` and will be deprecated in 4.0",
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"package_reference_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validate.GalleryApplicationVersionID,
+					Deprecated:   "`package_reference_id` has been renamed to `version_id` and will be deprecated in 4.0",
+				},
+
+				// Example: https://mystorageaccount.blob.core.windows.net/configurations/settings.config
+				"configuration_reference_blob_uri": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+					Deprecated:   "`configuration_reference_blob_uri` has been renamed to `configuration_blob_uri` and will be deprecated in 4.0",
+				},
+
+				"order": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(0, 2147483647),
+				},
+
+				// NOTE: Per the service team, "this is a pass through value that we just add to the model but don't depend on. It can be any string."
+				"tag": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func expandVirtualMachineScaleSetGalleryApplication(input []interface{}) *[]compute.VMGalleryApplication {
+	if len(input) == 0 {
+		return nil
+	}
+
+	out := make([]compute.VMGalleryApplication, 0)
+
+	for _, v := range input {
+		packageReferenceId := v.(map[string]interface{})["version_id"].(string)
+		configurationReference := v.(map[string]interface{})["configuration_blob_uri"].(string)
+		order := v.(map[string]interface{})["order"].(int)
+		tag := v.(map[string]interface{})["tag"].(string)
+
+		app := &compute.VMGalleryApplication{
+			PackageReferenceID:     utils.String(packageReferenceId),
+			ConfigurationReference: utils.String(configurationReference),
+			Order:                  utils.Int32(int32(order)),
+			Tags:                   utils.String(tag),
+		}
+
+		out = append(out, *app)
+	}
+
+	return &out
+}
+
+func flattenVirtualMachineScaleSetGalleryApplication(input *[]compute.VMGalleryApplication) []interface{} {
+	if len(*input) == 0 {
+		return nil
+	}
+
+	out := make([]interface{}, 0)
+
+	for _, v := range *input {
+		var packageReferenceId, configurationReference, tag string
+		var order int
+
+		if v.PackageReferenceID != nil {
+			packageReferenceId = *v.PackageReferenceID
+		}
+
+		if v.ConfigurationReference != nil {
+			configurationReference = *v.ConfigurationReference
+		}
+
+		if v.Order != nil {
+			order = int(*v.Order)
+		}
+
+		if v.Tags != nil {
+			tag = *v.Tags
+		}
+
+		app := map[string]interface{}{
+			"version_id":             packageReferenceId,
+			"configuration_blob_uri": configurationReference,
+			"order":                  order,
+			"tag":                    tag,
+		}
+
+		out = append(out, app)
+	}
+
+	return out
 }
 
 func expandVirtualMachineScaleSetGalleryApplications(input []interface{}) *[]compute.VMGalleryApplication {

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -889,29 +889,29 @@ func TestAccWindowsVirtualMachineScaleSet_otherLicenseTypeUpdated(t *testing.T) 
 	})
 }
 
-func TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationsBasic(t *testing.T) {
+func TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherGalleryApplicationsBasic(data),
+			Config: r.otherGalleryApplicationBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("gallery_applications.0.order").HasValue("0"),
+				check.That(data.ResourceName).Key("gallery_application.0.order").HasValue("0"),
 			),
 		},
 		data.ImportStep("admin_password"),
 	})
 }
 
-func TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationsComplete(t *testing.T) {
+func TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationComplete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.otherGalleryApplicationsComplete(data),
+			Config: r.otherGalleryApplicationComplete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -3535,7 +3535,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 `, r.template(data), licenseType)
 }
 
-func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationsBasic(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -3571,14 +3571,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 
-  gallery_applications {
-    package_reference_id = azurerm_gallery_application_version.test.id
+  gallery_application {
+    version_id = azurerm_gallery_application_version.test.id
   }
 }
-`, r.otherGalleryApplicationsTemplate(data))
+`, r.otherGalleryApplicationTemplate(data))
 }
 
-func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationsComplete(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationComplete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -3614,17 +3614,17 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 
-  gallery_applications {
-    package_reference_id             = azurerm_gallery_application_version.test.id
-    configuration_reference_blob_uri = azurerm_storage_blob.test2.id
-    order                            = 1
-    tag                              = "app"
+  gallery_application {
+    version_id             = azurerm_gallery_application_version.test.id
+    configuration_blob_uri = azurerm_storage_blob.test2.id
+    order                  = 1
+    tag                    = "app"
   }
 }
-`, r.otherGalleryApplicationsTemplate(data))
+`, r.otherGalleryApplicationTemplate(data))
 }
 
-func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationsTemplate(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) otherGalleryApplicationTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -168,7 +168,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
-* `gallery_applications` - (Optional) A `gallery_applications` block as defined below.
+* `gallery_application` - (Optional) A `gallery_application` block as defined below.
 
 * `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
 
@@ -360,13 +360,11 @@ An `extension` block supports the following:
 
 ---
 
-A `gallery_applications` block supports the following:
+A `gallery_application` block supports the following:
 
-* `package_reference_id` - (Required) Specifies the Gallery Application Version resource ID. Changing this forces a new resource to be created.
+* `version_id` - (Required) Specifies the Gallery Application Version resource ID. Changing this forces a new resource to be created.
 
--> **NOTE:** The `package_reference_id` should be in the form of `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/applications/application1/versions/version1`.
-
-* `configuration_reference_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided. Changing this forces a new resource to be created.
+* `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided. Changing this forces a new resource to be created.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -152,7 +152,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
-* `gallery_applications` - (Optional) A `gallery_applications` block as defined below.
+* `gallery_application` - (Optional) A `gallery_application` block as defined below.
 
 * `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
 
@@ -348,13 +348,11 @@ An `extension` block supports the following:
 
 ---
 
-A `gallery_applications` block supports the following:
+A `gallery_application` block supports the following:
 
-* `package_reference_id` - (Required) Specifies the Gallery Application Version resource ID. Changing this forces a new resource to be created.
+* `version_id` - (Required) Specifies the Gallery Application Version resource ID. Changing this forces a new resource to be created.
 
--> **NOTE:** The `package_reference_id` should be in the form of `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/applications/application1/versions/version1`.
-
-* `configuration_reference_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided. Changing this forces a new resource to be created.
+* `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided. Changing this forces a new resource to be created.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Renaming below properties according to https://github.com/hashicorp/terraform-provider-azurerm/pull/18406#issuecomment-1259034756
`gallery_applications` -> `gallery_application`
`gallery_applications.package_reference_id` -> `gallery_application.version_id`
`gallery_applications.configuration_reference_blob_uri` -> `gallery_application.configuration_blob_uri`
