### PR TITLE
`azurerm_public_ip` - support for the `ddos_protection_mode` and `ddos_protection_plan_id` properties

### DIFF
--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -45,6 +45,16 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"ddos_protection_mode": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"ddos_protection_plan_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"ip_version": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -137,6 +147,14 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			reverseFqdn = *dnsSettings.ReverseFqdn
 		}
 	}
+
+	if ddosSetting := props.DdosSettings; ddosSetting != nil {
+		d.Set("ddos_protection_mode", string(ddosSetting.ProtectionMode))
+		if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
+			d.Set("ddos_protection_plan_id", subResource.ID)
+		}
+	}
+
 	d.Set("domain_name_label", domainNameLabel)
 	d.Set("fqdn", fqdn)
 	d.Set("reverse_fqdn", reverseFqdn)

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -64,6 +64,23 @@ func resourcePublicIp() *pluginsdk.Resource {
 			},
 
 			// Optional
+			"ddos_protection_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.DdosSettingsProtectionModeDisabled),
+					string(network.DdosSettingsProtectionModeEnabled),
+					string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
+				}, false),
+				Default: string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
+			},
+
+			"ddos_protection_plan_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.DdosProtectionPlanID,
+			},
+
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
 			"ip_version": {
@@ -174,7 +191,7 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	sku := d.Get("sku").(string)
-	sku_tier := d.Get("sku_tier").(string)
+	skuTier := d.Get("sku_tier").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	idleTimeout := d.Get("idle_timeout_in_minutes").(int)
@@ -187,20 +204,34 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
+	ddosProtectionMode := d.Get("ddos_protection_mode").(string)
+
 	publicIp := network.PublicIPAddress{
 		Name:             utils.String(id.Name),
 		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
 		Location:         &location,
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuName(sku),
-			Tier: network.PublicIPAddressSkuTier(sku_tier),
+			Tier: network.PublicIPAddressSkuTier(skuTier),
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.IPAllocationMethod(ipAllocationMethod),
 			PublicIPAddressVersion:   ipVersion,
 			IdleTimeoutInMinutes:     utils.Int32(int32(idleTimeout)),
+			DdosSettings: &network.DdosSettings{
+				ProtectionMode: network.DdosSettingsProtectionMode(ddosProtectionMode),
+			},
 		},
 		Tags: tags.Expand(t),
+	}
+	ddosProtectionPlanId, planOk := d.GetOk("ddos_protection_plan_id")
+	if planOk {
+		if !strings.EqualFold(ddosProtectionMode, "enabled") {
+			return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
+		}
+		publicIp.PublicIPAddressPropertiesFormat.DdosSettings.DdosProtectionPlan = &network.SubResource{
+			ID: utils.String(ddosProtectionPlanId.(string)),
+		}
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
@@ -304,6 +335,13 @@ func resourcePublicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("fqdn", settings.Fqdn)
 			d.Set("reverse_fqdn", settings.ReverseFqdn)
 			d.Set("domain_name_label", settings.DomainNameLabel)
+		}
+
+		if ddosSetting := props.DdosSettings; ddosSetting != nil {
+			d.Set("ddos_protection_mode", string(ddosSetting.ProtectionMode))
+			if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
+				d.Set("ddos_protection_plan_id", subResource.ID)
+			}
 		}
 
 		d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -104,6 +104,8 @@ output "public_ip_address" {
 * `id` - The ID of the Public IP address.
 * `domain_name_label` - The label for the Domain Name.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
+* `ddos_protection_mode` - The DDoS protection mode of the public IP.
+* `ddos_protection_plan_id` - The ID of DDoS protection plan associated with the public IP. 
 * `fqdn` - Fully qualified domain name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.
 * `ip_address` - The IP address value that was allocated.
 * `ip_version` - The IP version being used, for example `IPv4` or `IPv6`.

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -50,6 +50,12 @@ The following arguments are supported:
 
 -> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/azure/availability-zones/az-overview) at this time. Standard SKU Public IP Addresses that do not specify a zone are **not** zone-redundant by default.
 
+* `ddos_protection_mode` - (Optional) The DDoS protection mode of the public IP. Possible values are `Disabled`, `Enabled`, and `VirtualNetworkInherited`. Defaults to `VirtualNetworkInherited`.
+ 
+* `ddos_protection_plan_id` - (Optional) The ID of DDoS protection plan associated with the public IP. 
+
+-> **Note:** `ddos_protection_plan_id` can only be set when `ddos_protection_mode` is `Enabled`.
+
 * `domain_name_label` - (Optional) Label for the Domain Name. Will be used to make up the FQDN.  If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Public IP should exist. Changing this forces a new Public IP to be created.


### PR DESCRIPTION
Ref:
1. [swagger](https://github.com/Azure/azure-rest-api-specs/blob/f194e2289df90e465f396dd4056bd0a0ca7739c5/specification/network/resource-manager/Microsoft.Network/stable/2022-05-01/publicIpAddress.json#L615-L638)
2. [Enable DDoS IP Protection for a public IP address](https://learn.microsoft.com/en-us/azure/ddos-protection/manage-ddos-protection-powershell-ip#enable-ddos-ip-protection-for-a-public-ip-address)

Test:
![image](https://user-images.githubusercontent.com/104055472/200754419-e38d6ab0-1393-43ee-b77e-be5afc245a30.png)

the failed test `TestAccPublicIpPrefix_prefixLength24` is not related to this PR.