### PR TITLE
`azurerm_application_gate_way` - fix `url_path_map` constraint

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4376,6 +4376,10 @@ func expandApplicationGatewayURLPathMaps(d *pluginsdk.ResourceData, gatewayID st
 		defaultBackendHTTPSettingsName := v["default_backend_http_settings_name"].(string)
 		defaultRedirectConfigurationName := v["default_redirect_configuration_name"].(string)
 
+		if defaultBackendAddressPoolName == "" && defaultBackendHTTPSettingsName == "" && defaultRedirectConfigurationName == "" {
+			return nil, fmt.Errorf("both the `default_backend_address_pool_name` and `default_backend_http_settings_name` or `default_redirect_configuration_name` must be specified")
+		}
+
 		if defaultBackendAddressPoolName != "" && defaultRedirectConfigurationName != "" {
 			return nil, fmt.Errorf("Conflict between `default_backend_address_pool_name` and `default_redirect_configuration_name` (back-end pool not applicable when redirection specified)")
 		}

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -5913,11 +5913,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
-
-  tags = {
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_virtual_network" "test" {

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -380,6 +380,21 @@ func TestAccApplicationGateway_routingRedirect_pathBased(t *testing.T) {
 	})
 }
 
+func TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+	r := ApplicationGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.pathBasedRoutingwithRedirection(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApplicationGateway_customErrorConfigurations(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
 	r := ApplicationGatewayResource{}
@@ -3302,6 +3317,101 @@ resource "azurerm_application_gateway" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
+func (r ApplicationGatewayResource) pathBasedRoutingwithRedirection(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  path_rule_name                 = "${azurerm_virtual_network.test.name}-pathrule1"
+  url_path_map_name              = "${azurerm_virtual_network.test.name}-urlpath1"
+  redirect_configuration_name    = "${azurerm_virtual_network.test.name}-redirect"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_Small"
+    tier     = "Standard"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name               = local.request_routing_rule_name
+    rule_type          = "PathBasedRouting"
+    url_path_map_name  = local.url_path_map_name
+    http_listener_name = local.listener_name
+  }
+
+  redirect_configuration {
+    name                 = local.redirect_configuration_name
+    redirect_type        = "Permanent"
+    target_url           = "http://example.com"
+    include_path         = true
+    include_query_string = false
+  }
+
+  url_path_map {
+    name                                = local.url_path_map_name
+    default_redirect_configuration_name = local.redirect_configuration_name
+
+    path_rule {
+      name                       = local.path_rule_name
+      backend_address_pool_name  = local.backend_address_pool_name
+      backend_http_settings_name = local.http_setting_name
+
+      paths = [
+        "/test",
+      ]
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (r ApplicationGatewayResource) routingRedirect_httpListener(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -5803,6 +5913,11 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
+
+  tags = {
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
 }
 
 resource "azurerm_virtual_network" "test" {

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -483,6 +483,8 @@ A `url_path_map` block supports the following:
 
 * `default_redirect_configuration_name` - (Optional) The Name of the Default Redirect Configuration which should be used for this URL Path Map. Cannot be set if either `default_backend_address_pool_name` or `default_backend_http_settings_name` is set.
 
+-> **NOTE:** Both `default_backend_address_pool_name` and `default_backend_http_settings_name` or `default_redirect_configuration_name` should be specified.
+
 * `default_rewrite_rule_set_name` - (Optional) The Name of the Default Rewrite Rule Set which should be used for this URL Path Map. Only valid for v2 SKUs.
 
 * `path_rule` - (Required) One or more `path_rule` blocks as defined above.


### PR DESCRIPTION
fixes #18064

Test
---
```
TF_ACC=1 go test -v ./internal/services/network -run=TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection -timeout=600m
=== RUN   TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection
=== PAUSE TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection
=== CONT  TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection
--- PASS: TestAccApplicationGateway_routingRedirect_pathBasedWithRedirection (1505.70s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1505.717s
```