### PR TITLE
New resource: `azurerm_orbital_contact`

### DIFF
--- a/internal/services/orbital/contact_resource.go
+++ b/internal/services/orbital/contact_resource.go
@@ -112,7 +112,7 @@ func (r ContactResource) Create() sdk.ResourceFunc {
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
-				metadata.ResourceRequiresImport(r.ResourceType(), id)
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
 			contactProfile := contact.ResourceReference{

--- a/internal/services/orbital/contact_resource.go
+++ b/internal/services/orbital/contact_resource.go
@@ -1,0 +1,205 @@
+package orbital
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/contact"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/contactprofile"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/spacecraft"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ContactResource struct{}
+
+type ContactResourceModel struct {
+	Name                 string `tfschema:"name"`
+	ResourceGroup        string `tfschema:"resource_group_name"`
+	Spacecraft           string `tfschema:"spacecraft"`
+	ReservationStartTime string `tfschema:"reservation_start_time"`
+	ReservationEndTime   string `tfschema:"reservation_end_time"`
+	GroundStationName    string `tfschema:"ground_station_name"`
+	ContactProfileId     string `tfschema:"contact_profile_id"`
+}
+
+func (r ContactResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"spacecraft": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: spacecraft.ValidateSpacecraftID,
+		},
+
+		"reservation_start_time": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"reservation_end_time": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"ground_station_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"contact_profile_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: contactprofile.ValidateContactProfileID,
+		},
+	}
+}
+
+func (r ContactResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (r ContactResource) ModelObject() interface{} {
+	return &ContactResourceModel{}
+}
+
+func (r ContactResource) ResourceType() string {
+	return "azurerm_orbital_contact"
+}
+
+func (r ContactResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model ContactResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			client := metadata.Client.Orbital.ContactClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			spacecraftId, err := contact.ParseSpacecraftID(model.Spacecraft)
+			if err != nil {
+				return err
+			}
+			id := contact.NewContactID(subscriptionId, model.ResourceGroup, spacecraftId.SpacecraftName, model.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			contactProfile := contact.ResourceReference{
+				Id: &model.ContactProfileId,
+			}
+
+			contactProperties := contact.ContactsProperties{
+				ContactProfile:       contactProfile,
+				GroundStationName:    model.GroundStationName,
+				ReservationEndTime:   model.ReservationEndTime,
+				ReservationStartTime: model.ReservationStartTime,
+			}
+
+			contact := contact.Contact{
+				Id:         utils.String(id.ID()),
+				Name:       utils.String(model.Name),
+				Properties: &contactProperties,
+			}
+			if _, err = client.Create(ctx, id, contact); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ContactResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Orbital.ContactClient
+			id, err := contact.ParseContactID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			spacecraftId := contact.NewSpacecraftID(id.SubscriptionId, id.ResourceGroupName, id.SpacecraftName)
+			if model := resp.Model; model != nil {
+				props := model.Properties
+				state := ContactResourceModel{
+					Name:                 id.ContactName,
+					ResourceGroup:        id.ResourceGroupName,
+					Spacecraft:           spacecraftId.ID(),
+					ReservationStartTime: props.ReservationStartTime,
+					ReservationEndTime:   props.ReservationEndTime,
+					GroundStationName:    props.GroundStationName,
+					ContactProfileId:     *props.ContactProfile.Id,
+				}
+
+				return metadata.Encode(&state)
+			}
+			return nil
+		},
+	}
+}
+
+func (r ContactResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Orbital.ContactClient
+			id, err := contact.ParseContactID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s", *id)
+
+			if resp, err := client.Delete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", *id, err)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (r ContactResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return contact.ValidateContactID
+}

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -1,0 +1,147 @@
+package orbital_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/contact"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ContactResource struct{}
+
+func TestAccContact_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orbital_contact", "test")
+	r := ContactResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ContactResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := contact.ParseContactID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Orbital.ContactClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retreiving %s: %+v", *id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r ContactResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_orbital_contact" "test" {
+  name                   = "testcontact-%[2]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  spacecraft             = azurerm_orbital_spacecraft.test.id
+  reservation_start_time = "2020-07-16T20:35:00.00Z"
+  reservation_end_time   = "2020-07-16T20:55:00.00Z"
+  ground_station_name    = "WESTUS2_0"
+  contact_profile_id     = azurerm_orbital_contact_profile.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContactResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_orbital_spacecraft" "test" {
+  name                = "acctestspacecraft-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  norad_id            = "12345"
+  links {
+    bandwidth_mhz        = 100
+    center_frequency_mhz = 101
+    direction            = "Uplink"
+    polarization         = "LHCP"
+    name                 = "linkname"
+  }
+  two_line_elements = ["1 23455U 94089A   97320.90946019  .00000140  00000-0  10191-3 0  2621", "2 23455  99.0090 272.6745 0008546 223.1686 136.8816 14.11711747148495"]
+  title_line        = "AQUA"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "testvnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "orbitalgateway"
+
+    service_delegation {
+      name = "Microsoft.Orbital/orbitalGateways"
+      actions = [
+        "Microsoft.Network/publicIPAddresses/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/read",
+        "Microsoft.Network/publicIPAddresses/read",
+      ]
+    }
+  }
+}
+
+resource "azurerm_orbital_contact_profile" "test" {
+  name                              = "testcontactprofile-%[1]d"
+  resource_group_name               = azurerm_resource_group.test.name
+  location                          = azurerm_resource_group.test.location
+  minimum_variable_contact_duration = "PT1M"
+  auto_tracking                     = "disabled"
+  links {
+    channels {
+      name                 = "channelname"
+      bandwidth_mhz        = 100
+      center_frequency_mhz = 101
+      end_point {
+        end_point_name = "AQUA_command"
+        ip_address     = "10.0.1.0"
+        port           = "49153"
+        protocol       = "TCP"
+      }
+    }
+    direction    = "Uplink"
+    name         = "RHCP_UL"
+    polarization = "RHCP"
+  }
+  network_configuration_subnet_id = azurerm_subnet.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -55,7 +55,7 @@ func (r ContactResource) basic(data acceptance.TestData) string {
 resource "azurerm_orbital_contact" "test" {
   name                   = "testcontact-%[2]d"
   resource_group_name    = azurerm_resource_group.test.name
-  spacecraft_id          = azurerm_orbital_spacecraft.test.id
+  spacecraft_id          = "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/spaceymcspaceface/providers/Microsoft.Orbital/spacecrafts/spaceymcspaceface"
   reservation_start_time = "2020-07-16T20:35:00.00Z"
   reservation_end_time   = "2020-07-16T20:55:00.00Z"
   ground_station_name    = "WESTUS2_0"
@@ -73,22 +73,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
-}
-
-resource "azurerm_orbital_spacecraft" "test" {
-  name                = "acctestspacecraft-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  norad_id            = "12345"
-  links {
-    bandwidth_mhz        = 100
-    center_frequency_mhz = 101
-    direction            = "Uplink"
-    polarization         = "LHCP"
-    name                 = "linkname"
-  }
-  two_line_elements = ["1 23455U 94089A   97320.90946019  .00000140  00000-0  10191-3 0  2621", "2 23455  99.0090 272.6745 0008546 223.1686 136.8816 14.11711747148495"]
-  title_line        = "AQUA"
 }
 
 resource "azurerm_virtual_network" "test" {

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -3,6 +3,7 @@ package orbital_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -17,6 +18,8 @@ import (
 type ContactResource struct{}
 
 func TestAccContact_basic(t *testing.T) {
+	skipContact(t)
+
 	data := acceptance.BuildTestData(t, "azurerm_orbital_contact", "test")
 	r := ContactResource{}
 
@@ -55,13 +58,13 @@ func (r ContactResource) basic(data acceptance.TestData) string {
 resource "azurerm_orbital_contact" "test" {
   name                   = "testcontact-%[2]d"
   resource_group_name    = azurerm_resource_group.test.name
-  spacecraft_id          = "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/spaceymcspaceface/providers/Microsoft.Orbital/spacecrafts/spaceymcspaceface"
+  spacecraft_id          = "%[3]s"
   reservation_start_time = "2020-07-16T20:35:00.00Z"
   reservation_end_time   = "2020-07-16T20:55:00.00Z"
   ground_station_name    = "WESTUS2_0"
   contact_profile_id     = azurerm_orbital_contact_profile.test.id
 }
-`, template, data.RandomInteger)
+`, template, data.RandomInteger, os.Getenv("ARM_TEST_SPACECRAFT_ID"))
 }
 
 func (r ContactResource) template(data acceptance.TestData) string {
@@ -128,4 +131,10 @@ resource "azurerm_orbital_contact_profile" "test" {
   network_configuration_subnet_id = azurerm_subnet.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func skipContact(t *testing.T) {
+	if os.Getenv("ARM_TEST_SPACECRAFT_ID") == "" {
+		t.Skip("Skipping as one of ")
+	}
 }

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -55,7 +55,7 @@ func (r ContactResource) basic(data acceptance.TestData) string {
 resource "azurerm_orbital_contact" "test" {
   name                   = "testcontact-%[2]d"
   resource_group_name    = azurerm_resource_group.test.name
-  spacecraft             = azurerm_orbital_spacecraft.test.id
+  spacecraft_id          = azurerm_orbital_spacecraft.test.id
   reservation_start_time = "2020-07-16T20:35:00.00Z"
   reservation_end_time   = "2020-07-16T20:55:00.00Z"
   ground_station_name    = "WESTUS2_0"

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -57,11 +57,10 @@ func (r ContactResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_orbital_contact" "test" {
   name                   = "testcontact-%[2]d"
-  resource_group_name    = azurerm_resource_group.test.name
   spacecraft_id          = "%[3]s"
-  reservation_start_time = "2020-07-16T20:35:00.00Z"
-  reservation_end_time   = "2020-07-16T20:55:00.00Z"
-  ground_station_name    = "WESTUS2_0"
+  reservation_start_time = "2025-07-16T20:35:00Z"
+  reservation_end_time   = "2025-07-16T20:55:00Z"
+  ground_station_name    = "Microsoft_Quincy"
   contact_profile_id     = azurerm_orbital_contact_profile.test.id
 }
 `, template, data.RandomInteger, os.Getenv("ARM_TEST_SPACECRAFT_ID"))

--- a/internal/services/orbital/contact_resource_test.go
+++ b/internal/services/orbital/contact_resource_test.go
@@ -45,7 +45,7 @@ func (r ContactResource) Exists(ctx context.Context, client *clients.Client, sta
 		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retreiving %s: %+v", *id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 	return utils.Bool(true), nil
 }
@@ -134,6 +134,6 @@ resource "azurerm_orbital_contact_profile" "test" {
 
 func skipContact(t *testing.T) {
 	if os.Getenv("ARM_TEST_SPACECRAFT_ID") == "" {
-		t.Skip("Skipping as one of ")
+		t.Skip("Skipping as `ARM_TEST_SPACECRAFT_ID` was not specified")
 	}
 }

--- a/internal/services/orbital/registration.go
+++ b/internal/services/orbital/registration.go
@@ -22,6 +22,7 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		SpacecraftResource{},
 		ContactProfileResource{},
+		ContactResource{},
 	}
 }
 

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -1,0 +1,146 @@
+---
+subcategory: "Orbital"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_orbital_contact_profile"
+description: |-
+Manages an orbital contact resource.
+---
+
+# azurerm_orbital_contact
+
+Manages an orbital contact.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
+resource "azurerm_orbital_spacecraft" "example" {
+  name                = "example-spacecraft"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = "westeurope"
+  norad_id            = "12345"
+
+  links {
+    bandwidth_mhz        = 100
+    center_frequency_mhz = 101
+    direction            = "Uplink"
+    polarization         = "LHCP"
+    name                 = "examplename"
+  }
+
+  two_line_elements = ["1 23455U 94089A   97320.90946019  .00000140  00000-0  10191-3 0  2621", "2 23455  99.0090 272.6745 0008546 223.1686 136.8816 14.11711747148495"]
+  title_line        = "AQUA"
+
+  tags = {
+    aks-managed-cluster-name = "9a57225d-a405-4d40-aa46-f13d2342abef"
+  }
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "orbitalgateway"
+
+    service_delegation {
+      name = "Microsoft.Orbital/orbitalGateways"
+      actions = [
+        "Microsoft.Network/publicIPAddresses/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/read",
+        "Microsoft.Network/publicIPAddresses/read",
+      ]
+    }
+  }
+}
+
+resource "azurerm_orbital_contact_profile" "example" {
+  name                              = "example-contactprofile"
+  resource_group_name               = azurerm_resource_group.example.name
+  location                          = azurerm_resource_group.example.location
+  minimum_variable_contact_duration = "PT1M"
+  auto_tracking                     = "disabled"
+  links {
+    channels {
+      name                 = "channelname"
+      bandwidth_mhz        = 100
+      center_frequency_mhz = 101
+      end_point {
+        end_point_name = "AQUA_command"
+        ip_address     = "10.0.1.0"
+        port           = "49153"
+        protocol       = "TCP"
+      }
+    }
+    direction    = "Uplink"
+    name         = "RHCP_UL"
+    polarization = "RHCP"
+  }
+  network_configuration_subnet_id = azurerm_subnet.example.id
+}
+
+resource "azurerm_orbital_contact" "example" {
+  name                   = "example-contact"
+  resource_group_name    = azurerm_resource_group.example.name
+  spacecraft             = azurerm_orbital_spacecraft.example.id
+  reservation_start_time = "2020-07-16T20:35:00.00Z"
+  reservation_end_time   = "2020-07-16T20:55:00.00Z"
+  ground_station_name    = "WESTUS2_0"
+  contact_profile_id     = azurerm_orbital_contact_profile.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Contact. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Contact exists.
+
+* `spacecraft` - (Required) The ID of the spacecraft which the contact will be made to.
+
+* `reservation_start_time` - (Required) Reservation start time of the Contact.
+
+* `reservation_end_time` - (Required) Reservation end time of the Contact.
+
+* `ground_station_name` - (Required) Name of the Azure ground station.
+
+* `contact_profile_id` - (Required) ID of the orbital contact profile.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Contact.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Contact.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Contact.
+* `update` - (Defaults to 30 minutes) Used when updating the Contact.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Contact.
+
+## Import
+
+Spacecraft can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_orbital_contact.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Orbital/spacecrafts/spacecraft1/contacts/contact1
+```

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -107,17 +107,17 @@ resource "azurerm_orbital_contact" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Contact. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Contact. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `spacecraft_id` - (Required) The ID of the spacecraft which the contact will be made to.
+* `spacecraft_id` - (Required) The ID of the spacecraft which the contact will be made to. Changing this forces a new resource to be created.
 
-* `reservation_start_time` - (Required) Reservation start time of the Contact.
+* `reservation_start_time` - (Required) Reservation start time of the Contact. Changing this forces a new resource to be created.
 
-* `reservation_end_time` - (Required) Reservation end time of the Contact.
+* `reservation_end_time` - (Required) Reservation end time of the Contact. Changing this forces a new resource to be created.
 
-* `ground_station_name` - (Required) Name of the Azure ground station.
+* `ground_station_name` - (Required) Name of the Azure ground station. Changing this forces a new resource to be created.
 
-* `contact_profile_id` - (Required) ID of the orbital contact profile.
+* `contact_profile_id` - (Required) ID of the orbital contact profile. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -95,8 +95,7 @@ resource "azurerm_orbital_contact_profile" "example" {
 
 resource "azurerm_orbital_contact" "example" {
   name                   = "example-contact"
-  resource_group_name    = azurerm_resource_group.example.name
-  spacecraft             = azurerm_orbital_spacecraft.example.id
+  spacecraft_id          = azurerm_orbital_spacecraft.example.id
   reservation_start_time = "2020-07-16T20:35:00.00Z"
   reservation_end_time   = "2020-07-16T20:55:00.00Z"
   ground_station_name    = "WESTUS2_0"
@@ -110,9 +109,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Contact. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Contact exists.
-
-* `spacecraft` - (Required) The ID of the spacecraft which the contact will be made to.
+* `spacecraft_id` - (Required) The ID of the spacecraft which the contact will be made to.
 
 * `reservation_start_time` - (Required) Reservation start time of the Contact.
 

--- a/website/docs/r/orbital_contact.html.markdown
+++ b/website/docs/r/orbital_contact.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Orbital"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_orbital_contact_profile"
 description: |-
-Manages an orbital contact resource.
+  Manages an orbital contact resource.
 ---
 
 # azurerm_orbital_contact


### PR DESCRIPTION
* New resource to create a contact between ground stations and spacecrafts.
* Acc tests are not runnable now. Due to restrictions of the service team, there're a few steps we need to follow to get the tests running.
>1. Submit the [Azure Orbital preview onboarding form](https://learn.microsoft.com/en-us/azure/orbital/orbital-preview#register-the-resource-provider). 
>2. Register a new spacecraft resource and make sure the spacecraft is authorized. Follow the steps [here](https://learn.microsoft.com/en-us/azure/orbital/register-spacecraft).
>3. Paste the ID of the authorized spacecraft in the PR.
>4. We will change the acc test accordingly after the spacecraft authorization to make sure they can run in team city.