### PR TITLE
`azurerm_log_analytics_workspace` - support for the `allow_resource_only_permissions` property

### DIFF
--- a/internal/services/loganalytics/client/client.go
+++ b/internal/services/loganalytics/client/client.go
@@ -28,7 +28,7 @@ type Client struct {
 	StorageInsightsClient      *storageinsights.StorageInsightsClient
 	QueryPackQueriesClient     *querypackqueries.QueryPackQueriesClient
 	WorkspacesClient           *workspaces.WorkspacesClient
-	FeatureWorkspaceClient     *featureWorkspaces.WorkspacesClient //2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
+	FeatureWorkspaceClient     *featureWorkspaces.WorkspacesClient // 2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
 }
 
 func NewClient(o *common.ClientOptions) *Client {

--- a/internal/services/loganalytics/client/client.go
+++ b/internal/services/loganalytics/client/client.go
@@ -27,8 +27,8 @@ type Client struct {
 	SolutionsClient            *solution.SolutionClient
 	StorageInsightsClient      *storageinsights.StorageInsightsClient
 	QueryPackQueriesClient     *querypackqueries.QueryPackQueriesClient
-	WorkspacesClient           *workspaces.WorkspacesClient
-	FeatureWorkspaceClient     *featureWorkspaces.WorkspacesClient // 2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
+	SharedKeyWorkspacesClient  *workspaces.WorkspacesClient
+	WorkspaceClient            *featureWorkspaces.WorkspacesClient // 2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -79,7 +79,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		SavedSearchesClient:        &SavedSearchesClient,
 		SolutionsClient:            &SolutionsClient,
 		StorageInsightsClient:      &StorageInsightsClient,
-		WorkspacesClient:           &WorkspacesClient,
-		FeatureWorkspaceClient:     &featureWorkspaceClient,
+		SharedKeyWorkspacesClient:  &WorkspacesClient,
+		WorkspaceClient:            &featureWorkspaceClient,
 	}
 }

--- a/internal/services/loganalytics/client/client.go
+++ b/internal/services/loganalytics/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	featureWorkspaces "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
@@ -27,6 +28,7 @@ type Client struct {
 	StorageInsightsClient      *storageinsights.StorageInsightsClient
 	QueryPackQueriesClient     *querypackqueries.QueryPackQueriesClient
 	WorkspacesClient           *workspaces.WorkspacesClient
+	FeatureWorkspaceClient     *featureWorkspaces.WorkspacesClient //2022-10-01 API version does not contain sharedkeys related API, so we keep two versions SDK of this API
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -41,6 +43,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	WorkspacesClient := workspaces.NewWorkspacesClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&WorkspacesClient.Client, o.ResourceManagerAuthorizer)
+
+	featureWorkspaceClient := featureWorkspaces.NewWorkspacesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&featureWorkspaceClient.Client, o.ResourceManagerAuthorizer)
 
 	SavedSearchesClient := savedsearches.NewSavedSearchesClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&SavedSearchesClient.Client, o.ResourceManagerAuthorizer)
@@ -75,5 +80,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		SolutionsClient:            &SolutionsClient,
 		StorageInsightsClient:      &StorageInsightsClient,
 		WorkspacesClient:           &WorkspacesClient,
+		FeatureWorkspaceClient:     &featureWorkspaceClient,
 	}
 }

--- a/internal/services/loganalytics/log_analytics_workspace_data_source.go
+++ b/internal/services/loganalytics/log_analytics_workspace_data_source.go
@@ -72,7 +72,7 @@ func dataSourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 }
 
 func dataSourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).LogAnalytics.WorkspacesClient
+	client := meta.(*clients.Client).LogAnalytics.SharedKeyWorkspacesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -406,7 +406,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 				d.Set("daily_quota_gb", utils.Float(-1))
 			}
 
-			allowResourceOnlyPermissions := false
+			allowResourceOnlyPermissions := true
 			if features := props.Features; features != nil {
 				v, ok := (*features).(map[string]interface{})["enableLogAccessUsingOnlyResourcePermissions"]
 				if ok {

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -287,7 +287,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	//`allow_resource_only_permissions` needs an additional update, tacked on https://github.com/Azure/azure-rest-api-specs/issues/21591
+	// `allow_resource_only_permissions` needs an additional update, tacked on https://github.com/Azure/azure-rest-api-specs/issues/21591
 	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return err

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -308,19 +308,19 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		Refresh: func() (interface{}, string, error) {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
-				return resp, "error", fmt.Errorf("retiring Log Analytics Workspace %q: %+v", id, err)
+				return resp, "error", fmt.Errorf("retiring %s: %+v", id, err)
 			}
 
 			if resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.Features != nil && resp.Model.Properties.Features.EnableLogAccessUsingOnlyResourcePermissions != nil {
 				return resp, strconv.FormatBool(*resp.Model.Properties.Features.EnableLogAccessUsingOnlyResourcePermissions), nil
 			}
 
-			return resp, "false", fmt.Errorf("retiring Log Analytics Workspace %q: feature is nil", id)
+			return resp, "false", fmt.Errorf("retiring %s: feature is nil", id)
 		},
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for on update for Log Analytics Workspace %q: %+v", id, err)
+		return fmt.Errorf("waiting on update for %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -621,11 +621,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name                 = "acctestLAW-%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  sku                  = "PerGB2018"
-  retention_in_days    = 30
+  name                            = "acctestLAW-%d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  sku                             = "PerGB2018"
+  retention_in_days               = 30
   allow_resource_only_permissions = %[4]t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, useResourceOnlyPermission)

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -308,7 +308,7 @@ func (t LogAnalyticsWorkspaceResource) Exists(ctx context.Context, clients *clie
 		return nil, err
 	}
 
-	resp, err := clients.LogAnalytics.WorkspacesClient.Get(ctx, *id)
+	resp, err := clients.LogAnalytics.SharedKeyWorkspacesClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("readingLog Analytics Workspace (%s): %+v", id.String(), err)
 	}

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -282,12 +282,6 @@ func TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission(t *testing.T
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withUseResourceOnlyPermission(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
 			Config: r.withUseResourceOnlyPermission(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -295,6 +289,12 @@ func TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission(t *testing.T
 		},
 		{
 			Config: r.withUseResourceOnlyPermission(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.withUseResourceOnlyPermission(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -221,18 +221,18 @@ func TestAccLogAnalyticsWorkspace_withCapacityReservation(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withCapacityReservation(data, 2300),
+			Config: r.withCapacityReservation(data, 2000),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("2300"),
+				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("2000"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.withCapacityReservationTypo(data, 2300),
+			Config: r.withCapacityReservationTypo(data, 5000),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("2300"),
+				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("5000"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -276,11 +276,23 @@ func TestAccLogAnalyticsWorkspace_cmkForQueryForced(t *testing.T) {
 	})
 }
 
-func TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission(t *testing.T) {
+func TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
 	r := LogAnalyticsWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withUseResourceOnlyPermission(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.withUseResourceOnlyPermission(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		{
 			Config: r.withUseResourceOnlyPermission(data, false),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -276,6 +276,20 @@ func TestAccLogAnalyticsWorkspace_cmkForQueryForced(t *testing.T) {
 	})
 }
 
+func TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
+	r := LogAnalyticsWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withUseResourceOnlyPermission(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (t LogAnalyticsWorkspaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := workspaces.ParseWorkspaceID(state.ID)
 	if err != nil {
@@ -593,4 +607,26 @@ resource "azurerm_log_analytics_workspace" "test" {
   cmk_for_query_forced = %t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, cmkForQueryForced)
+}
+
+func (LogAnalyticsWorkspaceResource) withUseResourceOnlyPermission(data acceptance.TestData, useResourceOnlyPermission bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                 = "acctestLAW-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  sku                  = "PerGB2018"
+  retention_in_days    = 30
+  allow_resource_only_permissions = %[4]t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, useResourceOnlyPermission)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -282,12 +282,6 @@ func TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission(t *testing.T
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withUseResourceOnlyPermission(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
 			Config: r.withUseResourceOnlyPermission(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -295,6 +289,12 @@ func TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission(t *testing.T
 		},
 		{
 			Config: r.withUseResourceOnlyPermission(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.withUseResourceOnlyPermission(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/README.md
@@ -1,0 +1,118 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces` Documentation
+
+The `workspaces` SDK allows for interaction with the Azure Resource Manager Service `operationalinsights` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
+```
+
+
+### Client Initialization
+
+```go
+client := workspaces.NewWorkspacesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `WorkspacesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue")
+
+payload := workspaces.Workspace{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `WorkspacesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue")
+
+if err := client.DeleteThenPoll(ctx, id, workspaces.DefaultDeleteOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `WorkspacesClient.Get`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WorkspacesClient.List`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+read, err := client.List(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WorkspacesClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+read, err := client.ListByResourceGroup(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WorkspacesClient.Update`
+
+```go
+ctx := context.TODO()
+id := workspaces.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceValue")
+
+payload := workspaces.WorkspacePatch{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/client.go
@@ -1,0 +1,18 @@
+package workspaces
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspacesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewWorkspacesClientWithBaseURI(endpoint string) WorkspacesClient {
+	return WorkspacesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/constants.go
@@ -1,0 +1,209 @@
+package workspaces
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CapacityReservationLevel int64
+
+const (
+	CapacityReservationLevelFiveHundred  CapacityReservationLevel = 500
+	CapacityReservationLevelFiveThousand CapacityReservationLevel = 5000
+	CapacityReservationLevelFourHundred  CapacityReservationLevel = 400
+	CapacityReservationLevelOneHundred   CapacityReservationLevel = 100
+	CapacityReservationLevelOneThousand  CapacityReservationLevel = 1000
+	CapacityReservationLevelThreeHundred CapacityReservationLevel = 300
+	CapacityReservationLevelTwoHundred   CapacityReservationLevel = 200
+	CapacityReservationLevelTwoThousand  CapacityReservationLevel = 2000
+)
+
+func PossibleValuesForCapacityReservationLevel() []int64 {
+	return []int64{
+		int64(CapacityReservationLevelFiveHundred),
+		int64(CapacityReservationLevelFiveThousand),
+		int64(CapacityReservationLevelFourHundred),
+		int64(CapacityReservationLevelOneHundred),
+		int64(CapacityReservationLevelOneThousand),
+		int64(CapacityReservationLevelThreeHundred),
+		int64(CapacityReservationLevelTwoHundred),
+		int64(CapacityReservationLevelTwoThousand),
+	}
+}
+
+func parseCapacityReservationLevel(input int64) (*CapacityReservationLevel, error) {
+	vals := map[int64]CapacityReservationLevel{
+		500:  CapacityReservationLevelFiveHundred,
+		5000: CapacityReservationLevelFiveThousand,
+		400:  CapacityReservationLevelFourHundred,
+		100:  CapacityReservationLevelOneHundred,
+		1000: CapacityReservationLevelOneThousand,
+		300:  CapacityReservationLevelThreeHundred,
+		200:  CapacityReservationLevelTwoHundred,
+		2000: CapacityReservationLevelTwoThousand,
+	}
+	if v, ok := vals[input]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CapacityReservationLevel(input)
+	return &out, nil
+}
+
+type DataIngestionStatus string
+
+const (
+	DataIngestionStatusApproachingQuota      DataIngestionStatus = "ApproachingQuota"
+	DataIngestionStatusForceOff              DataIngestionStatus = "ForceOff"
+	DataIngestionStatusForceOn               DataIngestionStatus = "ForceOn"
+	DataIngestionStatusOverQuota             DataIngestionStatus = "OverQuota"
+	DataIngestionStatusRespectQuota          DataIngestionStatus = "RespectQuota"
+	DataIngestionStatusSubscriptionSuspended DataIngestionStatus = "SubscriptionSuspended"
+)
+
+func PossibleValuesForDataIngestionStatus() []string {
+	return []string{
+		string(DataIngestionStatusApproachingQuota),
+		string(DataIngestionStatusForceOff),
+		string(DataIngestionStatusForceOn),
+		string(DataIngestionStatusOverQuota),
+		string(DataIngestionStatusRespectQuota),
+		string(DataIngestionStatusSubscriptionSuspended),
+	}
+}
+
+func parseDataIngestionStatus(input string) (*DataIngestionStatus, error) {
+	vals := map[string]DataIngestionStatus{
+		"approachingquota":      DataIngestionStatusApproachingQuota,
+		"forceoff":              DataIngestionStatusForceOff,
+		"forceon":               DataIngestionStatusForceOn,
+		"overquota":             DataIngestionStatusOverQuota,
+		"respectquota":          DataIngestionStatusRespectQuota,
+		"subscriptionsuspended": DataIngestionStatusSubscriptionSuspended,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataIngestionStatus(input)
+	return &out, nil
+}
+
+type PublicNetworkAccessType string
+
+const (
+	PublicNetworkAccessTypeDisabled PublicNetworkAccessType = "Disabled"
+	PublicNetworkAccessTypeEnabled  PublicNetworkAccessType = "Enabled"
+)
+
+func PossibleValuesForPublicNetworkAccessType() []string {
+	return []string{
+		string(PublicNetworkAccessTypeDisabled),
+		string(PublicNetworkAccessTypeEnabled),
+	}
+}
+
+func parsePublicNetworkAccessType(input string) (*PublicNetworkAccessType, error) {
+	vals := map[string]PublicNetworkAccessType{
+		"disabled": PublicNetworkAccessTypeDisabled,
+		"enabled":  PublicNetworkAccessTypeEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicNetworkAccessType(input)
+	return &out, nil
+}
+
+type WorkspaceEntityStatus string
+
+const (
+	WorkspaceEntityStatusCanceled            WorkspaceEntityStatus = "Canceled"
+	WorkspaceEntityStatusCreating            WorkspaceEntityStatus = "Creating"
+	WorkspaceEntityStatusDeleting            WorkspaceEntityStatus = "Deleting"
+	WorkspaceEntityStatusFailed              WorkspaceEntityStatus = "Failed"
+	WorkspaceEntityStatusProvisioningAccount WorkspaceEntityStatus = "ProvisioningAccount"
+	WorkspaceEntityStatusSucceeded           WorkspaceEntityStatus = "Succeeded"
+	WorkspaceEntityStatusUpdating            WorkspaceEntityStatus = "Updating"
+)
+
+func PossibleValuesForWorkspaceEntityStatus() []string {
+	return []string{
+		string(WorkspaceEntityStatusCanceled),
+		string(WorkspaceEntityStatusCreating),
+		string(WorkspaceEntityStatusDeleting),
+		string(WorkspaceEntityStatusFailed),
+		string(WorkspaceEntityStatusProvisioningAccount),
+		string(WorkspaceEntityStatusSucceeded),
+		string(WorkspaceEntityStatusUpdating),
+	}
+}
+
+func parseWorkspaceEntityStatus(input string) (*WorkspaceEntityStatus, error) {
+	vals := map[string]WorkspaceEntityStatus{
+		"canceled":            WorkspaceEntityStatusCanceled,
+		"creating":            WorkspaceEntityStatusCreating,
+		"deleting":            WorkspaceEntityStatusDeleting,
+		"failed":              WorkspaceEntityStatusFailed,
+		"provisioningaccount": WorkspaceEntityStatusProvisioningAccount,
+		"succeeded":           WorkspaceEntityStatusSucceeded,
+		"updating":            WorkspaceEntityStatusUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkspaceEntityStatus(input)
+	return &out, nil
+}
+
+type WorkspaceSkuNameEnum string
+
+const (
+	WorkspaceSkuNameEnumCapacityReservation  WorkspaceSkuNameEnum = "CapacityReservation"
+	WorkspaceSkuNameEnumFree                 WorkspaceSkuNameEnum = "Free"
+	WorkspaceSkuNameEnumLACluster            WorkspaceSkuNameEnum = "LACluster"
+	WorkspaceSkuNameEnumPerGBTwoZeroOneEight WorkspaceSkuNameEnum = "PerGB2018"
+	WorkspaceSkuNameEnumPerNode              WorkspaceSkuNameEnum = "PerNode"
+	WorkspaceSkuNameEnumPremium              WorkspaceSkuNameEnum = "Premium"
+	WorkspaceSkuNameEnumStandalone           WorkspaceSkuNameEnum = "Standalone"
+	WorkspaceSkuNameEnumStandard             WorkspaceSkuNameEnum = "Standard"
+)
+
+func PossibleValuesForWorkspaceSkuNameEnum() []string {
+	return []string{
+		string(WorkspaceSkuNameEnumCapacityReservation),
+		string(WorkspaceSkuNameEnumFree),
+		string(WorkspaceSkuNameEnumLACluster),
+		string(WorkspaceSkuNameEnumPerGBTwoZeroOneEight),
+		string(WorkspaceSkuNameEnumPerNode),
+		string(WorkspaceSkuNameEnumPremium),
+		string(WorkspaceSkuNameEnumStandalone),
+		string(WorkspaceSkuNameEnumStandard),
+	}
+}
+
+func parseWorkspaceSkuNameEnum(input string) (*WorkspaceSkuNameEnum, error) {
+	vals := map[string]WorkspaceSkuNameEnum{
+		"capacityreservation": WorkspaceSkuNameEnumCapacityReservation,
+		"free":                WorkspaceSkuNameEnumFree,
+		"lacluster":           WorkspaceSkuNameEnumLACluster,
+		"pergb2018":           WorkspaceSkuNameEnumPerGBTwoZeroOneEight,
+		"pernode":             WorkspaceSkuNameEnumPerNode,
+		"premium":             WorkspaceSkuNameEnumPremium,
+		"standalone":          WorkspaceSkuNameEnumStandalone,
+		"standard":            WorkspaceSkuNameEnumStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkspaceSkuNameEnum(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/id_workspace.go
@@ -1,0 +1,124 @@
+package workspaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = WorkspaceId{}
+
+// WorkspaceId is a struct representing the Resource ID for a Workspace
+type WorkspaceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	WorkspaceName     string
+}
+
+// NewWorkspaceID returns a new WorkspaceId struct
+func NewWorkspaceID(subscriptionId string, resourceGroupName string, workspaceName string) WorkspaceId {
+	return WorkspaceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		WorkspaceName:     workspaceName,
+	}
+}
+
+// ParseWorkspaceID parses 'input' into a WorkspaceId
+func ParseWorkspaceID(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WorkspaceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := WorkspaceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseWorkspaceIDInsensitively parses 'input' case-insensitively into a WorkspaceId
+// note: this method should only be used for API response data and not user input
+func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WorkspaceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := WorkspaceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateWorkspaceID checks that 'input' can be parsed as a Workspace ID
+func ValidateWorkspaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseWorkspaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Workspace ID
+func (id WorkspaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.OperationalInsights/workspaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Workspace ID
+func (id WorkspaceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftOperationalInsights", "Microsoft.OperationalInsights", "Microsoft.OperationalInsights"),
+		resourceids.StaticSegment("staticWorkspaces", "workspaces", "workspaces"),
+		resourceids.UserSpecifiedSegment("workspaceName", "workspaceValue"),
+	}
+}
+
+// String returns a human-readable description of this Workspace ID
+func (id WorkspaceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Workspace Name: %q", id.WorkspaceName),
+	}
+	return fmt.Sprintf("Workspace (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_createorupdate_autorest.go
@@ -1,0 +1,79 @@
+package workspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c WorkspacesClient) CreateOrUpdate(ctx context.Context, id WorkspaceId, input Workspace) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c WorkspacesClient) CreateOrUpdateThenPoll(ctx context.Context, id WorkspaceId, input Workspace) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c WorkspacesClient) preparerForCreateOrUpdate(ctx context.Context, id WorkspaceId, input Workspace) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c WorkspacesClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_delete_autorest.go
@@ -1,0 +1,107 @@
+package workspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+type DeleteOperationOptions struct {
+	Force *bool
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o DeleteOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Force != nil {
+		out["force"] = *o.Force
+	}
+
+	return out
+}
+
+// Delete ...
+func (c WorkspacesClient) Delete(ctx context.Context, id WorkspaceId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c WorkspacesClient) DeleteThenPoll(ctx context.Context, id WorkspaceId, options DeleteOperationOptions) error {
+	result, err := c.Delete(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c WorkspacesClient) preparerForDelete(ctx context.Context, id WorkspaceId, options DeleteOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c WorkspacesClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_get_autorest.go
@@ -1,0 +1,68 @@
+package workspaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Workspace
+}
+
+// Get ...
+func (c WorkspacesClient) Get(ctx context.Context, id WorkspaceId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c WorkspacesClient) preparerForGet(ctx context.Context, id WorkspaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c WorkspacesClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_list_autorest.go
@@ -1,0 +1,70 @@
+package workspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WorkspaceListResult
+}
+
+// List ...
+func (c WorkspacesClient) List(ctx context.Context, id commonids.SubscriptionId) (result ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "List", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForList(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "List", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForList prepares the List request.
+func (c WorkspacesClient) preparerForList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.OperationalInsights/workspaces", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c WorkspacesClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_listbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,70 @@
+package workspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WorkspaceListResult
+}
+
+// ListByResourceGroup ...
+func (c WorkspacesClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForListByResourceGroup(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c WorkspacesClient) preparerForListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.OperationalInsights/workspaces", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c WorkspacesClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/method_update_autorest.go
@@ -1,0 +1,69 @@
+package workspaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Workspace
+}
+
+// Update ...
+func (c WorkspacesClient) Update(ctx context.Context, id WorkspaceId, input WorkspacePatch) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "workspaces.WorkspacesClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c WorkspacesClient) preparerForUpdate(ctx context.Context, id WorkspaceId, input WorkspacePatch) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c WorkspacesClient) responderForUpdate(resp *http.Response) (result UpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_privatelinkscopedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_privatelinkscopedresource.go
@@ -1,0 +1,9 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopedResource struct {
+	ResourceId *string `json:"resourceId,omitempty"`
+	ScopeId    *string `json:"scopeId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspace.go
@@ -1,0 +1,21 @@
+package workspaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Workspace struct {
+	Etag       *string                           `json:"etag,omitempty"`
+	Id         *string                           `json:"id,omitempty"`
+	Identity   *identity.SystemOrUserAssignedMap `json:"identity,omitempty"`
+	Location   string                            `json:"location"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *WorkspaceProperties              `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData            `json:"systemData,omitempty"`
+	Tags       *map[string]string                `json:"tags,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacecapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacecapping.go
@@ -1,0 +1,10 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceCapping struct {
+	DailyQuotaGb        *float64             `json:"dailyQuotaGb,omitempty"`
+	DataIngestionStatus *DataIngestionStatus `json:"dataIngestionStatus,omitempty"`
+	QuotaNextResetTime  *string              `json:"quotaNextResetTime,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacefeatures.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacefeatures.go
@@ -1,0 +1,12 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceFeatures struct {
+	ClusterResourceId                           *string `json:"clusterResourceId,omitempty"`
+	DisableLocalAuth                            *bool   `json:"disableLocalAuth,omitempty"`
+	EnableDataExport                            *bool   `json:"enableDataExport,omitempty"`
+	EnableLogAccessUsingOnlyResourcePermissions *bool   `json:"enableLogAccessUsingOnlyResourcePermissions,omitempty"`
+	ImmediatePurgeDataOn30Days                  *bool   `json:"immediatePurgeDataOn30Days,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacelistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacelistresult.go
@@ -1,0 +1,8 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceListResult struct {
+	Value *[]Workspace `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacepatch.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacepatch.go
@@ -1,0 +1,18 @@
+package workspaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspacePatch struct {
+	Etag       *string                           `json:"etag,omitempty"`
+	Id         *string                           `json:"id,omitempty"`
+	Identity   *identity.SystemOrUserAssignedMap `json:"identity,omitempty"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *WorkspaceProperties              `json:"properties,omitempty"`
+	Tags       *map[string]string                `json:"tags,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspaceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspaceproperties.go
@@ -1,0 +1,20 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceProperties struct {
+	CreatedDate                         *string                      `json:"createdDate,omitempty"`
+	CustomerId                          *string                      `json:"customerId,omitempty"`
+	DefaultDataCollectionRuleResourceId *string                      `json:"defaultDataCollectionRuleResourceId,omitempty"`
+	Features                            *WorkspaceFeatures           `json:"features,omitempty"`
+	ForceCmkForQuery                    *bool                        `json:"forceCmkForQuery,omitempty"`
+	ModifiedDate                        *string                      `json:"modifiedDate,omitempty"`
+	PrivateLinkScopedResources          *[]PrivateLinkScopedResource `json:"privateLinkScopedResources,omitempty"`
+	ProvisioningState                   *WorkspaceEntityStatus       `json:"provisioningState,omitempty"`
+	PublicNetworkAccessForIngestion     *PublicNetworkAccessType     `json:"publicNetworkAccessForIngestion,omitempty"`
+	PublicNetworkAccessForQuery         *PublicNetworkAccessType     `json:"publicNetworkAccessForQuery,omitempty"`
+	RetentionInDays                     *int64                       `json:"retentionInDays,omitempty"`
+	Sku                                 *WorkspaceSku                `json:"sku,omitempty"`
+	WorkspaceCapping                    *WorkspaceCapping            `json:"workspaceCapping,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacesku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/model_workspacesku.go
@@ -1,0 +1,10 @@
+package workspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceSku struct {
+	CapacityReservationLevel *CapacityReservationLevel `json:"capacityReservationLevel,omitempty"`
+	LastSkuUpdate            *string                   `json:"lastSkuUpdate,omitempty"`
+	Name                     WorkspaceSkuNameEnum      `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/version.go
@@ -1,0 +1,12 @@
+package workspaces
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/workspaces/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -322,6 +322,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-0
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces
+github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/contact
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-03-01/contactprofile

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -37,6 +37,8 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+* `allow_resource_only_permissions` - (Optional) Specifies if the log Analytics Workspace allow users accessing to data associated with resources they have permission to view, without permission to workspace.
+
 * `sku` - (Optional) Specifies the SKU of the Log Analytics Workspace. Possible values are `Free`, `PerNode`, `Premium`, `Standard`, `Standalone`, `Unlimited`, `CapacityReservation`, and `PerGB2018` (new SKU as of `2018-04-03`). Defaults to `PerGB2018`.
 
 ~> **NOTE:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you're provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKUs defined above. More information about [the Pricing SKUs is available at the following URI](https://aka.ms/PricingTierWarning).

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `allow_resource_only_permissions` - (Optional) Specifies if the log Analytics Workspace allow users accessing to data associated with resources they have permission to view, without permission to workspace.
+* `allow_resource_only_permissions` - (Optional) Specifies if the log Analytics Workspace allow users accessing to data associated with resources they have permission to view, without permission to workspace. Defaults to `true`.
 
 * `sku` - (Optional) Specifies the SKU of the Log Analytics Workspace. Possible values are `Free`, `PerNode`, `Premium`, `Standard`, `Standalone`, `Unlimited`, `CapacityReservation`, and `PerGB2018` (new SKU as of `2018-04-03`). Defaults to `PerGB2018`.
 


### PR DESCRIPTION
close #18841

test
---
```
TF_ACC=1 go test -v ./internal/services/loganalytics -run=TestAccLogAnalyticsWorkspace -timeout=600m
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:92: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== RUN   TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission
=== PAUSE TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== CONT  TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_withUseOnlyResourcePermission (236.46s)
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (249.74s)
=== CONT  TestAccLogAnalyticsWorkspace_complete
--- PASS: TestAccLogAnalyticsWorkspace_basic (260.44s)
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (312.38s)
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (334.48s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (349.76s)
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (358.88s)
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (367.47s)
--- PASS: TestAccLogAnalyticsWorkspace_complete (233.41s)
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (270.36s)
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (287.78s)
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (246.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	560.513s
```