### PR TITLE
`vm/vmss` - move validation between `source_image_id` and `source_image_reference` to schema

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -300,6 +300,10 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 					computeValidate.SharedGalleryImageID,
 					computeValidate.SharedGalleryImageVersionID,
 				),
+				ExactlyOneOf: []string{
+					"source_image_id",
+					"source_image_reference",
+				},
 			},
 
 			"source_image_reference": sourceImageReferenceSchema(true),

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -1373,6 +1373,10 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 				validate.SharedGalleryImageID,
 				validate.SharedGalleryImageVersionID,
 			),
+			ExactlyOneOf: []string{
+				"source_image_id",
+				"source_image_reference",
+			},
 		},
 
 		"source_image_reference": sourceImageReferenceSchema(false),

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -226,6 +226,10 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 					computeValidate.SharedGalleryImageID,
 					computeValidate.SharedGalleryImageVersionID,
 				),
+				ExactlyOneOf: []string{
+					"source_image_id",
+					"source_image_reference",
+				},
 			},
 
 			"source_image_reference": sourceImageReferenceSchema(false),

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -1,8 +1,6 @@
 package compute
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -342,11 +340,14 @@ func sourceImageReferenceSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	// Id /...../Versions/16.04.201909091 is not a valid resource reference."
 	// as such the image is split into two fields (source_image_id and source_image_reference) to provide better validation
 	return &pluginsdk.Schema{
-		Type:          pluginsdk.TypeList,
-		Optional:      true,
-		ForceNew:      isVirtualMachine,
-		MaxItems:      1,
-		ConflictsWith: []string{"source_image_id"},
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: isVirtualMachine,
+		MaxItems: 1,
+		ExactlyOneOf: []string{
+			"source_image_id",
+			"source_image_reference",
+		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"publisher": {
@@ -420,10 +421,6 @@ func expandSourceImageReference(referenceInput []interface{}, imageId string) (*
 		return &compute.ImageReference{
 			ID: utils.String(imageId),
 		}, nil
-	}
-
-	if len(referenceInput) == 0 {
-		return nil, fmt.Errorf("either a `source_image_id` or a `source_image_reference` block must be specified")
 	}
 
 	raw := referenceInput[0].(map[string]interface{})

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -317,6 +317,10 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 					computeValidate.SharedGalleryImageID,
 					computeValidate.SharedGalleryImageVersionID,
 				),
+				ExactlyOneOf: []string{
+					"source_image_id",
+					"source_image_reference",
+				},
 			},
 
 			"source_image_reference": sourceImageReferenceSchema(true),

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -1421,6 +1421,10 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 				computeValidate.SharedGalleryImageID,
 				computeValidate.SharedGalleryImageVersionID,
 			),
+			ExactlyOneOf: []string{
+				"source_image_id",
+				"source_image_reference",
+			},
 		},
 
 		"source_image_reference": sourceImageReferenceSchema(false),


### PR DESCRIPTION
`source_image_reference` is set to `ConflictsWith: []string{"source_image_id"}`. And in Create/Update, there is a validation to ensure at least one of `source_image_reference` and `source_image_id` is specified. This combination is same as `ExactlyOneOf`, thus updating the schema to fail early when both or none of the properties are specified.

Affected resources:
`azurerm_linux_virtual_machine`
`azurerm_windows_virtual_machine`
`azurerm_linux_virtual_machine_scale_set`
`azurerm_windows_virtual_machine_scale_set`
`azurerm_orchestrated_virtual_machine_scale_set`