### PR TITLE
`azurerm_kubernetes_cluster` - Fix tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2231,18 +2231,19 @@ resource "azurerm_kubernetes_cluster" "test" {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
-
-  depends_on = [
-    azurerm_role_assignment.test
-  ]
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_DS2_v2"
+  vm_size               = "Standard_D2s_v3"
   node_count            = 1
   host_group_id         = azurerm_dedicated_host_group.test.id
+
+  depends_on = [
+    azurerm_role_assignment.test,
+    azurerm_dedicated_host.test
+  ]
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -268,7 +268,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   default_node_pool {
     name          = "default"
     node_count    = 1
-    vm_size       = "Standard_DS2_v2"
+    vm_size       = "Standard_D2s_v3"
     host_group_id = azurerm_dedicated_host_group.test.id
   }
 
@@ -278,7 +278,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   depends_on = [
-    azurerm_role_assignment.test
+    azurerm_role_assignment.test,
+    azurerm_dedicated_host.test
   ]
 }
   `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/containers/kubernetes_cluster_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_upgrade_test.go
@@ -136,7 +136,7 @@ func TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails(t *testing.
 		data.ImportStep(),
 		{
 			Config:      r.upgradeControlPlaneDefaultNodePoolConfig(data, olderKubernetesVersion, currentKubernetesVersion),
-			ExpectError: regexp.MustCompile("Node Pools cannot use a version of Kubernetes that is not supported on the Control Plane."),
+			ExpectError: regexp.MustCompile(fmt.Sprintf("Node pool version %s and control plane version %s are incompatible.", currentKubernetesVersion, olderKubernetesVersion)),
 		},
 	})
 }


### PR DESCRIPTION
Fixes 2 tests:
- `TestAccKubernetesCluster_upgradeNodePoolBeforeControlPlaneFails`
- `TestAccKubernetesCluster_dedicatedHost`

I tried my best for `TestAccKubernetesClusterNodePool_dedicatedHost` but it didn't work out unfortunately.

TODO:
- [x] Run the 2 tests successful based on the latest version on TC

<img width="734" alt="Screenshot 2022-10-31 at 13 13 49" src="https://user-images.githubusercontent.com/8375124/199005440-987ec2c6-baf9-4bbe-a91c-0eec473ff254.png">
