### PR TITLE
`azurerm_mssql_database` - Fix acctest failure for test case`TestAccMsSqlDatabase_elasticPool`

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -552,7 +552,7 @@ func resourceMsSqlDatabaseRead(d *pluginsdk.ResourceData, meta interface{}) erro
 				return err
 			}
 			d.Set("maintenance_configuration_name", maintenanceConfigId.ResourceName)
-		}else {
+		} else {
 			d.Set("maintenance_configuration_name", "SQL_Default")
 		}
 		d.Set("ledger_enabled", ledgerEnabled)

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -164,13 +164,6 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
-	maintenanceName := "SQL_Default"
-	if d.Get("elastic_pool_id").(string) == "" && d.Get("maintenance_configuration_name").(string) != "" {
-		// get maintenance name only if elastic pool is not used
-		maintenanceName = d.Get("maintenance_configuration_name").(string)
-	}
-	maintenanceConfigId := publicmaintenanceconfigurations.NewPublicMaintenanceConfigurationID(serverId.SubscriptionId, maintenanceName)
-
 	ledgerEnabled := d.Get("ledger_enabled").(bool)
 
 	// When databases are replicating, the primary cannot have a SKU belonging to a higher service tier than any of its
@@ -243,7 +236,6 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 			SampleName:                       sql.SampleName(d.Get("sample_name").(string)),
 			RequestedBackupStorageRedundancy: sql.RequestedBackupStorageRedundancy(d.Get("storage_account_type").(string)),
 			ZoneRedundant:                    utils.Bool(d.Get("zone_redundant").(bool)),
-			MaintenanceConfigurationID:       utils.String(maintenanceConfigId.ID()),
 			IsLedgerOn:                       utils.Bool(ledgerEnabled),
 		},
 
@@ -259,6 +251,16 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 	}
 	if _, dbok := d.GetOk("restore_dropped_database_id"); ok && createMode.(string) == string(sql.CreateModeRestore) && !dbok {
 		return fmt.Errorf("'restore_dropped_database_id' is required for create_mode %s", createMode.(string))
+	}
+
+	// we should not specify the value of `maintenance_configuration_name` when `elastic_pool_id` is set since its value depends on the elastic pool's `maintenance_configuration_name` value.
+	if _, ok := d.GetOk("elastic_pool_id"); !ok {
+		// set default value here because `elastic_pool_id` is not specified, API returns default value `SQL_Default` for `maintenance_configuration_name`
+		maintenanceConfigId := publicmaintenanceconfigurations.NewPublicMaintenanceConfigurationID(serverId.SubscriptionId, "SQL_Default")
+		if v, ok := d.GetOk("maintenance_configuration_name"); ok {
+			maintenanceConfigId = publicmaintenanceconfigurations.NewPublicMaintenanceConfigurationID(serverId.SubscriptionId, v.(string))
+		}
+		params.MaintenanceConfigurationID = utils.String(maintenanceConfigId.ID())
 	}
 
 	params.DatabaseProperties.CreateMode = sql.CreateMode(createMode.(string))
@@ -546,15 +548,17 @@ func resourceMsSqlDatabaseRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		if props.IsLedgerOn != nil {
 			ledgerEnabled = *props.IsLedgerOn
 		}
-		if props.ElasticPoolID == nil {
-			maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationID(*props.MaintenanceConfigurationID)
+
+		configurationName := ""
+		if v := props.MaintenanceConfigurationID; v != nil {
+			maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationID(*v)
 			if err != nil {
 				return err
 			}
-			d.Set("maintenance_configuration_name", maintenanceConfigId.ResourceName)
-		} else {
-			d.Set("maintenance_configuration_name", "SQL_Default")
+			configurationName = maintenanceConfigId.ResourceName
 		}
+		d.Set("maintenance_configuration_name", configurationName)
+
 		d.Set("ledger_enabled", ledgerEnabled)
 	}
 

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -552,6 +552,8 @@ func resourceMsSqlDatabaseRead(d *pluginsdk.ResourceData, meta interface{}) erro
 				return err
 			}
 			d.Set("maintenance_configuration_name", maintenanceConfigId.ResourceName)
+		}else {
+			d.Set("maintenance_configuration_name", "SQL_Default")
 		}
 		d.Set("ledger_enabled", ledgerEnabled)
 	}


### PR DESCRIPTION
After the [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/18321/files) is merged, `TestAccMsSqlDatabase_elasticPool` fails with the following error. In this PR, `maintenance_configuration_name` was  not set value in read() when `elastic_pool_id` is specified causing the following error. So submitted this PR to fix both acc test failure and issue [19080](https://github.com/hashicorp/terraform-provider-azurerm/issues/19080).
```
testcase.go:110: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=1) {
(string) (len=30) "maintenance_configuration_name": (string) (len=11) "SQL_Default"
}
```
Test results:
![image](https://user-images.githubusercontent.com/39109137/199440248-cec71a67-d841-4a3e-b337-93c6aa9c6653.png)
