### PR TITLE
`data.azurerm_databricks_workspace` - support for "storage_account_identity" property

### DIFF
--- a/internal/services/databricks/databricks_workspace_data_source.go
+++ b/internal/services/databricks/databricks_workspace_data_source.go
@@ -46,6 +46,31 @@ func dataSourceDatabricksWorkspace() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"storage_account_identity": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"principal_id": {
+							Type:      pluginsdk.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+
+						"tenant_id": {
+							Type:      pluginsdk.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+
+						"type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -77,6 +102,9 @@ func dataSourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("sku", sku.Name)
 		}
 		d.Set("workspace_id", model.Properties.WorkspaceId)
+		if err := d.Set("storage_account_identity", flattenWorkspaceStorageAccountIdentity(model.Properties.StorageAccountIdentity)); err != nil {
+			return fmt.Errorf("setting `storage_account_identity`: %+v", err)
+		}
 		d.Set("workspace_url", model.Properties.WorkspaceUrl)
 		d.Set("location", model.Location)
 

--- a/website/docs/d/databricks_workspace.html.markdown
+++ b/website/docs/d/databricks_workspace.html.markdown
@@ -40,7 +40,19 @@ output "databricks_workspace_id" {
 
 * `workspace_url` - URL this Databricks Workspace is accessible on.
 
+* `storage_account_identity` - A `storage_account_identity` block as documented below.
+
 * `tags` - A mapping of tags to assign to the Databricks Workspace.
+
+---
+
+A `storage_account_identity` block exports the following:
+
+* `principal_id` - The principal UUID for the internal databricks storage account needed to provide access to the workspace for enabling Customer Managed Keys.
+
+* `tenant_id` - The UUID of the tenant where the internal databricks storage account was created.
+
+* `type` - The type of the internal databricks storage account.
 
 ## Timeouts
 


### PR DESCRIPTION
Fix #19329.

Test result:
PASS: TestAccDatabricksWorkspaceDataSource_basic (488.18s)