### PR TITLE
Docs | azurerm_attestation_provider: corrected resource name

### DIFF
--- a/website/docs/r/attestation.html.markdown
+++ b/website/docs/r/attestation.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Attestation"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_attestation"
+page_title: "Azure Resource Manager: azurerm_attestation_provider"
 description: |-
   Manages a Attestation Provider.
 ---
 
-# azurerm_attestation
+# azurerm_attestation_provider
 
 Manages a Attestation Provider.
 


### PR DESCRIPTION
**Docs** | **azurerm_attestation_provider**: Corrected Resource Name
changed Resource name: `azurerm_attestation` to `azurerm_attestation_provider`
Document Link: 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/attestation
Refer Attached Image: 
![image](https://user-images.githubusercontent.com/36565350/200525110-74cdf344-e482-4f43-9f6a-02d6e08ffeb5.png)

