### PR TITLE
Fix acctest `*VirtualMachine_orchestratedWithPlatformFaultDomain`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_orchestrated_test.go
@@ -180,6 +180,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   platform_fault_domain_count = 2
+  single_placement_group      = false
 
   tags = {
     ENV = "Test"

--- a/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_orchestrated_test.go
@@ -179,6 +179,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   platform_fault_domain_count = 2
+  single_placement_group      = false
 
   tags = {
     ENV = "Test"


### PR DESCRIPTION
`single_placement_group` is automatically decided by server when not set, which causes the below issue when server set it to `true` (Seems to be a recent change but as we see this error, the value should be `false` anyway when `platform_fault_domain` is specified within the VM associated with the orchestrated VMSS). Fixing the tests by explicitly set it to `false`.
`Cannot set 'platformFaultDomain' on Virtual Machine '***' because the Virtual Machine Scale Set '***' that it references has 'singlePlacementGroup' = true.`