### PR TITLE
`azurerm_stream_analytics_output_eventhub`: Fix `authentication_mode` issue when it's toggled to `Msi`

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_eventhub_resource_test.go
@@ -165,7 +165,7 @@ func TestAccStreamAnalyticsOutputEventHub_authenticationMode(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("shared_access_policy_key"),
+		data.ImportStep(),
 	})
 }
 
@@ -394,8 +394,6 @@ resource "azurerm_stream_analytics_output_eventhub" "test" {
   resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
   eventhub_name             = azurerm_eventhub.test.name
   servicebus_namespace      = azurerm_eventhub_namespace.test.name
-  shared_access_policy_key  = azurerm_eventhub_namespace.test.name
-  shared_access_policy_name = "RootManageSharedAccessKey"
   authentication_mode       = "Msi"
 
   serialization {

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -68,9 +68,9 @@ The following arguments are supported:
 
 * `servicebus_namespace` - (Required) The namespace that is associated with the desired Event Hub, Service Bus Queue, Service Bus Topic, etc.
 
-* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy.
+* `shared_access_policy_key` - (Optional) The shared access policy key for the specified shared access policy. Required when `authentication_mode` is set to `ConnectionString`.
 
-* `shared_access_policy_name` - (Required) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
+* `shared_access_policy_name` - (Optional) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc. Required when `authentication_mode` is set to `ConnectionString`.
 
 * `serialization` - (Required) A `serialization` block as defined below.
 


### PR DESCRIPTION
* GH issue https://github.com/hashicorp/terraform-provider-azurerm/issues/19442
* When `authentication_mode` is `Msi`, `shared_access_policy_key` and `shared_access_policy_name` are not required.
* Test results:
```
=== RUN   TestAccStreamAnalyticsOutputEventHub_authenticationMode
=== PAUSE TestAccStreamAnalyticsOutputEventHub_authenticationMode
=== CONT  TestAccStreamAnalyticsOutputEventHub_authenticationMode
--- PASS: TestAccStreamAnalyticsOutputEventHub_authenticationMode (368.24s)
PASS

```
