### PR TITLE
`azurerm_disk_encryption_set` - add `federated_client_id` property

### DIFF
--- a/internal/services/compute/disk_encryption_set_resource.go
+++ b/internal/services/compute/disk_encryption_set_resource.go
@@ -132,8 +132,6 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 	encryptionType := diskencryptionsets.DiskEncryptionSetType(d.Get("encryption_type").(string))
 	t := d.Get("tags").(map[string]interface{})
 
-	federatedClientId := d.Get("federated_client_id").(string)
-
 	expandedIdentity, err := expandDiskEncryptionSetIdentity(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
@@ -147,10 +145,13 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 			},
 			RotationToLatestKeyVersionEnabled: utils.Bool(rotationToLatestKeyVersionEnabled),
 			EncryptionType:                    &encryptionType,
-			FederatedClientId:                 &federatedClientId,
 		},
 		Identity: expandedIdentity,
 		Tags:     tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("federated_client_id"); ok {
+		params.Properties.FederatedClientId = utils.String(v.(string))
 	}
 
 	if keyVaultDetails != nil {

--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -149,6 +149,28 @@ func TestAccDiskEncryptionSet_systemAssignedUserAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccDiskEncryptionSet_withFederatedClientId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_disk_encryption_set", "test")
+	r := DiskEncryptionSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withFederatedClientId(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withFederatedClientId(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (DiskEncryptionSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := diskencryptionsets.ParseDiskEncryptionSetID(state.ID)
 	if err != nil {
@@ -449,4 +471,52 @@ resource "azurerm_disk_encryption_set" "test" {
   depends_on = ["azurerm_key_vault_access_policy.user-assigned"]
 }
 	`, r.systemAssignedDependencies(data), data.RandomInteger)
+}
+
+func (r DiskEncryptionSetResource) withFederatedClientId(data acceptance.TestData, clean bool) string {
+	federatedClientId := `federated_client_id = azurerm_user_assigned_identity.test.client_id`
+	if clean {
+		federatedClientId = ""
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_key_vault_access_policy" "user-assigned" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.test.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  key_permissions = [
+    "Get",
+    "WrapKey",
+    "UnwrapKey",
+  ]
+
+  depends_on = ["azurerm_key_vault_access_policy.service-principal"]
+}
+
+resource "azurerm_disk_encryption_set" "test" {
+  name                = "acctestDES-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  key_vault_key_id    = azurerm_key_vault_key.test.id
+%[3]s
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  depends_on = ["azurerm_key_vault_access_policy.user-assigned"]
+}
+	`, r.dependencies(data), data.RandomInteger, federatedClientId)
 }

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -128,6 +128,8 @@ In this case, `azurerm_key_vault_access_policy` is not needed.
 
 * `encryption_type` - (Optional) The type of key used to encrypt the data of the disk. Possible values are `EncryptionAtRestWithCustomerKey`, `EncryptionAtRestWithPlatformAndCustomerKeys` and `ConfidentialVmEncryptedWithCustomerKey`. Defaults to `EncryptionAtRestWithCustomerKey`.
 
+* `federated_client_id` - (Optional) Multi-tenant application client id to access key vault in a different tenant.
+
 * `identity` - (Required) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the Disk Encryption Set.


### PR DESCRIPTION
Test
---
```
TF_ACC=1 go test -v ./internal/services/compute -run=TestAccDiskEncryptionSet_withFederatedClientId -timeout=600m
=== RUN   TestAccDiskEncryptionSet_withFederatedClientId
=== PAUSE TestAccDiskEncryptionSet_withFederatedClientId
=== CONT  TestAccDiskEncryptionSet_withFederatedClientId
--- PASS: TestAccDiskEncryptionSet_withFederatedClientId (580.20s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       580.218s
```