### PR TITLE
Docs : Fix  wrong description of `attachment_status` property for  ` Data Source: azurerm_public_ips`

### DIFF
--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -22,7 +22,7 @@ data "azurerm_public_ips" "example" {
 ## Argument Reference
 
 * `resource_group_name` - Specifies the name of the resource group.
-* `attachment_status` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`Attached`) or unattached (`Unattached`). To allow for both, use `All`.
+* `attachment_status` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`Attached`) or unattached (`Unattached`).
 * `name_prefix` - (Optional) A prefix match used for the IP Addresses `name` field, case sensitive.
 * `allocation_type` - (Optional) The Allocation Type for the Public IP Address. Possible values include `Static` or `Dynamic`.
 


### PR DESCRIPTION
The possible values for property `attachment_status` in code are `Attached` and `Unattached`.Bbut in the doc description, it is said that "To allow for both, use All". Actually, no setting the property `attachment_status` means All. So delete the inconsistency description in the doc to fix #19394.