### PR TITLE
`azurerm_kubernetes_cluster`: Support for `image_cleaner` block

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2059,8 +2059,12 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		if props.SecurityProfile != nil && props.SecurityProfile.ImageCleaner != nil {
-			d.Set("image_cleaner_enabled", props.SecurityProfile.ImageCleaner.Enabled)
-			d.Set("image_cleaner_interval_hours", props.SecurityProfile.ImageCleaner.IntervalHours)
+			if props.SecurityProfile.ImageCleaner.Enabled != nil {
+				d.Set("image_cleaner_enabled", props.SecurityProfile.ImageCleaner.Enabled)
+			}
+			if props.SecurityProfile.ImageCleaner.IntervalHours != nil {
+				d.Set("image_cleaner_interval_hours", props.SecurityProfile.ImageCleaner.IntervalHours)
+			}
 		}
 
 		httpProxyConfig := flattenKubernetesClusterHttpProxyConfig(props)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1245,7 +1245,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	imageCleanerSecurityProfileRaw := d.Get("image_cleaner").([]interface{})
-	imageCleanerSecurityProfile := expandKubernetesClusterimageCleanerSecurityProfile(imageCleanerSecurityProfileRaw)
+	imageCleanerSecurityProfile := expandKubernetesClusterImageCleanerSecurityProfile(imageCleanerSecurityProfileRaw)
 
 	if imageCleanerSecurityProfile != nil {
 		if securityProfile == nil {
@@ -1775,7 +1775,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChanges("image_cleaner") {
 		updateCluster = true
 		imageCleanerSecurityProfileRaw := d.Get("image_cleaner").([]interface{})
-		imageCleanerSecurityProfile := expandKubernetesClusterimageCleanerSecurityProfile(imageCleanerSecurityProfileRaw)
+		imageCleanerSecurityProfile := expandKubernetesClusterImageCleanerSecurityProfile(imageCleanerSecurityProfileRaw)
 		if existing.Model.Properties.SecurityProfile == nil {
 			existing.Model.Properties.SecurityProfile = &managedclusters.ManagedClusterSecurityProfile{}
 		}
@@ -2368,7 +2368,7 @@ func expandKubernetesClusterWorkloadAutoscalerProfile(input []interface{}) *mana
 	}
 }
 
-func expandKubernetesClusterimageCleanerSecurityProfile(input []interface{}) *managedclusters.ManagedClusterSecurityProfileImageCleaner {
+func expandKubernetesClusterImageCleanerSecurityProfile(input []interface{}) *managedclusters.ManagedClusterSecurityProfileImageCleaner {
 	if len(input) == 0 {
 		return nil
 	}

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -395,7 +395,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   image_cleaner {
     enabled        = %t
-	interval_hours = 48
+    interval_hours = 48
   }
 
   default_node_pool {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -106,15 +106,15 @@ func TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff(t *testing.T) {
 			Config: r.imageCleanerSecurityProfile(data, currentKubernetesVersion, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("image_cleaner.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("image_cleaner.0.interval_hours").HasValue("48"),
+				check.That(data.ResourceName).Key("image_cleaner_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("image_cleaner_interval_hours").HasValue("96"),
 			),
 		},
 		{
 			Config: r.imageCleanerSecurityProfile(data, currentKubernetesVersion, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("image_cleaner.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("image_cleaner_enabled").HasValue("false"),
 			),
 		},
 	})
@@ -393,10 +393,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   dns_prefix          = "acctestaks%d"
   kubernetes_version  = %q
 
-  image_cleaner {
-    enabled        = %t
-    interval_hours = 48
-  }
+  image_cleaner_enabled        = %t
+  image_cleaner_interval_hours = 96
 
   default_node_pool {
     name       = "default"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -115,7 +115,11 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 !> **Note:** A migration scenario from `service_principal` to `identity` is supported. When upgrading `service_principal` to `identity`, your cluster's control plane and addon pods will switch to use managed identity, but the kubelets will keep using your configured `service_principal` until you upgrade your Node Pool.
 
-* `image_cleaner` - (Optional) An `image_cleaner` block defined below.
+* `image_cleaner_enabled` - (Optional) Specifies whether Image Cleaner is enabled.
+
+* `image_cleaner_interval_hours` - (Optional) Specifies interval in hours when images should be cleaned up.
+
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/EnableImageCleanerPreview](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
 
 * `ingress_application_gateway` - (Optional) A `ingress_application_gateway` block as defined below.
 
@@ -720,15 +724,6 @@ A `gmsa` block supports the following:
 
 ---
 
-An `image_cleaner` block supports the following:
-
-* `enabled` - (Optional) Specifies whether Image Cleaner is enabled.
-
-* `interval_hours` - (Optional) Specifies interval in hours when images should be cleaned up.
-
--> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/EnableImageCleanerPreview](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
-
----
 A `workload_autoscaler_profile` block supports the following:
 
 * `keda_enabled` - (Optional) Specifies whether KEDA Autoscaler can be used for workloads.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -117,7 +117,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `image_cleaner_enabled` - (Optional) Specifies whether Image Cleaner is enabled.
 
-* `image_cleaner_interval_hours` - (Optional) Specifies interval in hours when images should be cleaned up.
+* `image_cleaner_interval_hours` - (Optional) Specifies the interval in hours when images should be cleaned up.
 
 -> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/EnableImageCleanerPreview](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -115,6 +115,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 !> **Note:** A migration scenario from `service_principal` to `identity` is supported. When upgrading `service_principal` to `identity`, your cluster's control plane and addon pods will switch to use managed identity, but the kubelets will keep using your configured `service_principal` until you upgrade your Node Pool.
 
+* `image_cleaner` - (Optional) An `image_cleaner` block defined below.
+
 * `ingress_application_gateway` - (Optional) A `ingress_application_gateway` block as defined below.
 
 * `key_vault_secrets_provider` - (Optional) A `key_vault_secrets_provider` block as defined below. For more details, please visit [Azure Keyvault Secrets Provider for AKS](https://docs.microsoft.com/azure/aks/csi-secrets-store-driver).
@@ -715,6 +717,16 @@ A `gmsa` block supports the following:
 * `root_domain` - (Required) Specifies the root domain name for Windows gMSA. Set this to an empty string if you have configured the DNS server in the VNet which was used to create the managed cluster.
 
 -> **Note:** The properties `dns_server` and `root_domain` must both either be set or unset, i.e. empty.
+
+---
+
+An `image_cleaner` block supports the following:
+
+* `enabled` - (Optional) Specifies whether Image Cleaner is enabled.
+
+* `interval_hours` - (Optional) Specifies interval in hours when images should be cleaned up.
+
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/EnableImageCleanerPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/EnableImageCleanerPreview](https://learn.microsoft.com/en-us/azure/aks/image-cleaner) for more information.
 
 ---
 A `workload_autoscaler_profile` block supports the following:


### PR DESCRIPTION
Fixes #19241

```
$ TF_ACC=1 go test -v ./internal/services/containers -timeout=1000m -run='TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff'
=== RUN   TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff
=== PAUSE TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff
=== CONT  TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff
--- PASS: TestAccKubernetesCluster_imageCleanerSecurityProfileOnOff (797.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	798.426s
```