### PR TITLE
`azurerm_storage_management_policy` - Support `rule.actions.base_blob.{tier_to_cool_after_days_since_creation_greater_than|tier_to_archive_after_days_since_creation_greater_than|delete_after_days_since_creation_greater_than}`

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -137,6 +137,12 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 													Default:      -1,
 													ValidateFunc: validation.IntBetween(0, 99999),
 												},
+												"tier_to_cool_after_days_since_creation_greater_than": {
+													Type:         pluginsdk.TypeInt,
+													Optional:     true,
+													Default:      -1,
+													ValidateFunc: validation.IntBetween(0, 99999),
+												},
 												"tier_to_archive_after_days_since_modification_greater_than": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
@@ -155,6 +161,12 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 													Default:      -1,
 													ValidateFunc: validation.IntBetween(0, 99999),
 												},
+												"tier_to_archive_after_days_since_creation_greater_than": {
+													Type:         pluginsdk.TypeInt,
+													Optional:     true,
+													Default:      -1,
+													ValidateFunc: validation.IntBetween(0, 99999),
+												},
 												"delete_after_days_since_modification_greater_than": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
@@ -162,6 +174,12 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 													ValidateFunc: validation.IntBetween(0, 99999),
 												},
 												"delete_after_days_since_last_access_time_greater_than": {
+													Type:         pluginsdk.TypeInt,
+													Optional:     true,
+													Default:      -1,
+													ValidateFunc: validation.IntBetween(0, 99999),
+												},
+												"delete_after_days_since_creation_greater_than": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
 													Default:      -1,
@@ -399,8 +417,8 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 		if _, ok := d.GetOk(fmt.Sprintf("rule.%d.actions.0.base_blob", ruleIndex)); ok {
 			baseBlob := &storage.ManagementPolicyBaseBlob{}
 			var (
-				sinceMod, sinceAccess     interface{}
-				sinceModOK, sinceAccessOK bool
+				sinceMod, sinceAccess, sinceCreate       interface{}
+				sinceModOK, sinceAccessOK, sinceCreateOK bool
 			)
 
 			sinceMod = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_cool_after_days_since_modification_greater_than", ruleIndex))
@@ -408,10 +426,25 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 
 			sinceAccess = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_cool_after_days_since_last_access_time_greater_than", ruleIndex))
 			sinceAccessOK = sinceAccess != -1
-			if sinceModOK && sinceAccessOK {
-				return nil, fmt.Errorf("can't specify `tier_to_cool_after_days_since_modification_greater_than` and `tier_to_cool_after_days_since_last_access_time_greater_than` at the same time")
+
+			sinceCreate = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_cool_after_days_since_creation_greater_than", ruleIndex))
+			sinceCreateOK = sinceCreate != -1
+
+			var cnt int
+			if sinceModOK {
+				cnt++
 			}
-			if sinceModOK || sinceAccessOK {
+			if sinceAccessOK {
+				cnt++
+			}
+			if sinceCreateOK {
+				cnt++
+			}
+			if cnt > 1 {
+				return nil, fmt.Errorf("Only one of `tier_to_cool_after_days_since_modification_greater_than`, `tier_to_cool_after_days_since_last_access_time_greater_than`, `tier_to_cool_after_days_since_creation_greater_than` can be specified at the same time")
+			}
+
+			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.TierToCool = &storage.DateAfterModification{}
 				if sinceModOK {
 					baseBlob.TierToCool.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
@@ -419,24 +452,42 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 				if sinceAccessOK {
 					baseBlob.TierToCool.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
 				}
+				if sinceCreateOK {
+					baseBlob.TierToCool.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+				}
 			}
 
 			sinceMod = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_modification_greater_than", ruleIndex))
 			sinceModOK = sinceMod != -1
 			sinceAccess = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_last_access_time_greater_than", ruleIndex))
 			sinceAccessOK = sinceAccess != -1
+			sinceCreate = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_creation_greater_than", ruleIndex))
+			sinceCreateOK = sinceCreate != -1
 
-			if sinceModOK && sinceAccessOK {
-				return nil, fmt.Errorf("can't specify `tier_to_archive_after_days_since_modification_greater_than` and `tier_to_archive_after_days_since_last_access_time_greater_than` at the same time")
+			cnt = 0
+			if sinceModOK {
+				cnt++
+			}
+			if sinceAccessOK {
+				cnt++
+			}
+			if sinceCreateOK {
+				cnt++
+			}
+			if cnt > 1 {
+				return nil, fmt.Errorf("Only one of `tier_to_archive_after_days_since_modification_greater_than`, `tier_to_archive_after_days_since_last_access_time_greater_than` and `tier_to_archive_after_days_since_creation_greater_than` can be specified at the same time")
 			}
 
-			if sinceModOK || sinceAccessOK {
+			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.TierToArchive = &storage.DateAfterModification{}
 				if sinceModOK {
 					baseBlob.TierToArchive.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
 					baseBlob.TierToArchive.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+				}
+				if sinceCreateOK {
+					baseBlob.TierToArchive.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
 				}
 				if v := d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_last_tier_change_greater_than", ruleIndex)); v != -1 {
 					baseBlob.TierToArchive.DaysAfterLastTierChangeGreaterThan = utils.Float(float64(v.(int)))
@@ -447,16 +498,32 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			sinceModOK = sinceMod != -1
 			sinceAccess = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.delete_after_days_since_last_access_time_greater_than", ruleIndex))
 			sinceAccessOK = sinceAccess != -1
-			if sinceModOK && sinceAccessOK {
-				return nil, fmt.Errorf("can't specify `delete_after_days_since_modification_greater_than` and `delete_after_days_since_last_access_time_greater_than` at the same time")
+			sinceCreate = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.delete_after_days_since_creation_greater_than", ruleIndex))
+			sinceCreateOK = sinceCreate != -1
+
+			cnt = 0
+			if sinceModOK {
+				cnt++
 			}
-			if sinceModOK || sinceAccessOK {
+			if sinceAccessOK {
+				cnt++
+			}
+			if sinceCreateOK {
+				cnt++
+			}
+			if cnt > 1 {
+				return nil, fmt.Errorf("Only one of `delete_after_days_since_modification_greater_than`, `delete_after_days_since_last_access_time_greater_than` and `delete_after_days_since_creation_greater_than` can be specified at the same time")
+			}
+			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.Delete = &storage.DateAfterModification{}
 				if sinceModOK {
 					baseBlob.Delete.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
 					baseBlob.Delete.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+				}
+				if sinceCreateOK {
+					baseBlob.Delete.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
 				}
 			}
 
@@ -567,11 +634,14 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 					var (
 						tierToCoolSinceMod               = -1
 						tierToCoolSinceAccess            = -1
+						tierToCoolSinceCreate            = -1
 						tierToArchiveSinceMod            = -1
 						tierToArchiveSinceAccess         = -1
+						tierToArchiveSinceCreate         = -1
 						tierToArchiveSinceLastTierChange = -1
 						deleteSinceMod                   = -1
 						deleteSinceAccess                = -1
+						deleteSinceCreate                = -1
 					)
 
 					if props := armActionBaseBlob.TierToCool; props != nil {
@@ -580,6 +650,9 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 						}
 						if props.DaysAfterLastAccessTimeGreaterThan != nil {
 							tierToCoolSinceAccess = int(*props.DaysAfterLastAccessTimeGreaterThan)
+						}
+						if props.DaysAfterCreationGreaterThan != nil {
+							tierToCoolSinceCreate = int(*props.DaysAfterCreationGreaterThan)
 						}
 					}
 					if props := armActionBaseBlob.TierToArchive; props != nil {
@@ -592,6 +665,9 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 						if props.DaysAfterLastTierChangeGreaterThan != nil {
 							tierToArchiveSinceLastTierChange = int(*props.DaysAfterLastTierChangeGreaterThan)
 						}
+						if props.DaysAfterCreationGreaterThan != nil {
+							tierToArchiveSinceCreate = int(*props.DaysAfterCreationGreaterThan)
+						}
 					}
 					if props := armActionBaseBlob.Delete; props != nil {
 						if props.DaysAfterModificationGreaterThan != nil {
@@ -600,16 +676,22 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 						if props.DaysAfterLastAccessTimeGreaterThan != nil {
 							deleteSinceAccess = int(*props.DaysAfterLastAccessTimeGreaterThan)
 						}
+						if props.DaysAfterCreationGreaterThan != nil {
+							deleteSinceCreate = int(*props.DaysAfterCreationGreaterThan)
+						}
 					}
 					action["base_blob"] = []interface{}{
 						map[string]interface{}{
 							"tier_to_cool_after_days_since_modification_greater_than":        tierToCoolSinceMod,
 							"tier_to_cool_after_days_since_last_access_time_greater_than":    tierToCoolSinceAccess,
+							"tier_to_cool_after_days_since_creation_greater_than":            tierToCoolSinceCreate,
 							"tier_to_archive_after_days_since_modification_greater_than":     tierToArchiveSinceMod,
 							"tier_to_archive_after_days_since_last_access_time_greater_than": tierToArchiveSinceAccess,
 							"tier_to_archive_after_days_since_last_tier_change_greater_than": tierToArchiveSinceLastTierChange,
+							"tier_to_archive_after_days_since_creation_greater_than":         tierToArchiveSinceCreate,
 							"delete_after_days_since_modification_greater_than":              deleteSinceMod,
 							"delete_after_days_since_last_access_time_greater_than":          deleteSinceAccess,
+							"delete_after_days_since_creation_greater_than":                  deleteSinceCreate,
 						},
 					}
 				}

--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -384,6 +384,13 @@ func TestAccStorageManagementPolicy_baseblobAccessTimeBased(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.baseblobCreateBased(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.baseblobModificationBased(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -996,6 +1003,32 @@ resource "azurerm_storage_management_policy" "test" {
         tier_to_cool_after_days_since_modification_greater_than    = 10
         tier_to_archive_after_days_since_modification_greater_than = 50
         delete_after_days_since_modification_greater_than          = 100
+      }
+    }
+  }
+}
+`, r.templateLastAccessTimeEnabled(data))
+}
+
+func (r StorageManagementPolicyResource) baseblobCreateBased(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_management_policy" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+
+  rule {
+    name    = "rule-1"
+    enabled = true
+    filters {
+      prefix_match = ["container1/prefix1"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_creation_greater_than    = 10
+        tier_to_archive_after_days_since_creation_greater_than = 50
+        delete_after_days_since_creation_greater_than          = 100
       }
     }
   }

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -123,20 +123,23 @@ The following arguments are supported:
 
 * `tier_to_cool_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between 0 and 99999.
 * `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
+* `tier_to_cool_after_days_since_creation_greater_than` - The age in days after creation to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
 
-~> **Note:** The `tier_to_cool_after_days_since_modification_greater_than` and `tier_to_cool_after_days_since_last_access_time_greater_than` can not be set at the same time.
+~> **Note:** The `tier_to_cool_after_days_since_modification_greater_than`, `tier_to_cool_after_days_since_last_access_time_greater_than` and `tier_to_cool_after_days_since_creation_greater_than` can not be set at the same time.
 
 * `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between 0 and 99999.
-* `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0 and`99999`.
+* `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
+* `tier_to_archive_after_days_since_creation_greater_than` - The age in days after creation to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
 
-~> **Note:** The `tier_to_archive_after_days_since_modification_greater_than` and `tier_to_archive_after_days_since_last_access_time_greater_than` can not be set at the same time.
+~> **Note:** The `tier_to_archive_after_days_since_modification_greater_than`, `tier_to_archive_after_days_since_last_access_time_greater_than` and `tier_to_archive_after_days_since_creation_greater_than` can not be set at the same time.
 
 * `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
 
 * `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob. Must be between 0 and 99999.
 * `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob. Must be between `0` and `99999`.
+* `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob. Must be between `0` and `99999`.
 
-~> **Note:** The `delete_after_days_since_modification_greater_than` and `delete_after_days_since_last_access_time_greater_than` can not be set at the same time.
+~> **Note:** The `delete_after_days_since_modification_greater_than`, `delete_after_days_since_last_access_time_greater_than` and `delete_after_days_since_creation_greater_than` can not be set at the same time.
 
 ~> **Note:** The [`last_access_time_enabled`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#last_access_time_enabled) must be set to `true` in the `azurerm_storage_account` in order to use `tier_to_cool_after_days_since_last_access_time_greater_than`, `tier_to_archive_after_days_since_last_access_time_greater_than` and `delete_after_days_since_last_access_time_greater_than`.
 


### PR DESCRIPTION
Fix #19435.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run=TestAccStorageManagementPolicy_baseblobAccessTimeBased
=== RUN   TestAccStorageManagementPolicy_baseblobAccessTimeBased
=== PAUSE TestAccStorageManagementPolicy_baseblobAccessTimeBased
=== CONT  TestAccStorageManagementPolicy_baseblobAccessTimeBased
--- PASS: TestAccStorageManagementPolicy_baseblobAccessTimeBased (261.95s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       261.992s
```