### PR TITLE
`azurerm_mysql_flexible_server` - expand max value for the `iops` property

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -212,7 +212,7 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.IntBetween(360, 20000),
+							ValidateFunc: validation.IntBetween(360, 48000),
 						},
 
 						"size_gb": {


### PR DESCRIPTION
This PR is to expand max value for the `iops` property.

Note: If increasing the `iops` would increase the cost in test case, so I didn't update the test case. But I updated the test case and ran it locally and it worked fine.

--- PASS: TestAccMySqlFlexibleServer_updateStorage (780.48s)