### PR TITLE
Fix fmt with go 1.19.3

### DIFF
--- a/helpers/validate/float.go
+++ b/helpers/validate/float.go
@@ -6,7 +6,6 @@ import (
 
 // FloatInSlice returns a SchemaValidateFunc which tests if the provided value
 // is of type float64 and matches the value of an element in the valid slice
-//
 func FloatInSlice(valid []float64) func(interface{}, string) ([]string, []error) {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(float64)

--- a/internal/sdk/resource_decode.go
+++ b/internal/sdk/resource_decode.go
@@ -13,9 +13,10 @@ import (
 //
 // Example Usage:
 //
-// type Person struct {
-//	 Name string `tfschema:"name"
-// }
+//	type Person struct {
+//		 Name string `tfschema:"name"
+//	}
+//
 // var person Person
 // if err := metadata.Decode(&person); err != nil { .. }
 func (rmd ResourceMetaData) Decode(input interface{}) error {

--- a/internal/services/appconfiguration/sdk/1.0/appconfiguration/client.go
+++ b/internal/services/appconfiguration/sdk/1.0/appconfiguration/client.go
@@ -1,6 +1,4 @@
 // Package appconfiguration implements the Azure ARM Appconfiguration service API version 1.0.
-//
-//
 package appconfiguration
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/internal/services/blueprints/blueprint_definition_data_source_test.go
+++ b/internal/services/blueprints/blueprint_definition_data_source_test.go
@@ -10,7 +10,7 @@ import (
 
 type BlueprintDefinitionDataSource struct{}
 
-//lintignore:AT001
+// lintignore:AT001
 func TestAccBlueprintDefinitionDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_definition", "test")
 	r := BlueprintDefinitionDataSource{}
@@ -30,7 +30,7 @@ func TestAccBlueprintDefinitionDataSource_basic(t *testing.T) {
 	})
 }
 
-//lintignore:AT001
+// lintignore:AT001
 func TestAccBlueprintDefinitionDataSource_basicAtRootManagementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_definition", "test")
 	r := BlueprintDefinitionDataSource{}

--- a/internal/services/blueprints/blueprint_published_version_data_source_test.go
+++ b/internal/services/blueprints/blueprint_published_version_data_source_test.go
@@ -10,7 +10,7 @@ import (
 
 type BlueprintPublishedVersionDataSource struct{}
 
-//lintignore:AT001
+// lintignore:AT001
 func TestAccBlueprintPublishedVersionDataSource_atSubscription(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_published_version", "test")
 	r := BlueprintPublishedVersionDataSource{}

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -49,8 +49,9 @@ func userDataStateFunc(v interface{}) string {
 }
 
 // NOTE: the `azurerm_virtual_machine` resource has been superseded by the `azurerm_linux_virtual_machine` and
-// 		 `azurerm_windows_virtual_machine` resources - as such this resource is feature-frozen and new
-//		 functionality will be added to these new resources instead.
+//
+//	`azurerm_windows_virtual_machine` resources - as such this resource is feature-frozen and new
+//	functionality will be added to these new resources instead.
 func resourceVirtualMachine() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceVirtualMachineCreateUpdate,

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -27,8 +27,9 @@ import (
 )
 
 // NOTE: the `azurerm_virtual_machine_scale_set` resource has been superseded by the
-//       `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources
-//       and as such this resource is feature-frozen and new functionality will be added to these new resources instead.
+//
+//	`azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources
+//	and as such this resource is feature-frozen and new functionality will be added to these new resources instead.
 func resourceVirtualMachineScaleSet() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceVirtualMachineScaleSetCreateUpdate,

--- a/internal/services/legacy/virtual_machine_unmanaged_disks_resource_test.go
+++ b/internal/services/legacy/virtual_machine_unmanaged_disks_resource_test.go
@@ -337,7 +337,8 @@ func TestAccVirtualMachine_changeOSDiskVhdUri(t *testing.T) {
 }
 
 // to accept terms for config:
-//   get-AzureRmMarketplaceTerms -publisher kemptech -product vlm-azure -name freeloadmaster | Set-AzureRmMarketplaceTerms -accept
+//
+//	get-AzureRmMarketplaceTerms -publisher kemptech -product vlm-azure -name freeloadmaster | Set-AzureRmMarketplaceTerms -accept
 func TestAccVirtualMachine_plan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -125,44 +125,43 @@ func TestAccMonitorActionGroup_webhookReceiver(t *testing.T) {
 }
 
 /*
-
 @favoretti: Disabling this one, since it's written in such a way that it will never succeed in CI
 
-func TestAccMonitorActionGroup_secureWebhookReceiver(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
-	r := MonitorActionGroupResource{}
+	func TestAccMonitorActionGroup_secureWebhookReceiver(t *testing.T) {
+		data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
+		r := MonitorActionGroupResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.webhookReceiver(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.secureWebhookReceiver(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
+		data.ResourceTest(t, r, []acceptance.TestStep{
+			{
+				Config: r.basic(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.webhookReceiver(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.secureWebhookReceiver(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.basic(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep(),
+		})
+	}
 */
 func TestAccMonitorActionGroup_automationRunbookReceiver(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")

--- a/internal/services/mssql/validate/mssql.go
+++ b/internal/services/mssql/validate/mssql.go
@@ -54,8 +54,9 @@ func ValidateMsSqlJobAgentName(i interface{}, k string) (_ []string, errors []er
 
 // ValidateMsSqlDNSAliasName
 // Server DNS Alias name cannot be empty or null. It can only be made
-//        up of lowercase letters 'a'-'z', the numbers 0-9 and the hyphen. The hyphen
-//        may not lead or trail in the name.
+//
+//	up of lowercase letters 'a'-'z', the numbers 0-9 and the hyphen. The hyphen
+//	may not lead or trail in the name.
 func ValidateMsSqlDNSAliasName(i interface{}, k string) ([]string, []error) {
 	if m, regexErrs := validate.RegExHelper(i, k, `^[0-9a-z][-0-9a-z]{0,127}[0-9a-z]$`); !m {
 		return nil, append(regexErrs, fmt.Errorf("`%q` Server DNS Alias name cannot be empty or null. It can only be made up of lowercase letters 'a'-'z', the numbers 0-9 and the hyphen. The hyphen may not lead or trail in the name.", k))

--- a/internal/services/serviceconnector/helper.go
+++ b/internal/services/serviceconnector/helper.go
@@ -264,7 +264,7 @@ func flattenServiceConnectorAuthInfo(input servicelinker.AuthInfoBase) []AuthInf
 	}
 }
 
-//TODO: Only support Azure resource for now. Will include ConfluentBootstrapServer and ConfluentSchemaRegistry in the future.
+// TODO: Only support Azure resource for now. Will include ConfluentBootstrapServer and ConfluentSchemaRegistry in the future.
 func flattenTargetService(input servicelinker.TargetServiceBase) string {
 	var targetServiceId string
 

--- a/internal/services/sql/sql_virtual_network_rule_resource_test.go
+++ b/internal/services/sql/sql_virtual_network_rule_resource_test.go
@@ -17,9 +17,9 @@ import (
 type SqlVirtualNetworkRuleResource struct{}
 
 /*
-	---Testing for Success---
-	Test a basic SQL virtual network rule configuration setup and update scenario, and
-	validate that new property is set correctly.
+---Testing for Success---
+Test a basic SQL virtual network rule configuration setup and update scenario, and
+validate that new property is set correctly.
 */
 func TestAccSqlVirtualNetworkRule_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -62,9 +62,9 @@ func TestAccSqlVirtualNetworkRule_requiresImport(t *testing.T) {
 }
 
 /*
-	---Testing for Success---
-	Test an update to the SQL Virtual Network Rule to connect to a different subnet, and
-	validate that new subnet is set correctly.
+---Testing for Success---
+Test an update to the SQL Virtual Network Rule to connect to a different subnet, and
+validate that new subnet is set correctly.
 */
 func TestAccSqlVirtualNetworkRule_switchSubnets(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -93,7 +93,7 @@ func TestAccSqlVirtualNetworkRule_switchSubnets(t *testing.T) {
 }
 
 /*
-	---Testing for Success---
+---Testing for Success---
 */
 func TestAccSqlVirtualNetworkRule_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -108,9 +108,9 @@ func TestAccSqlVirtualNetworkRule_disappears(t *testing.T) {
 }
 
 /*
-	--Testing for Success--
-	Test if we are able to create a vnet without the SQL endpoint, but SQL rule
-	is still applied since the endpoint validation will be set to false.
+--Testing for Success--
+Test if we are able to create a vnet without the SQL endpoint, but SQL rule
+is still applied since the endpoint validation will be set to false.
 */
 func TestAccSqlVirtualNetworkRule_ignoreEndpointValid(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -127,9 +127,9 @@ func TestAccSqlVirtualNetworkRule_ignoreEndpointValid(t *testing.T) {
 }
 
 /*
-	--Testing for Failure--
-	Test if we are able to create a vnet with out the SQL endpoint, but SQL rule
-	is still applied since the endpoint validation will be set to false.
+--Testing for Failure--
+Test if we are able to create a vnet with out the SQL endpoint, but SQL rule
+is still applied since the endpoint validation will be set to false.
 */
 func TestAccSqlVirtualNetworkRule_IgnoreEndpointInvalid(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -144,9 +144,9 @@ func TestAccSqlVirtualNetworkRule_IgnoreEndpointInvalid(t *testing.T) {
 }
 
 /*
-	--Testing for Success--
-	Test if we are able to create multiple subnets and connect multiple subnets to the
-	SQL server.
+--Testing for Success--
+Test if we are able to create multiple subnets and connect multiple subnets to the
+SQL server.
 */
 func TestAccSqlVirtualNetworkRule_multipleSubnets(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sql_virtual_network_rule", "test")
@@ -198,8 +198,8 @@ func (r SqlVirtualNetworkRuleResource) Destroy(ctx context.Context, client *clie
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	Basic Provisioning Configuration
+(This test configuration is intended to succeed.)
+Basic Provisioning Configuration
 */
 func (r SqlVirtualNetworkRuleResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -261,9 +261,9 @@ resource "azurerm_sql_virtual_network_rule" "import" {
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	Basic Provisioning Update Configuration (all other properties would recreate the rule)
-	ignore_missing_vnet_service_endpoint (false ==> true)
+(This test configuration is intended to succeed.)
+Basic Provisioning Update Configuration (all other properties would recreate the rule)
+ignore_missing_vnet_service_endpoint (false ==> true)
 */
 func (r SqlVirtualNetworkRuleResource) withUpdates(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -311,9 +311,9 @@ resource "azurerm_sql_virtual_network_rule" "test" {
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	This test is designed to set up a scenario where a user would want to update the subnet
-	on a given SQL virtual network rule. This configuration sets up the resources initially.
+(This test configuration is intended to succeed.)
+This test is designed to set up a scenario where a user would want to update the subnet
+on a given SQL virtual network rule. This configuration sets up the resources initially.
 */
 func (r SqlVirtualNetworkRuleResource) subnetSwitchPre(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -368,10 +368,10 @@ resource "azurerm_sql_virtual_network_rule" "test" {
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	This test is designed to set up a scenario where a user would want to update the subnet
-	on a given SQL virtual network rule. This configuration contains the update from
-	azurerm_subnet.test1 to azurerm_subnet.test2.
+(This test configuration is intended to succeed.)
+This test is designed to set up a scenario where a user would want to update the subnet
+on a given SQL virtual network rule. This configuration contains the update from
+azurerm_subnet.test1 to azurerm_subnet.test2.
 */
 func (r SqlVirtualNetworkRuleResource) subnetSwitchPost(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -426,10 +426,10 @@ resource "azurerm_sql_virtual_network_rule" "test" {
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	Succeeds because subnet's service_endpoints does not include 'Microsoft.Sql' and the SQL
-    virtual network rule is set to *not* validate that the service_endpoint includes that value.
-    The endpoint is purposefully set to Microsoft.Storage.
+		(This test configuration is intended to succeed.)
+		Succeeds because subnet's service_endpoints does not include 'Microsoft.Sql' and the SQL
+	    virtual network rule is set to *not* validate that the service_endpoint includes that value.
+	    The endpoint is purposefully set to Microsoft.Storage.
 */
 func (r SqlVirtualNetworkRuleResource) ignoreEndpointValid(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -477,10 +477,10 @@ resource "azurerm_sql_virtual_network_rule" "test" {
 }
 
 /*
-	(This test configuration is intended to fail.)
-	Fails because subnet's service_endpoints does not include 'Microsoft.Sql' and the SQL
-    virtual network rule is set to validate that the service_endpoint includes that value.
-    The endpoint is purposefully set to Microsoft.Storage.
+		(This test configuration is intended to fail.)
+		Fails because subnet's service_endpoints does not include 'Microsoft.Sql' and the SQL
+	    virtual network rule is set to validate that the service_endpoint includes that value.
+	    The endpoint is purposefully set to Microsoft.Storage.
 */
 func (r SqlVirtualNetworkRuleResource) ignoreEndpointInvalid(data acceptance.TestData) string {
 	return fmt.Sprintf(`
@@ -528,9 +528,9 @@ resource "azurerm_sql_virtual_network_rule" "test" {
 }
 
 /*
-	(This test configuration is intended to succeed.)
-	This configuration sets up 3 subnets in 2 different virtual networks, and adds
-	SQL virtual network rules for all 3 subnets to the SQL server.
+(This test configuration is intended to succeed.)
+This configuration sets up 3 subnets in 2 different virtual networks, and adds
+SQL virtual network rules for all 3 subnets to the SQL server.
 */
 func (r SqlVirtualNetworkRuleResource) multipleSubnets(data acceptance.TestData) string {
 	return fmt.Sprintf(`

--- a/internal/services/sql/validate/virtual_network_rule_name_test.go
+++ b/internal/services/sql/validate/virtual_network_rule_name_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 /*
-	--Testing for Failure--
-	Validation Function Tests - Invalid Name Validations
+--Testing for Failure--
+Validation Function Tests - Invalid Name Validations
 */
 func TestVirtualNetworkRuleInvalidNameValidation(t *testing.T) {
 	cases := []struct {
@@ -83,8 +83,8 @@ func TestVirtualNetworkRuleInvalidNameValidation(t *testing.T) {
 }
 
 /*
-	--Testing for Success--
-	Validation Function Tests - (Barely) Valid Name Validations
+--Testing for Success--
+Validation Function Tests - (Barely) Valid Name Validations
 */
 func TestVirtualNetworkRuleValidNameValidation(t *testing.T) {
 	cases := []struct {

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -20,6 +20,7 @@ func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //
 
 // Any returns a SchemaValidateFunc which tests if the provided value
 // passes any of the provided SchemaValidateFunc
+//
 //lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
 func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.Any(validators...)


### PR DESCRIPTION
I see some differences in comments with `make fmt` after upgrading the go version. Updating the comment with running `make fmt`
`go version go1.19.3 windows/amd64`