### PR TITLE
`azurerm_data_factory_linked_service_azure_file_storage` - only pass `host` and `user_id` when they're set

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_file_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_file_storage_resource.go
@@ -173,8 +173,14 @@ func resourceDataFactoryLinkedServiceAzureFileStorageCreateUpdate(d *pluginsdk.R
 			Type:  datafactory.TypeSecureString,
 		},
 		FileShare: d.Get("file_share").(string),
-		Host:      d.Get("host").(string),
-		UserID:    d.Get("user_id").(string),
+	}
+
+	if host := d.Get("host").(string); host != "" {
+		fileStorageProperties.Host = host
+	}
+
+	if userId := d.Get("user_id").(string); userId != "" {
+		fileStorageProperties.UserID = userId
 	}
 
 	password := d.Get("password").(string)


### PR DESCRIPTION
<img width="631" alt="image" src="https://user-images.githubusercontent.com/79895375/204442773-5a2a46fd-e5f1-428b-9f70-5950602534f5.png">

fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19409