### PR TITLE
`azurerm_virtual_network_gateway`: fix AccTest for public ip resource with zones

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -1285,7 +1285,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -1397,7 +1397,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_virtual_network_gateway" "test" {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -1229,7 +1229,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -1341,7 +1341,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["1", "2"]
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_virtual_network_gateway" "test" {


### PR DESCRIPTION
public ip resource with zones property should contain all `1`, `2`, `3` zones.

- TestAccVirtualNetworkGateway_customRoute
- TestAccVirtualNetworkGateway_privateIpAddressEnabled

current error message:

```
        Terraform will perform the following actions:
        
          # azurerm_public_ip.test must be replaced
        -/+ resource "azurerm_public_ip" "test" {
              + fqdn                    = (known after apply)
              ~ id                      = "/subscriptions/*******/resourceGroups/acctestRG-221109055705027305/providers/Microsoft.Network/publicIPAddresses/acctest-221109055705027305" -> (known after apply)
              ~ ip_address              = "20.120.140.39" -> (known after apply)
              - ip_tags                 = {} -> null
                name                    = "acctest-221109055705027305"
              - tags                    = {} -> null
              ~ zones                   = [ # forces replacement
                  - "3",
                    # (2 unchanged elements hidden)
                ]
                # (7 unchanged attributes hidden)
            }
````

Current test result:

![image](https://user-images.githubusercontent.com/2633022/202341651-e271e310-3249-4830-9479-4809e2e4f83d.png)
