### PR TITLE
`azurerm_security_center_setting` - `setting_name` supports `WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW` and `SENTINEL`

### DIFF
--- a/internal/services/securitycenter/security_center_setting_resource.go
+++ b/internal/services/securitycenter/security_center_setting_resource.go
@@ -43,7 +43,6 @@ func resourceSecurityCenterSetting() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"MCAS",
 					"WDATP",
-					"WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
 					"SENTINEL",
 				}, false),
 			},
@@ -138,7 +137,7 @@ func resourceSecurityCenterSettingDelete(d *pluginsdk.ResourceData, meta interfa
 
 func expandSecurityCenterSetting(name string, enabled bool) (security.BasicSetting, error) {
 	switch name {
-	case "MCAS", "WDATP", "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW":
+	case "MCAS", "WDATP":
 		return security.DataExportSettings{
 			DataExportSettingProperties: &security.DataExportSettingProperties{
 				Enabled: &enabled,

--- a/internal/services/securitycenter/security_center_setting_resource.go
+++ b/internal/services/securitycenter/security_center_setting_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // TODO: this resource should be split into data_export_setting and alert_sync_setting
@@ -44,6 +43,8 @@ func resourceSecurityCenterSetting() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"MCAS",
 					"WDATP",
+					"WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW",
+					"SENTINEL",
 				}, false),
 			},
 			"enabled": {
@@ -75,12 +76,9 @@ func resourceSecurityCenterSettingUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	enabled := d.Get("enabled").(bool)
-	setting := security.DataExportSettings{
-		DataExportSettingProperties: &security.DataExportSettingProperties{
-			Enabled: &enabled,
-		},
-		Kind: security.KindDataExportSettings,
+	setting, err := expandSecurityCenterSetting(id.Name, d.Get("enabled").(bool))
+	if err != nil {
+		return err
 	}
 
 	if _, err := client.Update(ctx, id.Name, setting); err != nil {
@@ -126,11 +124,9 @@ func resourceSecurityCenterSettingDelete(d *pluginsdk.ResourceData, meta interfa
 		return err
 	}
 
-	setting := security.DataExportSettings{
-		DataExportSettingProperties: &security.DataExportSettingProperties{
-			Enabled: utils.Bool(false),
-		},
-		Kind: security.KindDataExportSettings,
+	setting, err := expandSecurityCenterSetting(id.Name, false)
+	if err != nil {
+		return err
 	}
 
 	if _, err := client.Update(ctx, id.Name, setting); err != nil {
@@ -138,4 +134,23 @@ func resourceSecurityCenterSettingDelete(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func expandSecurityCenterSetting(name string, enabled bool) (security.BasicSetting, error) {
+	switch name {
+	case "MCAS", "WDATP", "WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW":
+		return security.DataExportSettings{
+			DataExportSettingProperties: &security.DataExportSettingProperties{
+				Enabled: &enabled,
+			},
+		}, nil
+	case "SENTINEL":
+		return security.AlertSyncSettings{
+			AlertSyncSettingProperties: &security.AlertSyncSettingProperties{
+				Enabled: &enabled,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("failed to deduce the kind from its name %q", name)
+	}
 }

--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -57,6 +57,29 @@ func TestAccSecurityCenterSetting_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.cfg("SENTINEL", true),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
+		data.ImportStep(),
+		{
+			Config: r.cfg("SENTINEL", false),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
+		data.ImportStep(),
+
+		// WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW is skipped on purpose as it is enabled by default (at least in our subscription).
+		//
+		// {
+		// 	Config: r.cfg("WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW", true),
+		// 	Check:  acceptance.ComposeTestCheckFunc(),
+		// },
+		// data.ImportStep(),
+		// {
+		// 	Config: r.cfg("WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW", false),
+		// 	Check:  acceptance.ComposeTestCheckFunc(),
+		// },
+		// data.ImportStep(),
 	})
 }
 
@@ -72,6 +95,11 @@ func TestAccSecurityCenterSetting_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+		// reset
+		{
+			Config: r.cfg("MCAS", false),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
 	})
 }
 

--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -67,19 +67,6 @@ func TestAccSecurityCenterSetting_update(t *testing.T) {
 			Check:  acceptance.ComposeTestCheckFunc(),
 		},
 		data.ImportStep(),
-
-		// WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW is skipped on purpose as it is enabled by default (at least in our subscription).
-		//
-		// {
-		// 	Config: r.cfg("WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW", true),
-		// 	Check:  acceptance.ComposeTestCheckFunc(),
-		// },
-		// data.ImportStep(),
-		// {
-		// 	Config: r.cfg("WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW", false),
-		// 	Check:  acceptance.ComposeTestCheckFunc(),
-		// },
-		// data.ImportStep(),
 	})
 }
 

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_security_center_setting" "example" {
 
 The following arguments are supported:
 
-* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP`, `WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW` and `SENTINEL`. Changing this forces a new resource to be created.
+* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP` and `SENTINEL`. Changing this forces a new resource to be created.
 * `enabled` - (Required) Boolean flag to enable/disable data access.
 
 ## Attributes Reference

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_security_center_setting" "example" {
 
 The following arguments are supported:
 
-* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` and `WDATP`. Changing this forces a new resource to be created.
+* `setting_name` - (Required) The setting to manage. Possible values are `MCAS` , `WDATP`, `WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW` and `SENTINEL`. Changing this forces a new resource to be created.
 * `enabled` - (Required) Boolean flag to enable/disable data access.
 
 ## Attributes Reference


### PR DESCRIPTION
Fix #18344 

## Test

```shell
>  TF_ACC=1 go test -v -timeout=20h ./internal/services/securitycenter -run=TestAccSecurityCenterSetting_
=== RUN   TestAccSecurityCenterSetting_update
--- PASS: TestAccSecurityCenterSetting_update (81.13s)
=== RUN   TestAccSecurityCenterSetting_requiresImport
--- PASS: TestAccSecurityCenterSetting_requiresImport (28.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter        109.697s
```