### PR TITLE
Fix Test Cases `azurerm_monitor_aad_diagnostic_setting`, `azurerm_monitor_log_profile` - Change to `data.ResourceSequentialTest` for Serial Test Cases

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -46,7 +46,7 @@ func TestAccMonitorAADDiagnosticSetting(t *testing.T) {
 func testAccMonitorAADDiagnosticSetting_eventhubDefault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.eventhubDefault(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -60,7 +60,7 @@ func testAccMonitorAADDiagnosticSetting_eventhubDefault(t *testing.T) {
 func testAccMonitorAADDiagnosticSetting_eventhub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.eventhub(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -75,7 +75,7 @@ func testAccMonitorAADDiagnosticSetting_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.eventhub(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -93,7 +93,7 @@ func testAccMonitorAADDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.logAnalyticsWorkspace(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -108,7 +108,7 @@ func testAccMonitorAADDiagnosticSetting_storageAccount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_aad_diagnostic_setting", "test")
 	r := MonitorAADDiagnosticSettingResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.storageAccount(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/monitor/monitor_log_profile_data_source_test.go
+++ b/internal/services/monitor/monitor_log_profile_data_source_test.go
@@ -18,7 +18,7 @@ func testAccDataSourceMonitorLogProfile_storageaccount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileDataSource{}
 
-	data.DataSourceTest(t, []acceptance.TestStep{
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
 		{
 			Config: r.storageaccountConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -39,7 +39,7 @@ func testAccDataSourceMonitorLogProfile_eventhub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileDataSource{}
 
-	data.DataSourceTest(t, []acceptance.TestStep{
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
 		{
 			Config: r.eventhubConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/monitor/monitor_log_profile_resource_test.go
+++ b/internal/services/monitor/monitor_log_profile_resource_test.go
@@ -54,7 +54,7 @@ func testAccMonitorLogProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -69,7 +69,7 @@ func testAccMonitorLogProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -87,7 +87,7 @@ func testAccMonitorLogProfile_servicebus(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.servicebusConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -101,7 +101,7 @@ func testAccMonitorLogProfile_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.completeConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -115,7 +115,7 @@ func testAccMonitorLogProfile_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_log_profile", "test")
 	r := MonitorLogProfileResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
 			Config:       r.basicConfig,
 			TestResource: r,


### PR DESCRIPTION
`testAccMonitorLogProfile_servicebus` this test is failed due to service problem, other tests should work well.

```
make acctests SERVICE="monitor" TESTARGS="-parallel 1 -test.run=TestAccMonitorLogProfile" TESTTIMEOUT='1440m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -parallel 1 -test.run=TestAccMonitorLogProfile -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorLogProfile
=== RUN   TestAccMonitorLogProfile/basic
=== RUN   TestAccMonitorLogProfile/basic/disappears
=== RUN   TestAccMonitorLogProfile/basic/basic
=== RUN   TestAccMonitorLogProfile/basic/requiresImport
=== RUN   TestAccMonitorLogProfile/basic/servicebus
    testcase.go:117: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating/updating Monitor Log Profile: (Name "acctestlp-221116162100285207"): insights.LogProfilesClient#CreateOrUpdate: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> <nil>
        
          with azurerm_monitor_log_profile.test,
          on terraform_plugin_test.tf line 27, in resource "azurerm_monitor_log_profile" "test":
          27: resource "azurerm_monitor_log_profile" "test" {
        
=== RUN   TestAccMonitorLogProfile/basic/complete
=== RUN   TestAccMonitorLogProfile/datasource
=== RUN   TestAccMonitorLogProfile/datasource/eventhub
=== RUN   TestAccMonitorLogProfile/datasource/storageaccount
--- FAIL: TestAccMonitorLogProfile (2551.46s)
    --- FAIL: TestAccMonitorLogProfile/basic (1851.14s)
        --- PASS: TestAccMonitorLogProfile/basic/disappears (340.41s)
        --- PASS: TestAccMonitorLogProfile/basic/basic (342.68s)
        --- PASS: TestAccMonitorLogProfile/basic/requiresImport (368.78s)
        --- FAIL: TestAccMonitorLogProfile/basic/servicebus (370.90s)
        --- PASS: TestAccMonitorLogProfile/basic/complete (428.36s)
    --- PASS: TestAccMonitorLogProfile/datasource (700.32s)
        --- PASS: TestAccMonitorLogProfile/datasource/eventhub (350.89s)
        --- PASS: TestAccMonitorLogProfile/datasource/storageaccount (349.43s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       2551.481s
FAIL
make: *** [GNUmakefile:100: acctests] Error 1
```