### PR TITLE
dependencies: updating to v0.46.0 of hashicorp/go-azure-helpers / `v0.20221028.1081410` of `hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
-	github.com/hashicorp/go-azure-helpers v0.45.0
-	github.com/hashicorp/go-azure-sdk v0.20221025.1113207
+	github.com/hashicorp/go-azure-helpers v0.46.0
+	github.com/hashicorp/go-azure-sdk v0.20221028.1081410
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -214,10 +214,10 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.45.0 h1:xuht3X0L5S8ma5HR6IY+jvzkkLwvQ9ifDmpVGUcOB8s=
-github.com/hashicorp/go-azure-helpers v0.45.0/go.mod h1:WiJNl0fD6PoM/MYuGTZ8yuzIaXQR3m2H2g6+EJ8nSwc=
-github.com/hashicorp/go-azure-sdk v0.20221025.1113207 h1:6aFDSayJrCI6MoOLBV1bzvjo2R7KVzynVeOboQcVPa4=
-github.com/hashicorp/go-azure-sdk v0.20221025.1113207/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
+github.com/hashicorp/go-azure-helpers v0.46.0 h1:KWJZ7FYDbrkZck36LmySSFrLOO4gGp7Wv3yBFmLcSes=
+github.com/hashicorp/go-azure-helpers v0.46.0/go.mod h1:WiJNl0fD6PoM/MYuGTZ8yuzIaXQR3m2H2g6+EJ8nSwc=
+github.com/hashicorp/go-azure-sdk v0.20221028.1081410 h1:GARE074AdigygZXXyitw+H7iePIhugytrtkt7uv6fgQ=
+github.com/hashicorp/go-azure-sdk v0.20221028.1081410/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/apimanagement/api_management_data_source.go
+++ b/internal/services/apimanagement/api_management_data_source.go
@@ -365,7 +365,7 @@ func flattenDataSourceApiManagementAdditionalLocations(input *[]apimanagement.Ad
 			"private_ip_addresses": privateIpAddresses,
 			"public_ip_address_id": publicIpAddressId,
 			"public_ip_addresses":  publicIpAddresses,
-			"zones":                zones.Flatten(prop.Zones),
+			"zones":                zones.FlattenUntyped(prop.Zones),
 		})
 	}
 

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -803,7 +803,7 @@ func resourceApiManagementServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 		if publicIpAddressId == "" {
 			return fmt.Errorf("`public_ip_address` must be specified when `zones` are provided")
 		}
-		zones := zones.Expand(v)
+		zones := zones.ExpandUntyped(v)
 		properties.Zones = &zones
 	}
 
@@ -1049,7 +1049,7 @@ func resourceApiManagementServiceRead(d *pluginsdk.ResourceData, meta interface{
 		return fmt.Errorf("setting `policy`: %+v", err)
 	}
 
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if resp.Sku.Name != apimanagement.SkuTypeConsumption {
 		signInSettings, err := signInClient.Get(ctx, id.ResourceGroup, id.ServiceName)
@@ -1424,7 +1424,7 @@ func expandAzureRmApiManagementAdditionalLocations(d *pluginsdk.ResourceData, sk
 			additionalLocation.PublicIPAddressID = &publicIPAddressID
 		}
 
-		zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+		zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 		if len(zones) > 0 {
 			additionalLocation.Zones = &zones
 		}
@@ -1480,7 +1480,7 @@ func flattenApiManagementAdditionalLocations(input *[]apimanagement.AdditionalLo
 			"public_ip_address_id":          publicIpAddressId,
 			"public_ip_addresses":           publicIPAddresses,
 			"virtual_network_configuration": flattenApiManagementVirtualNetworkConfiguration(prop.VirtualNetworkConfiguration),
-			"zones":                         zones.Flatten(prop.Zones),
+			"zones":                         zones.FlattenUntyped(prop.Zones),
 			"gateway_disabled":              gatewayDisabled,
 		})
 	}

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -84,7 +84,7 @@ func resourceCapacityReservationGroupCreate(d *pluginsdk.ResourceData, meta inte
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		parameters.Zones = &zones
 	}

--- a/internal/services/compute/dedicated_host_group_data_source.go
+++ b/internal/services/compute/dedicated_host_group_data_source.go
@@ -75,7 +75,7 @@ func dataSourceDedicatedHostGroupRead(d *pluginsdk.ResourceData, meta interface{
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		if props := model.Properties; props != nil {
 			d.Set("automatic_placement_enabled", props.SupportAutomaticPlacement)

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -121,7 +121,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	sshKeys := ExpandSSHKeys(sshKeysRaw)
 
 	provisionVMAgent := d.Get("provision_vm_agent").(bool)
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	healthProbeId := d.Get("health_probe_id").(string)
 	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
 	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
@@ -531,7 +531,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 
 		if d.HasChange("rolling_upgrade_policy") {
 			rollingRaw := d.Get("rolling_upgrade_policy").([]interface{})
-			zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+			zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 			rollingUpgradePolicy, err := ExpandVirtualMachineScaleSetRollingUpgradePolicy(rollingRaw, len(zones) > 0)
 			if err != nil {
 				return err
@@ -829,7 +829,7 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	var skuName *string
 	var instances int

--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -171,7 +171,7 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		storageAccountType := ""
 		if sku := model.Sku; sku != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -305,7 +305,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		props.VirtualMachineScaleSetProperties.SinglePlacementGroup = utils.Bool(d.Get("single_placement_group").(bool))
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		props.Zones = &zones
 	}
@@ -1129,7 +1129,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	var skuName *string
 	var instances int

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -118,7 +118,7 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	provisionVMAgent := d.Get("provision_vm_agent").(bool)
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	healthProbeId := d.Get("health_probe_id").(string)
 	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
 	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
@@ -536,7 +536,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 
 		if d.HasChange("rolling_upgrade_policy") {
 			rollingRaw := d.Get("rolling_upgrade_policy").([]interface{})
-			zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+			zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 			rollingUpgradePolicy, err := ExpandVirtualMachineScaleSetRollingUpgradePolicy(rollingRaw, len(zones) > 0)
 			if err != nil {
 				return err
@@ -845,7 +845,7 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	var skuName *string
 	var instances int

--- a/internal/services/containers/container_group_data_source.go
+++ b/internal/services/containers/container_group_data_source.go
@@ -87,7 +87,7 @@ func dataSourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -675,7 +675,7 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	zones := zones.Expand(d.Get("zones").(*pluginsdk.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*pluginsdk.Set).List())
 	initContainers, initContainerVolumes, err := expandContainerGroupInitContainers(d, addedEmptyDirs)
 	if err != nil {
 		return err
@@ -828,7 +828,7 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 			return err
 		}
 
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		props := model.Properties
 		containerConfigs := flattenContainerGroupContainers(d, &props.Containers, props.Volumes)

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -1051,7 +1051,7 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]managedcluster
 			"upgrade_settings":         flattenKubernetesClusterDataSourceUpgradeSettings(profile.UpgradeSettings),
 			"vm_size":                  vmSize,
 			"vnet_subnet_id":           vnetSubnetId,
-			"zones":                    zones.Flatten(profile.AvailabilityZones),
+			"zones":                    zones.FlattenUntyped(profile.AvailabilityZones),
 		}
 		agentPoolProfiles = append(agentPoolProfiles, out)
 	}

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -194,7 +194,7 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 
 	if model := resp.Model; model != nil && model.Properties != nil {
 		props := model.Properties
-		d.Set("zones", zones.Flatten(props.AvailabilityZones))
+		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 
 		d.Set("enable_auto_scaling", props.EnableAutoScaling)
 		d.Set("enable_node_public_ip", props.EnableNodePublicIP)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -448,7 +448,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.OrchestratorVersion = utils.String(orchestratorVersion)
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		profile.AvailabilityZones = &zones
 	}
@@ -765,7 +765,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 
 	if model := resp.Model; model != nil && model.Properties != nil {
 		props := model.Properties
-		d.Set("zones", zones.Flatten(props.AvailabilityZones))
+		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 		d.Set("enable_auto_scaling", props.EnableAutoScaling)
 		d.Set("enable_node_public_ip", props.EnableNodePublicIP)
 		d.Set("enable_host_encryption", props.EnableEncryptionAtHost)

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -763,7 +763,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		// ScaleSetPriority:       "",
 	}
 
-	zones := zones.Expand(raw["zones"].(*schema.Set).List())
+	zones := zones.ExpandUntyped(raw["zones"].(*schema.Set).List())
 	if len(zones) > 0 {
 		profile.AvailabilityZones = &zones
 	}
@@ -1261,7 +1261,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"only_critical_addons_enabled":  criticalAddonsEnabled,
 		"kubelet_config":                flattenClusterNodePoolKubeletConfig(agentPool.KubeletConfig),
 		"linux_os_config":               linuxOSConfig,
-		"zones":                         zones.Flatten(agentPool.AvailabilityZones),
+		"zones":                         zones.FlattenUntyped(agentPool.AvailabilityZones),
 		"capacity_reservation_group_id": capacityReservationGroupId,
 	}
 

--- a/internal/services/firewall/firewall_data_source.go
+++ b/internal/services/firewall/firewall_data_source.go
@@ -170,7 +170,7 @@ func firewallDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	d.Set("location", location.NormalizeNilable(read.Location))
-	d.Set("zones", zones.Flatten(read.Zones))
+	d.Set("zones", zones.FlattenUntyped(read.Zones))
 
 	if props := read.AzureFirewallPropertiesFormat; props != nil {
 		if err := d.Set("ip_configuration", flattenFirewallIPConfigurations(props.IPConfigurations)); err != nil {

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -263,7 +263,7 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		Tags: tags.Expand(t),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		parameters.Zones = &zones
 	}
@@ -391,7 +391,7 @@ func resourceFirewallRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	d.Set("location", location.NormalizeNilable(read.Location))
-	d.Set("zones", zones.Flatten(read.Zones))
+	d.Set("zones", zones.FlattenUntyped(read.Zones))
 
 	if props := read.AzureFirewallPropertiesFormat; props != nil {
 		if err := d.Set("ip_configuration", flattenFirewallIPConfigurations(props.IPConfigurations)); err != nil {

--- a/internal/services/hsm/dedicated_hardware_security_module_resource.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource.go
@@ -178,7 +178,7 @@ func resourceDedicatedHardwareSecurityModuleCreate(d *pluginsdk.ResourceData, me
 	}
 
 	if v, ok := d.GetOk("zones"); ok {
-		zones := zones.Expand(v.(*pluginsdk.Set).List())
+		zones := zones.ExpandUntyped(v.(*pluginsdk.Set).List())
 		if len(zones) > 0 {
 			parameters.Zones = &zones
 		}
@@ -218,7 +218,7 @@ func resourceDedicatedHardwareSecurityModuleRead(d *pluginsdk.ResourceData, meta
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		props := model.Properties
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -362,7 +362,7 @@ func resourceKustoClusterCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 		Tags:              tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		kustoCluster.Zones = &zones
 	}
@@ -444,7 +444,7 @@ func resourceKustoClusterRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	d.Set("public_network_access_enabled", resp.PublicNetworkAccess == kusto.PublicNetworkAccessEnabled)
 

--- a/internal/services/loadbalancer/loadbalancer_data_source.go
+++ b/internal/services/loadbalancer/loadbalancer_data_source.go
@@ -207,7 +207,7 @@ func flattenLoadBalancerDataSourceFrontendIpConfiguration(ipConfigs *[]network.F
 			"private_ip_address_version":    privateIpAddressVersion,
 			"public_ip_address_id":          publicIpAddressId,
 			"subnet_id":                     subnetId,
-			"zones":                         zones.Flatten(config.Zones),
+			"zones":                         zones.FlattenUntyped(config.Zones),
 		})
 	}
 	return result

--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -246,7 +246,7 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *pluginsdk.ResourceData
 			FrontendIPConfigurationPropertiesFormat: &properties,
 		}
 
-		zones := zones.Expand(data["zones"].(*pluginsdk.Set).List())
+		zones := zones.ExpandUntyped(data["zones"].(*pluginsdk.Set).List())
 		if len(zones) > 0 {
 			frontEndConfig.Zones = &zones
 		}
@@ -348,7 +348,7 @@ func flattenLoadBalancerFrontendIpConfiguration(ipConfigs *[]network.FrontendIPC
 			"private_ip_address_allocation": privateIPAllocationMethod,
 			"public_ip_prefix_id":           publicIpPrefixId,
 			"subnet_id":                     subnetId,
-			"zones":                         zones.Flatten(config.Zones),
+			"zones":                         zones.FlattenUntyped(config.Zones),
 		}
 
 		result = append(result, out)

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1643,7 +1643,7 @@ func resourceApplicationGatewayCreate(d *pluginsdk.ResourceData, meta interface{
 		},
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		gateway.Zones = &zones
 	}
@@ -1907,7 +1907,7 @@ func resourceApplicationGatewayUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("zones") {
-		zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+		zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 		if len(zones) > 0 {
 			applicationGateway.Zones = &zones
 		}
@@ -2040,7 +2040,7 @@ func resourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{})
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	d.Set("location", location.NormalizeNilable(applicationGateway.Location))
-	d.Set("zones", zones.Flatten(applicationGateway.Zones))
+	d.Set("zones", zones.FlattenUntyped(applicationGateway.Zones))
 
 	identity, err := flattenApplicationGatewayIdentity(applicationGateway.Identity)
 	if err != nil {

--- a/internal/services/network/nat_gateway_data_source.go
+++ b/internal/services/network/nat_gateway_data_source.go
@@ -98,7 +98,7 @@ func dataSourceNatGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if props := resp.NatGatewayPropertiesFormat; props != nil {
 		d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)

--- a/internal/services/network/nat_gateway_resource.go
+++ b/internal/services/network/nat_gateway_resource.go
@@ -124,7 +124,7 @@ func resourceNatGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		Tags: tags.Expand(t),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		parameters.Zones = &zones
 	}
@@ -245,7 +245,7 @@ func resourceNatGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("resource_guid", props.ResourceGUID)
 	}
 
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -109,7 +109,7 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.SetId(id.ID())
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if resp.PublicIPAddressPropertiesFormat == nil {
 		return fmt.Errorf("retreving %s: `properties` was nil", id)

--- a/internal/services/network/public_ip_prefix_data_source.go
+++ b/internal/services/network/public_ip_prefix_data_source.go
@@ -73,7 +73,7 @@ func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.SetId(id.ID())
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if sku := resp.Sku; sku != nil {
 		d.Set("sku", string(sku.Name))

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -132,7 +132,7 @@ func resourcePublicIpPrefixCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		Tags: tags.Expand(t),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		publicIpPrefix.Zones = &zones
 	}
@@ -174,7 +174,7 @@ func resourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("name", id.PublicIPPrefixeName)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	skuName := ""
 	if sku := resp.Sku; sku != nil {

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -203,7 +203,7 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		Tags: tags.Expand(t),
 	}
 
-	zones := zones.Expand(d.Get("zones").(*schema.Set).List())
+	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
 	if len(zones) > 0 {
 		publicIp.Zones = &zones
 	}
@@ -285,7 +285,7 @@ func resourcePublicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if sku := resp.Sku; sku != nil {
 		d.Set("sku", string(sku.Name))

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -244,7 +244,7 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.SetId(id.ID())
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if sku := resp.Sku; sku != nil {
 		d.Set("capacity", sku.Capacity)

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -451,7 +451,7 @@ func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("zones"); ok {
-		zones := zones.Expand(v.(*schema.Set).List())
+		zones := zones.ExpandUntyped(v.(*schema.Set).List())
 		if len(zones) > 0 {
 			parameters.Zones = &zones
 		}
@@ -669,7 +669,7 @@ func resourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("name", id.RediName)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("zones", zones.Flatten(resp.Zones))
+	d.Set("zones", zones.FlattenUntyped(resp.Zones))
 
 	if sku := resp.Sku; sku != nil {
 		d.Set("capacity", sku.Capacity)

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -138,7 +138,7 @@ func resourceRedisEnterpriseClusterCreate(d *pluginsdk.ResourceData, meta interf
 		if err := validate.RedisEnterpriseClusterLocationZoneSupport(location); err != nil {
 			return fmt.Errorf("%s: %s", id, err)
 		}
-		zones := zones.Expand(v.(*pluginsdk.Set).List())
+		zones := zones.ExpandUntyped(v.(*pluginsdk.Set).List())
 		if len(zones) > 0 {
 			parameters.Zones = &zones
 		}
@@ -198,7 +198,7 @@ func resourceRedisEnterpriseClusterRead(d *pluginsdk.ResourceData, meta interfac
 			return fmt.Errorf("setting `sku_name`: %+v", err)
 		}
 
-		d.Set("zones", zones.Flatten(model.Zones))
+		d.Set("zones", zones.FlattenUntyped(model.Zones))
 		if props := model.Properties; props != nil {
 			d.Set("hostname", props.HostName)
 

--- a/vendor/github.com/hashicorp/go-azure-helpers/LICENSE
+++ b/vendor/github.com/hashicorp/go-azure-helpers/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2018 HashiCorp, Inc.
+
 Mozilla Public License, version 2.0
 
 1. Definitions

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/zones/expand.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/zones/expand.go
@@ -1,6 +1,18 @@
 package zones
 
-func Expand(input []interface{}) []string {
+func Expand(input []string) Schema {
+	out := Schema{}
+
+	if input != nil {
+		for _, v := range input {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+func ExpandUntyped(input []interface{}) []string {
 	out := make([]string, 0)
 
 	if input != nil {

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/zones/flatten.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/zones/flatten.go
@@ -1,6 +1,18 @@
 package zones
 
-func Flatten(input *[]string) []interface{} {
+func Flatten(input *Schema) []string {
+	out := make([]string, 0)
+
+	if input != nil {
+		for _, v := range *input {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+func FlattenUntyped(input *[]string) []interface{} {
 	out := make([]interface{}, 0)
 
 	if input != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_resourceskurestrictioninfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2021-04-30/cognitiveservicesaccounts/model_resourceskurestrictioninfo.go
@@ -1,9 +1,13 @@
 package cognitiveservicesaccounts
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ResourceSkuRestrictionInfo struct {
-	Locations *[]string `json:"locations,omitempty"`
-	Zones     *[]string `json:"zones,omitempty"`
+	Locations *[]string     `json:"locations,omitempty"`
+	Zones     *zones.Schema `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/model_dedicatedhostgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/model_dedicatedhostgroup.go
@@ -1,5 +1,9 @@
 package dedicatedhostgroups
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
@@ -10,5 +14,5 @@ type DedicatedHostGroup struct {
 	Properties *DedicatedHostGroupProperties `json:"properties,omitempty"`
 	Tags       *map[string]string            `json:"tags,omitempty"`
 	Type       *string                       `json:"type,omitempty"`
-	Zones      *[]string                     `json:"zones,omitempty"`
+	Zones      *zones.Schema                 `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/model_dedicatedhostgroupupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/model_dedicatedhostgroupupdate.go
@@ -1,10 +1,14 @@
 package dedicatedhostgroups
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type DedicatedHostGroupUpdate struct {
 	Properties *DedicatedHostGroupProperties `json:"properties,omitempty"`
 	Tags       *map[string]string            `json:"tags,omitempty"`
-	Zones      *[]string                     `json:"zones,omitempty"`
+	Zones      *zones.Schema                 `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/disks/model_disk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/disks/model_disk.go
@@ -2,6 +2,7 @@ package disks
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 )
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -18,5 +19,5 @@ type Disk struct {
 	Sku               *DiskSku           `json:"sku,omitempty"`
 	Tags              *map[string]string `json:"tags,omitempty"`
 	Type              *string            `json:"type,omitempty"`
-	Zones             *[]string          `json:"zones,omitempty"`
+	Zones             *zones.Schema      `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/model_containergroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/model_containergroup.go
@@ -2,6 +2,7 @@ package containerinstance
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 )
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -15,5 +16,5 @@ type ContainerGroup struct {
 	Properties ContainerGroupPropertiesProperties `json:"properties"`
 	Tags       *map[string]string                 `json:"tags,omitempty"`
 	Type       *string                            `json:"type,omitempty"`
-	Zones      *[]string                          `json:"zones,omitempty"`
+	Zones      *zones.Schema                      `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/model_resource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/model_resource.go
@@ -1,5 +1,9 @@
 package containerinstance
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
@@ -9,5 +13,5 @@ type Resource struct {
 	Name     *string            `json:"name,omitempty"`
 	Tags     *map[string]string `json:"tags,omitempty"`
 	Type     *string            `json:"type,omitempty"`
-	Zones    *[]string          `json:"zones,omitempty"`
+	Zones    *zones.Schema      `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-08-02-preview/agentpools/model_managedclusteragentpoolprofileproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-08-02-preview/agentpools/model_managedclusteragentpoolprofileproperties.go
@@ -1,10 +1,14 @@
 package agentpools
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ManagedClusterAgentPoolProfileProperties struct {
-	AvailabilityZones          *[]string                 `json:"availabilityZones,omitempty"`
+	AvailabilityZones          *zones.Schema             `json:"availabilityZones,omitempty"`
 	CapacityReservationGroupID *string                   `json:"capacityReservationGroupID,omitempty"`
 	Count                      *int64                    `json:"count,omitempty"`
 	CreationData               *CreationData             `json:"creationData,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-08-02-preview/managedclusters/model_managedclusteragentpoolprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-08-02-preview/managedclusters/model_managedclusteragentpoolprofile.go
@@ -1,10 +1,14 @@
 package managedclusters
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ManagedClusterAgentPoolProfile struct {
-	AvailabilityZones          *[]string                 `json:"availabilityZones,omitempty"`
+	AvailabilityZones          *zones.Schema             `json:"availabilityZones,omitempty"`
 	CapacityReservationGroupID *string                   `json:"capacityReservationGroupID,omitempty"`
 	Count                      *int64                    `json:"count,omitempty"`
 	CreationData               *CreationData             `json:"creationData,omitempty"`

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_dedicatedhsm.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/model_dedicatedhsm.go
@@ -2,6 +2,7 @@ package dedicatedhsms
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 )
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -16,5 +17,5 @@ type DedicatedHsm struct {
 	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
 	Tags       *map[string]string     `json:"tags,omitempty"`
 	Type       *string                `json:"type,omitempty"`
-	Zones      *[]string              `json:"zones,omitempty"`
+	Zones      *zones.Schema          `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/model_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/model_cluster.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 )
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -19,5 +20,5 @@ type Cluster struct {
 	SystemData *systemdata.SystemData             `json:"systemData,omitempty"`
 	Tags       *map[string]string                 `json:"tags,omitempty"`
 	Type       *string                            `json:"type,omitempty"`
-	Zones      *[]string                          `json:"zones,omitempty"`
+	Zones      *zones.Schema                      `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/model_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/model_cluster.go
@@ -1,5 +1,9 @@
 package redisenterprise
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
@@ -11,5 +15,5 @@ type Cluster struct {
 	Sku        Sku                `json:"sku"`
 	Tags       *map[string]string `json:"tags,omitempty"`
 	Type       *string            `json:"type,omitempty"`
-	Zones      *[]string          `json:"zones,omitempty"`
+	Zones      *zones.Schema      `json:"zones,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/model_diskpoolcreateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/model_diskpoolcreateproperties.go
@@ -1,11 +1,15 @@
 package diskpools
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type DiskPoolCreateProperties struct {
-	AdditionalCapabilities *[]string `json:"additionalCapabilities,omitempty"`
-	AvailabilityZones      *[]string `json:"availabilityZones,omitempty"`
-	Disks                  *[]Disk   `json:"disks,omitempty"`
-	SubnetId               string    `json:"subnetId"`
+	AdditionalCapabilities *[]string     `json:"additionalCapabilities,omitempty"`
+	AvailabilityZones      *zones.Schema `json:"availabilityZones,omitempty"`
+	Disks                  *[]Disk       `json:"disks,omitempty"`
+	SubnetId               string        `json:"subnetId"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/model_diskpoolproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/model_diskpoolproperties.go
@@ -1,11 +1,15 @@
 package diskpools
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type DiskPoolProperties struct {
 	AdditionalCapabilities *[]string          `json:"additionalCapabilities,omitempty"`
-	AvailabilityZones      []string           `json:"availabilityZones"`
+	AvailabilityZones      zones.Schema       `json:"availabilityZones"`
 	Disks                  *[]Disk            `json:"disks,omitempty"`
 	ProvisioningState      ProvisioningStates `json:"provisioningState"`
 	Status                 OperationalStatus  `json:"status"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.45.0
+# github.com/hashicorp/go-azure-helpers v0.46.0
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/lang/dates
@@ -180,7 +180,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20221025.1113207
+# github.com/hashicorp/go-azure-sdk v0.20221028.1081410
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR:

* Updates to `v0.46.0` of `github.com/hashicorp/go-azure-helpers`
* Updates to `v0.20221028.1081410` of `github.com/hashicorp/go-azure-sdk`
* Updates usages of `zones.Expand` -> `zones.ExpandUntyped` (since `zones.Expand` now requires a Typed object)
* Updates usages of `zones.Flatten` -> `zones.FlattenUntyped` (since `zones.Flatten` now requires a Typed object)