### PR TITLE
`azurerm_container_registry_token_password` - Make `password{1|2}.0.expiry` to be `ForceNew`

### DIFF
--- a/internal/services/containers/container_registry_token_password_resource.go
+++ b/internal/services/containers/container_registry_token_password_resource.go
@@ -49,8 +49,10 @@ func (r ContainerRegistryTokenPasswordResource) Arguments() map[string]*pluginsd
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"expiry": {
-						Type:             pluginsdk.TypeString,
-						Optional:         true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						// TODO: Remove the force new and add customize diff to SetNewComputed on the `value` once https://github.com/hashicorp/terraform-plugin-sdk/issues/459 is addressed.
+						ForceNew:         true,
 						ValidateFunc:     validation.IsRFC3339Time,
 						DiffSuppressFunc: suppress.RFC3339Time,
 					},
@@ -71,8 +73,10 @@ func (r ContainerRegistryTokenPasswordResource) Arguments() map[string]*pluginsd
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"expiry": {
-						Type:             pluginsdk.TypeString,
-						Optional:         true,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						// TODO: Remove the force new and add customize diff to SetNewComputed on the `value` once https://github.com/hashicorp/terraform-plugin-sdk/issues/459 is addressed.
+						ForceNew:         true,
 						ValidateFunc:     validation.IsRFC3339Time,
 						DiffSuppressFunc: suppress.RFC3339Time,
 					},

--- a/website/docs/r/container_registry_token_password.html.markdown
+++ b/website/docs/r/container_registry_token_password.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 A `password` block supports the following:
 
-* `expiry` - (Optional) The expiration date of the password in RFC3339 format.
+* `expiry` - (Optional) The expiration date of the password in RFC3339 format. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix #19138

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run=TestAccContainerRegistryTokenPassword_updateExpiryReflectNewValue
=== RUN   TestAccContainerRegistryTokenPassword_updateExpiryReflectNewValue
=== PAUSE TestAccContainerRegistryTokenPassword_updateExpiryReflectNewValue
=== CONT  TestAccContainerRegistryTokenPassword_updateExpiryReflectNewValue
--- PASS: TestAccContainerRegistryTokenPassword_updateExpiryReflectNewValue (349.72s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    349.730s
```