### PR TITLE
`azurerm_backup_container_storage_account` - fix a potential panic

### DIFF
--- a/internal/services/recoveryservices/backup_container_storage_account_resource.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource.go
@@ -113,7 +113,7 @@ func resourceBackupProtectionContainerStorageAccountCreate(d *pluginsdk.Resource
 	}
 
 	operationID := parsedLocation.Path["operationResults"]
-	if _, err = resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx, opStatusClient, vaultName, resGroup, operationID, d); err != nil {
+	if err = resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx, opStatusClient, vaultName, resGroup, operationID, d); err != nil {
 		return err
 	}
 
@@ -185,7 +185,7 @@ func resourceBackupProtectionContainerStorageAccountDelete(d *pluginsdk.Resource
 	}
 	operationID := parsedLocation.Path["backupOperationResults"]
 
-	if _, err = resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx, opClient, id.VaultName, id.ResourceGroup, operationID, d); err != nil {
+	if err = resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx, opClient, id.VaultName, id.ResourceGroup, operationID, d); err != nil {
 		return err
 	}
 
@@ -193,7 +193,7 @@ func resourceBackupProtectionContainerStorageAccountDelete(d *pluginsdk.Resource
 }
 
 // nolint unused - linter mistakenly things this function isn't used?
-func resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx context.Context, client *backup.OperationStatusesClient, vaultName, resourceGroup, operationID string, d *pluginsdk.ResourceData) (backup.OperationStatus, error) {
+func resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx context.Context, client *backup.OperationStatusesClient, vaultName, resourceGroup, operationID string, d *pluginsdk.ResourceData) error {
 	state := &pluginsdk.StateChangeConf{
 		MinTimeout:                10 * time.Second,
 		Delay:                     10 * time.Second,
@@ -210,11 +210,11 @@ func resourceBackupProtectionContainerStorageAccountWaitForOperation(ctx context
 	}
 
 	log.Printf("[DEBUG] Waiting for backup container operation %q (Vault %q) to complete", operationID, vaultName)
-	resp, err := state.WaitForStateContext(ctx)
+	_, err := state.WaitForStateContext(ctx)
 	if err != nil {
-		return resp.(backup.OperationStatus), err
+		return err
 	}
-	return resp.(backup.OperationStatus), nil
+	return nil
 }
 
 func resourceBackupProtectionContainerStorageAccountCheckOperation(ctx context.Context, client *backup.OperationStatusesClient, vaultName, resourceGroup, operationID string) pluginsdk.StateRefreshFunc {


### PR DESCRIPTION
fix a potenial panic, it happened once on TeamCity's test. 

the type assert on Line 215 may panic, and it's unused now, so remove it.

Panic Log
---
```
Test ended in panic.
------- Stdout: -------
=== RUN   TestAccBackupProtectedFileShare_basic
=== PAUSE TestAccBackupProtectedFileShare_basic
=== CONT  TestAccBackupProtectedFileShare_basic
------- Stderr: -------
panic: interface conversion: interface {} is nil, not backup.OperationStatus
goroutine 675 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices.resourceBackupProtectionContainerStorageAccountWaitForOperation({0x6e56000, 0xc0026e6ba0}, 0x0?, {0xc0000588a0, 0x20}, {0xc001d8b650?, 0x0?}, {0xc0009b0b39, 0x24}, 0xc0028b5c80)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/internal/services/recoveryservices/backup_container_storage_account_resource.go:215 +0x38c
github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices.resourceBackupProtectionContainerStorageAccountCreate(0xc0028b5c80, {0x5c01b20?, 0xc001286800})
  /opt/teamcity-agent/work/5e6516bb4d10eb66/internal/services/recoveryservices/backup_container_storage_account_resource.go:116 +0xb3f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x6e56038?, {0x6e56038?, 0xc0028520f0?}, 0xd?, {0x5c01b20?, 0xc001286800?})
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:695 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0007d75e0, {0x6e56038, 0xc0028520f0}, 0xc002521c70, 0xc0028b5b00, {0x5c01b20, 0xc001286800})
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:837 +0xa7a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000473cc8, {0x6e56038?, 0xc002f9ddd0?}, 0xc000dcba40)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:1021 +0xe3c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc001fbeaa0, {0x6e56038?, 0xc002f9c9f0?}, 0xc00113cfc0)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go:813 +0x4fc
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x62698c0?, 0xc001fbeaa0}, {0x6e56038, 0xc002f9c9f0}, 0xc0026e66c0, 0x0)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc002896380, {0x6e685c8, 0xc0017a44e0}, 0xc002b93440, 0xc000c2d020, 0xb112c60, 0x0)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/google.golang.org/grpc/server.go:1283 +0xcfd
google.golang.org/grpc.(*Server).handleStream(0xc002896380, {0x6e685c8, 0xc0017a44e0}, 0xc002b93440, 0x0)
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/google.golang.org/grpc/server.go:1620 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/google.golang.org/grpc/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
  /opt/teamcity-agent/work/5e6516bb4d10eb66/vendor/google.golang.org/grpc/server.go:920 +0x28a
```

Test
---
```
TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccBackupProtectionContainerStorageAccount -timeout=600m 
=== RUN   TestAccBackupProtectionContainerStorageAccount_basic
=== PAUSE TestAccBackupProtectionContainerStorageAccount_basic
=== CONT  TestAccBackupProtectionContainerStorageAccount_basic
--- PASS: TestAccBackupProtectionContainerStorageAccount_basic (605.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      606.354s

```
