### PR TITLE
Doc: Fix incorrect import spec for `azurerm_postgresql_flexible_server_active_directory_administrator`

### DIFF
--- a/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
@@ -82,5 +82,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 A PostgreSQL Flexible Server Active Directory Administrator can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_postgresql_flexible_server_active_directory_administrator /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforPostgreSQL/flexibleServers/myserver/administrators/objectId
+terraform import azurerm_postgresql_flexible_server_active_directory_administrator.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforPostgreSQL/flexibleServers/myserver/administrators/objectId
 ```


### PR DESCRIPTION
Fix incorrect import spec for `azurerm_postgresql_flexible_server_active_directory_administrator`