### PR TITLE
`azurerm_sentinel_alert_rule_fusion` - support for `source`block

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
@@ -63,7 +63,7 @@ func resourceSentinelAlertRuleFusion() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"source_setting": {
+			"source": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				// Service will auto-fill this if not given in request, based on the "alert_rule_template_guid".
@@ -80,7 +80,7 @@ func resourceSentinelAlertRuleFusion() *pluginsdk.Resource {
 							Optional: true,
 							Default:  true,
 						},
-						"source_sub_type": {
+						"sub_type": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
 							Elem: &pluginsdk.Resource{
@@ -154,7 +154,7 @@ func resourceSentinelAlertRuleFusionCreateUpdate(d *pluginsdk.ResourceData, meta
 		FusionAlertRuleProperties: &securityinsight.FusionAlertRuleProperties{
 			AlertRuleTemplateName: utils.String(d.Get("alert_rule_template_guid").(string)),
 			Enabled:               utils.Bool(d.Get("enabled").(bool)),
-			SourceSettings:        expandFusionSourceSettings(d.Get("source_setting").([]interface{})),
+			SourceSettings:        expandFusionSourceSettings(d.Get("source").([]interface{})),
 		},
 	}
 
@@ -212,8 +212,8 @@ func resourceSentinelAlertRuleFusionRead(d *pluginsdk.ResourceData, meta interfa
 	if prop := rule.FusionAlertRuleProperties; prop != nil {
 		d.Set("enabled", prop.Enabled)
 		d.Set("alert_rule_template_guid", prop.AlertRuleTemplateName)
-		if err := d.Set("source_setting", flattenFusionSourceSettings(prop.SourceSettings)); err != nil {
-			return fmt.Errorf("setting `source_setting`: %v", err)
+		if err := d.Set("source", flattenFusionSourceSettings(prop.SourceSettings)); err != nil {
+			return fmt.Errorf("setting `source`: %v", err)
 		}
 	}
 
@@ -249,7 +249,7 @@ func expandFusionSourceSettings(input []interface{}) *[]securityinsight.FusionSo
 		setting := securityinsight.FusionSourceSettings{
 			Enabled:        utils.Bool(e["enabled"].(bool)),
 			SourceName:     utils.String(e["name"].(string)),
-			SourceSubTypes: expandFusionSourceSubTypes(e["source_sub_type"].([]interface{})),
+			SourceSubTypes: expandFusionSourceSubTypes(e["sub_type"].([]interface{})),
 		}
 		result = append(result, setting)
 	}
@@ -327,9 +327,9 @@ func flattenFusionSourceSettings(input *[]securityinsight.FusionSourceSettings) 
 		}
 
 		output = append(output, map[string]interface{}{
-			"name":            name,
-			"enabled":         enabled,
-			"source_sub_type": flattenFusionSourceSubTypes(e.SourceSubTypes),
+			"name":     name,
+			"enabled":  enabled,
+			"sub_type": flattenFusionSourceSubTypes(e.SourceSubTypes),
 		})
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
@@ -95,7 +95,7 @@ func resourceSentinelAlertRuleFusion() *pluginsdk.Resource {
 										Optional: true,
 										Default:  true,
 									},
-									"enabled_severities": {
+									"severities_allowed": {
 										Type:     pluginsdk.TypeSet,
 										Required: true,
 										MinItems: 1,
@@ -270,7 +270,7 @@ func expandFusionSourceSubTypes(input []interface{}) *[]securityinsight.FusionSo
 			Enabled:           utils.Bool(e["enabled"].(bool)),
 			SourceSubTypeName: utils.String(e["name"].(string)),
 			SeverityFilters: &securityinsight.FusionSubTypeSeverityFilter{
-				Filters: expandFusionSubTypeSeverityFiltersItems(e["enabled_severities"].(*pluginsdk.Set).List()),
+				Filters: expandFusionSubTypeSeverityFiltersItems(e["severities_allowed"].(*pluginsdk.Set).List()),
 			},
 		}
 		result = append(result, setting)
@@ -362,7 +362,7 @@ func flattenFusionSourceSubTypes(input *[]securityinsight.FusionSourceSubTypeSet
 		output = append(output, map[string]interface{}{
 			"name":               name,
 			"enabled":            enabled,
-			"enabled_severities": enabledSeverities,
+			"severities_allowed": enabledSeverities,
 		})
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -176,52 +176,52 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
     name    = "Alert providers"
     enabled = %[3]t
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Active Directory Identity Protection"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft 365 Defender"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Cloud App Security"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Defender"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Endpoint"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Identity"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Defender for IoT"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Office 365"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Sentinel scheduled analytics rules"
       enabled            = %[3]t
     }
     sub_type {
-      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      severities_allowed = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Sentinel NRT analytic rules"
       enabled            = %[3]t
     }

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -168,59 +168,59 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%[2]d"
   log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
-  source_setting {
+  source {
     name    = "Anomalies"
     enabled = %[3]t
   }
-  source_setting {
+  source {
     name    = "Alert providers"
     enabled = %[3]t
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Active Directory Identity Protection"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft 365 Defender"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Cloud App Security"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Defender"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Endpoint"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Identity"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Defender for IoT"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Microsoft Defender for Office 365"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Sentinel scheduled analytics rules"
       enabled            = %[3]t
     }
-    source_sub_type {
+    sub_type {
       enabled_severities = ["High", "Informational", "Low", "Medium"]
       name               = "Azure Sentinel NRT analytic rules"
       enabled            = %[3]t

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -31,13 +31,27 @@ func TestAccSentinelAlertRuleFusion_basic(t *testing.T) {
 	})
 }
 
-func TestAccSentinelAlertRuleFusion_complete(t *testing.T) {
+func TestAccSentinelAlertRuleFusion_disable(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_fusion", "test")
 	r := SentinelAlertRuleFusionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.disabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -46,27 +60,19 @@ func TestAccSentinelAlertRuleFusion_complete(t *testing.T) {
 	})
 }
 
-func TestAccSentinelAlertRuleFusion_update(t *testing.T) {
+func TestAccSentinelAlertRuleFusion_sourceSetting(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_alert_rule_fusion", "test")
 	r := SentinelAlertRuleFusionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.sourceSetting(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
 		{
-			Config: r.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
+			Config: r.sourceSetting(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -131,7 +137,7 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r SentinelAlertRuleFusionResource) complete(data acceptance.TestData) string {
+func (r SentinelAlertRuleFusionResource) disabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -147,6 +153,81 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
   enabled                    = false
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r SentinelAlertRuleFusionResource) sourceSetting(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azurerm_sentinel_alert_rule_template" "test" {
+  display_name               = "Advanced Multistage Attack Detection"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+}
+
+resource "azurerm_sentinel_alert_rule_fusion" "test" {
+  name                       = "acctest-SentinelAlertRule-Fusion-%[2]d"
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+  source_setting {
+    name    = "Anomalies"
+    enabled = %[3]t
+  }
+  source_setting {
+    name    = "Alert providers"
+    enabled = %[3]t
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Azure Active Directory Identity Protection"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Microsoft 365 Defender"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Microsoft Cloud App Security"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Azure Defender"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Microsoft Defender for Endpoint"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Microsoft Defender for Identity"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Azure Defender for IoT"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Microsoft Defender for Office 365"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Azure Sentinel scheduled analytics rules"
+      enabled            = %[3]t
+    }
+    source_sub_type {
+      enabled_severities = ["High", "Informational", "Low", "Medium"]
+      name               = "Azure Sentinel NRT analytic rules"
+      enabled            = %[3]t
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, enabled)
 }
 
 func (r SentinelAlertRuleFusionResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -57,6 +57,28 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should this Sentinel Fusion Alert Rule be enabled? Defaults to `true`.
 
+* `source_setting` (Optional) One or more `source_setting` blocks as defined below.
+
+---
+
+A `source_setting` block supports the following:
+
+* `name` - (Required) The name of the Fusion source signal. Refer to Fusion alert rule template for supported values.
+
+* `enabled` - (Optional) Whether this source signal is enabled or disabled in Fusion detection? Defaults to `true`.
+
+* `source_sub_type` - (Optional) One or more `source_sub_type` blocks as defined below.
+
+---
+
+A `source_sub_type` block supports the following:
+
+* `name` - (Required) The Name of the source subtype under a given source signal in Fusion detection. Refer to Fusion alert rule template for supported values.
+
+* `enabled` - (Optional) Whether this source subtype under source signal is enabled or disabled in Fusion detection. Defaults to `true`.
+
+* `enabled_severities` - (Optional) A list of severities that are enabled for this source subtype consumed in Fusion detection. Possible values for each element are `High`, `Medium`, `Low`, `Informational`.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -77,7 +77,7 @@ A `sub_type` block supports the following:
 
 * `enabled` - (Optional) Whether this source subtype under source signal is enabled or disabled in Fusion detection. Defaults to `true`.
 
-* `enabled_severities` - (Optional) A list of severities that are enabled for this source subtype consumed in Fusion detection. Possible values for each element are `High`, `Medium`, `Low`, `Informational`.
+* `severities_allowed` - (Optional) A list of severities that are enabled for this source subtype consumed in Fusion detection. Possible values for each element are `High`, `Medium`, `Low`, `Informational`.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -57,21 +57,21 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should this Sentinel Fusion Alert Rule be enabled? Defaults to `true`.
 
-* `source_setting` (Optional) One or more `source_setting` blocks as defined below.
+* `source` (Optional) One or more `source` blocks as defined below.
 
 ---
 
-A `source_setting` block supports the following:
+A `source` block supports the following:
 
 * `name` - (Required) The name of the Fusion source signal. Refer to Fusion alert rule template for supported values.
 
 * `enabled` - (Optional) Whether this source signal is enabled or disabled in Fusion detection? Defaults to `true`.
 
-* `source_sub_type` - (Optional) One or more `source_sub_type` blocks as defined below.
+* `sub_type` - (Optional) One or more `sub_type` blocks as defined below.
 
 ---
 
-A `source_sub_type` block supports the following:
+A `sub_type` block supports the following:
 
 * `name` - (Required) The Name of the source subtype under a given source signal in Fusion detection. Refer to Fusion alert rule template for supported values.
 


### PR DESCRIPTION
Add new property `source_setting` for `azurerm_sentinel_alert_rule_fusion`.

In my first try, I've omit the `enabled` properties in the schema (see: https://github.com/hashicorp/terraform-provider-azurerm/commit/383de98afb4786c063a6048982478bfdb37f7248). Due to the API issue https://github.com/Azure/azure-rest-api-specs/issues/21387, it won't work.

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel -run=TestAccSentinelAlertRuleFusion_
=== RUN   TestAccSentinelAlertRuleFusion_basic
=== PAUSE TestAccSentinelAlertRuleFusion_basic
=== RUN   TestAccSentinelAlertRuleFusion_disable
=== PAUSE TestAccSentinelAlertRuleFusion_disable
=== RUN   TestAccSentinelAlertRuleFusion_sourceSetting
=== PAUSE TestAccSentinelAlertRuleFusion_sourceSetting
=== RUN   TestAccSentinelAlertRuleFusion_requiresImport
=== PAUSE TestAccSentinelAlertRuleFusion_requiresImport
=== CONT  TestAccSentinelAlertRuleFusion_basic
=== CONT  TestAccSentinelAlertRuleFusion_sourceSetting
=== CONT  TestAccSentinelAlertRuleFusion_requiresImport
=== CONT  TestAccSentinelAlertRuleFusion_disable
--- PASS: TestAccSentinelAlertRuleFusion_basic (185.42s)
--- PASS: TestAccSentinelAlertRuleFusion_requiresImport (230.13s)
--- PASS: TestAccSentinelAlertRuleFusion_sourceSetting (234.34s)
--- PASS: TestAccSentinelAlertRuleFusion_disable (258.68s)
PASS
```