### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - serialize test cases

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -15,6 +15,10 @@ import (
 
 type MonitorAADDiagnosticSettingResource struct{}
 
+// NOTE: this is a combined test rather than separate split out tests due to
+// Azure only being happy about provisioning five per subscription at once and
+// there are existing resource in the test subscription hard to clear.
+// (which our test suite can't easily workaround)
 func TestAccAADDiagnosticSetting(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"basic": {

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -19,7 +19,7 @@ type MonitorAADDiagnosticSettingResource struct{}
 // Azure only being happy about provisioning five per subscription at once and
 // there are existing resource in the test subscription hard to clear.
 // (which our test suite can't easily workaround)
-func TestAccAADDiagnosticSetting(t *testing.T) {
+func TestAccMonitorAADDiagnosticSetting(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"basic": {
 			"eventhubDefault":       testAccMonitorAADDiagnosticSetting_eventhubDefault,

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -31,8 +31,10 @@ func TestAccMonitorAADDiagnosticSetting(t *testing.T) {
 	}
 
 	for group, m := range testCases {
+		m := m
 		t.Run(group, func(t *testing.T) {
 			for name, tc := range m {
+				tc := tc
 				t.Run(name, func(t *testing.T) {
 					tc(t)
 				})

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -15,7 +15,29 @@ import (
 
 type MonitorAADDiagnosticSettingResource struct{}
 
-func TestAccMonitorAADDiagnosticSetting_eventhubDefault(t *testing.T) {
+func TestAccAADDiagnosticSetting(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"basic": {
+			"eventhubDefault":       testAccMonitorAADDiagnosticSetting_eventhubDefault,
+			"eventhub":              testAccMonitorAADDiagnosticSetting_eventhub,
+			"requiresImport":        testAccMonitorAADDiagnosticSetting_requiresImport,
+			"logAnalyticsWorkspace": testAccMonitorAADDiagnosticSetting_logAnalyticsWorkspace,
+			"storageAccount":        testAccMonitorAADDiagnosticSetting_storageAccount,
+		},
+	}
+
+	for group, m := range testCases {
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccMonitorAADDiagnosticSetting_eventhubDefault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -29,7 +51,7 @@ func TestAccMonitorAADDiagnosticSetting_eventhubDefault(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAADDiagnosticSetting_eventhub(t *testing.T) {
+func testAccMonitorAADDiagnosticSetting_eventhub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -43,7 +65,7 @@ func TestAccMonitorAADDiagnosticSetting_eventhub(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAADDiagnosticSetting_requiresImport(t *testing.T) {
+func testAccMonitorAADDiagnosticSetting_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 
@@ -61,7 +83,7 @@ func TestAccMonitorAADDiagnosticSetting_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAADDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) {
+func testAccMonitorAADDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 
@@ -76,7 +98,7 @@ func TestAccMonitorAADDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAADDiagnosticSetting_storageAccount(t *testing.T) {
+func testAccMonitorAADDiagnosticSetting_storageAccount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 


### PR DESCRIPTION
Azure only being happy about provisioning five per subscription at once and there are existing resource in the test subscriptions hard to clear. So making it a serialized to enhance stability.