### PR TITLE
remove tags in acctest

### DIFF
--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1881,9 +1881,6 @@ func (LogicAppStandardResource) vNetIntegration_basic(data acceptance.TestData) 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
-  tags = {
-    "SkipNRMSNSG" = "true"
-  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -1965,9 +1962,6 @@ func (LogicAppStandardResource) vNetIntegration_subnet1(data acceptance.TestData
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
-  tags = {
-    "SkipNRMSNSG" = "true"
-  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -2050,9 +2044,6 @@ func (LogicAppStandardResource) vNetIntegration_subnet2(data acceptance.TestData
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
-  tags = {
-    "SkipNRMSNSG" = "true"
-  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -142,12 +142,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -187,12 +181,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {

--- a/internal/services/netapp/netapp_pool_resource_test.go
+++ b/internal/services/netapp/netapp_pool_resource_test.go
@@ -130,12 +130,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -182,12 +176,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {
@@ -227,12 +215,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_netapp_account" "test" {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -898,12 +898,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%d"
   location = "%s"
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true",
-    "SkipNRMSNSG"      = "true"
-  }
 }
 
 resource "azurerm_virtual_network" "test" {


### PR DESCRIPTION
remove the tags in acctest of `azurerm_logic_app_standard` and `azurerm_netapp_account`

<details><summary>Affected Test</summary>
<p>

logic

```
TestAccLogicAppStandard_vNetIntegration
    === RUN   TestAccLogicAppStandard_vNetIntegration
    === PAUSE TestAccLogicAppStandard_vNetIntegration
    === CONT  TestAccLogicAppStandard_vNetIntegration
    --- PASS: TestAccLogicAppStandard_vNetIntegration (399.27s)
    PASS

TestAccLogicAppStandard_vNetIntegrationUpdate
    === RUN   TestAccLogicAppStandard_vNetIntegrationUpdate
    === PAUSE TestAccLogicAppStandard_vNetIntegrationUpdate
    === CONT  TestAccLogicAppStandard_vNetIntegrationUpdate
    --- PASS: TestAccLogicAppStandard_vNetIntegrationUpdate (830.33s)
    PASS
```

netapp
```
TestAccNetAppAccount
    === RUN   TestAccNetAppAccount
    === RUN   TestAccNetAppAccount/Resource
    === RUN   TestAccNetAppAccount/Resource/requiresImport
    === PAUSE TestAccNetAppAccount/Resource/requiresImport
    === CONT  TestAccNetAppAccount/Resource/requiresImport
    === RUN   TestAccNetAppAccount/Resource#01
    === RUN   TestAccNetAppAccount/Resource#01/complete
    === PAUSE TestAccNetAppAccount/Resource#01/complete
    === CONT  TestAccNetAppAccount/Resource#01/complete
    === RUN   TestAccNetAppAccount/Resource#02
    === RUN   TestAccNetAppAccount/Resource#02/update
    === PAUSE TestAccNetAppAccount/Resource#02/update
    === CONT  TestAccNetAppAccount/Resource#02/update
    === RUN   TestAccNetAppAccount/Resource#03
    === RUN   TestAccNetAppAccount/Resource#03/basic
    === PAUSE TestAccNetAppAccount/Resource#03/basic
    === CONT  TestAccNetAppAccount/Resource#03/basic
    === RUN   TestAccNetAppAccount/DataSource
    === RUN   TestAccNetAppAccount/DataSource/basic
    === PAUSE TestAccNetAppAccount/DataSource/basic
    === CONT  TestAccNetAppAccount/DataSource/basic
    --- PASS: TestAccNetAppAccount (1184.74s)
        --- PASS: TestAccNetAppAccount/Resource (0.00s)
            --- PASS: TestAccNetAppAccount/Resource/requiresImport (270.17s)
        --- PASS: TestAccNetAppAccount/Resource#01 (0.00s)
            --- PASS: TestAccNetAppAccount/Resource#01/complete (248.76s)
        --- PASS: TestAccNetAppAccount/Resource#02 (0.00s)
            --- PASS: TestAccNetAppAccount/Resource#02/update (315.53s)
        --- PASS: TestAccNetAppAccount/Resource#03 (0.00s)
            --- PASS: TestAccNetAppAccount/Resource#03/basic (179.58s)
        --- PASS: TestAccNetAppAccount/DataSource (0.00s)
            --- PASS: TestAccNetAppAccount/DataSource/basic (170.69s)
    PASS

TestAccNetAppPool_complete
    === RUN   TestAccNetAppPool_complete
    === PAUSE TestAccNetAppPool_complete
    === CONT  TestAccNetAppPool_complete
    --- PASS: TestAccNetAppPool_complete (401.56s)
    PASS

TestAccNetAppVolume_basic
    === RUN   TestAccNetAppVolume_basic
    === PAUSE TestAccNetAppVolume_basic
    === CONT  TestAccNetAppVolume_basic
    --- PASS: TestAccNetAppVolume_basic (1140.40s)
    PASS
```

</p>