### PR TITLE
`azurerm_integration_service_environment` - mark as deprecated

### DIFF
--- a/internal/services/logic/integration_service_environment.go
+++ b/internal/services/logic/integration_service_environment.go
@@ -28,11 +28,11 @@ import (
 
 func resourceIntegrationServiceEnvironment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		DeprecationMessage: "Integration service environments are getting deprecated. Please use Logic Apps Standard instead. Please see https://aka.ms/isedeprecation for more details.",
 		Create:             resourceIntegrationServiceEnvironmentCreateUpdate,
 		Read:               resourceIntegrationServiceEnvironmentRead,
 		Update:             resourceIntegrationServiceEnvironmentCreateUpdate,
 		Delete:             resourceIntegrationServiceEnvironmentDelete,
+		DeprecationMessage: "The \"azurerm_integrated_service_environment\" resource is deprecated and will be removed in v4.0 of the Azure Provider. The underlying Azure Service is being retired on 2024-08-31 and new instances cannot be provisioned by default after 2022-11-01. More information on the retirement and how to migrate to Logic Apps Standard (\"azurerm_logic_app_standard\") can be found here: https://aka.ms/isedeprecation.",
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.IntegrationServiceEnvironmentID(id)

--- a/internal/services/logic/integration_service_environment.go
+++ b/internal/services/logic/integration_service_environment.go
@@ -28,10 +28,11 @@ import (
 
 func resourceIntegrationServiceEnvironment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceIntegrationServiceEnvironmentCreateUpdate,
-		Read:   resourceIntegrationServiceEnvironmentRead,
-		Update: resourceIntegrationServiceEnvironmentCreateUpdate,
-		Delete: resourceIntegrationServiceEnvironmentDelete,
+		DeprecationMessage: "Integration service environments are getting deprecated. Please use Logic Apps Standard instead. Please see https://aka.ms/isedeprecation for more details.",
+		Create:             resourceIntegrationServiceEnvironmentCreateUpdate,
+		Read:               resourceIntegrationServiceEnvironmentRead,
+		Update:             resourceIntegrationServiceEnvironmentCreateUpdate,
+		Delete:             resourceIntegrationServiceEnvironmentDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.IntegrationServiceEnvironmentID(id)

--- a/website/docs/r/integration_service_environment.html.markdown
+++ b/website/docs/r/integration_service_environment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages private and isolated Logic App instances within an Azure virtual network.
 
+!> **NOTE:** This resource is getting deprecated (https://aka.ms/isedeprecation). Please use [`azurerm_logic_app_standard`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_standard) instead.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/integration_service_environment.html.markdown
+++ b/website/docs/r/integration_service_environment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages private and isolated Logic App instances within an Azure virtual network.
 
-!> **NOTE:** This resource is getting deprecated (https://aka.ms/isedeprecation). Please use [`azurerm_logic_app_standard`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_standard) instead.
+!> **NOTE:** The `azurerm_integration_service_environment` resource is deprecated and will be removed in v4.0 of the Azure Provider. The underlying Azure Service is being retired on 2024-08-31 and new instances cannot be provisioned by default after 2022-11-01. More information on the retirement and how to migrate to [Logic Apps Standard](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_standard) [can be found here](https://aka.ms/isedeprecation).
 
 ## Example Usage
 


### PR DESCRIPTION
`azurerm_integration_service_environment` is getting deprecated (https://techcommunity.microsoft.com/t5/integrations-on-azure-blog/ise-retirement-what-you-need-to-know/ba-p/3645220). Mark it as deprecated in provider.