### PR TITLE
`azurerm_stream_analytics_job`: fix `job_storage_account: authentication_mode` unsupported mode issue

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -542,14 +542,19 @@ func expandJobStorageAccount(input []interface{}) *streamingjobs.JobStorageAccou
 }
 
 func flattenJobStorageAccount(d *pluginsdk.ResourceData, input *streamingjobs.JobStorageAccount) []interface{} {
-	if input == nil || input.AccountName == nil {
+	if input == nil {
 		return []interface{}{}
+	}
+
+	accountName := ""
+	if v := input.AccountName; v != nil {
+		accountName = *v
 	}
 
 	return []interface{}{
 		map[string]interface{}{
 			"authentication_mode": string(*input.AuthenticationMode),
-			"account_name":        *input.AccountName,
+			"account_name":        accountName,
 			"account_key":         d.Get("job_storage_account.0.account_key").(string),
 		},
 	}

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -148,11 +148,10 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 					Schema: map[string]*schema.Schema{
 						"authentication_mode": {
 							Type:     pluginsdk.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  string(streamingjobs.AuthenticationModeConnectionString),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(streamingjobs.AuthenticationModeConnectionString),
-								string(streamingjobs.AuthenticationModeMsi),
-								string(streamingjobs.AuthenticationModeUserToken),
 							}, false),
 						},
 
@@ -543,7 +542,7 @@ func expandJobStorageAccount(input []interface{}) *streamingjobs.JobStorageAccou
 }
 
 func flattenJobStorageAccount(d *pluginsdk.ResourceData, input *streamingjobs.JobStorageAccount) []interface{} {
-	if input == nil {
+	if input == nil || input.AccountName == nil {
 		return []interface{}{}
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_job_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource_test.go
@@ -405,9 +405,8 @@ resource "azurerm_stream_analytics_job" "test" {
   streaming_units        = 3
   content_storage_policy = "JobStorageAccount"
   job_storage_account {
-    authentication_mode = "ConnectionString"
-    account_name        = azurerm_storage_account.test.name
-    account_key         = azurerm_storage_account.test.primary_access_key
+    account_name = azurerm_storage_account.test.name
+    account_key  = azurerm_storage_account.test.primary_access_key
   }
 
   tags = {

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 ---
 
-* `authentication_mode` - (Required) The authentication mode of the storage account. Possible values are `ConnectionString`, `Msi` and `UserToken`.
+* `authentication_mode` - (Optional) The authentication mode of the storage account. The only supported value is `ConnectionString`. Defaults to `ConnectionString`.
 
 * `account_name` - (Required) The name of the Azure storage account.
 


### PR DESCRIPTION
* GH issue https://github.com/hashicorp/terraform-provider-azurerm/issues/19152

* `azurerm_stream_analytics_job` now only support `authentication_mode` as `ConnectionString`.

* Now `authentication_mode` is `ConnectionString` by default.

* Test passed.

```
=== RUN   TestAccStreamAnalyticsJob_jobStorageAccount
=== PAUSE TestAccStreamAnalyticsJob_jobStorageAccount
=== CONT  TestAccStreamAnalyticsJob_jobStorageAccount
--- PASS: TestAccStreamAnalyticsJob_jobStorageAccount (282.41s)
PASS

```