### PR TITLE
web and and service: update the php versions to match the portal versions

### DIFF
--- a/internal/services/appservice/helpers/web_app_schema.go
+++ b/internal/services/appservice/helpers/web_app_schema.go
@@ -915,6 +915,8 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"7.4",
+						"8.0",
+						"8.1",
 					}, false),
 					AtLeastOneOf: []string{
 						"site_config.0.application_stack.0.docker_container_name",

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -318,13 +318,9 @@ func schemaAppServiceSiteConfig() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						"5.5",
-						"5.6",
-						"7.0",
-						"7.1",
-						"7.2",
-						"7.3",
 						"7.4",
+						"8.0",
+						"8.1",
 					}, false),
 				},
 

--- a/internal/services/web/app_service_resource_test.go
+++ b/internal/services/web/app_service_resource_test.go
@@ -4471,7 +4471,7 @@ resource "azurerm_app_service" "test" {
   app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
-    php_version = "7.3"
+    php_version = "8.0"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/web/app_service_slot_resource_test.go
+++ b/internal/services/web/app_service_slot_resource_test.go
@@ -3426,7 +3426,7 @@ resource "azurerm_app_service_slot" "test" {
   app_service_name    = azurerm_app_service.test.name
 
   site_config {
-    php_version = "7.3"
+    php_version = "8.0"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)


### PR DESCRIPTION
The Azure portal support 7.4, 8.0 and 8.1. This is to make the provider inline with that