### PR TITLE
Docs: Fix wrong name for the forwarding_rule_state property of azurerm_private_dns_resolver_forwarding_rule

### DIFF
--- a/website/docs/r/private_dns_resolver_forwarding_rule.html.markdown
+++ b/website/docs/r/private_dns_resolver_forwarding_rule.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `target_dns_servers` - (Required) Can be specified multiple times to define multiple target DNS servers. Each `target_dns_servers` block as defined below.
 
-* `forwarding_rule_state` - (Optional) Specifies the state of the Private DNS Resolver Forwarding Rule.
+* `enabled` - (Optional) Specifies the state of the Private DNS Resolver Forwarding Rule. Defaults to `true`.
 
 * `metadata` - (Optional) Metadata attached to the Private DNS Resolver Forwarding Rule.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19250

The `forwarding_rule_state` should be updated to `enabled` since it doesn't exist in the resource.