### PR TITLE
`azurerm_mariadb_server` and `azurerm_mysql_flexible_server` - Fix acc test failures for `TestAccMariaDbServer_createPointInTimeRestore` and `TestAccMySqlFlexibleServer_updateMaintenanceWindow`

### DIFF
--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -188,7 +188,7 @@ func TestAccMariaDbServer_createPointInTimeRestore(t *testing.T) {
 		data.ImportStep("administrator_login_password"), // not returned as sensitive
 		{
 			PreConfig: func() { time.Sleep(restoreTime.Sub(time.Now().Add(-7 * time.Minute))) },
-			Config:    r.createPointInTimeRestore(data, version, restoreTime.Format(time.RFC3339)),
+			Config:    r.createPointInTimeRestore(data, version, restoreTime.Add(5 * time.Second).Format(time.RFC3339)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That("azurerm_mariadb_server.restore").ExistsInAzure(r),

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -188,7 +188,7 @@ func TestAccMariaDbServer_createPointInTimeRestore(t *testing.T) {
 		data.ImportStep("administrator_login_password"), // not returned as sensitive
 		{
 			PreConfig: func() { time.Sleep(restoreTime.Sub(time.Now().Add(-7 * time.Minute))) },
-			Config:    r.createPointInTimeRestore(data, version, restoreTime.Add(5 * time.Second).Format(time.RFC3339)),
+			Config:    r.createPointInTimeRestore(data, version, restoreTime.Add(5*time.Second).Format(time.RFC3339)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That("azurerm_mariadb_server.restore").ExistsInAzure(r),

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -390,7 +390,6 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 		if err != nil {
 			return fmt.Errorf("updating Mysql Flexible Server %q maintenance window (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
-
 		if err := mwFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for the update of the Mysql Flexible Server %q maintenance window (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
@@ -406,7 +405,7 @@ func mySqlFlexibleServerCreationRefreshFunc(ctx context.Context, client *mysqlfl
 		resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return resp, "Pending", err
+				return resp, "Pending", nil
 			}
 			return resp, "Error", err
 		}


### PR DESCRIPTION
- For test case `TestAccMariaDbServer_createPointInTimeRestore` failed with "The value '10/31/2022 1:08:55 AM' for configuration 'PointInTime' is not valid. The allFowed values are '> 10/31/2022 1:08:55 AM and < 10/31/2022 1:16:29 AM'.", so add 5 seconds to fix the error.

- Fix test case `TestAccMySqlFlexibleServer_updateMaintenanceWindow` failed with "The Resource 'Microsoft.DBforMySQL/flexibleServers/acctest-fs-221031041020484194' under resource group 'acctestRG-mysql-221031041020484194' was not found", while waiting for resource creation to complete, if the resource is not found,  need to return nil instead of error.