### PR TITLE
`azurerm_log_analytics_cluster` - reduce default `size_gb` from 1000 GB to 500 GB in v4.0 provider

### DIFF
--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -54,9 +55,14 @@ func resourceLogAnalyticsCluster() *pluginsdk.Resource {
 			"identity": commonschema.SystemAssignedIdentityRequiredForceNew(),
 
 			"size_gb": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      1000,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Default: func() int {
+					if !features.FourPointOh() {
+						return 1000
+					}
+					return 500
+				}(),
 				ValidateFunc: validation.IntInSlice([]int{500, 1000, 2000, 5000}),
 			},
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `size_gb` - (Optional) The capacity of the Log Analytics Cluster is specified in GB/day. Possible values include `500`, `1000`, `2000` or `5000`. Defaults to `1000`.
 
-~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters).
+~> **NOTE:** The cluster capacity must start at 500 GB and can be set to 1000, 2000 or 5000 GB/day. For more information on cluster costs, see [Dedicated clusters](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#dedicated-clusters). In v3.x the default value is `1000` GB, in v4.0 of the provider this will default to `500` GB.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Log Analytics Cluster.
 


### PR DESCRIPTION
(fixes #19001)