### PR TITLE
`azurerm_storage_account` - Support for `sas_policy`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -793,18 +793,19 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"expiration_action": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								// There is no definition of this enum in the Track1 SDK due to: https://github.com/Azure/azure-sdk-for-go/issues/14589
-								string("Log"),
-							}, false),
-						},
 						"expiration_period": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"expiration_action": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							Default:  "Log",
+							ValidateFunc: validation.StringInSlice([]string{
+								// There is no definition of this enum in the Track1 SDK due to: https://github.com/Azure/azure-sdk-for-go/issues/14589
+								"Log",
+							}, false),
 						},
 					},
 				},

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -786,6 +786,30 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"sas_policy": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"expiration_action": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								// There is no definition of this enum in the Track1 SDK due to: https://github.com/Azure/azure-sdk-for-go/issues/14589
+								string("Log"),
+							}, false),
+						},
+						"expiration_period": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
 			"large_file_share_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -1071,6 +1095,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			AllowSharedKeyAccess:         &allowSharedKeyAccess,
 			DefaultToOAuthAuthentication: &defaultToOAuthAuthentication,
 			AllowCrossTenantReplication:  &crossTenantReplication,
+			SasPolicy:                    expandStorageAccountSASPolicy(d.Get("sas_policy").([]interface{})),
 		},
 	}
 
@@ -1677,6 +1702,18 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
+	if d.HasChange("sas_policy") {
+		// TODO: Currently, due to Track1 SDK has no way to represent a `null` value in the payload - instead it will be omitted, `sas_policy` can not be disabled once enabled.
+		opts := storage.AccountUpdateParameters{
+			AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
+				SasPolicy: expandStorageAccountSASPolicy(d.Get("sas_policy").([]interface{})),
+			},
+		}
+		if _, err := client.Update(ctx, id.ResourceGroup, id.Name, opts); err != nil {
+			return fmt.Errorf("updating Azure Storage Account sas_policy %q: %+v", id.Name, err)
+		}
+	}
+
 	supportLevel := resolveStorageAccountServiceSupportLevel(storage.Kind(accountKind), storage.SkuTier(accountTier))
 
 	if d.HasChange("blob_properties") {
@@ -2004,6 +2041,10 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 			infrastructureEncryption = *encryption.RequireInfrastructureEncryption
 		}
 		d.Set("infrastructure_encryption_enabled", infrastructureEncryption)
+
+		if err := d.Set("sas_policy", flattenStorageAccountSASPolicy(props.SasPolicy)); err != nil {
+			return fmt.Errorf("setting `sas_policy`: %+v", err)
+		}
 	}
 
 	if accessKeys := keys.Keys; accessKeys != nil {
@@ -3465,4 +3506,40 @@ func flattenEdgeZone(input *storage.ExtendedLocation) string {
 		return ""
 	}
 	return edgezones.NormalizeNilable(input.Name)
+}
+
+func expandStorageAccountSASPolicy(input []interface{}) *storage.SasPolicy {
+	if len(input) == 0 {
+		return nil
+	}
+
+	e := input[0].(map[string]interface{})
+
+	return &storage.SasPolicy{
+		ExpirationAction:    utils.String(e["expiration_action"].(string)),
+		SasExpirationPeriod: utils.String(e["expiration_period"].(string)),
+	}
+}
+
+func flattenStorageAccountSASPolicy(input *storage.SasPolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var expirationAction string
+	if input.ExpirationAction != nil {
+		expirationAction = *input.ExpirationAction
+	}
+
+	var expirationPeriod string
+	if input.SasExpirationPeriod != nil {
+		expirationPeriod = *input.SasExpirationPeriod
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"expiration_action": expirationAction,
+			"expiration_period": expirationPeriod,
+		},
+	}
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1556,11 +1556,6 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
-  sas_policy {
-    expiration_action = "Log"
-    expiration_period = "1.15:5:05"
-  }
-
   tags = {
     environment = "staging"
   }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -164,6 +164,8 @@ The following arguments are supported:
 
 * `immutability_policy` - (Optional) An `immutability_policy` block as defined below.
 
+* `sas_policy` - (Optional) A `sas_policy` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -366,6 +368,14 @@ A `queue_properties` block supports the following:
 * `minute_metrics` - (Optional) A `minute_metrics` block as defined below.
 
 * `hour_metrics` - (Optional) A `hour_metrics` block as defined below.
+
+---
+
+A `sas_policy` block supports the following:
+
+* `expiration_action` - (Required) The SAS expiration action. The only possible value is `Log` at this moment.
+
+* `expiration_period` - (Required) The SAS expiration period in format of `DD.HH:MM:SS`.
 
 ---
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -373,9 +373,9 @@ A `queue_properties` block supports the following:
 
 A `sas_policy` block supports the following:
 
-* `expiration_action` - (Required) The SAS expiration action. The only possible value is `Log` at this moment.
-
 * `expiration_period` - (Required) The SAS expiration period in format of `DD.HH:MM:SS`.
+
+* `expiration_action` - (Optional) The SAS expiration action. The only possible value is `Log` at this moment. Defaults to `Log`.
 
 ---
 


### PR DESCRIPTION
Fix #19188 

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_sasPolicy'
=== RUN   TestAccStorageAccount_sasPolicy
=== PAUSE TestAccStorageAccount_sasPolicy
=== CONT  TestAccStorageAccount_sasPolicy
--- PASS: TestAccStorageAccount_sasPolicy (199.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       199.361s
```