### PR TITLE
`azurerm_windows_web_app`, `azurerm_windows_web_app_slot` - Supporting java 17 in app runtime.

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -967,6 +967,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						"1.8",
 						"11",
+						"17",
 					}, false),
 					AtLeastOneOf: []string{
 						"site_config.0.application_stack.0.docker_container_name",

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -705,6 +705,21 @@ func TestAccWindowsWebApp_withJava11Java(t *testing.T) {
 	})
 }
 
+func TestAccWindowsWebApp_withJava17Java(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.java(data, "17", "JAVA", "9.3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccWindowsWebApp_basicDockerContainer(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
 	r := WindowsWebAppResource{}

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -152,7 +152,7 @@ An `application_stack` block supports the following:
 
 * `java_container_version` - (Optional) The Version of the `java_container` to use. Required with `java_version` and `java_container`.
 
-* `java_version` - (Optional) The version of Java to use when `current_stack` is set to `java`. Possible values include `1.7`, `1.8` and `11`. Required with `java_container` and `java_container_version`.
+* `java_version` - (Optional) The version of Java to use when `current_stack` is set to `java`. Possible values include `1.7`, `1.8`, `11` and `17`. Required with `java_container` and `java_container_version`.
 
 ~> **NOTE:** For compatible combinations of `java_version`, `java_container` and `java_container_version` users can use `az webapp list-runtimes` from command line.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -156,7 +156,7 @@ A `application_stack` block supports the following:
 
 * `java_container_version` - (Optional) The Version of the `java_container` to use. Required with `java_version` and `java_container`.
 
-* `java_version` - (Optional) The version of Java to use when `current_stack` is set to `java`. Possible values include `1.7`, `1.8` and `11`. Required with `java_container` and `java_container_version`.
+* `java_version` - (Optional) The version of Java to use when `current_stack` is set to `java`. Possible values include `1.7`, `1.8`, `11` and `17`. Required with `java_container` and `java_container_version`.
 
 ~> **NOTE:** For compatible combinations of `java_version`, `java_container` and `java_container_version` users can use `az webapp list-runtimes` from command line.
 


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/19171