### PR TITLE
`azurerm_monitor_diagnostic_setting` - support `partner_solution_id`

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -287,7 +287,7 @@ func resourceMonitorDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	if !valid {
-		return fmt.Errorf("Either a `eventhub_authorization_rule_id`, `log_analytics_workspace_id` or `storage_account_id` or `partner_solution_id` must be set")
+		return fmt.Errorf("either a `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` or `storage_account_id` must be set")
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, diagnosticSettingId, parameters); err != nil {

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -86,6 +86,12 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 				ValidateFunc: storageValidate.StorageAccountID,
 			},
 
+			"partner_solution_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
 			"log_analytics_destination_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -266,6 +272,12 @@ func resourceMonitorDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, met
 		valid = true
 	}
 
+	partnerSolutionId := d.Get("partner_solution_id").(string)
+	if partnerSolutionId != "" {
+		parameters.Properties.MarketplacePartnerId = utils.String(partnerSolutionId)
+		valid = true
+	}
+
 	if v := d.Get("log_analytics_destination_type").(string); v != "" {
 		if workspaceId != "" {
 			parameters.Properties.LogAnalyticsDestinationType = &v
@@ -275,7 +287,7 @@ func resourceMonitorDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	if !valid {
-		return fmt.Errorf("Either a `eventhub_authorization_rule_id`, `log_analytics_workspace_id` or `storage_account_id` must be set")
+		return fmt.Errorf("Either a `eventhub_authorization_rule_id`, `log_analytics_workspace_id` or `storage_account_id` or `partner_solution_id` must be set")
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, diagnosticSettingId, parameters); err != nil {
@@ -354,6 +366,12 @@ func resourceMonitorDiagnosticSettingRead(d *pluginsdk.ResourceData, meta interf
 
 				storageAccountId = parsedId.ID()
 				d.Set("storage_account_id", storageAccountId)
+			}
+
+			partnerSolutionId := ""
+			if props.MarketplacePartnerId != nil && *props.MarketplacePartnerId != "" {
+				partnerSolutionId = *props.MarketplacePartnerId
+				d.Set("partner_solution_id", partnerSolutionId)
 			}
 
 			d.Set("log_analytics_destination_type", resp.Model.Properties.LogAnalyticsDestinationType)

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -102,6 +102,24 @@ func TestAccMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated(t *testing.T
 	})
 }
 
+func TestAccMonitorDiagnosticSetting_partnerSolution(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_diagnostic_setting", "test")
+	r := MonitorDiagnosticSettingResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.partnerSolution(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("partner_solution_id").Exists(),
+				check.That(data.ResourceName).Key("log.#").HasValue("2"),
+				check.That(data.ResourceName).Key("metric.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMonitorDiagnosticSetting_storageAccount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_diagnostic_setting", "test")
 	r := MonitorDiagnosticSettingResource{}
@@ -543,6 +561,71 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (MonitorDiagnosticSettingResource) partnerSolution(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctest%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_elastic_cloud_elasticsearch" "test" {
+  name                        = "acctest-elastic%[3]d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  sku_name                    = "ess-monthly-consumption_Monthly"
+  elastic_cloud_email_address = "user@example.com"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                = "acctest-DS-%[1]d"
+  target_resource_id  = azurerm_key_vault.test.id
+  partner_solution_id = azurerm_elastic_cloud_elasticsearch.test.id
+
+  log {
+    category = "AuditEvent"
+    enabled  = false
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  log {
+    category = "AzurePolicyEvaluationDetails"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
 }
 
 func (MonitorDiagnosticSettingResource) storageAccount(data acceptance.TestData) string {

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 -> **NOTE:** This can be sourced from [the `azurerm_eventhub_namespace_authorization_rule` resource](eventhub_namespace_authorization_rule.html) and is different from [a `azurerm_eventhub_authorization_rule` resource](eventhub_authorization_rule.html).
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
+-> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `log` - (Optional) One or more `log` blocks as defined below.
 
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent.
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
+-> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `metric` - (Optional) One or more `metric` blocks as defined below.
 
@@ -87,11 +87,15 @@ The following arguments are supported:
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where logs should be sent. Changing this forces a new resource to be created.
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
+-> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `log_analytics_destination_type` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
 
 -> **NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please [see the documentation](https://docs.microsoft.com/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
+
+* `partner_solution_id` - (Optional) The ID of the market partner solution where Diagnostics Data should be sent. For potential partner integrations, [click to learn more about partner integration](https://learn.microsoft.com/en-us/azure/partner-solutions/overview).
+
+-> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 ---
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/19076

Ref:
1. [swagger](https://github.com/Azure/azure-rest-api-specs/blob/591b17c5a50e7fc0ef09211197279e6d9f7ebc22/specification/monitor/resource-manager/Microsoft.Insights/preview/2021-05-01-preview/diagnosticsSettings_API.json#L319-L322)
2. [Microsoft docs](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/diagnostic-settings?tabs=portal#destinations)

Test:
```
make acctests SERVICE="monitor" TESTARGS="-parallel 20 -test.run=TestAccMonitorDiagnosticSetting_partnerSolution$" TESTTIMEOUT='1440m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorDiagnosticSetting_partnerSolution$ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDiagnosticSetting_partnerSolution
=== PAUSE TestAccMonitorDiagnosticSetting_partnerSolution
=== CONT  TestAccMonitorDiagnosticSetting_partnerSolution
--- PASS: TestAccMonitorDiagnosticSetting_partnerSolution (568.74s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       568.774s
```

