### PR TITLE
`azurerm_stream_analytics_job`: add support for `job_storage_account`

### DIFF
--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -79,6 +79,20 @@ The following arguments are supported:
 
 -> **NOTE:** `streaming_units` must be set when `type` is `Cloud`.
 
+* `content_storage_policy` - (Optional) The policy for storing stream analytics content. Possible values are `JobStorageAccount`, `SystemAccount`.
+
+* `job_storage_account` - (Optional) The details of the job storage account. A `job_storage_account` block as defined below. 
+
+---
+
+* `authentication_mode` - (Required) The authentication mode of the storage account. Possible values are `ConnectionString`, `Msi` and `UserToken`.
+
+* `account_name` - (Required) The name of the Azure storage account.
+
+* `account_key` - (Required) The account key for the Azure storage account.
+
+---
+
 * `transformation_query` - (Required) Specifies the query that will be run in the streaming job, [written in Stream Analytics Query Language (SAQL)](https://msdn.microsoft.com/library/azure/dn834998).
 
 * `tags` - A mapping of tags assigned to the resource.


### PR DESCRIPTION
* Add support for `job_storage_account` in `azurerm_stream_analytics_job` resource.

* All related tests passed.

```
=== RUN   TestAccStreamAnalyticsJob_basic
=== PAUSE TestAccStreamAnalyticsJob_basic
=== RUN   TestAccStreamAnalyticsJob_complete
=== PAUSE TestAccStreamAnalyticsJob_complete
=== RUN   TestAccStreamAnalyticsJob_requiresImport
=== PAUSE TestAccStreamAnalyticsJob_requiresImport
=== RUN   TestAccStreamAnalyticsJob_update
--- PASS: TestAccStreamAnalyticsJob_update (374.74s)
=== RUN   TestAccStreamAnalyticsJob_identity
--- PASS: TestAccStreamAnalyticsJob_identity (230.61s)
=== RUN   TestAccStreamAnalyticsJob_jobTypeCloud
=== PAUSE TestAccStreamAnalyticsJob_jobTypeCloud
=== RUN   TestAccStreamAnalyticsJob_jobTypeEdge
=== PAUSE TestAccStreamAnalyticsJob_jobTypeEdge
=== RUN   TestAccStreamAnalyticsJob_jobStorageAccount
=== PAUSE TestAccStreamAnalyticsJob_jobStorageAccount
=== CONT  TestAccStreamAnalyticsJob_basic
=== CONT  TestAccStreamAnalyticsJob_jobTypeCloud
=== CONT  TestAccStreamAnalyticsJob_jobStorageAccount
=== CONT  TestAccStreamAnalyticsJob_jobTypeEdge
=== CONT  TestAccStreamAnalyticsJob_requiresImport
=== CONT  TestAccStreamAnalyticsJob_complete
--- PASS: TestAccStreamAnalyticsJob_jobTypeCloud (224.54s)
--- PASS: TestAccStreamAnalyticsJob_jobTypeEdge (244.15s)
--- PASS: TestAccStreamAnalyticsJob_basic (245.49s)
--- PASS: TestAccStreamAnalyticsJob_requiresImport (266.22s)
--- PASS: TestAccStreamAnalyticsJob_jobStorageAccount (275.87s)
```