### PR TITLE
`azurerm_postgresql_flexible_server` - remove `Standard_E96ds_v5` and `Standard_E104ids_v5` since they're not ready

### DIFF
--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -12,7 +12,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|((104)ids_v5))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|((104)ids_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -12,7 +12,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|((104)ids_v5))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name_test.go
@@ -99,11 +99,6 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:  "MO_Standard_E104ids_v5",
-			input: "MO_Standard_E104ids_v5",
-			valid: true,
-		},
-		{
 			name:  "MO_Standard_E16ads_v5",
 			input: "MO_Standard_E16ads_v5",
 			valid: true,


### PR DESCRIPTION
@katbyte , sorry. Service team just confirmed the `Standard_E96ds_v5` and `Standard_E104ids_v5` aren't ready for now. So I have to remove them from the validation.

--- PASS: TestFlexibleServerSkuName/GP_Standard_E64s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D64s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ds_v4 (0.00s)
    --- PASS: TestFlexibleServerSkuName/Standard (0.00s)
    --- PASS: TestFlexibleServerSkuName/Empty (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_E32s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_E30s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16s (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E2s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E64ds_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B1ms (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B1 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_D2s_v3 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ds_v4 (0.00s)
    --- PASS: TestFlexibleServerSkuName/B_Standard_B20ms (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ds_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/GP_Standard_D16ads_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ds_v5 (0.00s)
    --- PASS: TestFlexibleServerSkuName/MO_Standard_E16ads_v5 (0.00s)