### PR TITLE
`azurerm_eventhub_namespace` - fix `zone_redundant` property for namespace

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -91,10 +91,12 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			// zone redundant is computed by service based on the availability of availability zone feature.
+			// for premium namespace, zone redundant is computed by service based on the availability of availability zone feature.
 			"zone_redundant": {
 				Type:     pluginsdk.TypeBool,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"dedicated_cluster_id": {
@@ -343,7 +345,8 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 		Tags: tags.Expand(t),
 	}
 
-	if !features.FourPointOhBeta() {
+	// for premium namespace, the zone_redundant is computed based on the region, user's input will be overridden
+	if sku != string(namespaces.SkuNamePremium) {
 		parameters.Properties.ZoneRedundant = utils.Bool(d.Get("zone_redundant").(bool))
 	}
 

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -671,6 +671,7 @@ resource "azurerm_eventhub_namespace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Premium"
   capacity            = "1"
+  zone_redundant      = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `zone_redundant` - (Optional) Specifies if the EventHub Namespace should be Zone Redundant (created across Availability Zones). Changing this forces a new resource to be created. Defaults to `false`.
 
-~> **Note:** `zone_redundant` is computed by api based on the availability zone in each region. User's input will be overridden. It will turn into a computed property in 4.0 provider.
+~> **Note:** For eventhub premium namespace, `zone_redundant` is computed by api based on the availability zone feature in each region. User's input will be overridden. Please explicitly sets the property to `true` when creating the premium namespace in a region that supports availability zone since the default value is `false` in 3.0 provider.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
For eventhub premium namespace, the zone_redundant feature is computed by system based on the availability zone feature in the selected region. 

For standard namespace, the zone_redundant feature is turned off by default and can be set by user.

fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18756