### PR TITLE
Docs: data.azurerm_management_group requires name or display_name in example

### DIFF
--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -101,7 +101,7 @@ data "azurerm_client_config" "example" {
 }
 
 data "azurerm_management_group" "example" {
-  name               = "00000000-0000-0000-0000-000000000000"
+  name = "00000000-0000-0000-0000-000000000000"
 }
 
 resource "azurerm_role_definition" "example" {

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -101,6 +101,7 @@ data "azurerm_client_config" "example" {
 }
 
 data "azurerm_management_group" "example" {
+  name               = "00000000-0000-0000-0000-000000000000"
 }
 
 resource "azurerm_role_definition" "example" {


### PR DESCRIPTION
While following the example I found an issue with the docs were the example provided does not include a required argument.
Error: "name": one of `display_name,group_id,name` must be specified