### PR TITLE
Docs: Fix wrong description of `azurerm_mssql_database_extended_auditing_policy`

### DIFF
--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages a MS SQL Database Extended Auditing Policy.
 
-~> **NOTE:** The Database Extended Auditing Policy can also be set in the `extended_auditing_policy` block in the [azurerm_mssql_database](mssql_database.html) resource. You can only use one or the other and using both will cause a conflict.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Remove the following description for `azurerm_mssql_database_extended_auditing_policy` since actually `extended_auditing_policy`  is not supported.
 
![image](https://user-images.githubusercontent.com/39109137/203259530-c205459f-628e-4954-89ac-a94a0b8d0665.png)

Fix #[19376](https://github.com/hashicorp/terraform-provider-azurerm/issues/19376).