### PR TITLE
`azurerm_firewall_policy` - support for `explicit_proxy` and `auto_learn_private_ranges_mode` properties

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -204,13 +204,15 @@ func resourceFirewallPolicyRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 
 		var privateIPRanges []interface{}
+		var isAutoLearnPrivateRangeEnabled bool
 		if prop.Snat != nil {
 			privateIPRanges = utils.FlattenStringSlice(prop.Snat.PrivateRanges)
+			isAutoLearnPrivateRangeEnabled = prop.Snat.AutoLearnPrivateRanges == network.AutoLearnPrivateRangesModeEnabled
 		}
 		if err := d.Set("private_ip_ranges", privateIPRanges); err != nil {
 			return fmt.Errorf("setting `private_ip_ranges`: %+v", err)
 		}
-		isAutoLearnPrivateRangeEnabled := prop.Snat.AutoLearnPrivateRanges == network.AutoLearnPrivateRangesModeEnabled
+
 		if err := d.Set("auto_learn_private_ranges_enabled", isAutoLearnPrivateRangeEnabled); err != nil {
 			return fmt.Errorf("setting `auto_learn_private_ranges_enabled`: %+v", err)
 		}

--- a/internal/services/firewall/firewall_policy_resource_test.go
+++ b/internal/services/firewall/firewall_policy_resource_test.go
@@ -248,6 +248,15 @@ resource "azurerm_firewall_policy" "test" {
     ip_addresses = ["1.1.1.1", "2.2.2.2", "10.0.0.0/16"]
     fqdns        = ["foo.com", "bar.com"]
   }
+  explicit_proxy {
+    enabled         = true
+    http_port       = 8087
+    https_port      = 8088
+    enable_pac_file = true
+    pac_file_port   = 8089
+    pac_file        = "https://tinawstorage.file.core.windows.net/?sv=2020-02-10&ss=bfqt&srt=sco&sp=rwdlacuptfx&se=2021-06-04T07:01:12Z&st=2021-06-03T23:01:12Z&sip=68.65.171.11&spr=https&sig=Plsa0RRVpGbY0IETZZOT6znOHcSro71LLTTbzquYPgs%%3D"
+  }
+  auto_learn_private_ranges_mode = "Enabled"
   dns {
     servers       = ["1.1.1.1", "3.3.3.3", "2.2.2.2"]
     proxy_enabled = true
@@ -274,6 +283,15 @@ resource "azurerm_firewall_policy" "test" {
     ip_addresses = ["1.1.1.1", "2.2.2.2", "10.0.0.0/16"]
     fqdns        = ["foo.com", "bar.com"]
   }
+  explicit_proxy {
+    enabled         = true
+    http_port       = 8087
+    https_port      = 8088
+    enable_pac_file = true
+    pac_file_port   = 8089
+    pac_file        = "https://tinawstorage.file.core.windows.net/?sv=2020-02-10&ss=bfqt&srt=sco&sp=rwdlacuptfx&se=2021-06-04T07:01:12Z&st=2021-06-03T23:01:12Z&sip=68.65.171.11&spr=https&sig=Plsa0RRVpGbY0IETZZOT6znOHcSro71LLTTbzquYPgs%%3D"
+  }
+  auto_learn_private_ranges_mode = "Enabled"
   dns {
     servers       = ["1.1.1.1", "2.2.2.2"]
     proxy_enabled = true

--- a/internal/services/firewall/firewall_policy_resource_test.go
+++ b/internal/services/firewall/firewall_policy_resource_test.go
@@ -256,7 +256,7 @@ resource "azurerm_firewall_policy" "test" {
     pac_file_port   = 8089
     pac_file        = "https://tinawstorage.file.core.windows.net/?sv=2020-02-10&ss=bfqt&srt=sco&sp=rwdlacuptfx&se=2021-06-04T07:01:12Z&st=2021-06-03T23:01:12Z&sip=68.65.171.11&spr=https&sig=Plsa0RRVpGbY0IETZZOT6znOHcSro71LLTTbzquYPgs%%3D"
   }
-  auto_learn_private_ranges_mode = "Enabled"
+  auto_learn_private_ranges_enabled = true
   dns {
     servers       = ["1.1.1.1", "3.3.3.3", "2.2.2.2"]
     proxy_enabled = true
@@ -291,7 +291,7 @@ resource "azurerm_firewall_policy" "test" {
     pac_file_port   = 8089
     pac_file        = "https://tinawstorage.file.core.windows.net/?sv=2020-02-10&ss=bfqt&srt=sco&sp=rwdlacuptfx&se=2021-06-04T07:01:12Z&st=2021-06-03T23:01:12Z&sip=68.65.171.11&spr=https&sig=Plsa0RRVpGbY0IETZZOT6znOHcSro71LLTTbzquYPgs%%3D"
   }
-  auto_learn_private_ranges_mode = "Enabled"
+  auto_learn_private_ranges_enabled = true
   dns {
     servers       = ["1.1.1.1", "2.2.2.2"]
     proxy_enabled = true

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `private_ip_ranges` - (Optional) A list of private IP ranges to which traffic will not be SNAT.
 
-* `auto_learn_private_ranges_mode` - (Optional) Specify the mode of auto learn private range. Possible values are `Enabled` and `Disabled`.
+* `auto_learn_private_ranges_enabled` - (Optional) Whether enable auto learn private ip range. Defaults to `false`.
 
 * `sku` - (Optional) The SKU Tier of the Firewall Policy. Possible values are `Standard`, `Premium` and `Basic`. Changing this forces a new Firewall Policy to be created.
 

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 
 * `private_ip_ranges` - (Optional) A list of private IP ranges to which traffic will not be SNAT.
 
+* `auto_learn_private_ranges_mode` - (Optional) Specify the mode of auto learn private range. Possible values are `Enabled` and `Disabled`.
+
 * `sku` - (Optional) The SKU Tier of the Firewall Policy. Possible values are `Standard`, `Premium` and `Basic`. Changing this forces a new Firewall Policy to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Firewall Policy.
@@ -60,6 +62,8 @@ The following arguments are supported:
 * `tls_certificate` - (Optional) A `tls_certificate` block as defined below.
 
 * `sql_redirect_allowed` - (Optional) Whether SQL Redirect traffic filtering is allowed. Enabling this flag requires no rule using ports between `11000`-`11999`.
+
+* `explicit_proxy` - (Optional) A `explicit_proxy` block as defined below.
 
 ---
 
@@ -152,6 +156,22 @@ A `traffic_bypass` block supports the following:
 * `source_addresses` - (Optional) Specifies a list of source addresses that shall be bypassed by intrusion detection.
 
 * `source_ip_groups` - (Optional) Specifies a list of source IP groups that shall be bypassed by intrusion detection.
+
+---
+
+A `explicit_proxy` block supports the following:
+
+* `enabled` (Optional) Whether the explicit proxy is enabled for this Firewall Policy.
+
+* `http_port` (Optional) The port number for explicit http protocol.
+
+* `https_port` (Optional) The port number for explicit proxy https protocol.
+
+* `enable_pac_file` (Optional) Whether the pac file port and url need to be provided.
+
+* `pac_file_port` (Optional) Specifies a port number for firewall to serve PAC file.
+
+* `pac_file` (Optional) Specifies a SAS URL for PAC file.
 
 ## Attributes Reference
 


### PR DESCRIPTION
test result:

```
=== RUN   TestAccFirewallPolicy_complete
=== PAUSE TestAccFirewallPolicy_complete
=== CONT  TestAccFirewallPolicy_complete
--- PASS: TestAccFirewallPolicy_complete (145.61s)
PASS

```