### PR TITLE
azurerm_postgresql_flexible_server - support new SKUs for Postgresql Flexible Server

### DIFF
--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -12,7 +12,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B(1ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|((104)ids_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name_test.go
@@ -78,6 +78,36 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			input: "MO_Standard_E16ds_v4",
 			valid: true,
 		},
+		{
+			name:  "B_Standard_B20ms",
+			input: "B_Standard_B20ms",
+			valid: true,
+		},
+		{
+			name:  "GP_Standard_D16ds_v5",
+			input: "GP_Standard_D16ds_v5",
+			valid: true,
+		},
+		{
+			name:  "GP_Standard_D16ads_v5",
+			input: "GP_Standard_D16ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_E16ds_v5",
+			input: "MO_Standard_E16ds_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_E104ids_v5",
+			input: "MO_Standard_E104ids_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_E16ads_v5",
+			input: "MO_Standard_E16ads_v5",
+			valid: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR is to support new SKUs for Postgresql Flexible Server.

Below is the list of new SKUs:
```
B: Standard_B(2|4|8|12|16|20)ms
GP: Standard_D(2|4|8|16|32|48|64|96)ds_v5, Standard_D(2|4|8|16|32|48|64|96)ads_v5
MO: Standard_E(2|4|8|16|20|32|48|64|96)ds_v5, Standard_E(2|4|8|16|32|48|64)ads_v5
```

--- PASS: TestFlexibleServerSkuName/GP_Standard_E64s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D64s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ds_v4 (0.00s)
    --- PASS: TestFlexibleServerSkuName/Standard (0.00s)
    --- PASS: TestFlexibleServerSkuName/Empty (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_E32s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_E30s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16s (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E2s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E64ds_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B1ms (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B1 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_D2s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ds_v4 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B20ms (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ds_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ads_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ds_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ads_v5 (0.00s)