### PR TITLE
`azurerm_cognitive_account` - Support property `dynamic_throttling_enabled`

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -141,9 +141,9 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"dynamic_throttling_enabled":{
-				Type:pluginsdk.TypeBool,
-				Optional:true,
+			"dynamic_throttling_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
 			},
 
 			"fqdns": {
@@ -559,11 +559,11 @@ func resourceCognitiveAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 				return fmt.Errorf("setting `network_acls` for Cognitive Account %q: %+v", id, err)
 			}
 
-			dynamicThrottlingEnabled:=false
-			if props.DynamicThrottlingEnabled!=nil{
-				dynamicThrottlingEnabled=*props.DynamicThrottlingEnabled
+			dynamicThrottlingEnabled := false
+			if props.DynamicThrottlingEnabled != nil {
+				dynamicThrottlingEnabled = *props.DynamicThrottlingEnabled
 			}
-			d.Set("dynamic_throttling_enabled",dynamicThrottlingEnabled)
+			d.Set("dynamic_throttling_enabled", dynamicThrottlingEnabled)
 
 			d.Set("fqdns", utils.FlattenStringSlice(props.AllowedFqdnList))
 

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -141,6 +141,11 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"dynamic_throttling_enabled":{
+				Type:pluginsdk.TypeBool,
+				Optional:true,
+			},
+
 			"fqdns": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -375,6 +380,7 @@ func resourceCognitiveAccountCreate(d *pluginsdk.ResourceData, meta interface{})
 			UserOwnedStorage:              expandCognitiveAccountStorage(d.Get("storage").([]interface{})),
 			RestrictOutboundNetworkAccess: utils.Bool(d.Get("outbound_network_access_restricted").(bool)),
 			DisableLocalAuth:              utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			DynamicThrottlingEnabled:      utils.Bool(d.Get("dynamic_throttling_enabled").(bool)),
 			Encryption:                    expandCognitiveAccountCustomerManagedKey(d.Get("customer_managed_key").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -459,6 +465,7 @@ func resourceCognitiveAccountUpdate(d *pluginsdk.ResourceData, meta interface{})
 			UserOwnedStorage:              expandCognitiveAccountStorage(d.Get("storage").([]interface{})),
 			RestrictOutboundNetworkAccess: utils.Bool(d.Get("outbound_network_access_restricted").(bool)),
 			DisableLocalAuth:              utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			DynamicThrottlingEnabled:      utils.Bool(d.Get("dynamic_throttling_enabled").(bool)),
 			Encryption:                    expandCognitiveAccountCustomerManagedKey(d.Get("customer_managed_key").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -551,6 +558,13 @@ func resourceCognitiveAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 			if err := d.Set("network_acls", flattenCognitiveAccountNetworkAcls(props.NetworkAcls)); err != nil {
 				return fmt.Errorf("setting `network_acls` for Cognitive Account %q: %+v", id, err)
 			}
+
+			dynamicThrottlingEnabled:=false
+			if props.DynamicThrottlingEnabled!=nil{
+				dynamicThrottlingEnabled=*props.DynamicThrottlingEnabled
+			}
+			d.Set("dynamic_throttling_enabled",dynamicThrottlingEnabled)
+
 			d.Set("fqdns", utils.FlattenStringSlice(props.AllowedFqdnList))
 
 			publicNetworkAccess := true

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -35,6 +35,50 @@ func TestAccCognitiveAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccCognitiveAccount_openAI(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
+	r := CognitiveAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.openAI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCognitiveAccount_dynamicThrottlingEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
+	r := CognitiveAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dynamicThrottlingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateDynamicThrottlingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dynamicThrottlingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCognitiveAccount_speechServices(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
 	r := CognitiveAccountResource{}
@@ -756,6 +800,65 @@ resource "azurerm_cognitive_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
   kind                = "CognitiveServices"
   sku_name            = "S0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (CognitiveAccountResource) openAI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%d"
+  location = "%s"
+}
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "OpenAI"
+  sku_name            = "S0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (CognitiveAccountResource) dynamicThrottlingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%d"
+  location = "%s"
+}
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "LUIS"
+  sku_name            = "S0"
+  dynamic_throttling_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (CognitiveAccountResource) updateDynamicThrottlingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%d"
+  location = "%s"
+}
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "LUIS"
+  sku_name            = "S0"
+  dynamic_throttling_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -833,11 +833,11 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 resource "azurerm_cognitive_account" "test" {
-  name                = "acctestcogacc-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  kind                = "LUIS"
-  sku_name            = "S0"
+  name                       = "acctestcogacc-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  kind                       = "LUIS"
+  sku_name                   = "S0"
   dynamic_throttling_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -853,11 +853,11 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 resource "azurerm_cognitive_account" "test" {
-  name                = "acctestcogacc-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  kind                = "LUIS"
-  sku_name            = "S0"
+  name                       = "acctestcogacc-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  kind                       = "LUIS"
+  sku_name                   = "S0"
   dynamic_throttling_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -35,21 +35,6 @@ func TestAccCognitiveAccount_basic(t *testing.T) {
 	})
 }
 
-func TestAccCognitiveAccount_openAI(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
-	r := CognitiveAccountResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.openAI(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccCognitiveAccount_dynamicThrottlingEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
 	r := CognitiveAccountResource{}

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `custom_subdomain_name` - (Required) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.
 
+* `dynamic_throttling_enabled` - (Optional) Whether to enable the dynamic throttling for this Cognitive Service Account. Defaults to `false`.
+
 * `customer_managed_key` (Optional) A `customer_managed_key` block as documented below.
 
 * `fqdns` - (Optional) List of FQDNs allowed for the Cognitive Account.


### PR DESCRIPTION
Test Results:
PASS: TestAccCognitiveAccount_dynamicThrottlingEnabled (488.31s)