### PR TITLE
`azurerm_orchestrated_virtual_machine_scale_set` - fix issue with no image is specified

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -226,13 +226,12 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 					computeValidate.SharedGalleryImageID,
 					computeValidate.SharedGalleryImageVersionID,
 				),
-				ExactlyOneOf: []string{
-					"source_image_id",
+				ConflictsWith: []string{
 					"source_image_reference",
 				},
 			},
 
-			"source_image_reference": sourceImageReferenceSchema(false),
+			"source_image_reference": sourceImageReferenceSchemaOrchestratedVMSS(),
 
 			"zone_balance": {
 				Type:     pluginsdk.TypeBool,

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -379,6 +379,43 @@ func sourceImageReferenceSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	}
 }
 
+func sourceImageReferenceSchemaOrchestratedVMSS() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		ConflictsWith: []string{
+			"source_image_id",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"publisher": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"offer": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"sku": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"version": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
 func isValidHotPatchSourceImageReference(referenceInput []interface{}, imageId string) bool {
 	if imageId != "" {
 		return false


### PR DESCRIPTION
Fix a regression within `azurerm_orchestrated_virtual_machine_scale_set` introduced by #19230. Unlike Uniform VMSS, Orchestrated VMSS doesn't enforce `source_image_id`/`source_image_reference` to be set.
https://github.com/hashicorp/terraform-provider-azurerm/blob/adcc312b7365d2a5030f2aec1757c877ec5010fe/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go#L381-L384
