### PR TITLE
`azurerm_kubernetes_cluster` - Make sure `auto_scaler_profile.expander` has a default value

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -125,7 +125,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"expander": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Computed: true,
+							Default:  string(managedclusters.ExpanderRandom),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(managedclusters.ExpanderLeastNegativewaste),
 								string(managedclusters.ExpanderMostNegativepods),


### PR DESCRIPTION
Fixes #19034

## Acceptance Test:
Locally the expanded test succeeded, a test run on TC has shown good results:

![image](https://user-images.githubusercontent.com/8375124/198865628-17b4f24e-afe9-4a12-8685-4ea70b08f50e.jpeg)

```bash
❯ go install && make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_autoScalingProfile'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesCluster_autoScalingProfile -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_autoScalingProfile
=== PAUSE TestAccKubernetesCluster_autoScalingProfile
=== CONT  TestAccKubernetesCluster_autoScalingProfile
--- PASS: TestAccKubernetesCluster_autoScalingProfile (955.94s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    957.806s
```