### PR TITLE
fix: azurerm_federated_identity_credential: An argument named locatio…

### DIFF
--- a/website/docs/r/federated_identity_credential.html.markdown
+++ b/website/docs/r/federated_identity_credential.html.markdown
@@ -25,7 +25,6 @@ resource "azurerm_user_assigned_identity" "example" {
 }
 
 resource "azurerm_federated_identity_credential" "example" {
-  location            = azurerm_resource_group.example.location
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   audience            = ["foo"]
@@ -38,8 +37,6 @@ resource "azurerm_federated_identity_credential" "example" {
 ## Arguments Reference
 
 The following arguments are supported:
-
-* `location` - (Required) The Azure Region where the Federated Identity Credential should exist. Changing this forces a new Federated Identity Credential to be created.
 
 * `name` - (Required) Specifies the name of this Federated Identity Credential. Changing this forces a new Federated Identity Credential to be created.
 


### PR DESCRIPTION
Creating an azurerm_federated_identity_credential resource according to the example code in the doc leads to the following error:

Error: Unsupported argument
│ 
│   on identity_federation.tf line 16, in resource "azurerm_federated_identity_credential" "example":
│   16:   location            = azurerm_resource_group.test.location
│ 
│ An argument named "location" is not expected here.

Removing the location field fixes the problem.

This pull request updates the documentation to reflect the code:

https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/managedidentity/federated_identity_credential_resource.go

Thanks