### PR TITLE
azurerm_kubernetes_cluster - Adding support for VerticalPodAutoscaler

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2369,12 +2369,9 @@ func expandKubernetesClusterWorkloadAutoscalerProfile(input []interface{}) *mana
 		profile.Keda = &kedaEnabled
 	}
 
-	vpaEnabled := managedclusters.ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{}
 	if v := config["vpa_enabled"].(bool); v {
-		vpaEnabled.Enabled = v
-
-		profile.VerticalPodAutoscaler = &vpaEnabled
 		profile.VerticalPodAutoscaler = expandKubernetesClusterWorkloadAutoscalerProfileVerticalPodAutoscaler(config["vpa_config"].([]interface{}))
+		profile.VerticalPodAutoscaler.Enabled = v
 	}
 
 	return profile

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1091,7 +1091,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 											string(managedclusters.ControlledValuesRequestsAndLimits),
 											string(managedclusters.ControlledValuesRequestsOnly),
 										}, false),
-									},	
+									},
 								},
 							},
 						},
@@ -2343,7 +2343,6 @@ func expandKubernetesClusterWindowsProfile(input []interface{}) *managedclusters
 	}
 }
 
-
 func expandKubernetesClusterWorkloadAutoscalerProfileVerticalPodAutoscaler(input []interface{}) *managedclusters.ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler {
 	if len(input) == 0 {
 		return nil
@@ -2351,7 +2350,7 @@ func expandKubernetesClusterWorkloadAutoscalerProfileVerticalPodAutoscaler(input
 
 	config := input[0].(map[string]interface{})
 	return &managedclusters.ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler{
-		UpdateMode: managedclusters.UpdateMode(config["update_mode"].(string)),
+		UpdateMode:       managedclusters.UpdateMode(config["update_mode"].(string)),
 		ControlledValues: managedclusters.ControlledValues(config["controlled_values"].(string)),
 	}
 }
@@ -2458,7 +2457,7 @@ func flattenKubernetesClusterWorkloadAutoscalerProfileVerticalPodAutoscaler(prof
 
 	cv := ""
 	if controlledValues := profile.ControlledValues; controlledValues != "" {
-		cv =  string(profile.ControlledValues)
+		cv = string(profile.ControlledValues)
 	}
 
 	um := ""
@@ -2468,8 +2467,8 @@ func flattenKubernetesClusterWorkloadAutoscalerProfileVerticalPodAutoscaler(prof
 
 	return []interface{}{
 		map[string]interface{}{
-			"controlled_values":  cv,
-			"update_mode": um,
+			"controlled_values": cv,
+			"update_mode":       um,
 		},
 	}
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -721,7 +721,21 @@ A `workload_autoscaler_profile` block supports the following:
 
 * `keda_enabled` - (Optional) Specifies whether KEDA Autoscaler can be used for workloads.
 
--> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AKS-KedaPreview` is enabled and the Resource Provider is re-registered, see [the documentation]([Microsoft.ContainerService/AKS-KedaPreview](https://docs.microsoft.com/azure/aks/keda-deploy-add-on-arm#register-the-aks-kedapreview-feature-flag) for more information.
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AKS-KedaPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/azure/aks/keda-deploy-add-on-arm#register-the-aks-kedapreview-feature-flag) for more information.
+
+* `vpa_enabled` - (Optional) Specifies whether VerticalPodAutoscaler (VPA) can be used for workloads.
+
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AKS-VPAPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/azure/aks/vertical-pod-autoscaler#register-the-vpa-provider-feature) for more information.
+
+* `vpa_config` - (Optional) A `vpc_config` block as defined below.
+
+---
+
+A `vpa_config` block supports the following:
+
+* `update_mode` - (Required) Can be set to `Auto`, `Initial`, `Off` or `Recreate`.
+
+* `controlled_values` - (Required) Can be set to either `RequestsAndLimits` or `RequestsOnly`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -737,6 +737,8 @@ A `vpa_config` block supports the following:
 
 * `controlled_values` - (Required) Can be set to either `RequestsAndLimits` or `RequestsOnly`.
 
+-> **Note:** The ControlledValues of vertical Pod Autoscaler can't be changed in preview.
+
 ---
 
 A `http_proxy_config` block supports the following:


### PR DESCRIPTION
This PR adds support to configure the VerticalPodAutoscaler as requested in issue https://github.com/hashicorp/terraform-provider-azurerm/issues/19022. It extendds the `workload_autoscaler_profile` with two new arguments:

* `vpa_enabled` to enable or disable the vpa 
* `vpa_config` to configure the vpa

The `vpa_config` block has two arguments:

* `update_mode` which can be set to `Auto`, `Initial`, `Off` or `Recreate`
* `controlled_values` which  can be set to either `RequestsAndLimits` or `RequestsOnly`

Configuration example:

```hcl

  workload_autoscaler_profile {
    keda_enabled = false
    vpa_enabled = false

    vpa_config {
        update_mode = "Off"
        controlled_values = "RequestsOnly" # "RequestsAndLimits"
    }
  }
```
