### PR TITLE
`azurerm_mssql_database` and `azurerm_mariadb_server` - Fix acctest for `TestAccMariaDbServer_createPointInTimeRestore`, `TestAccMsSqlDatabase_createPITRMode` and `TestAccMsSqlDatabase_scaleReplicaSet``

### DIFF
--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -188,7 +188,7 @@ func TestAccMariaDbServer_createPointInTimeRestore(t *testing.T) {
 		data.ImportStep("administrator_login_password"), // not returned as sensitive
 		{
 			PreConfig: func() { time.Sleep(restoreTime.Sub(time.Now().Add(-7 * time.Minute))) },
-			Config:    r.createPointInTimeRestore(data, version, restoreTime.Add(5*time.Second).Format(time.RFC3339)),
+			Config:    r.createPointInTimeRestore(data, version, restoreTime.Add(3*time.Minute).Format(time.RFC3339)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That("azurerm_mariadb_server.restore").ExistsInAzure(r),

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -251,7 +251,7 @@ func TestAccMsSqlDatabase_createPITRMode(t *testing.T) {
 
 		{
 			PreConfig: func() { time.Sleep(11 * time.Minute) },
-			Config:    r.createPITRMode(data, time.Now().Add(time.Duration(9)*time.Minute).UTC().Format(time.RFC3339)),
+			Config:    r.createPITRMode(data, time.Now().Add(time.Duration(13)*time.Minute).UTC().Format(time.RFC3339)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That("azurerm_mssql_database.pitr").ExistsInAzure(r),
 			),
@@ -328,56 +328,56 @@ func TestAccMsSqlDatabase_scaleReplicaSet(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "P2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "BC_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "GP_Gen5_2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "S2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "Basic"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 		{
 			Config: r.scaleReplicaSet(data, "S1"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sample_name"),
+		data.ImportStep("sample_name", "license_type"),
 	})
 }
 


### PR DESCRIPTION
For test case `TestAccMariaDbServer_createPointInTimeRestore` fails with error ""

For test case `TestAccMsSqlDatabase_createPITRMode` fails with error "The specified point in time, '11/15/2022 12:19:51 AM', is not valid for database 'acctest-db-221115001051240774'. Valid points in time are between '11/15/2022 12:22:47 AM' and '11/15/2022 12:28:11 AM' inclusive."

For test case `TestAccMsSqlDatabase_scaleReplicaSet` fails with the follows error:


Test Result:
```
PASS: TestAccMariaDbServer_createPointInTimeRestore (1619.68s)
PASS: TestAccMsSqlDatabase_createPITRMode (1726.52s)
PASS: TestAccMsSqlDatabase_scaleReplicaSet (4175.90s) 
```