### PR TITLE
New Resource `azurerm_network_manager`

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -207,6 +207,9 @@ service/mysql:
 service/netapp:
   - internal/services/netapp/**/*
 
+service/network:
+  - internal/services/network/**/*
+
 service/nginx:
   - internal/services/nginx/**/*
 

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -141,6 +141,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		loganalytics.Registration{},
 		monitor.Registration{},
 		mssql.Registration{},
+		network.Registration{},
 		nginx.Registration{},
 		policy.Registration{},
 		privatednsresolver.Registration{},

--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	InterfacesClient                       *network.InterfacesClient
 	IPGroupsClient                         *network.IPGroupsClient
 	LocalNetworkGatewaysClient             *network.LocalNetworkGatewaysClient
+	ManagersClient                         *network.ManagersClient
 	NatRuleClient                          *network.NatRulesClient
 	PointToSiteVpnGatewaysClient           *network.P2sVpnGatewaysClient
 	ProfileClient                          *network.ProfilesClient
@@ -121,6 +122,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	LocalNetworkGatewaysClient := network.NewLocalNetworkGatewaysClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&LocalNetworkGatewaysClient.Client, o.ResourceManagerAuthorizer)
+
+	ManagersClient := network.NewManagersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&ManagersClient.Client, o.ResourceManagerAuthorizer)
 
 	NatRuleClient := network.NewNatRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&NatRuleClient.Client, o.ResourceManagerAuthorizer)
@@ -253,6 +257,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		InterfacesClient:                       &InterfacesClient,
 		IPGroupsClient:                         &IpGroupsClient,
 		LocalNetworkGatewaysClient:             &LocalNetworkGatewaysClient,
+		ManagersClient:                         &ManagersClient,
 		NatRuleClient:                          &NatRuleClient,
 		PointToSiteVpnGatewaysClient:           &pointToSiteVpnGatewaysClient,
 		ProfileClient:                          &ProfileClient,

--- a/internal/services/network/network_manager_resource.go
+++ b/internal/services/network/network_manager_resource.go
@@ -1,0 +1,367 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	managementGroupValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-05-01/network"
+)
+
+type ManagerModel struct {
+	CrossTenantScopes []ManagerCrossTenantScopeModel `tfschema:"cross_tenant_scopes"`
+	Scope             []ManagerScopeModel            `tfschema:"scope"`
+	ScopeAccesses     []string                       `tfschema:"scope_accesses"`
+	Description       string                         `tfschema:"description"`
+	Name              string                         `tfschema:"name"`
+	Location          string                         `tfschema:"location"`
+	ResourceGroupName string                         `tfschema:"resource_group_name"`
+	Tags              map[string]interface{}         `tfschema:"tags"`
+}
+
+type ManagerScopeModel struct {
+	ManagementGroups []string `tfschema:"management_group_ids"`
+	Subscriptions    []string `tfschema:"subscription_ids"`
+}
+
+type ManagerCrossTenantScopeModel struct {
+	TenantId         string   `tfschema:"tenant_id"`
+	ManagementGroups []string `tfschema:"management_groups"`
+	Subscriptions    []string `tfschema:"subscriptions"`
+}
+
+type ManagerResource struct{}
+
+func (r ManagerResource) ResourceType() string {
+	return "azurerm_network_manager"
+}
+
+func (r ManagerResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.NetworkManagerID
+}
+
+func (r ManagerResource) ModelObject() interface{} {
+	return &ManagerModel{}
+}
+
+func (r ManagerResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"location": commonschema.Location(),
+
+		"scope": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"management_group_ids": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: managementGroupValidate.ManagementGroupID,
+						},
+						AtLeastOneOf: []string{"scope.0.management_group_ids", "scope.0.subscription_ids"},
+					},
+					"subscription_ids": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: commonids.ValidateSubscriptionID,
+						},
+						AtLeastOneOf: []string{"scope.0.management_group_ids", "scope.0.subscription_ids"},
+					},
+				},
+			},
+		},
+
+		"scope_accesses": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.ConfigurationTypeConnectivity),
+					string(network.ConfigurationTypeSecurityAdmin),
+				}, false),
+			},
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r ManagerResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"cross_tenant_scopes": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"tenant_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"subscriptions": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"management_groups": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r ManagerResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			metadata.Logger.Info("Decoding state..")
+			var state ManagerModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			client := metadata.Client.Network.ManagersClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			id := parse.NewNetworkManagerID(subscriptionId, state.ResourceGroupName, state.Name)
+			metadata.Logger.Infof("creating %s", id)
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+			if err != nil && !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			input := network.Manager{
+				Location: utils.String(azure.NormalizeLocation(state.Location)),
+				Name:     utils.String(state.Name),
+				ManagerProperties: &network.ManagerProperties{
+					Description:                 utils.String(state.Description),
+					NetworkManagerScopes:        expandNetworkManagerScope(state.Scope),
+					NetworkManagerScopeAccesses: expandNetworkManagerScopeAccesses(state.ScopeAccesses),
+				},
+				Tags: tags.Expand(state.Tags),
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, input, id.ResourceGroup, id.Name); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r ManagerResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Network.ManagersClient
+			id, err := parse.NetworkManagerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("retrieving %s", *id)
+			resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					metadata.Logger.Infof("%s was not found - removing from state!", *id)
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			var description string
+			var scope []ManagerScopeModel
+			var ScopeAccesses []string
+			if prop := resp.ManagerProperties; prop != nil {
+				if prop.Description != nil {
+					description = *resp.Description
+				}
+				scope = flattenNetworkManagerScope(resp.NetworkManagerScopes)
+				ScopeAccesses = flattenNetworkManagerScopeAccesses(resp.NetworkManagerScopeAccesses)
+			}
+
+			return metadata.Encode(&ManagerModel{
+				Description:       description,
+				Location:          location.NormalizeNilable(resp.Location),
+				Name:              id.Name,
+				ResourceGroupName: id.ResourceGroup,
+				ScopeAccesses:     ScopeAccesses,
+				Scope:             scope,
+				Tags:              tags.Flatten(resp.Tags),
+			})
+		},
+		Timeout: 5 * time.Minute,
+	}
+}
+
+func (r ManagerResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := parse.NetworkManagerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("updating %s..", *id)
+			client := metadata.Client.Network.ManagersClient
+			existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			if existing.ManagerProperties == nil {
+				return fmt.Errorf("unexpected null properties of %s", *id)
+			}
+			var state ManagerModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			if metadata.ResourceData.HasChange("description") {
+				existing.ManagerProperties.Description = utils.String(state.Description)
+			}
+
+			if metadata.ResourceData.HasChange("scope") {
+				existing.ManagerProperties.NetworkManagerScopes = expandNetworkManagerScope(state.Scope)
+			}
+
+			if metadata.ResourceData.HasChange("scope_accesses") {
+				existing.ManagerProperties.NetworkManagerScopeAccesses = expandNetworkManagerScopeAccesses(state.ScopeAccesses)
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				existing.Tags = tags.Expand(state.Tags)
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, existing, id.ResourceGroup, id.Name); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+			return nil
+
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r ManagerResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Network.ManagersClient
+			id, err := parse.NetworkManagerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s..", *id)
+			future, err := client.Delete(ctx, id.ResourceGroup, id.Name, utils.Bool(true))
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+			}
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func stringSlice(input []string) *[]string {
+	return &input
+}
+
+func expandNetworkManagerScope(input []ManagerScopeModel) *network.ManagerPropertiesNetworkManagerScopes {
+	if len(input) == 0 {
+		return nil
+	}
+
+	return &network.ManagerPropertiesNetworkManagerScopes{
+		ManagementGroups: stringSlice(input[0].ManagementGroups),
+		Subscriptions:    stringSlice(input[0].Subscriptions),
+	}
+}
+
+func expandNetworkManagerScopeAccesses(input []string) *[]network.ConfigurationType {
+	result := make([]network.ConfigurationType, 0)
+	for _, v := range input {
+		result = append(result, network.ConfigurationType(v))
+	}
+	return &result
+}
+
+func flattenStringSlicePtr(input *[]string) []string {
+	if input == nil {
+		return make([]string, 0)
+	}
+	return *input
+}
+
+func flattenNetworkManagerScope(input *network.ManagerPropertiesNetworkManagerScopes) []ManagerScopeModel {
+	if input == nil {
+		return make([]ManagerScopeModel, 0)
+	}
+
+	return []ManagerScopeModel{{
+		ManagementGroups: flattenStringSlicePtr(input.ManagementGroups),
+		Subscriptions:    flattenStringSlicePtr(input.Subscriptions),
+	}}
+}
+
+func flattenNetworkManagerScopeAccesses(input *[]network.ConfigurationType) []string {
+	var result []string
+	if input == nil {
+		return result
+	}
+
+	for _, v := range *input {
+		result = append(result, string(v))
+	}
+	return result
+}

--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -1,0 +1,197 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ManagerResource struct{}
+
+func TestAccNetworkManager(t *testing.T) {
+	// NOTE: this is a combined test rather than separate split out tests due to
+	// Azure only being happy about provisioning one network manager per subscription at once
+	// (which our test suite can't easily work around)
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"Manager": {
+			"basic":          testAccNetworkManager_basic,
+			"complete":       testAccNetworkManager_complete,
+			"update":         testAccNetworkManager_update,
+			"requiresImport": testAccNetworkManager_requiresImport,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccNetworkManager_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_manager", "test")
+	r := ManagerResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccNetworkManager_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_manager", "test")
+	r := ManagerResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccNetworkManager_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_manager", "test")
+	r := ManagerResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccNetworkManager_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_manager", "test")
+	r := ManagerResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r ManagerResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.NetworkManagerID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clients.Network.ManagersClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r ManagerResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_network_manager" "test" {
+  name                = "acctest-networkmanager-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+  scope_accesses = ["SecurityAdmin"]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ManagerResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_network_manager" "import" {
+  name                = azurerm_network_manager.test.name
+  location            = azurerm_network_manager.test.location
+  resource_group_name = azurerm_network_manager.test.resource_group_name
+  scope {
+    subscription_ids = azurerm_network_manager.test.scope.0.subscription_ids
+  }
+  scope_accesses = azurerm_network_manager.test.scope_accesses
+}
+`, r.basic(data))
+}
+
+func (r ManagerResource) complete(data acceptance.TestData) string {
+
+	return fmt.Sprintf(`
+%s
+resource "azurerm_network_manager" "test" {
+  name                = "acctest-networkmanager-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+  scope_accesses = ["Connectivity", "SecurityAdmin"]
+  description    = "test network manager"
+  tags = {
+    foo = "bar"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (ManagerResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-network-manager-%d"
+  location = "%s"
+}
+data "azurerm_subscription" "current" {
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/network/parse/network_manager.go
+++ b/internal/services/network/parse/network_manager.go
@@ -1,0 +1,69 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NetworkManagerId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNetworkManagerID(subscriptionId, resourceGroup, name string) NetworkManagerId {
+	return NetworkManagerId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NetworkManagerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Network Manager", segmentsStr)
+}
+
+func (id NetworkManagerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkManagers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NetworkManagerID parses a NetworkManager ID into an NetworkManagerId struct
+func NetworkManagerID(input string) (*NetworkManagerId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NetworkManagerId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("networkManagers"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/network_manager_test.go
+++ b/internal/services/network/parse/network_manager_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NetworkManagerId{}
+
+func TestNetworkManagerIDFormatter(t *testing.T) {
+	actual := NewNetworkManagerID("12345678-1234-9876-4563-123456789012", "resGroup1", "manager1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/manager1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNetworkManagerID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NetworkManagerId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/manager1",
+			Expected: &NetworkManagerId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "manager1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/NETWORKMANAGERS/MANAGER1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NetworkManagerID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -1,20 +1,40 @@
 package network
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 type Registration struct{}
+
+var (
+	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
 
 // Name is the name of this Service
 func (r Registration) Name() string {
 	return "Network"
 }
 
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/network"
+}
+
 // WebsiteCategories returns a list of categories which can be used for the sidebar
 func (r Registration) WebsiteCategories() []string {
 	return []string{
 		"Network",
+	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		ManagerResource{},
 	}
 }
 

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -109,3 +109,6 @@ package network
 
 // Virtual Machine Scale Set
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualMachineScaleSetPublicIPAddress -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/virtualMachines/virtualMachine1/networkInterfaces/networkInterface1/ipConfigurations/ipConfiguration1/publicIPAddresses/publicIpAddress1
+
+// Network Manager
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NetworkManager -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/manager1

--- a/internal/services/network/validate/network_manager_id.go
+++ b/internal/services/network/validate/network_manager_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+func NetworkManagerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.NetworkManagerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/network_manager_id_test.go
+++ b/internal/services/network/validate/network_manager_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestNetworkManagerID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkManagers/manager1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/NETWORKMANAGERS/MANAGER1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := NetworkManagerID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/network_manager.html.markdown
+++ b/website/docs/r/network_manager.html.markdown
@@ -1,0 +1,98 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_network_manager"
+description: |-
+Manages a Network Managers.
+---
+
+# azurerm_network_manager
+
+Manages a Network Managers.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+data "azurerm_subscription" "current" {
+}
+
+resource "azurerm_network_manager" "example" {
+  name                = "example-network-manager"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+  scope_accesses = ["Connectivity", "SecurityAdmin"]
+  description    = "example network manager"
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this Network Managers. Changing this forces a new Network Managers to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Network Managers should exist. Changing this forces a new Network Managers to be created.
+
+* `location` - (Required) Specifies the Azure Region where the Network Managers should exist.
+
+* `scope` - (Required) A `scope` block as defined below.
+
+* `scope_accesses` - (Required) A list of configuration deployment type. Possible values are `Connectivity` and `SecurityAdmin`, corresponds to if Connectivity Configuration and Security Admin Configuration is allowed for the Network Manager.
+
+* `description` - (Optional) A description of the network manager.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Network Managers.
+
+---
+
+A `scope` block supports the following:
+
+* `management_group_ids` - (Optional) A list of management group IDs.
+
+* `subscription_ids` - (Optional) A list of subscription IDs.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Network Managers.
+
+* `cross_tenant_scopes` - A `cross_tenant_scopes` block as defined below.
+
+---
+
+A `cross_tenant_scopes` block exports the following:
+
+* `management_groups` - List of management groups.
+
+* `subscriptions` - List of subscriptions.
+
+* `tenant_id` - Tenant ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Network Managers.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Network Managers.
+* `update` - (Defaults to 30 minutes) Used when updating the Network Managers.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Network Managers.
+
+## Import
+
+Network Managers can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_network_manager.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/networkManagers/networkManager1
+```

--- a/website/docs/r/network_manager.html.markdown
+++ b/website/docs/r/network_manager.html.markdown
@@ -3,7 +3,8 @@ subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_manager"
 description: |-
-Manages a Network Managers.
+  Manages a Network Managers.
+
 ---
 
 # azurerm_network_manager


### PR DESCRIPTION
### Notes
-  [What is Azure Virtual Network Manager](https://learn.microsoft.com/en-us/azure/virtual-network-manager/overview)
- Network Manager resources need to perform a [commit (deploy)](https://learn.microsoft.com/en-us/azure/virtual-network-manager/concept-deployments#-goal-state-model) operation (a POST API) to work, by evaluating the service model, we choose to make the network manager commit a independent resource, [click to see a possible config](https://github.com/teowa/terraform-provider-azurerm/blob/virtual_network_manager/website/docs/r/network_manager_commit.html.markdown).

### Coming Resources:
1.	[Network Managers](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManager.json#L37)                       /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}
2.	[Network Groups](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerGroup.json#L37)                            /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}
3.	[Static Members](https://github.com/Azure/azure-rest-api-specs/blob/b32e1896f30e6ea155449cb49719a6286e32b961/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerGroup.json#L240)                             /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}/staticMembers/{staticMemberName}
4.	[Connectivity Configurations](https://github.com/Azure/azure-rest-api-specs/blob/b32e1896f30e6ea155449cb49719a6286e32b961/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerConnectivityConfiguration.json#L37)        /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/connectivityConfigurations/{configurationName}
5.	[Security Admin Configurations](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerSecurityAdminConfiguration.json#L36)   /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations
6.	[Admin Rule Collections](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerSecurityAdminConfiguration.json#L273)                /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}
7.	[Admin Rules](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerSecurityAdminConfiguration.json#L465)                                   /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}
8.	[Network Manager Connections](https://github.com/Azure/azure-rest-api-specs/blob/b32e1896f30e6ea155449cb49719a6286e32b961/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerConnection.json#L37) /subscriptions/{subscriptionId}/providers/Microsoft.Network/networkManagerConnections/{networkManagerConnectionName}  
/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Network/networkManagerConnections/{networkManagerConnectionName}
9.	[Scope Connections](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManagerScopeConnection.json#L37)                       /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/scopeConnections/{scopeConnectionName}
10.	[Network Manager Commit](https://github.com/Azure/azure-rest-api-specs/blob/b749953e21e5c3f275d839862323920ef7bf716e/specification/network/resource-manager/Microsoft.Network/stable/2022-01-01/networkManager.json#L203)         /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/commit

### Test:
```
TF_ACC=1 go test -v ./internal/services/network -parallel 20 -test.run=TestAccNetworkManager$ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetworkManager
=== RUN   TestAccNetworkManager/Manager
=== RUN   TestAccNetworkManager/Manager/basic
=== RUN   TestAccNetworkManager/Manager/complete
=== RUN   TestAccNetworkManager/Manager/update
=== RUN   TestAccNetworkManager/Manager/requiresImport
--- PASS: TestAccNetworkManager (1145.03s)
    --- PASS: TestAccNetworkManager/Manager (1145.03s)
        --- PASS: TestAccNetworkManager/Manager/basic (229.55s)
        --- PASS: TestAccNetworkManager/Manager/complete (227.58s)
        --- PASS: TestAccNetworkManager/Manager/update (434.87s)
        --- PASS: TestAccNetworkManager/Manager/requiresImport (253.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1145.063s

```
