### PR TITLE
`azurerm_storage_blob_inventory_policy` - support for deleted blobs in inventory policy via include_deleted property on filters

### DIFF
--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -138,6 +138,12 @@ func storageBlobInventoryPolicyResourceSchema() map[string]*pluginsdk.Schema {
 									Default:  false,
 								},
 
+								"include_deleted": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
 								"include_snapshots": {
 									Type:     pluginsdk.TypeBool,
 									Optional: true,
@@ -283,6 +289,7 @@ func expandBlobInventoryPolicyFilter(input []interface{}) *storage.BlobInventory
 		PrefixMatch:         utils.ExpandStringSlice(v["prefix_match"].(*pluginsdk.Set).List()),
 		BlobTypes:           utils.ExpandStringSlice(v["blob_types"].(*pluginsdk.Set).List()),
 		IncludeBlobVersions: utils.Bool(v["include_blob_versions"].(bool)),
+		IncludeDeleted:      utils.Bool(v["include_deleted"].(bool)),
 		IncludeSnapshots:    utils.Bool(v["include_snapshots"].(bool)),
 	}
 }
@@ -330,6 +337,10 @@ func flattenBlobInventoryPolicyFilter(input *storage.BlobInventoryPolicyFilter) 
 	if input.IncludeBlobVersions != nil {
 		includeBlobVersions = *input.IncludeBlobVersions
 	}
+	var includeDeleted bool
+	if input.IncludeDeleted != nil {
+		includeDeleted = *input.IncludeDeleted
+	}
 	var includeSnapshots bool
 	if input.IncludeSnapshots != nil {
 		includeSnapshots = *input.IncludeSnapshots
@@ -338,6 +349,7 @@ func flattenBlobInventoryPolicyFilter(input *storage.BlobInventoryPolicyFilter) 
 		map[string]interface{}{
 			"blob_types":            utils.FlattenStringSlice(input.BlobTypes),
 			"include_blob_versions": includeBlobVersions,
+			"include_deleted":       includeDeleted,
 			"include_snapshots":     includeSnapshots,
 			"prefix_match":          utils.FlattenStringSlice(input.PrefixMatch),
 		},

--- a/internal/services/storage/storage_blob_inventory_policy_resource_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_test.go
@@ -210,8 +210,8 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       "IsCurrentVersion",
       "Snapshot",
       "BlobType",
-	  "Deleted",
-	  "RemainingRetentionDays",
+      "Deleted",
+      "RemainingRetentionDays",
     ]
     filter {
       blob_types            = ["blockBlob", "pageBlob"]
@@ -246,8 +246,8 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       "IsCurrentVersion",
       "Snapshot",
       "BlobType",
-	  "Deleted",
-	  "RemainingRetentionDays",
+      "Deleted",
+      "RemainingRetentionDays",
     ]
     filter {
       blob_types            = ["blockBlob", "pageBlob"]

--- a/internal/services/storage/storage_blob_inventory_policy_resource_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_test.go
@@ -210,10 +210,13 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       "IsCurrentVersion",
       "Snapshot",
       "BlobType",
+	  "Deleted",
+	  "RemainingRetentionDays",
     ]
     filter {
       blob_types            = ["blockBlob", "pageBlob"]
       include_blob_versions = true
+	  include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
     }
@@ -243,10 +246,13 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       "IsCurrentVersion",
       "Snapshot",
       "BlobType",
+	  "Deleted",
+	  "RemainingRetentionDays",
     ]
     filter {
       blob_types            = ["blockBlob", "pageBlob"]
       include_blob_versions = true
+	  include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
     }

--- a/internal/services/storage/storage_blob_inventory_policy_resource_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_test.go
@@ -216,7 +216,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
     filter {
       blob_types            = ["blockBlob", "pageBlob"]
       include_blob_versions = true
-	  include_deleted       = true
+      include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
     }
@@ -252,7 +252,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
     filter {
       blob_types            = ["blockBlob", "pageBlob"]
       include_blob_versions = true
-	  include_deleted       = true
+      include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
     }

--- a/website/docs/r/storage_blob_inventory_policy.html.markdown
+++ b/website/docs/r/storage_blob_inventory_policy.html.markdown
@@ -77,6 +77,10 @@ A `filter` block supports the following:
 
 ~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `IsCurrentVersion` and `VersionId` so that you can specify the `include_blob_versions`.
 
+* `include_deleted` - (Optional) Includes deleted blobs in blob inventory or not? Defaults to `false`.
+
+~> **NOTE:** If `rules.*.scope` is `Container`, the `rules.*.schema_fields` for this rule must include `Deleted`, `Version`, `DeletedTime`, and `RemainingRetentionDays` so that you can specify the `include_deleted`. If `rules.*.scope` is `Blob`, the `rules.*.schema_fields` must include `Deleted` and `RemainingRetentionDays` so that you can specify the `include_deleted`. If `rules.*.scope` is `Blob` and the storage account specified by `storage_account_id` has hierarchical namespaces enabled (`is_hns_enabled` is `true` on the storage account), the `rules.*.schema_fields` for this rule must include `Deleted`, `Version`, `DeletedTime`, and `RemainingRetentionDays` so that you can specify the `include_deleted`.
+
 * `include_snapshots` - (Optional) Includes blob snapshots in blob inventory or not? Defaults to `false`.
 
 ~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `Snapshot` so that you can specify the `include_snapshots`.


### PR DESCRIPTION
Adds support for the "includeDeleted" flag on blob and container inventory policies. See [Microsoft documentation](https://learn.microsoft.com/en-us/rest/api/storagerp/blob-inventory-policies/create-or-update?tabs=HTTP#blobinventorypolicyfilter) for more information.

PR includes:
- Implementation of `includeDeleted` flag
- Modification of acceptance tests to include testing `includeDeleted` flag
- Modification of documentation to include new `include_deleted` property on filters

Closes #19279

Acceptance tests pass:
```
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageBlobInventoryPolicy_.* -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageBlobInventoryPolicy_basic
=== PAUSE TestAccStorageBlobInventoryPolicy_basic
=== RUN   TestAccStorageBlobInventoryPolicy_requiresImport
=== PAUSE TestAccStorageBlobInventoryPolicy_requiresImport
=== RUN   TestAccStorageBlobInventoryPolicy_complete
=== PAUSE TestAccStorageBlobInventoryPolicy_complete
=== RUN   TestAccStorageBlobInventoryPolicy_update
=== PAUSE TestAccStorageBlobInventoryPolicy_update
=== CONT  TestAccStorageBlobInventoryPolicy_basic
=== CONT  TestAccStorageBlobInventoryPolicy_complete
=== CONT  TestAccStorageBlobInventoryPolicy_update
=== CONT  TestAccStorageBlobInventoryPolicy_requiresImport
--- PASS: TestAccStorageBlobInventoryPolicy_complete (162.97s)
--- PASS: TestAccStorageBlobInventoryPolicy_requiresImport (189.53s)
--- PASS: TestAccStorageBlobInventoryPolicy_basic (222.85s)
--- PASS: TestAccStorageBlobInventoryPolicy_update (390.16s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       390.172s
```