### PR TITLE
`azurerm_private_dns_resolver_dns_forwarding_ruleset` Fix wrong property/field name in Docs.

### DIFF
--- a/website/docs/r/private_dns_resolver_dns_forwarding_ruleset.html.markdown
+++ b/website/docs/r/private_dns_resolver_dns_forwarding_ruleset.html.markdown
@@ -76,11 +76,11 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group where the Private DNS Resolver Dns Forwarding Ruleset should exist. Changing this forces a new Private DNS Resolver Dns Forwarding Ruleset to be created.
 
-* `dns_resolver_outbound_endpoints` - (Required)  The list of IDs of the Private DNS Resolver Outbound Endpoint that is linked to the Private DNS Resolver Dns Forwarding Ruleset .
+* `private_dns_resolver_outbound_endpoint_ids` - (Required)  The list of IDs of the Private DNS Resolver Outbound Endpoint that is linked to the Private DNS Resolver Dns Forwarding Ruleset.
 
-* `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Dns Forwarding Ruleset should exist. Changing this forces a new Private DNS Resolver Dns Forwarding Ruleset to be created.
+* `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Dns Forwarding Ruleset should exist. Changing this forces a new Private DNS Resolver Dns Forwarding Ruleset to be created. 
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Private DNS Resolver Dns Forwarding Ruleset.
+* `tags` - (Optional) A mapping of tags to assign to the Private DNS Resolver Dns Forwarding Ruleset.
 
 ## Attributes Reference
 

--- a/website/docs/r/private_dns_resolver_dns_forwarding_ruleset.html.markdown
+++ b/website/docs/r/private_dns_resolver_dns_forwarding_ruleset.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `private_dns_resolver_outbound_endpoint_ids` - (Required)  The list of IDs of the Private DNS Resolver Outbound Endpoint that is linked to the Private DNS Resolver Dns Forwarding Ruleset.
 
-* `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Dns Forwarding Ruleset should exist. Changing this forces a new Private DNS Resolver Dns Forwarding Ruleset to be created. 
+* `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Dns Forwarding Ruleset should exist. Changing this forces a new Private DNS Resolver Dns Forwarding Ruleset to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Private DNS Resolver Dns Forwarding Ruleset.
 


### PR DESCRIPTION
- Replacing `dns_resolver_outbound_endpoints` with `private_dns_resolver_outbound_endpoint_ids`, as it is the expected name. This may solve #19194.
- A couple of grammar stuff.
