### PR TITLE
`azurerm_site_recovery_replication_policy` - improve existing check

### DIFF
--- a/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
@@ -76,7 +76,6 @@ resource "azurerm_backup_container_storage_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
   recovery_vault_name = azurerm_recovery_services_vault.testvlt.name
   storage_account_id  = azurerm_storage_account.test.id
-  depends_on          = [azurerm_recovery_services_vault.testvlt]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
@@ -76,6 +76,7 @@ resource "azurerm_backup_container_storage_account" "test" {
   resource_group_name = azurerm_resource_group.test.name
   recovery_vault_name = azurerm_recovery_services_vault.testvlt.name
   storage_account_id  = azurerm_storage_account.test.id
+  depends_on          = [azurerm_recovery_services_vault.testvlt]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -69,7 +69,7 @@ func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{
 		existing, err := client.Get(ctx, name)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequest(existing.Response) {
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithNotRegistered(existing.Response, err) {
 				return fmt.Errorf("checking for presence of existing site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 			}
 		}

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -69,7 +69,7 @@ func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{
 		existing, err := client.Get(ctx, name)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithNotRegistered(existing.Response, err) {
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithServiceCode(existing.Response, err, "SubscriptionIdNotRegisteredWithSrs") {
 				return fmt.Errorf("checking for presence of existing site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 			}
 		}

--- a/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
@@ -56,7 +56,8 @@ func dataSourceSiteRecoveryReplicationPolicyRead(d *pluginsdk.ResourceData, meta
 
 	resp, err := client.Get(ctx, id.Name)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
+		if utils.ResponseWasNotFound(resp.Response) || utils.ResponseWasBadRequest(resp.Response) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making Read request on site recovery replication policy %s : %+v", id.String(), err)

--- a/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
@@ -57,7 +57,7 @@ func dataSourceSiteRecoveryReplicationPolicyRead(d *pluginsdk.ResourceData, meta
 	resp, err := client.Get(ctx, id.Name)
 	if err != nil {
 		// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-		if utils.ResponseWasNotFound(resp.Response) || utils.ResponseWasBadRequest(resp.Response) {
+		if utils.ResponseWasNotFound(resp.Response) || utils.ResponseWasBadRequestWithNotRegistered(resp.Response, err) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making Read request on site recovery replication policy %s : %+v", id.String(), err)

--- a/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_data_source.go
@@ -57,7 +57,7 @@ func dataSourceSiteRecoveryReplicationPolicyRead(d *pluginsdk.ResourceData, meta
 	resp, err := client.Get(ctx, id.Name)
 	if err != nil {
 		// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-		if utils.ResponseWasNotFound(resp.Response) || utils.ResponseWasBadRequestWithNotRegistered(resp.Response, err) {
+		if utils.ResponseWasNotFound(resp.Response) || utils.ResponseWasBadRequestWithServiceCode(resp.Response, err, "SubscriptionIdNotRegisteredWithSrs") {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making Read request on site recovery replication policy %s : %+v", id.String(), err)

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -80,7 +80,7 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 		existing, err := client.Get(ctx, name)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithNotRegistered(existing.Response, err) {
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithServiceCode(existing.Response, err, "SubscriptionIdNotRegisteredWithSrs") {
 				return fmt.Errorf("checking for presence of existing site recovery replication policy %s: %+v", name, err)
 			}
 		}

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -79,7 +79,8 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, name)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequest(existing.Response) {
 				return fmt.Errorf("checking for presence of existing site recovery replication policy %s: %+v", name, err)
 			}
 		}

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -80,7 +80,7 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 		existing, err := client.Get(ctx, name)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequest(existing.Response) {
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithNotRegistered(existing.Response, err) {
 				return fmt.Errorf("checking for presence of existing site recovery replication policy %s: %+v", name, err)
 			}
 		}

--- a/utils/response.go
+++ b/utils/response.go
@@ -48,3 +48,23 @@ func ResponseWasStatusCode(resp autorest.Response, statusCode int) bool { // nol
 
 	return false
 }
+
+// ResponseWasBadRequestWithNotRegistered is a workaround for https://github.com/Azure/azure-rest-api-specs/issues/12759
+func ResponseWasBadRequestWithNotRegistered(resp autorest.Response, err error) bool {
+	e, ok := err.(autorest.DetailedError)
+	if !ok {
+		return false
+	}
+
+	v, ok := e.Original.(*autorest.DetailedError)
+	if !ok {
+		return false
+	}
+
+	originalCode, ok := v.StatusCode.(string)
+	if !ok {
+		return false
+	}
+
+	return ResponseWasStatusCode(resp, http.StatusBadRequest) && originalCode == "SubscriptionIdNotRegisteredWithSrs"
+}

--- a/utils/response.go
+++ b/utils/response.go
@@ -50,8 +50,7 @@ func ResponseWasStatusCode(resp autorest.Response, statusCode int) bool { // nol
 	return false
 }
 
-// ResponseWasBadRequestWithNotRegistered is a workaround for https://github.com/Azure/azure-rest-api-specs/issues/12759
-func ResponseWasBadRequestWithNotRegistered(resp autorest.Response, err error) bool {
+func ResponseWasBadRequestWithServiceCode(resp autorest.Response, err error, serviceCode string) bool {
 	e, ok := err.(autorest.DetailedError)
 	if !ok {
 		return false
@@ -66,10 +65,10 @@ func ResponseWasBadRequestWithNotRegistered(resp autorest.Response, err error) b
 		return false
 	}
 
-	serviceCode, ok := r.ServiceError.Details[0]["code"]
+	sc, ok := r.ServiceError.Details[0]["code"]
 	if !ok {
 		return false
 	}
 
-	return ResponseWasStatusCode(resp, http.StatusBadRequest) && serviceCode == "SubscriptionIdNotRegisteredWithSrs"
+	return ResponseWasStatusCode(resp, http.StatusBadRequest) && sc == serviceCode
 }


### PR DESCRIPTION
caused by https://github.com/Azure/azure-rest-api-specs/issues/12759

sometimes acctests will fail because the service returned http 400 on existing check 
```
------- Stdout: -------
=== RUN   TestAccSiteRecoveryReplicationPolicy_basic
=== PAUSE TestAccSiteRecoveryReplicationPolicy_basic
=== CONT  TestAccSiteRecoveryReplicationPolicy_basic
testcase.go:110: Step 1/2 error: Error running apply: exit status 1
Error: checking for presence of existing site recovery replication policy acctest-policy-221121032940985007: siterecovery.ReplicationPoliciesClient#Get: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="The resource with ID 9076266923593873117 isn't registered with the service." Details=[{"activityId":"affaea0c-cda8-4bde-fbc8-e4f52a2399e2","clientRequestId":"19db9646-236d-4fd8-8579-3100e18b9c7d","code":"SubscriptionIdNotRegisteredWithSrs","message":"The resource with ID 9076266923593873117 isn't registered with the service.","possibleCauses":"The operation failed due to an internal error.","recommendedAction":"Retry the last action. If the issue persists, contact Support."}]
with azurerm_site_recovery_replication_policy.test,
on terraform_plugin_test.tf line 31, in resource "azurerm_site_recovery_replication_policy" "test":
31: resource "azurerm_site_recovery_replication_policy" "test" {
--- FAIL: TestAccSiteRecoveryReplicationPolicy_basic (68.21s)
FAIL
```
<img width="514" alt="Screenshot 2022-11-23 at 15 24 21" src="https://user-images.githubusercontent.com/51212351/203491563-cee94d18-d9e1-4b30-8282-87e7ee7016f7.png">

The other failed acctests in Recovery Services will be fixed in other PRs.