### PR TITLE
[BUG:] `azurerm_cdn_frontdoor_route` - fix read function to parse `cdn_frontdoor_origin_group_id` insensitively

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn"
 	"github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2020-11-01/frontdoor"
+	dnsValidate "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -58,12 +59,43 @@ func expandResourceReference(input string) *cdn.ResourceReference {
 	}
 }
 
-func flattenResourceReference(input *cdn.ResourceReference) string {
+func flattenOriginGroupResourceReference(input *cdn.ResourceReference) (string, error) {
 	if input != nil && input.ID != nil {
-		return *input.ID
+		id, err := parse.FrontDoorOriginGroupIDInsensitively(*input.ID)
+		if err != nil {
+			return "", err
+		}
+
+		return id.ID(), nil
 	}
 
-	return ""
+	return "", nil
+}
+
+func flattenSecretResourceReference(input *cdn.ResourceReference) (string, error) {
+	if input != nil && input.ID != nil {
+		id, err := parse.FrontDoorSecretIDInsensitively(*input.ID)
+		if err != nil {
+			return "", err
+		}
+
+		return id.ID(), nil
+	}
+
+	return "", nil
+}
+
+func flattenDNSZoneResourceReference(input *cdn.ResourceReference) (string, error) {
+	if input != nil && input.ID != nil {
+		id, err := dnsValidate.ParseDnsZoneIDInsensitively(*input.ID)
+		if err != nil {
+			return "", err
+		}
+
+		return id.ID(), nil
+	}
+
+	return "", nil
 }
 
 func flattenEnabledBool(input cdn.EnabledState) bool {

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -326,7 +326,7 @@ func resourceCdnFrontDoorRouteRead(d *pluginsdk.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.FrontDoorRouteIDInsensitively(d.Id())
+	id, err := parse.FrontDoorRouteID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -326,7 +326,7 @@ func resourceCdnFrontDoorRouteRead(d *pluginsdk.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.FrontDoorRouteID(d.Id())
+	id, err := parse.FrontDoorRouteIDInsensitively(d.Id())
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,12 @@ func resourceCdnFrontDoorRouteRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("setting `cache`: %+v", err)
 		}
 
-		if err := d.Set("cdn_frontdoor_origin_group_id", flattenResourceReference(props.OriginGroup)); err != nil {
+		originGroupId, err := flattenOriginGroupResourceReference(props.OriginGroup)
+		if err != nil {
+			return fmt.Errorf("flattening `cdn_frontdoor_origin_group_id`: %+v", err)
+		}
+
+		if err := d.Set("cdn_frontdoor_origin_group_id", originGroupId); err != nil {
 			return fmt.Errorf("setting `cdn_frontdoor_origin_group_id`: %+v", err)
 		}
 


### PR DESCRIPTION
(fixes #19103)