### PR TITLE
`azurerm_windows_web_app`, `azurerm_windows_web_app_slot` - add node 18 support and fix node version not being set issue.

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -949,6 +949,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 						"12-LTS",
 						"14-LTS",
 						"16-LTS",
+						"18-LTS",
 					}, false),
 					AtLeastOneOf: []string{
 						"site_config.0.application_stack.0.docker_container_name",
@@ -1225,6 +1226,7 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 						"12-lts",
 						"14-lts",
 						"16-lts",
+						"18-lts",
 					}, false),
 					AtLeastOneOf: []string{
 						"site_config.0.application_stack.0.docker_image",

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -273,6 +273,13 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 
 			var healthCheckCount *int
 			webApp.AppSettings, healthCheckCount = helpers.FlattenAppSettings(appSettings)
+
+			// Remove node version if not set by user explicitly
+			appSettingRawData := metadata.ResourceData.Get("app_settings").(map[string]interface{})
+			if appSettingRawData["WEBSITE_NODE_DEFAULT_VERSION"] == nil && webApp.AppSettings["WEBSITE_NODE_DEFAULT_VERSION"] != "" {
+				delete(webApp.AppSettings, "WEBSITE_NODE_DEFAULT_VERSION")
+			}
+
 			webApp.Kind = utils.NormalizeNilableString(existing.Kind)
 			webApp.Location = location.NormalizeNilable(existing.Location)
 			webApp.Tags = tags.ToTypedObject(existing.Tags)

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -151,7 +151,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** The valid version combinations for `java_version`, `java_server` and `java_server_version` can be checked from the command line via `az webapp list-runtimes --linux`.
 
-* `node_version` - (Optional) The version of Node to run. Possible values include `12-lts`, `14-lts`, and `16-lts`. This property conflicts with `java_version`.
+* `node_version` - (Optional) The version of Node to run. Possible values include `12-lts`, `14-lts`, `16-lts` and `18-lts`. This property conflicts with `java_version`.
 
 ~> **NOTE:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -152,7 +152,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** The valid version combinations for `java_version`, `java_server` and `java_server_version` can be checked from the command line via `az webapp list-runtimes --linux`.
 
-* `node_version` - (Optional) The version of Node to run. Possible values include `12-lts`, `14-lts`, and `16-lts`. This property conflicts with `java_version`.
+* `node_version` - (Optional) The version of Node to run. Possible values include `12-lts`, `14-lts`, `16-lts` and `18-lts`. This property conflicts with `java_version`.
 
 ~> **NOTE:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -156,7 +156,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** For compatible combinations of `java_version`, `java_container` and `java_container_version` users can use `az webapp list-runtimes` from command line.
 
-* `node_version` - (Optional) The version of node to use when `current_stack` is set to `node`. Possible values include `12-LTS`, `14-LTS`, and `16-LTS`.
+* `node_version` - (Optional) The version of node to use when `current_stack` is set to `node`. Possible values include `12-LTS`, `14-LTS`, `16-LTS` and `18-LTS`.
 
 ~> **NOTE:** This property conflicts with `java_version`.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -160,7 +160,7 @@ A `application_stack` block supports the following:
 
 ~> **NOTE:** For compatible combinations of `java_version`, `java_container` and `java_container_version` users can use `az webapp list-runtimes` from command line.
 
-* `node_version` - (Optional) The version of node to use when `current_stack` is set to `node`. Possible values include `12-LTS`, `14-LTS`, and `16-LTS`.
+* `node_version` - (Optional) The version of node to use when `current_stack` is set to `node`. Possible values include `12-LTS`, `14-LTS`, `16-LTS` and `18-LTS`.
 
 ~> **NOTE:** This property conflicts with `java_version`.
 


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/19289

For windows web app, we need to add the key `WEBSITE_NODE_DEFAULT_VERSION` in `app_setting` block to save the node version.
![image](https://user-images.githubusercontent.com/92154856/202388730-6835faa8-be1c-40f0-af16-c62d7932f11f.png)


For linux web app, this key is not necessary as linux web app using linuxFxVersion to save the version information.
