### PR TITLE
GHA - possible fix for gradually-deprecated

### DIFF
--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -3,7 +3,7 @@
 function runGraduallyDeprecatedFunctions {
   echo "==> Checking for use of gradually deprecated functions..."
 
-  IFS=$'\n' read -r -d '' -a flist < <(git diff --diff-filter=AMRC main --name-only)
+  IFS=$'\n' read -r -d '' -a flist < <(git diff --diff-filter=AMRC origin/main --name-only)
 
   for f in "${flist[@]}"; do
     # require resources to be imported is now hard-coded on - but only checking for additions


### PR DESCRIPTION
Hopefully fixes run-gradually-deprecated which has been silently failing with `fatal: ambiguous argument 'main': unknown revision or path not in the working tree`, but wasn't able to reproduce this.
