### PR TITLE
`azurerm_application_gateway`: fix SKU `WAF_v2` need waf configuration

### DIFF
--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -2316,6 +2316,16 @@ resource "azurerm_application_gateway" "test" {
     subnet_id = "${azurerm_subnet.test.id}"
   }
 
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
+  }
+
   identity {
     type         = "UserAssigned"
     identity_ids = ["${azurerm_user_assigned_identity.test.id}"]
@@ -2491,6 +2501,16 @@ resource "azurerm_application_gateway" "test" {
     subnet_id = azurerm_subnet.test.id
   }
 
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
+  }
+
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
@@ -2651,6 +2671,16 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
+  }
+
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
   }
 
   frontend_port {
@@ -3189,6 +3219,16 @@ resource "azurerm_application_gateway" "test" {
   frontend_ip_configuration {
     name                 = local.frontend_ip_configuration_name
     public_ip_address_id = azurerm_public_ip.teststd.id
+  }
+
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
   }
 
   backend_address_pool {
@@ -4437,6 +4477,16 @@ resource "azurerm_application_gateway" "test" {
     subnet_id = azurerm_subnet.test.id
   }
 
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
+  }
+
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
@@ -4585,6 +4635,16 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
+  }
+
+  waf_configuration {
+    enabled                  = true
+    firewall_mode            = "Detection"
+    rule_set_type            = "OWASP"
+    rule_set_version         = "3.0"
+    file_upload_limit_mb     = 100
+    request_body_check       = true
+    max_request_body_size_kb = 100
   }
 
   identity {


### PR DESCRIPTION
## Fix Tests list:

- TestAccApplicationGateway_trustedRootCertificate
- TestAccApplicationGateway_trustedRootCertificate_keyvault
- TestAccApplicationGateway_sslCertificate_keyvault_versionless
- TestAccApplicationGateway_sslCertificate_keyvault_versioned

## Current failure message: 

```
        Error: creating Application Gateway: (Name "acctestag-221115003210252912" / Resource Group "acctestRG-221115003210252912"): 
network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ApplicationGatewayFirewallNotConfiguredForSelectedSku" 
Message="Application Gateway /subscriptions/*******/resourceGroups/acctestRG-221115003210252912/providers/
Microsoft.Network/applicationGateways/acctestag-221115003210252912 
with the selected SKU tier WAF_v2 must have a valid WAF policy or configuration" Details=[]

```

## Current PR test result:
![image](https://user-images.githubusercontent.com/2633022/202120249-23252025-d8bb-4f87-a5a7-f264ca7ce49c.png)
