### PR TITLE
`azurerm_sentinel_alert_rule_nrt` - Add support for `techniques`

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
@@ -119,6 +119,15 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 				},
 			},
 
+			"techniques": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			"incident": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -341,6 +350,7 @@ func resourceSentinelAlertRuleNrtCreateUpdate(d *pluginsdk.ResourceData, meta in
 		NrtAlertRuleProperties: &securityinsight.NrtAlertRuleProperties{
 			Description:           utils.String(d.Get("description").(string)),
 			DisplayName:           utils.String(d.Get("display_name").(string)),
+			Techniques:            expandAlertRuleTechnicals(d.Get("techniques").(*pluginsdk.Set).List()),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
 			IncidentConfiguration: expandAlertRuleIncidentConfiguration(d.Get("incident").([]interface{}), "create_incident_enabled", false),
 			Severity:              securityinsight.AlertSeverity(d.Get("severity").(string)),
@@ -425,6 +435,9 @@ func resourceSentinelAlertRuleNrtRead(d *pluginsdk.ResourceData, meta interface{
 		d.Set("display_name", prop.DisplayName)
 		if err := d.Set("tactics", flattenAlertRuleTactics(prop.Tactics)); err != nil {
 			return fmt.Errorf("setting `tactics`: %+v", err)
+		}
+		if err := d.Set("techniques", prop.Techniques); err != nil {
+			return fmt.Errorf("setting `techniques`: %+v", err)
 		}
 		if err := d.Set("incident", flattenAlertRuleIncidentConfiguration(prop.IncidentConfiguration, "create_incident_enabled", false)); err != nil {
 			return fmt.Errorf("setting `incident`: %+v", err)

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -153,6 +153,7 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
+  techniques                 = ["T1560", "T1123"]
   severity                   = "Low"
   enabled                    = false
   incident {

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -94,6 +94,8 @@ The following arguments are supported:
 
 * `tactics` - (Optional) A list of categories of attacks by which to classify the rule. Possible values are `Collection`, `CommandAndControl`, `CredentialAccess`, `DefenseEvasion`, `Discovery`, `Execution`, `Exfiltration`, `Impact`, `InitialAccess`, `LateralMovement`, `Persistence` and `PrivilegeEscalation`.
 
+* `techniques` - (Optional) A list of techniques of attacks by which to classify the rule.
+
 ---
 
 An `alert_details_override` block supports the following:


### PR DESCRIPTION
`azurerm_sentinel_alert_rule_nrt` add new property `techniques`.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel -run=TestAccSentinelAlertRuleNrt_
=== RUN   TestAccSentinelAlertRuleNrt_basic
=== PAUSE TestAccSentinelAlertRuleNrt_basic
=== RUN   TestAccSentinelAlertRuleNrt_complete
=== PAUSE TestAccSentinelAlertRuleNrt_complete
=== RUN   TestAccSentinelAlertRuleNrt_update
=== PAUSE TestAccSentinelAlertRuleNrt_update
=== RUN   TestAccSentinelAlertRuleNrt_requiresImport
=== PAUSE TestAccSentinelAlertRuleNrt_requiresImport
=== RUN   TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== PAUSE TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleNrt_basic
=== CONT  TestAccSentinelAlertRuleNrt_requiresImport
=== CONT  TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleNrt_update
=== CONT  TestAccSentinelAlertRuleNrt_complete
--- PASS: TestAccSentinelAlertRuleNrt_complete (160.15s)
--- PASS: TestAccSentinelAlertRuleNrt_basic (160.31s)
--- PASS: TestAccSentinelAlertRuleNrt_requiresImport (168.30s)
--- PASS: TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid (177.06s)
--- PASS: TestAccSentinelAlertRuleNrt_update (229.71s)
PASS
```