### PR TITLE
`azurerm_function_app_host_keys` - support for `webpubsub_extension_key`

### DIFF
--- a/internal/services/web/function_app_host_keys_data_source.go
+++ b/internal/services/web/function_app_host_keys_data_source.go
@@ -57,6 +57,12 @@ func dataSourceFunctionAppHostKeys() *pluginsdk.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"webpubsub_extension_key": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -114,6 +120,12 @@ func dataSourceFunctionAppHostKeysRead(d *pluginsdk.ResourceData, meta interface
 			durableTaskExtensionKey = *v
 		}
 		d.Set("durabletask_extension_key", durableTaskExtensionKey)
+
+		webPubSubExtensionKey := ""
+		if v, ok := res.SystemKeys["webpubsub_extension"]; ok {
+			webPubSubExtensionKey = *v
+		}
+		d.Set("webpubsub_extension_key", webPubSubExtensionKey)
 
 		return nil
 	})

--- a/website/docs/d/function_app_host_keys.html.markdown
+++ b/website/docs/d/function_app_host_keys.html.markdown
@@ -42,3 +42,5 @@ The following arguments are supported:
 - `signalr_extension_key` - Function App resource's SignalR Extension system key.
 
 - `durabletask_extension_key` - Function App resource's Durable Task Extension system key.
+
+- `webpubsub_extension_key` - Function App resource's Web PubSub Extension system key.


### PR DESCRIPTION
Fix #15587 similar to #10823