### PR TITLE
`azurerm_virtual_machine_extension` `azurerm_virtual_machine_scale_set_extension` `azurerm_*_virtual_machine_scale_set` - support `protected_settings_from_key_vault`

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -237,6 +237,9 @@ func OrchestratedVirtualMachineScaleSetExtensionsSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringIsJSON,
 				},
 
+				// Need to check `protected_settings_from_key_vault` conflicting with `protected_settings` in iteration
+				"protected_settings_from_key_vault": protectedSettingsFromKeyVaultSchema(false),
+
 				"extensions_to_provision_after_vm_creation": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
@@ -1389,7 +1392,14 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 			extensionProps.Settings = settings
 		}
 
+		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVault(extensionRaw["protected_settings_from_key_vault"].([]interface{}))
+		extensionProps.ProtectedSettingsFromKeyVault = protectedSettingsFromKeyVault
+
 		if val, ok := extensionRaw["protected_settings"]; ok && val.(string) != "" {
+			if protectedSettingsFromKeyVault != nil {
+				return nil, false, fmt.Errorf("`protected_settings_from_key_vault` cannot be used with `protected_settings`")
+			}
+
 			protectedSettings, err := pluginsdk.ExpandJsonFromString(val.(string))
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to parse JSON for `protected_settings`: %+v", err)
@@ -1438,6 +1448,7 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 		forceUpdateTag := ""
 		provisionAfterExtension := make([]interface{}, 0)
 		protectedSettings := ""
+		var protectedSettingsFromKeyVault *compute.KeyVaultSecretReference
 		extPublisher := ""
 		extSettings := ""
 		extType := ""
@@ -1483,6 +1494,8 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 				}
 				extSettings = extSettingsRaw
 			}
+
+			protectedSettingsFromKeyVault = props.ProtectedSettingsFromKeyVault
 		}
 		// protected_settings isn't returned, so we attempt to get it from state otherwise set to empty string
 		if ext, ok := extensionsFromState[name]; ok {
@@ -1501,6 +1514,7 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *compute.VirtualM
 			"failure_suppression_enabled":               suppressFailures,
 			"extensions_to_provision_after_vm_creation": provisionAfterExtension,
 			"protected_settings":                        protectedSettings,
+			"protected_settings_from_key_vault":         flattenProtectedSettingsFromKeyVault(protectedSettingsFromKeyVault),
 			"publisher":                                 extPublisher,
 			"settings":                                  extSettings,
 			"type":                                      extType,

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_extensions_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_extensions_resource_test.go
@@ -134,6 +134,28 @@ func TestAccOrchestratedVirtualMachineScaleSet_extensionFailureSuppression(t *te
 	})
 }
 
+func TestAccOrchestratedVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionProtectedSettingsFromKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+		{
+			Config: r.extensionProtectedSettingsFromKeyVaultUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
 func (OrchestratedVirtualMachineScaleSetResource) extensionTemplateUpdated(data acceptance.TestData) string {
 	r := OrchestratedVirtualMachineScaleSetResource{}
 	return fmt.Sprintf(`
@@ -825,4 +847,132 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVault(data acceptance.TestData) string {
+	return r.extensionProtectedSettingsFromKeyVaultTemplate(data, 0)
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVaultUpdated(data acceptance.TestData) string {
+	return r.extensionProtectedSettingsFromKeyVaultTemplate(data, 1)
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVaultTemplate(data acceptance.TestData, index int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults       = false
+      purge_soft_delete_on_destroy          = false
+      purge_soft_deleted_keys_on_destroy    = false
+      purge_soft_deleted_secrets_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[3]d"
+  location = "%[2]s"
+}
+
+%[1]s
+
+resource "azurerm_key_vault" "test" {
+  count = 2
+
+  name                   = "acctestkv${count.index}%[4]s"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  tenant_id              = data.azurerm_client_config.current.tenant_id
+  sku_name               = "standard"
+  enabled_for_deployment = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  count = 2
+
+  name         = "secret"
+  value        = "{\"commandToExecute\":\"echo $HOSTNAME\"}"
+  key_vault_id = azurerm_key_vault.test[count.index].id
+}
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "Standard_D1_v2"
+
+  # Orchestrated VMSS allocation will timeout at service side due to extension, set instances to 0 to avoid the timeout
+  instances = 0
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[3]d"
+      admin_username       = "myadmin"
+
+      admin_ssh_key {
+        username   = "myadmin"
+        public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
+      }
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  extension {
+    name                 = "CustomScript"
+    publisher            = "Microsoft.Azure.Extensions"
+    type                 = "CustomScript"
+    type_handler_version = "2.1"
+
+    protected_settings_from_key_vault {
+      secret_url      = azurerm_key_vault_secret.test[%[5]d].id
+      source_vault_id = azurerm_key_vault.test[%[5]d].id
+    }
+  }
+}
+`, r.natgateway_template(data), data.Locations.Primary, data.RandomInteger, data.RandomString, index)
 }

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -1,0 +1,75 @@
+package compute
+
+import (
+	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/compute/2022-08-01/compute"
+)
+
+func protectedSettingsFromKeyVaultSchema(conflictsWithProtectedSettings bool) *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		ConflictsWith: func() []string {
+			if conflictsWithProtectedSettings {
+				return []string{"protected_settings"}
+			}
+			return []string{}
+		}(),
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"secret_url": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: keyVaultValidate.NestedItemId,
+				},
+
+				"source_vault_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: keyVaultValidate.VaultID,
+				},
+			},
+		},
+	}
+}
+
+func expandProtectedSettingsFromKeyVault(input []interface{}) *compute.KeyVaultSecretReference {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	return &compute.KeyVaultSecretReference{
+		SecretURL: utils.String(v["secret_url"].(string)),
+		SourceVault: &compute.SubResource{
+			ID: utils.String(v["source_vault_id"].(string)),
+		},
+	}
+}
+
+func flattenProtectedSettingsFromKeyVault(input *compute.KeyVaultSecretReference) []interface{} {
+	if input == nil {
+		return nil
+	}
+
+	secretUrl := ""
+	if input.SecretURL != nil {
+		secretUrl = *input.SecretURL
+	}
+
+	sourceVaultId := ""
+	if input.SourceVault != nil && input.SourceVault.ID != nil {
+		sourceVaultId = *input.SourceVault.ID
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"secret_url":      secretUrl,
+			"source_vault_id": sourceVaultId,
+		},
+	}
+}

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -99,7 +99,10 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 				Sensitive:        true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+				ConflictsWith:    []string{"protected_settings_from_key_vault"},
 			},
+
+			"protected_settings_from_key_vault": protectedSettingsFromKeyVaultSchema(true),
 
 			"tags": tags.Schema(),
 		},
@@ -152,12 +155,13 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 	extension := compute.VirtualMachineExtension{
 		Location: &location,
 		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
-			Publisher:               &publisher,
-			Type:                    &extensionType,
-			TypeHandlerVersion:      &typeHandlerVersion,
-			AutoUpgradeMinorVersion: &autoUpgradeMinor,
-			EnableAutomaticUpgrade:  &enableAutomaticUpgrade,
-			SuppressFailures:        &suppressFailure,
+			Publisher:                     &publisher,
+			Type:                          &extensionType,
+			TypeHandlerVersion:            &typeHandlerVersion,
+			AutoUpgradeMinorVersion:       &autoUpgradeMinor,
+			EnableAutomaticUpgrade:        &enableAutomaticUpgrade,
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
+			SuppressFailures:              &suppressFailure,
 		},
 		Tags: tags.Expand(t),
 	}
@@ -231,6 +235,7 @@ func resourceVirtualMachineExtensionsRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("type_handler_version", props.TypeHandlerVersion)
 		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
 		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
+		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
 
 		suppressFailure := false
 		if props.SuppressFailures != nil {

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -112,6 +112,28 @@ func TestAccVirtualMachineExtension_linuxDiagnostics(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineExtension_protectedSettingsFromKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
+	r := VirtualMachineExtensionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.protectedSettingsFromKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.protectedSettingsFromKeyVaultUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VirtualMachineExtensionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VirtualMachineExtensionID(state.ID)
 	if err != nil {
@@ -690,4 +712,102 @@ resource "azurerm_virtual_machine_extension" "test" {
 SETTINGS
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r VirtualMachineExtensionResource) protectedSettingsFromKeyVault(data acceptance.TestData) string {
+	return r.protectedSettingsFromKeyVaultTemplate(data, 0)
+}
+
+func (r VirtualMachineExtensionResource) protectedSettingsFromKeyVaultUpdated(data acceptance.TestData) string {
+	return r.protectedSettingsFromKeyVaultTemplate(data, 1)
+}
+
+func (VirtualMachineExtensionResource) protectedSettingsFromKeyVaultTemplate(data acceptance.TestData, index int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults       = false
+      purge_soft_delete_on_destroy          = false
+      purge_soft_deleted_keys_on_destroy    = false
+      purge_soft_deleted_secrets_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+%[1]s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  count = 2
+
+  name                   = "acctestkv${count.index}%[3]s"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  tenant_id              = data.azurerm_client_config.current.tenant_id
+  sku_name               = "standard"
+  enabled_for_deployment = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  count = 2
+
+  name         = "secret"
+  value        = "{\"commandToExecute\":\"echo $HOSTNAME\"}"
+  key_vault_id = azurerm_key_vault.test[count.index].id
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                 = "acctvme-%[2]d"
+  virtual_machine_id   = azurerm_linux_virtual_machine.test.id
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.1"
+
+  protected_settings_from_key_vault {
+    secret_url      = azurerm_key_vault_secret.test[%[4]d].id
+    source_vault_id = azurerm_key_vault.test[%[4]d].id
+  }
+}
+`, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomString, index)
 }

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -105,6 +105,8 @@ func resourceVirtualMachineScaleSetExtension() *pluginsdk.Resource {
 				DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
 			},
 
+			"protected_settings_from_key_vault": protectedSettingsFromKeyVaultSchema(true),
+
 			"provision_after_extensions": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -157,31 +159,30 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 	provisionAfterExtensionsRaw := d.Get("provision_after_extensions").([]interface{})
 	provisionAfterExtensions := utils.ExpandStringSlice(provisionAfterExtensionsRaw)
 
-	protectedSettings := map[string]interface{}{}
-	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
-		ps, err := pluginsdk.ExpandJsonFromString(protectedSettingsString)
-		if err != nil {
-			return fmt.Errorf("unable to parse `protected_settings`: %s", err)
-		}
-		protectedSettings = ps
-	}
-
 	props := compute.VirtualMachineScaleSetExtension{
 		Name: utils.String(id.ExtensionName),
 		VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-			Publisher:                utils.String(d.Get("publisher").(string)),
-			Type:                     utils.String(d.Get("type").(string)),
-			TypeHandlerVersion:       utils.String(d.Get("type_handler_version").(string)),
-			AutoUpgradeMinorVersion:  utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
-			EnableAutomaticUpgrade:   utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
-			SuppressFailures:         utils.Bool(d.Get("failure_suppression_enabled").(bool)),
-			ProtectedSettings:        protectedSettings,
-			ProvisionAfterExtensions: provisionAfterExtensions,
-			Settings:                 settings,
+			Publisher:                     utils.String(d.Get("publisher").(string)),
+			Type:                          utils.String(d.Get("type").(string)),
+			TypeHandlerVersion:            utils.String(d.Get("type_handler_version").(string)),
+			AutoUpgradeMinorVersion:       utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
+			EnableAutomaticUpgrade:        utils.Bool(d.Get("automatic_upgrade_enabled").(bool)),
+			SuppressFailures:              utils.Bool(d.Get("failure_suppression_enabled").(bool)),
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
+			ProvisionAfterExtensions:      provisionAfterExtensions,
+			Settings:                      settings,
 		},
 	}
 	if v, ok := d.GetOk("force_update_tag"); ok {
 		props.VirtualMachineScaleSetExtensionProperties.ForceUpdateTag = utils.String(v.(string))
+	}
+
+	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
+		protectedSettings, err := pluginsdk.ExpandJsonFromString(protectedSettingsString)
+		if err != nil {
+			return fmt.Errorf("unable to parse `protected_settings`: %s", err)
+		}
+		props.VirtualMachineScaleSetExtensionProperties.ProtectedSettings = &protectedSettings
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName, props)
@@ -233,6 +234,10 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 		}
 
 		props.ProtectedSettings = protectedSettings
+	}
+
+	if d.HasChange("protected_settings_from_key_vault") {
+		props.ProtectedSettingsFromKeyVault = expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{}))
 	}
 
 	if d.HasChange("provision_after_extensions") {
@@ -323,6 +328,7 @@ func resourceVirtualMachineScaleSetExtensionRead(d *pluginsdk.ResourceData, meta
 		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
 		d.Set("automatic_upgrade_enabled", props.EnableAutomaticUpgrade)
 		d.Set("force_update_tag", props.ForceUpdateTag)
+		d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
 		d.Set("provision_after_extensions", utils.FlattenStringSlice(props.ProvisionAfterExtensions))
 		d.Set("publisher", props.Publisher)
 		d.Set("type", props.Type)

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
@@ -148,6 +148,27 @@ func TestAccVirtualMachineScaleSetExtension_protectedSettings(t *testing.T) {
 	})
 }
 
+func TestAccVirtualMachineScaleSetExtension_protectedSettingsFromKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_extension", "test")
+	r := VirtualMachineScaleSetExtensionResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.protectedSettingsFromKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.protectedSettingsFromKeyVaultUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualMachineScaleSetExtension_protectedSettingsOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_extension", "test")
 	r := VirtualMachineScaleSetExtensionResource{}
@@ -361,6 +382,131 @@ resource "azurerm_virtual_machine_scale_set_extension" "test" {
   })
 }
 `, r.templateLinux(data), data.RandomInteger)
+}
+
+func (r VirtualMachineScaleSetExtensionResource) protectedSettingsFromKeyVault(data acceptance.TestData) string {
+	return r.protectedSettingsFromKeyVaultTemplate(data, 0)
+}
+
+func (r VirtualMachineScaleSetExtensionResource) protectedSettingsFromKeyVaultUpdated(data acceptance.TestData) string {
+	return r.protectedSettingsFromKeyVaultTemplate(data, 1)
+}
+
+func (VirtualMachineScaleSetExtensionResource) protectedSettingsFromKeyVaultTemplate(data acceptance.TestData, index int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults       = false
+      purge_soft_delete_on_destroy          = false
+      purge_soft_deleted_keys_on_destroy    = false
+      purge_soft_deleted_secrets_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%[2]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  count = 2
+
+  name                   = "acctestkv${count.index}%[3]s"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  tenant_id              = data.azurerm_client_config.current.tenant_id
+  sku_name               = "standard"
+  enabled_for_deployment = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  count = 2
+
+  name         = "secret"
+  value        = "{\"commandToExecute\":\"echo $HOSTNAME\"}"
+  key_vault_id = azurerm_key_vault.test[count.index].id
+}
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%[2]d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.1"
+
+  protected_settings_from_key_vault {
+    secret_url      = azurerm_key_vault_secret.test[%[4]d].id
+    source_vault_id = azurerm_key_vault.test[%[4]d].id
+  }
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString, index)
 }
 
 func (r VirtualMachineScaleSetExtensionResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
@@ -356,6 +356,28 @@ func TestAccWindowsVirtualMachineScaleSet_extensionOperationsDisabled(t *testing
 	})
 }
 
+func TestAccWindowsVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionProtectedSettingsFromKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.extensionProtectedSettingsFromKeyVaultUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func (r WindowsVirtualMachineScaleSetResource) extensionDoNotRunOnOverProvisionedMachines(data acceptance.TestData, enabled bool) string {
 	return fmt.Sprintf(`
 %s
@@ -1241,4 +1263,106 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   }
 }
 `, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVault(data acceptance.TestData) string {
+	return r.extensionProtectedSettingsFromKeyVaultTemplate(data, 0)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVaultUpdated(data acceptance.TestData) string {
+	return r.extensionProtectedSettingsFromKeyVaultTemplate(data, 1)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) extensionProtectedSettingsFromKeyVaultTemplate(data acceptance.TestData, index int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults       = false
+      purge_soft_delete_on_destroy          = false
+      purge_soft_deleted_keys_on_destroy    = false
+      purge_soft_deleted_secrets_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  count = 2
+
+  name                   = "acctestkv${count.index}%[2]s"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  tenant_id              = data.azurerm_client_config.current.tenant_id
+  sku_name               = "standard"
+  enabled_for_deployment = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  count = 2
+
+  name         = "secret"
+  value        = "{\"commandToExecute\":\"echo $HOSTNAME\"}"
+  key_vault_id = azurerm_key_vault.test[count.index].id
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                 = "CustomScript"
+    publisher            = "Microsoft.Compute"
+    type                 = "CustomScriptExtension"
+    type_handler_version = "1.10"
+
+    protected_settings_from_key_vault {
+      secret_url      = azurerm_key_vault_secret.test[%[3]d].id
+      source_vault_id = azurerm_key_vault.test[%[3]d].id
+    }
+  }
+}
+`, r.template(data), data.RandomString, index)
 }

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -350,6 +350,10 @@ An `extension` block supports the following:
 
 -> **NOTE:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
 
+* `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
+
+~> **Note:** `protected_settings_from_key_vault` cannot be used with `protected_settings`
+
 * `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
 
 * `settings` - (Optional) A JSON String which specifies Settings for the Extension.
@@ -483,6 +487,14 @@ A `plan` block supports the following:
 * `publisher` - (Required) Specifies the publisher of the image. Changing this forces a new resource to be created.
 
 * `product` - (Required) Specifies the product of the image from the marketplace. Changing this forces a new resource to be created.
+
+---
+
+A `protected_settings_from_key_vault` block supports the following:
+
+* `secret_url` - (Required) The URL to the Key Vault Secret which stores the protected settings.
+
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ---
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -301,6 +301,10 @@ An `extension` block supports the following:
 
 -> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. `TitleCase` vs `snakeCase`) depends on the Extension being used. Please refer to the documentation for the specific Orchestrated Virtual Machine Extension you're looking to use for more information.
 
+* `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
+
+~> **Note:** `protected_settings_from_key_vault` cannot be used with `protected_settings`
+
 * `failure_suppression_enabled` - (Optional) Should failures from the extension be suppressed? Possible values are `true` or `false`. Defaults to `false`.
 
 -> **NOTE:** Operational failures such as not connecting to the VM will not be suppressed regardless of the `failure_suppression_enabled` value.
@@ -384,6 +388,14 @@ A `plan` block supports the following:
 * `publisher` - (Required) Specifies the publisher of the image. Changing this forces a new resource to be created.
 
 * `product` - (Required) Specifies the product of the image from the marketplace. Changing this forces a new resource to be created.
+
+---
+
+A `protected_settings_from_key_vault` block supports the following:
+
+* `secret_url` - (Required) The URL to the Key Vault Secret which stores the protected settings.
+
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ---
 

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -165,7 +165,19 @@ az vm extension image list --location westus -o table
 
 ~> **Please Note:** Certain VM Extensions require that the keys in the `protected_settings` block are case sensitive. If you're seeing unhelpful errors, please ensure the keys are consistent with how Azure is expecting them (for instance, for the `JsonADDomainExtension` extension, the keys are expected to be in `TitleCase`.)
 
+* `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
+
+~> **Note:** `protected_settings_from_key_vault` cannot be used with `protected_settings`
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `protected_settings_from_key_vault` block supports the following:
+
+* `secret_url` - (Required) The URL to the Key Vault Secret which stores the protected settings.
+
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -92,11 +92,23 @@ az vmss extension image list --location westus -o table
 
 ~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
 
+* `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
+
+~> **Note:** `protected_settings_from_key_vault` cannot be used with `protected_settings`
+
 * `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
 
 * `settings` - (Optional) A JSON String which specifies Settings for the Extension.
 
 ~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+---
+
+A `protected_settings_from_key_vault` block supports the following:
+
+* `secret_url` - (Required) The URL to the Key Vault Secret which stores the protected settings.
+
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ## Attributes Reference
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -338,6 +338,10 @@ An `extension` block supports the following:
 
 -> **NOTE:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
 
+* `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
+
+~> **Note:** `protected_settings_from_key_vault` cannot be used with `protected_settings`
+
 * `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
 
 * `settings` - (Optional) A JSON String which specifies Settings for the Extension.
@@ -479,6 +483,14 @@ A `scale_in` block supports the following:
 * `rule` - (Optional) The scale-in policy rule that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled in. Possible values for the scale-in policy rules are `Default`, `NewestVM` and `OldestVM`, defaults to `Default`. For more information about scale in policy, please [refer to this doc](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy).
 
 * `force_deletion_enabled` - (Optional) Should the virtual machines chosen for removal be force deleted when the virtual machine scale set is being scaled-in? Possible values are `true` or `false`. Defaults to `false`.
+
+---
+
+A `protected_settings_from_key_vault` block supports the following:
+
+* `secret_url` - (Required) The URL to the Key Vault Secret which stores the protected settings.
+
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ---
 


### PR DESCRIPTION
- Currently we have `protected_settings` which is a Json encoded string to specify secret value for a VM/VMSS extension. This change is to add the support for `protected_settings_from_key_vault` which allows the extension to read the protected settings from a Key Vault Secret instead.

- Swagger:
[VM](https://github.com/Azure/azure-rest-api-specs/blob/0c21115ccacbbad11c4aa13a711e4990ebf07752/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/virtualMachine.json#L1961)
[VMSS](https://github.com/Azure/azure-rest-api-specs/blob/0c21115ccacbbad11c4aa13a711e4990ebf07752/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/virtualMachineScaleSet.json#L4553)
[protectedSettingsFromKeyVault (KeyVaultSecretReference)](https://github.com/Azure/azure-rest-api-specs/blob/0c21115ccacbbad11c4aa13a711e4990ebf07752/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/computeRPCommon.json#L689)

- Affected resources:
`azurerm_virtual_machine_extension`
`azurerm_virtual_machine_scale_set_extension`
`azurerm_linux_virtual_machine_scale_set`
`azurerm_windows_virtual_machine_scale_set`
`azurerm_orchestrated_virtual_machine_scale_set`