### PR TITLE
azurerm_app_configuration - Checking for deleted configuration stores should ignore StatusForbidden responses

### DIFF
--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -249,7 +249,7 @@ func resourceAppConfigurationCreate(d *pluginsdk.ResourceData, meta interface{})
 	deletedConfigurationStoresId := deletedconfigurationstores.NewDeletedConfigurationStoreID(subscriptionId, location, name)
 	deleted, err := deletedConfigurationStoresClient.ConfigurationStoresGetDeleted(ctx, deletedConfigurationStoresId)
 	if err != nil {
-		if !response.WasNotFound(deleted.HttpResponse) {
+		if !response.WasNotFound(deleted.HttpResponse) && !response.WasStatusCode(deleted.HttpResponse, http.StatusForbidden) {
 			return fmt.Errorf("checking for presence of deleted %s: %+v", deletedConfigurationStoresId, err)
 		}
 	}


### PR DESCRIPTION
Reading and purging soft-deleted App Configurations requires additional permissions.

If you don't have permissions then terraform should not throw. 

This matches the existing behaviour of the keyvault resource provider:

https://github.com/hashicorp/terraform-provider-azurerm/blob/ef9adad3defd33f3be1af02fc9e504f696a219b1/internal/services/keyvault/key_vault_resource.go#L269-L287