### PR TITLE
`azurerm_logic_app_standard` - fix the UserAssigned Identity

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1346,7 +1346,7 @@ func expandLogicAppStandardIdentity(input []interface{}) (*web.ManagedServiceIde
 
 func expandLogicAppStandardUserAssignedIdentity(input map[string]identity.UserAssignedIdentityDetails) map[string]*web.UserAssignedIdentity {
 	output := make(map[string]*web.UserAssignedIdentity)
-	for k, _ := range input {
+	for k := range input {
 		output[k] = &web.UserAssignedIdentity{}
 	}
 	return output

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -598,7 +598,10 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	identity := flattenLogicAppStandardIdentity(resp.Identity)
+	identity, err := flattenLogicAppStandardIdentity(resp.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
 	if err := d.Set("identity", identity); err != nil {
 		return fmt.Errorf("setting `identity`: %s", err)
 	}
@@ -1325,21 +1328,35 @@ func expandLogicAppStandardSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig
 }
 
 func expandLogicAppStandardIdentity(input []interface{}) (*web.ManagedServiceIdentity, error) {
-	expanded, err := identity.ExpandSystemAssigned(input)
+	expanded, err := identity.ExpandSystemAndUserAssignedMap(input)
 	if err != nil {
 		return nil, err
 	}
 
-	return &web.ManagedServiceIdentity{
+	output := web.ManagedServiceIdentity{
 		Type: web.ManagedServiceIdentityType(expanded.Type),
-	}, nil
+	}
+
+	if expanded.Type == identity.TypeUserAssigned || expanded.Type == identity.TypeSystemAssignedUserAssigned {
+		output.UserAssignedIdentities = expandLogicAppStandardUserAssignedIdentity(expanded.IdentityIds)
+	}
+
+	return &output, nil
 }
 
-func flattenLogicAppStandardIdentity(input *web.ManagedServiceIdentity) []interface{} {
-	var transform *identity.SystemAssigned
+func expandLogicAppStandardUserAssignedIdentity(input map[string]identity.UserAssignedIdentityDetails) map[string]*web.UserAssignedIdentity {
+	output := make(map[string]*web.UserAssignedIdentity)
+	for k, _ := range input {
+		output[k] = &web.UserAssignedIdentity{}
+	}
+	return output
+}
+
+func flattenLogicAppStandardIdentity(input *web.ManagedServiceIdentity) ([]interface{}, error) {
+	var transform *identity.SystemAndUserAssignedMap
 
 	if input != nil {
-		transform = &identity.SystemAssigned{
+		transform = &identity.SystemAndUserAssignedMap{
 			Type: identity.Type(string(input.Type)),
 		}
 		if input.PrincipalID != nil {
@@ -1348,9 +1365,31 @@ func flattenLogicAppStandardIdentity(input *web.ManagedServiceIdentity) []interf
 		if input.TenantID != nil {
 			transform.TenantId = *input.TenantID
 		}
+		if input.UserAssignedIdentities != nil {
+			transform.IdentityIds = flattenLogicAppStandardUserAssignedIdentity(input.UserAssignedIdentities)
+		}
 	}
 
-	return identity.FlattenSystemAssigned(transform)
+	output, err := identity.FlattenSystemAndUserAssignedMap(transform)
+	if err != nil {
+		return nil, err
+	}
+	return *output, nil
+}
+
+func flattenLogicAppStandardUserAssignedIdentity(input map[string]*web.UserAssignedIdentity) map[string]identity.UserAssignedIdentityDetails {
+	expanded := make(map[string]identity.UserAssignedIdentityDetails)
+	for k, v := range input {
+		identityDetail := identity.UserAssignedIdentityDetails{}
+		if v.PrincipalID != nil {
+			identityDetail.PrincipalId = v.PrincipalID
+		}
+		if v.ClientID != nil {
+			identityDetail.ClientId = v.ClientID
+		}
+		expanded[k] = identityDetail
+	}
+	return expanded
 }
 
 func expandLogicAppStandardSettings(

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -344,6 +344,22 @@ func TestAccLogicAppStandard_updateIdentity(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_userAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+			),
+		},
+	})
+}
+
 func TestAccLogicAppStandard_corsSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
@@ -1284,6 +1300,39 @@ resource "azurerm_logic_app_standard" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogicAppStandardResource) userAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  name = "acctest%[2]d"
+}
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%[2]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  identity {
+    type = "UserAssigned"
+	identity_ids = [
+		azurerm_user_assigned_identity.test.id
+	]
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1330,9 +1330,9 @@ resource "azurerm_logic_app_standard" "test" {
 
   identity {
     type = "UserAssigned"
-	identity_ids = [
-		azurerm_user_assigned_identity.test.id
-	]
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
   }
 }
 `, r.template(data), data.RandomInteger)


### PR DESCRIPTION
fix #19139 

<details><summary>Test</summary>
<p>

```bash
TF_ACC=1 go test -v ./internal/services/logic -run=TestAccLogicAppStandard -timeout=600m
=== RUN   TestAccLogicAppStandardDataSource_basic
=== PAUSE TestAccLogicAppStandardDataSource_basic
=== RUN   TestAccLogicAppStandard_basic
=== PAUSE TestAccLogicAppStandard_basic
=== RUN   TestAccLogicAppStandard_containerized
=== PAUSE TestAccLogicAppStandard_containerized
=== RUN   TestAccLogicAppStandard_extensionBundle
=== PAUSE TestAccLogicAppStandard_extensionBundle
=== RUN   TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
=== PAUSE TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
=== RUN   TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
=== PAUSE TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
=== RUN   TestAccLogicAppStandard_requiresImport
=== PAUSE TestAccLogicAppStandard_requiresImport
=== RUN   TestAccLogicAppStandard_tags
=== PAUSE TestAccLogicAppStandard_tags
=== RUN   TestAccLogicAppStandard_tagsUpdate
=== PAUSE TestAccLogicAppStandard_tagsUpdate
=== RUN   TestAccLogicAppStandard_appSettings
=== PAUSE TestAccLogicAppStandard_appSettings
=== RUN   TestAccLogicAppStandard_customShare
=== PAUSE TestAccLogicAppStandard_customShare
=== RUN   TestAccLogicAppStandard_siteConfig
=== PAUSE TestAccLogicAppStandard_siteConfig
=== RUN   TestAccLogicAppStandard_healthCheck
=== PAUSE TestAccLogicAppStandard_healthCheck
=== RUN   TestAccLogicAppStandard_connectionStrings
=== PAUSE TestAccLogicAppStandard_connectionStrings
=== RUN   TestAccLogicAppStandard_updateVersion
=== PAUSE TestAccLogicAppStandard_updateVersion
=== RUN   TestAccLogicAppStandard_3264bit
=== PAUSE TestAccLogicAppStandard_3264bit
=== RUN   TestAccLogicAppStandard_httpsOnly
=== PAUSE TestAccLogicAppStandard_httpsOnly
=== RUN   TestAccLogicAppStandard_createIdentity
=== PAUSE TestAccLogicAppStandard_createIdentity
=== RUN   TestAccLogicAppStandard_updateIdentity
=== PAUSE TestAccLogicAppStandard_updateIdentity
=== RUN   TestAccLogicAppStandard_userAssignedIdentity
=== PAUSE TestAccLogicAppStandard_userAssignedIdentity
=== RUN   TestAccLogicAppStandard_corsSettings
=== PAUSE TestAccLogicAppStandard_corsSettings
=== RUN   TestAccLogicAppStandard_enableHttp2
=== PAUSE TestAccLogicAppStandard_enableHttp2
=== RUN   TestAccLogicAppStandard_minTlsVersion
=== PAUSE TestAccLogicAppStandard_minTlsVersion
=== RUN   TestAccLogicAppStandard_ftpsState
=== PAUSE TestAccLogicAppStandard_ftpsState
=== RUN   TestAccLogicAppStandard_preWarmedInstanceCount
=== PAUSE TestAccLogicAppStandard_preWarmedInstanceCount
=== RUN   TestAccLogicAppStandard_computedPreWarmedInstanceCount
=== PAUSE TestAccLogicAppStandard_computedPreWarmedInstanceCount
=== RUN   TestAccLogicAppStandard_oneIpRestriction
=== PAUSE TestAccLogicAppStandard_oneIpRestriction
=== RUN   TestAccLogicAppStandard_oneServiceTagIpRestriction
=== PAUSE TestAccLogicAppStandard_oneServiceTagIpRestriction
=== RUN   TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
=== PAUSE TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
=== RUN   TestAccLogicAppStandard_oneVNetSubnetIpRestriction
=== PAUSE TestAccLogicAppStandard_oneVNetSubnetIpRestriction
=== RUN   TestAccLogicAppStandard_ipRestrictionRemoved
=== PAUSE TestAccLogicAppStandard_ipRestrictionRemoved
=== RUN   TestAccLogicAppStandard_manyIpRestrictions
=== PAUSE TestAccLogicAppStandard_manyIpRestrictions
=== RUN   TestAccLogicAppStandard_scmType
=== PAUSE TestAccLogicAppStandard_scmType
=== RUN   TestAccLogicAppStandard_scmUseMainIpRestriction
=== PAUSE TestAccLogicAppStandard_scmUseMainIpRestriction
=== RUN   TestAccLogicAppStandard_scmOneIpRestriction
=== PAUSE TestAccLogicAppStandard_scmOneIpRestriction
=== RUN   TestAccLogicAppStandard_scmMinTlsVersion
=== PAUSE TestAccLogicAppStandard_scmMinTlsVersion
=== RUN   TestAccLogicAppStandard_updateStorageAccountKey
=== PAUSE TestAccLogicAppStandard_updateStorageAccountKey
=== RUN   TestAccLogicAppStandard_clientCertMode
=== PAUSE TestAccLogicAppStandard_clientCertMode
=== RUN   TestAccLogicAppStandard_elasticInstanceMinimum
=== PAUSE TestAccLogicAppStandard_elasticInstanceMinimum
=== RUN   TestAccLogicAppStandard_appScaleLimit
=== PAUSE TestAccLogicAppStandard_appScaleLimit
=== RUN   TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
=== PAUSE TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
=== RUN   TestAccLogicAppStandard_dotnetVersion4
=== PAUSE TestAccLogicAppStandard_dotnetVersion4
=== RUN   TestAccLogicAppStandard_dotnetVersion5
=== PAUSE TestAccLogicAppStandard_dotnetVersion5
=== RUN   TestAccLogicAppStandard_dotnetVersion6
=== PAUSE TestAccLogicAppStandard_dotnetVersion6
=== RUN   TestAccLogicAppStandard_vNetIntegration
=== PAUSE TestAccLogicAppStandard_vNetIntegration
=== RUN   TestAccLogicAppStandard_vNetIntegrationUpdate
=== PAUSE TestAccLogicAppStandard_vNetIntegrationUpdate
=== CONT  TestAccLogicAppStandardDataSource_basic
=== CONT  TestAccLogicAppStandard_ftpsState
=== CONT  TestAccLogicAppStandard_scmMinTlsVersion
=== CONT  TestAccLogicAppStandard_dotnetVersion4
=== CONT  TestAccLogicAppStandard_elasticInstanceMinimum
=== CONT  TestAccLogicAppStandard_oneVNetSubnetIpRestriction
=== CONT  TestAccLogicAppStandard_scmType
=== CONT  TestAccLogicAppStandard_runtimeScaleMonitoringEnabled
--- PASS: TestAccLogicAppStandard_runtimeScaleMonitoringEnabled (346.42s)
=== CONT  TestAccLogicAppStandard_oneIpRestriction
--- PASS: TestAccLogicAppStandard_dotnetVersion4 (352.29s)
=== CONT  TestAccLogicAppStandard_changeIpToServiceTagIpRestriction
--- PASS: TestAccLogicAppStandard_ftpsState (353.51s)
=== CONT  TestAccLogicAppStandard_oneServiceTagIpRestriction
--- PASS: TestAccLogicAppStandard_elasticInstanceMinimum (356.96s)
=== CONT  TestAccLogicAppStandard_scmOneIpRestriction
--- PASS: TestAccLogicAppStandard_scmMinTlsVersion (357.45s)
=== CONT  TestAccLogicAppStandard_computedPreWarmedInstanceCount
--- PASS: TestAccLogicAppStandard_scmType (359.22s)
=== CONT  TestAccLogicAppStandard_appScaleLimit
--- PASS: TestAccLogicAppStandard_oneVNetSubnetIpRestriction (361.59s)
=== CONT  TestAccLogicAppStandard_manyIpRestrictions
--- PASS: TestAccLogicAppStandardDataSource_basic (369.83s)
=== CONT  TestAccLogicAppStandard_preWarmedInstanceCount
--- PASS: TestAccLogicAppStandard_oneServiceTagIpRestriction (275.01s)
=== CONT  TestAccLogicAppStandard_scmUseMainIpRestriction
--- PASS: TestAccLogicAppStandard_oneIpRestriction (345.65s)
=== CONT  TestAccLogicAppStandard_ipRestrictionRemoved
--- PASS: TestAccLogicAppStandard_computedPreWarmedInstanceCount (345.36s)
=== CONT  TestAccLogicAppStandard_healthCheck
--- PASS: TestAccLogicAppStandard_appScaleLimit (352.03s)
=== CONT  TestAccLogicAppStandard_minTlsVersion
--- PASS: TestAccLogicAppStandard_scmOneIpRestriction (357.47s)
=== CONT  TestAccLogicAppStandard_enableHttp2
--- PASS: TestAccLogicAppStandard_manyIpRestrictions (356.35s)
=== CONT  TestAccLogicAppStandard_corsSettings
--- PASS: TestAccLogicAppStandard_preWarmedInstanceCount (421.80s)
=== CONT  TestAccLogicAppStandard_userAssignedIdentity
--- PASS: TestAccLogicAppStandard_changeIpToServiceTagIpRestriction (594.76s)
=== CONT  TestAccLogicAppStandard_updateIdentity
--- PASS: TestAccLogicAppStandard_scmUseMainIpRestriction (337.72s)
=== CONT  TestAccLogicAppStandard_createIdentity
--- PASS: TestAccLogicAppStandard_healthCheck (332.98s)
=== CONT  TestAccLogicAppStandard_httpsOnly
--- PASS: TestAccLogicAppStandard_minTlsVersion (324.97s)
=== CONT  TestAccLogicAppStandard_3264bit
--- PASS: TestAccLogicAppStandard_enableHttp2 (323.43s)
=== CONT  TestAccLogicAppStandard_updateVersion
--- PASS: TestAccLogicAppStandard_corsSettings (328.85s)
=== CONT  TestAccLogicAppStandard_connectionStrings
--- PASS: TestAccLogicAppStandard_userAssignedIdentity (312.49s)
=== CONT  TestAccLogicAppStandard_requiresImport
--- PASS: TestAccLogicAppStandard_createIdentity (308.61s)
=== CONT  TestAccLogicAppStandard_siteConfig
--- PASS: TestAccLogicAppStandard_httpsOnly (297.20s)
=== CONT  TestAccLogicAppStandard_customShare
--- PASS: TestAccLogicAppStandard_ipRestrictionRemoved (649.48s)
=== CONT  TestAccLogicAppStandard_appSettings
--- PASS: TestAccLogicAppStandard_connectionStrings (337.44s)
=== CONT  TestAccLogicAppStandard_tagsUpdate
--- PASS: TestAccLogicAppStandard_updateIdentity (459.20s)
=== CONT  TestAccLogicAppStandard_tags
--- PASS: TestAccLogicAppStandard_requiresImport (354.82s)
=== CONT  TestAccLogicAppStandard_clientCertMode
--- PASS: TestAccLogicAppStandard_3264bit (435.73s)
=== CONT  TestAccLogicAppStandard_extensionBundle
--- PASS: TestAccLogicAppStandard_updateVersion (450.95s)
=== CONT  TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled
--- PASS: TestAccLogicAppStandard_siteConfig (338.31s)
=== CONT  TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled
--- PASS: TestAccLogicAppStandard_customShare (324.83s)
=== CONT  TestAccLogicAppStandard_containerized
--- PASS: TestAccLogicAppStandard_tags (337.34s)
=== CONT  TestAccLogicAppStandard_vNetIntegration
--- PASS: TestAccLogicAppStandard_extensionBundle (329.49s)
=== CONT  TestAccLogicAppStandard_vNetIntegrationUpdate
--- PASS: TestAccLogicAppStandard_tagsUpdate (419.48s)
=== CONT  TestAccLogicAppStandard_dotnetVersion6
--- PASS: TestAccLogicAppStandard_appSettingsVnetRouteAllEnabled (333.30s)
=== CONT  TestAccLogicAppStandard_basic
--- PASS: TestAccLogicAppStandard_siteConfigVnetRouteAllEnabled (325.30s)
=== CONT  TestAccLogicAppStandard_dotnetVersion5
--- PASS: TestAccLogicAppStandard_containerized (331.14s)
=== CONT  TestAccLogicAppStandard_updateStorageAccountKey
--- PASS: TestAccLogicAppStandard_appSettings (669.44s)
--- PASS: TestAccLogicAppStandard_clientCertMode (674.00s)
--- PASS: TestAccLogicAppStandard_dotnetVersion6 (330.44s)
--- PASS: TestAccLogicAppStandard_vNetIntegration (399.20s)
--- PASS: TestAccLogicAppStandard_basic (331.83s)
--- PASS: TestAccLogicAppStandard_dotnetVersion5 (320.29s)
--- PASS: TestAccLogicAppStandard_updateStorageAccountKey (663.05s)
--- PASS: TestAccLogicAppStandard_vNetIntegrationUpdate (1139.78s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 2941.251s
```

</p>
</details>