### PR TITLE
Use Page Blob in tests of Gallery Application Version

### DIFF
--- a/internal/services/compute/gallery_application_version_resource_test.go
+++ b/internal/services/compute/gallery_application_version_resource_test.go
@@ -305,8 +305,8 @@ resource "azurerm_storage_blob" "test" {
   name                   = "scripts"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "[scripts file content]"
+  type                   = "Page" # Use Page Blob as a workaround to UnmanagedStorageAccount quota issue
+  size                   = 512
 }
 
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1548,16 +1548,16 @@ resource "azurerm_storage_blob" "test" {
   name                   = "script"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_storage_blob" "test2" {
   name                   = "script2"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script2"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_shared_image_gallery" "test" {

--- a/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -3182,16 +3182,16 @@ resource "azurerm_storage_blob" "test" {
   name                   = "script"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_storage_blob" "test2" {
   name                   = "script2"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script2"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_shared_image_gallery" "test" {

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1900,16 +1900,16 @@ resource "azurerm_storage_blob" "test" {
   name                   = "script"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_storage_blob" "test2" {
   name                   = "script2"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script2"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_shared_image_gallery" "test" {

--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -3646,16 +3646,16 @@ resource "azurerm_storage_blob" "test" {
   name                   = "script"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_storage_blob" "test2" {
   name                   = "script2"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "script2"
+  type                   = "Page"
+  size                   = 512
 }
 
 resource "azurerm_shared_image_gallery" "test" {


### PR DESCRIPTION
`UnmanagedStorageAccountCount` limits the quota when creating Gallery Application Version with Block Blob, which cause some tests to fail intermittently due to below error. Use Page Blob as a workaround
`Error: waiting for creation of Gallery Application Version: (Version Name "0.0.1" / Application Name "acctest-app-221026002219818373" / Gallery Name "acctestsig221026002219818373" / Resource Group "acctest-compute-221026002219818373"): Code="GalleryApplicationVersionInternalError" Message="{\r\n  \"error\": {\r\n    \"innererror\": {},\r\n    \"code\": \"OperationNotAllowed\",\r\n    \"message\": \"Operation could not be completed as it results in exceeding approved UnmanagedStorageAccountCount quota.`

Affected tests: (TestAccGalleryApplicationVersion_|TestAccLinuxVirtualMachine_otherGalleryApplication|TestAccLinuxVirtualMachineScaleSet_otherGalleryApplication|TestAccWindowsVirtualMachine_otherGalleryApplication|TestAccWindowsVirtualMachineScaleSet_otherGalleryApplication)