### PR TITLE
`azurerm_app_configuration_feature` - add feature name validation

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -62,7 +62,7 @@ func (k FeatureResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			ValidateFunc: validate.AppConfigurationFeatureName,
 		},
 		"etag": {
 			Type:     pluginsdk.TypeString,

--- a/internal/services/appconfiguration/validate/app_configuration_feature_name.go
+++ b/internal/services/appconfiguration/validate/app_configuration_feature_name.go
@@ -1,0 +1,25 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func AppConfigurationFeatureName(input interface{}, key string) ([]string, []error) {
+	v, ok := input.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", key)}
+	}
+
+	if idx := strings.Index(v, "%"); idx != -1 {
+		return nil, []error{fmt.Errorf(`character "%%" is not allowed in %q`, key)}
+	}
+
+	if idx := strings.Index(v, ":"); idx != -1 {
+		return nil, []error{fmt.Errorf(`character ":" is not allowed in %q`, key)}
+	}
+
+	return validation.StringIsNotWhiteSpace(input, key)
+}


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/19027

Add validation for name property which not allow `%` and `:` character. In Portal:
![image](https://user-images.githubusercontent.com/104055472/198962158-c5594cb8-cda6-4b56-a670-e7e2ca23c48e.png)

---
test result:
![image](https://user-images.githubusercontent.com/104055472/198965719-8daec09a-80a2-4b30-8381-33beb3f1938c.png)
