### PR TITLE
`azurerm_public_ip_prefix`: skip `TestAccPublicIpPrefix_prefixLength24`

### DIFF
--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -116,6 +116,7 @@ func TestAccPublicIpPrefix_prefixLength31(t *testing.T) {
 func TestAccPublicIpPrefix_prefixLength24(t *testing.T) {
 	// NOTE: This test will fail unless the subscription is updated
 	//        to accept a minimum PrefixLength of 24
+	t.Skip("skip for test subscription's `Public IPv4 Prefix Length` is 28")
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixResource{}
 

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -118,7 +118,6 @@ func TestAccPublicIpPrefix_prefixLength24(t *testing.T) {
 	//        to accept a minimum PrefixLength of 24
 	// more detail about [public ip limits](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#limits)
 	// you can submit a support request to increase the limit in [Azure Portal](https://learn.microsoft.com/en-us/azure/networking/check-usage-against-limits#azure-portal)
-	t.Skip("skip for test subscription's `Public IPv4 Prefix Length` is 28")
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixResource{}
 

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -116,6 +116,8 @@ func TestAccPublicIpPrefix_prefixLength31(t *testing.T) {
 func TestAccPublicIpPrefix_prefixLength24(t *testing.T) {
 	// NOTE: This test will fail unless the subscription is updated
 	//        to accept a minimum PrefixLength of 24
+	// more detail about [public ip limits](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#limits)
+	// you can submit a support request to increase the limit in [Azure Portal](https://learn.microsoft.com/en-us/azure/networking/check-usage-against-limits#azure-portal)
 	t.Skip("skip for test subscription's `Public IPv4 Prefix Length` is 28")
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixResource{}
@@ -184,6 +186,7 @@ func TestAccPublicIpPrefix_zonesSingle(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+
 func TestAccPublicIpPrefix_zonesMultiple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixResource{}
@@ -360,6 +363,7 @@ resource "azurerm_public_ip_prefix" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
+
 func (PublicIPPrefixResource) zonesMultiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {


### PR DESCRIPTION
## Background Info
This Test needs a subscription to be updated to accept a minimum PrefixLength of 24, but a subscription in TeamCity with a Prefix Length of 28. add a skip to it.


## Current Test Result
```
        Error: creating/Updating Public Ip Prefix: (Public I P Prefixe Name "acctestpublicipprefix-220915005537181309" / Resource Group "acctestRG-220915005537181309"): network.PublicIPPrefixesClient#CreateOrUpdate:
 Failure sending request: StatusCode=400 -- Original Error: 
Code="SpecifiedPrefixLengthNotSupported" 
Message="Specified PrefixLength 24 for PublicIpPrefix /subscriptions/*******/resourceGroups/acctestRG-220915005537181309/providers/Microsoft.Network/publicIPPrefixes/acctestpublicipprefix-220915005537181309
 is outside limits. Minimum PrefixLength 28 Maximum PrefixLength 31."
 Details=[]
```