### PR TITLE
`azurerm_kusto_database_principal_assignment` - add `name` property discription

### DIFF
--- a/website/docs/r/kusto_database_principal_assignment.html.markdown
+++ b/website/docs/r/kusto_database_principal_assignment.html.markdown
@@ -58,6 +58,8 @@ resource "azurerm_kusto_database_principal_assignment" "example" {
 
 The following arguments are supported:
 
+* `name` - (Required) The name of the kusto principal assignment. Changing this forces a new resource to be created.
+
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource. Changing this forces a new resource to be created.
 
 * `cluster_name` - (Required) The name of the cluster in which to create the resource. Changing this forces a new resource to be created.


### PR DESCRIPTION
`azurerm_kusto_database_principal_assignment` - add `name` property discription which is previous missing.

Fix https://github.com/hashicorp/terraform-provider-azurerm/issues/19349