### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert_v2` - fix `evaluation_frequency` to Required in 4.0

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -207,8 +208,10 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"evaluation_frequency": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
+			Type: pluginsdk.TypeString,
+			// this field is required, missing this field will get an error from service
+			Optional: !features.FourPointOhBeta(),
+			Required: features.FourPointOhBeta(),
 			ValidateFunc: validation.StringInSlice([]string{
 				"PT1M",
 				"PT5M",


### PR DESCRIPTION

The `evaluation_frequency` should be Required as marked in [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2#evaluation_frequency), otherwise service returned error: 
```
{
    "error": {
        "code": "BadRequest",
        "message": "Invalid Input :\r\nEvaluationFrequency: Property is missing"
    }
}
```

This is a mistake when first release the resource, but should has little impact to user.