### PR TITLE
Support Upload creation_type with uploadSizeBytes

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -88,6 +88,7 @@ func resourceManagedDisk() *pluginsdk.Resource {
 					string(disks.DiskCreateOptionFromImage),
 					string(disks.DiskCreateOptionImport),
 					string(disks.DiskCreateOptionRestore),
+					string(disks.DiskCreateOptionUpload),
 				}, false),
 			},
 
@@ -153,6 +154,12 @@ func resourceManagedDisk() *pluginsdk.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validate.ManagedDiskSizeGB,
+			},
+
+			"upload_size_bytes": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 
 			"disk_iops_read_write": {
@@ -412,6 +419,14 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 			}
 		} else {
 			return fmt.Errorf("`image_reference_id` or `gallery_image_reference_id` must be specified when `create_option` is set to `FromImage`")
+		}
+	}
+
+	if createOption == disks.DiskCreateOptionUpload {
+		if uploadSizeBytes := d.Get("upload_size_bytes").(int); uploadSizeBytes != 0 {
+			props.CreationData.UploadSizeBytes = utils.Int64(int64(uploadSizeBytes))
+		} else {
+			return fmt.Errorf("`upload_size_bytes` must be specified when `create_option` is set to `Upload`")
 		}
 	}
 

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -124,6 +124,22 @@ func TestAccManagedDisk_fromGalleryImage(t *testing.T) {
 	})
 }
 
+func TestAccManagedDisk_upload(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.upload(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("upload_size_bytes").HasValue("21475885568"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccManagedDisk_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
@@ -1176,6 +1192,28 @@ resource "azurerm_managed_disk" "test" {
   storage_account_type       = "Standard_LRS"
 }
 `, LinuxVirtualMachineResource{}.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (ManagedDiskResource) upload(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctestd-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name  
+  create_option        = "Upload"  
+  storage_account_type = "Standard_LRS"  
+  upload_size_bytes    = 21475885568
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (ManagedDiskResource) encryptionTemplate(data acceptance.TestData) string {

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `Copy` - Copy an existing managed disk or snapshot (specified with `source_resource_id`).
 * `FromImage` - Copy a Platform Image (specified with `image_reference_id`)
 * `Restore` - Set by Azure Backup or Site Recovery on a restored disk (specified with `source_resource_id`).
+* `Upload` - Upload a VHD disk with the help of SAS URL (to be used with with `upload_size_bytes`).
 
 ---
 
@@ -106,6 +107,8 @@ The following arguments are supported:
 * `disk_mbps_read_only` - (Optional) The bandwidth allowed across all VMs mounting the shared disk as read-only; only settable for UltraSSD disks and PremiumV2 disks with shared disk enabled. MBps means millions of bytes per second.
 
 * `disk_size_gb` - (Optional, Required for a new managed disk) Specifies the size of the managed disk to create in gigabytes. If `create_option` is `Copy` or `FromImage`, then the value must be equal to or greater than the source's size. The size can only be increased.
+
+* `upload_size_bytes` - (Optional, Required when create_option is `Upload`) Specifies the size of the managed disk to create in bytes. If `create_option` is `Upload`, the value of the disk must be equal to the source disk to be copied in bytes. Source disk size could be calculated with `ls -l` or `wc -c`. More information can be found at [Copy a managed disk](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-upload-vhd-to-managed-disk-cli#copy-a-managed-disk)
 
 -> **NOTE:** In certain conditions the Data Disk size can be updated without shutting down the Virtual Machine, however only a subset of Virtual Machine SKUs/Disk combinations support this. More information can be found [for Linux Virtual Machines](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) and [Windows Virtual Machines](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime) respectively.
 


### PR DESCRIPTION
Support `Upload` as one of the `create_option`. To be used in combination with `upload_size_bytes`. 
Helpful to upload VHD disks from On-Prem <-> Azure, Azure <-> Azure etc., 