### PR TITLE
`VirtualMachineScaleSetTerminationNotificationSchema` - add feature flag for `ConflictsWith`

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1933,8 +1933,12 @@ func VirtualMachineScaleSetTerminationNotificationSchema() *pluginsdk.Schema {
 				},
 			},
 		},
-		// TODO remove ConflictsWith in 4.0
-		ConflictsWith: []string{"terminate_notification"},
+		ConflictsWith: func() []string {
+			if !features.FourPointOhBeta() {
+				return []string{"terminate_notification"}
+			}
+			return []string{}
+		}(),
 	}
 }
 


### PR DESCRIPTION
Apply function pattern instead of using comment for `ConflictsWith` in `VirtualMachineScaleSetTerminationNotificationSchema`, similar to:
https://github.com/hashicorp/terraform-provider-azurerm/blob/262049d573c34b4e3f61d977ff7e76c3f2213e7a/internal/services/compute/virtual_machine_scale_set.go#L187-L192
o.w. the provider throws error that ConflictsWith could not find the specified field when enabling 4.0 flag