### PR TITLE
`azurerm_servicebus_subscription_rule` - `correlation_filter` with empty attributes no longer crashes

### DIFF
--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -330,6 +330,9 @@ func expandAzureRmServiceBusCorrelationFilter(d *pluginsdk.ResourceData) (*rules
 		return nil, fmt.Errorf("`correlation_filter` is required when `filter_type` is set to `CorrelationFilter`")
 	}
 
+	if configs[0] == nil {
+		return nil, fmt.Errorf("at least one property must not be empty in the `correlation_filter` block")
+	}
 	config := configs[0].(map[string]interface{})
 
 	contentType := config["content_type"].(string)


### PR DESCRIPTION
Fixes #18891

Unfortunately, there isn't a way in Terraform to just specify an empty label without any other attributes specified. This at least fixes the panic and returns an error if no attributes are specified under a `correlation_filter`

```
--- PASS: TestAccServiceBusSubscriptionRule_correlationFilterWhiteSpace (323.73s)
```