### PR TITLE
`azurerm_application_gateway` - data source - add backend_address_pool attribute

### DIFF
--- a/internal/services/network/application_gateway_data_source.go
+++ b/internal/services/network/application_gateway_data_source.go
@@ -27,6 +27,36 @@ func dataSourceApplicationGateway() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 			},
+			"backend_address_pool": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"fqdns": {
+							Type:     pluginsdk.TypeSet,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+						"ip_addresses": {
+							Type:     pluginsdk.TypeSet,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 
 			"location": commonschema.LocationComputed(),
 
@@ -56,6 +86,12 @@ func dataSourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	d.SetId(id.ID())
+
+	if props := resp.ApplicationGatewayPropertiesFormat; props != nil {
+		if err := d.Set("backend_address_pool", flattenApplicationGatewayBackendAddressPools(props.BackendAddressPools)); err != nil {
+			return fmt.Errorf("setting `backend_address_pool`: %+v", err)
+		}
+	}
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
 

--- a/internal/services/network/application_gateway_data_source_test.go
+++ b/internal/services/network/application_gateway_data_source_test.go
@@ -38,6 +38,21 @@ func TestAccDataSourceAppGateway_userAssignedIdentity(t *testing.T) {
 		},
 	})
 }
+func TestAccDataSourceAppGateway_backendAddressPool(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_application_gateway", "test")
+	r := AppGatewayDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.backendAddressPool(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("backend_address_pool.0.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backend_address_pool.0.id").Exists(),
+				check.That(data.ResourceName).Key("backend_address_pool.0.name").Exists(),
+			),
+		},
+	})
+}
 
 func (AppGatewayDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -59,4 +74,14 @@ data "azurerm_application_gateway" "test" {
   name                = azurerm_application_gateway.test.name
 }
 `, ApplicationGatewayResource{}.UserDefinedIdentity(data))
+}
+func (AppGatewayDataSource) backendAddressPool(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_application_gateway" "test" {
+  resource_group_name = azurerm_application_gateway.test.resource_group_name
+  name                = azurerm_application_gateway.test.name
+}
+`, ApplicationGatewayResource{}.backendAddressPoolEmptyIpList(data))
 }

--- a/internal/services/network/application_gateway_data_source_test.go
+++ b/internal/services/network/application_gateway_data_source_test.go
@@ -46,7 +46,6 @@ func TestAccDataSourceAppGateway_backendAddressPool(t *testing.T) {
 		{
 			Config: r.backendAddressPool(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("backend_address_pool.0.#").HasValue("1"),
 				check.That(data.ResourceName).Key("backend_address_pool.0.id").Exists(),
 				check.That(data.ResourceName).Key("backend_address_pool.0.name").Exists(),
 			),

--- a/website/docs/d/application_gateway.html.markdown
+++ b/website/docs/d/application_gateway.html.markdown
@@ -37,11 +37,25 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Application Gateway.
 
+* `backend_address_pool` - A `backend_address_pool` block as defined below.
+
 * `identity` - A `identity` block as defined below.
 
 * `location` - The Azure Region where the Application Gateway exists.
 
 * `tags` - A mapping of tags assigned to the Application Gateway.
+
+---
+
+A `backend_address_pool` block exports the following:
+
+* `id` - The ID of the Backend Address Pool.
+
+* `name` - The name of the Backend Address Pool.
+
+* `fqdns` - A list of FQDN's that are included in the Backend Address Pool.
+
+* `ip_addresses` - A list of IP Addresses that are included in the Backend Address Pool.
 
 ---
 


### PR DESCRIPTION
Updated the `azurerm_application_gateway` datasource to expose the `backend_address_pool` configuration as a list to enable adding targets to backend pools in different terraform projects. 