### PR TITLE
Docs: `healthcare_dicom` and `healthcare_fhir_service`

### DIFF
--- a/website/docs/d/healthcare_dicom.html.markdown
+++ b/website/docs/d/healthcare_dicom.html.markdown
@@ -27,7 +27,7 @@ output "azurerm_healthcare_dicom_service" {
 
 * `name` - The name of the Healthcare DICOM Service
 
-* `workspace_id` - The name of the Healthcare Workspace in which the Healthcare DICOM Service exists.
+* `workspace_id` - The id of the Healthcare Workspace in which the Healthcare DICOM Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/healthcare_dicom.html.markdown
+++ b/website/docs/d/healthcare_dicom.html.markdown
@@ -15,7 +15,7 @@ Use this data source to access information about an existing Healthcare DICOM Se
 ```hcl
 data "azurerm_healthcare_dicom_service" "example" {
   name         = "example-healthcare_dicom_service"
-  workspace_id = "example_healthcare_workspace"
+  workspace_id = data.azurerm_healthcare_workspace.example.id
 }
 
 output "azurerm_healthcare_dicom_service" {

--- a/website/docs/d/healthcare_fhir_service.html.markdown
+++ b/website/docs/d/healthcare_fhir_service.html.markdown
@@ -27,7 +27,7 @@ output "healthcare_fhir_service_id" {
 
 * `name` - The name of the Healthcare FHIR Service.
 
-* `workspace_id` - The name of the Healthcare Workspace in which the Healthcare FHIR Service exists.
+* `workspace_id` - The id of the Healthcare Workspace in which the Healthcare FHIR Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/r/healthcare_dicom.html.markdown
+++ b/website/docs/r/healthcare_dicom.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Healthcare DICOM Service. Changing this forces a new Healthcare DICOM Service to be created.
 
-* `workspace_id`  - (Required) Specifies the name of the Healthcare Workspace where the Healthcare DICOM Service should exist. Changing this forces a new Healthcare DICOM Service to be created.
+* `workspace_id`  - (Required) Specifies the id of the Healthcare Workspace where the Healthcare DICOM Service should exist. Changing this forces a new Healthcare DICOM Service to be created.
 
 * `location` - (Required) Specifies the Azure Region where the Healthcare DICOM Service should be created. Changing this forces a new Healthcare DICOM Service to be created.
 

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Healthcare FHIR Service. Changing this forces a new Healthcare FHIR Service to be created.
 
-* `workspace_id`  - (Required) Specifies the name of the Healthcare Workspace where the Healthcare FHIR Service should exist. Changing this forces a new Healthcare FHIR Service to be created.
+* `workspace_id`  - (Required) Specifies the id of the Healthcare Workspace where the Healthcare FHIR Service should exist. Changing this forces a new Healthcare FHIR Service to be created.
 
 * `location` - (Required) Specifies the Azure Region where the Healthcare FHIR Service should be created. Changing this forces a new Healthcare FHIR Service to be created.
 


### PR DESCRIPTION
Updates the documentation for the DICOM and FHIR healthcare services (resource and data) to clarify the `workspace_id` field actually requires an id rather than the name of e.g.  ..."the Healthcare Workspace in which the Healthcare DICOM Service exists.". Also updates the data DICOM example to reference the id, which is already present in the `[FHIR equivalent](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/d/healthcare_fhir_service.html.markdown)`. 

